### PR TITLE
chore: just build-docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,7 +1,7 @@
 name: Deploy mkdocs site to Pages
 
 on:
-  pull_request:
+  push:
     branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,7 +1,7 @@
 name: Deploy mkdocs site to Pages
 
 on:
-  push:
+  pull_request:
     branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,8 +31,9 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
-      - name: Build with mkdocs
-        run: mkdocs build
+      - name: Build docs
+        run: |
+          just build-docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/justfile
+++ b/justfile
@@ -45,3 +45,7 @@ verify-e2e token: install check test (test-e2e token)
 # clean up poetry environments
 clean:
     poetry env remove --all
+
+# build docs
+build-docs:
+    poetry run mkdocs build


### PR DESCRIPTION
the doc deploy failed, presumably due to using `mkdocs` rather than `poetry run mkdocs`. Added a `just` command for building the docs, and use that in the action. 

Testing: I now realize I can change the workflow to `on: pull_request` to test it on this PR, and then can switch it back to `on: push` before merging! The deployment step failed, but the `build` step succeeded, so I think we're good.