### PR TITLE
fix: search_runs parameter rename: exact_name -> name_substring

### DIFF
--- a/nominal/_utils.py
+++ b/nominal/_utils.py
@@ -7,10 +7,10 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import BinaryIO, Callable, Iterable, Iterator, Literal, NamedTuple, ParamSpec, TypeVar, Union
+from typing import BinaryIO, Callable, Iterable, Iterator, Literal, NamedTuple, TypeVar, Union
 
 import dateutil.parser
-from typing_extensions import TypeAlias  # typing.TypeAlias in 3.10+
+from typing_extensions import TypeAlias, ParamSpec
 
 from ._api.combined import api, ingest_api, scout_run_api
 

--- a/nominal/_utils.py
+++ b/nominal/_utils.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import BinaryIO, Callable, Iterable, Iterator, Literal, NamedTuple, TypeVar, Union
 
 import dateutil.parser
-from typing_extensions import TypeAlias, ParamSpec
+from typing_extensions import ParamSpec, TypeAlias
 
 from ._api.combined import api, ingest_api, scout_run_api
 

--- a/nominal/core.py
+++ b/nominal/core.py
@@ -45,6 +45,7 @@ from ._utils import (
     _global_conjure_api_to_integral_nanoseconds,
     _timestamp_type_to_conjure_ingest_api,
     construct_user_agent_string,
+    deprecate_keyword_argument,
     update_dataclass,
 )
 from .exceptions import NominalIngestError, NominalIngestFailed
@@ -667,6 +668,7 @@ class NominalClient:
         for run in self._search_runs_paginated(request):
             yield Run._from_conjure(self, run)
 
