### PR TITLE
Make run start_time required [sdk]

### DIFF
--- a/nominal/sdk.py
+++ b/nominal/sdk.py
@@ -145,7 +145,7 @@ class Run:
             properties=MappingProxyType(run.properties),
             labels=tuple(run.labels),
             start=_conjure_time_to_integral_nanoseconds(run.start_time),
-            end=(_conjure_time_to_integral_nanoseconds(run.end_time) if run.end_time else None),
+            end=None if run.end_time is None else _conjure_time_to_integral_nanoseconds(run.end_time),
             _client=nominal_client,
         )
 
@@ -367,7 +367,7 @@ class NominalClient:
         title: str,
         description: str,
         start_time: datetime | IntegralNanosecondsUTC,
-        end_time: datetime | IntegralNanosecondsUTC | None = None,
+        end_time: datetime | IntegralNanosecondsUTC,
         *,
         datasets: Mapping[str, str] | None = None,
         labels: Sequence[str] = (),
@@ -381,7 +381,7 @@ class NominalClient:
             retrieved from `Dataset.rid` after getting or creating a dataset.
         """
         start_abs = _flexible_time_to_conjure_scout_run_api(start_time)
-        end_abs = _flexible_time_to_conjure_scout_run_api(end_time) if end_time else None
+        end_abs = _flexible_time_to_conjure_scout_run_api(end_time)
         datasets = datasets or {}
         request = scout_run_api.CreateRunRequest(
             attachments=list(attachment_rids),

--- a/nominal/sdk.py
+++ b/nominal/sdk.py
@@ -145,7 +145,7 @@ class Run:
             properties=MappingProxyType(run.properties),
             labels=tuple(run.labels),
             start=_conjure_time_to_integral_nanoseconds(run.start_time),
-            end=None if run.end_time is None else _conjure_time_to_integral_nanoseconds(run.end_time),
+            end=(_conjure_time_to_integral_nanoseconds(run.end_time) if run.end_time else None),
             _client=nominal_client,
         )
 


### PR DESCRIPTION
We technically support this on the API side, but we want to start with time bounds being required from the lib for now