### PR TITLE
fix: remove component from release please tag

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "component": "nominal"


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

- set `include-component-in-tag: false` ([defaults to true](https://github.com/googleapis/release-please/blob/64ffba96734bf158818121c067870077d903611b/schemas/config.json#L78)) to prevent release-please from searching for `nominal-vX.Y.Z` formatted tags