+    @deprecate_keyword_argument("name_substring", "exact_name")
     def search_runs(
         self,
         start: datetime | IntegralNanosecondsUTC | None = None,

--- a/nominal/core.py
+++ b/nominal/core.py
@@ -652,13 +652,13 @@ class NominalClient:
         self,
         start: datetime | IntegralNanosecondsUTC | None = None,
         end: datetime | IntegralNanosecondsUTC | None = None,
-        exact_name: str | None = None,
+        name_substring: str | None = None,
         label: str | None = None,
         property: tuple[str, str] | None = None,
     ) -> Iterable[Run]:
         request = scout_run_api.SearchRunsRequest(
             page_size=100,
-            query=_create_search_runs_query(start, end, exact_name, label, property),
+            query=_create_search_runs_query(start, end, name_substring, label, property),
             sort=scout_run_api.SortOptions(
                 field=scout_run_api.SortField.START_TIME,
                 is_descending=True,
@@ -671,17 +671,17 @@ class NominalClient:
         self,
         start: datetime | IntegralNanosecondsUTC | None = None,
         end: datetime | IntegralNanosecondsUTC | None = None,
-        exact_name: str | None = None,
+        name_substring: str | None = None,
         label: str | None = None,
         property: tuple[str, str] | None = None,
     ) -> Sequence[Run]:
         """Search for runs meeting the specified filters.
         Filters are ANDed together, e.g. `(run.label == label) AND (run.end <= end)`
         - `start` and `end` times are both inclusive
-        - `exact_name` is case-insensitive
+        - `name_substring`: search for a (case-insensitive) substring in the name
         - `property` is a key-value pair, e.g. ("name", "value")
         """
-        return list(self._iter_search_runs(start, end, exact_name, label, property))
+        return list(self._iter_search_runs(start, end, name_substring, label, property))
 
     def create_csv_dataset(
         self,
@@ -968,7 +968,7 @@ def _rid_from_instance_or_string(value: Attachment | Run | Dataset | Video | Log
 def _create_search_runs_query(
     start: datetime | IntegralNanosecondsUTC | None = None,
     end: datetime | IntegralNanosecondsUTC | None = None,
-    exact_name: str | None = None,
+    name_substring: str | None = None,
     label: str | None = None,
     property: tuple[str, str] | None = None,
 ) -> scout_run_api.SearchQuery:
@@ -979,8 +979,8 @@ def _create_search_runs_query(
     if end is not None:
         q = scout_run_api.SearchQuery(end_time_inclusive=_flexible_time_to_conjure_scout_run_api(end))
         queries.append(q)
-    if exact_name is not None:
-        q = scout_run_api.SearchQuery(exact_match=exact_name)
+    if name_substring is not None:
+        q = scout_run_api.SearchQuery(exact_match=name_substring)
         queries.append(q)
     if label is not None:
         q = scout_run_api.SearchQuery(label=label)

--- a/nominal/nominal.py
+++ b/nominal/nominal.py
@@ -15,6 +15,7 @@ from ._utils import (
     IntegralNanosecondsUTC,
     TimestampColumnType,
     _parse_timestamp,
+    deprecate_keyword_argument,
     reader_writer,
 )
 from .core import Attachment, Dataset, LogSet, NominalClient, Run, Video
@@ -235,6 +236,7 @@ def get_run(rid: str) -> Run:
     return conn.get_run(rid)
 
 
+@deprecate_keyword_argument("name_substring", "exact_name")
 def search_runs(
     *,
     start: str | datetime | IntegralNanosecondsUTC | None = None,

--- a/nominal/nominal.py
+++ b/nominal/nominal.py
@@ -239,7 +239,7 @@ def search_runs(
     *,
     start: str | datetime | IntegralNanosecondsUTC | None = None,
     end: str | datetime | IntegralNanosecondsUTC | None = None,
-    exact_name: str | None = None,
+    name_substring: str | None = None,
     label: str | None = None,
     property: tuple[str, str] | None = None,
 ) -> list[Run]:
@@ -247,16 +247,16 @@ def search_runs(
 
     Filters are ANDed together, e.g. `(run.label == label) AND (run.end <= end)`
     - `start` and `end` times are both inclusive
-    - `exact_name` is case-insensitive
+    - `name_substring`: search for a (case-insensitive) substring in the name
     - `property` is a key-value pair, e.g. ("name", "value")
     """
-    if all([v is None for v in (start, end, exact_name, label, property)]):
-        raise ValueError("must provide one of: start, end, exact_name, label, or property")
+    if all([v is None for v in (start, end, name_substring, label, property)]):
+        raise ValueError("must provide one of: start, end, name_substring, label, or property")
     conn = get_default_client()
     runs = conn.search_runs(
         start=None if start is None else _parse_timestamp(start),
         end=None if end is None else _parse_timestamp(end),
-        exact_name=exact_name,
+        name_substring=name_substring,
         label=label,
         property=property,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ mkdocs-material = "^9.5.34"
 mkdocstrings = "^0.26.1"
 mkdocstrings-python = "^1.11.1"
 black = "^24.8.0"
-mkdocs-click = {git = "https://github.com/alkasm/mkdocs-click", rev = "alkasm/keep-context-settings"}
+mkdocs-click = { git = "https://github.com/alkasm/mkdocs-click", rev = "alkasm/keep-context-settings" }
 jupyterlab = "^4.2.5"
 
 
@@ -69,6 +69,7 @@ disable_error_code = ["no-any-return", "no-untyped-def"]
 
 [tool.pytest.ini_options]
 filterwarnings = [
+    "error", # transform all warnings into errors, except ignore: ones.
     # DeprecationWarning: The 'strict' parameter is no longer needed on Python 3+. This will raise an error in urllib3 v2.1.0.
     # from conjure-python-client, in conjure_python_client/_http/requests_client.py,
     # TransportAdapter.init_poolmanager() uses urllib3.poolmanager.PoolManager(..., strict=True) which is deprecated.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -82,4 +82,5 @@ def mp4_data():
         curl https://raw.githubusercontent.com/chromium/chromium/main/media/test/data/bear-1280x720.mp4 -o data/bear-1280x720.mp4
     """
     path = Path(__file__).parent / "data/bear-1280x720.mp4"
-    return open(path, "rb").read()
+    with open(path, "rb") as f:
+        return f.read()

--- a/tests/e2e/test_core.py
+++ b/tests/e2e/test_core.py
@@ -59,8 +59,8 @@ def test_update_run():
     assert run.description == new_desc
     assert run.properties == new_props
     assert run.labels == tuple(new_labels)
-    assert run.start == _utils._datetime_to_integral_nanoseconds(new_start)
-    assert run.end == _utils._datetime_to_integral_nanoseconds(new_end)
+    assert run.start == _datetime_to_integral_nanoseconds(new_start)
+    assert run.end == _datetime_to_integral_nanoseconds(new_end)
 
 
 def test_add_dataset_to_run_and_list_datasets(csv_data):

--- a/tests/e2e/test_toplevel.py
+++ b/tests/e2e/test_toplevel.py
@@ -181,6 +181,19 @@ def test_search_runs():
     assert run2.labels == run.labels == ()
 
 
+def test_search_runs_substring():
+    name = f"run-{uuid4()}"
+    desc = f"top-level test to search for a run by name {uuid4()}"
+    start, end = _create_random_start_end()
+    run = nm.create_run(name, start, end, desc)
+    runs = nm.search_runs(name_substring=name[4:])
+    assert len(runs) == 1
+    run2 = runs[0]
+
+    assert run2.rid == run.rid != ""
+    assert run2.name == run.name == name
+
+
 def test_upload_attachment(csv_data):
     at_title = f"attachment-{uuid4()}"
     at_desc = f"top-level test to upload an attachment {uuid4()}"

--- a/tests/e2e/test_toplevel.py
+++ b/tests/e2e/test_toplevel.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import pandas as pd
 import polars as pl
+import pytest
 
 import nominal as nm
 from nominal import _utils
@@ -187,6 +188,21 @@ def test_search_runs_substring():
     start, end = _create_random_start_end()
     run = nm.create_run(name, start, end, desc)
     runs = nm.search_runs(name_substring=name[4:])
+    assert len(runs) == 1
+    run2 = runs[0]
+
+    assert run2.rid == run.rid != ""
+    assert run2.name == run.name == name
+
+
+def test_search_runs_substring_deprecated():
+    name = f"run-{uuid4()}"
+    desc = f"top-level test to search for a run by name {uuid4()}"
+    start, end = _create_random_start_end()
+    run = nm.create_run(name, start, end, desc)
+
+    with pytest.warns(UserWarning):
+        runs = nm.search_runs(exact_name=name[4:])
     assert len(runs) == 1
     run2 = runs[0]
 


### PR DESCRIPTION
This change renames the parameter `exact_name` to `name_substring` to communicate the intent. This performs an exact (as opposed to fuzzy) substring match on the name.

You should update your code accordingly:

```py
# in nominal-client<1.3
nm.search_runs(exact_name="some_substring")
```

should become

```py
# in nominal-client>=1.3
nm.search_runs(name_substring="some_substring")
```

This change is backwards compatible; the old argument "exact_name" is soft-deprecated - it warns, but still works, and will be removed later. Functionality with the new and old argument name is tested, as is the warning.