### PR TITLE
chore: add package-name to config

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -4,7 +4,8 @@
   "include-component-in-tag": false,
   "packages": {
     ".": {
-      "component": "nominal"
+      "component": "nominal",
+      "package-name": "nominal"
     }
   },
   "plugins": [],


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

I found this note https://github.com/googleapis/release-please/blob/64ffba96734bf158818121c067870077d903611b/docs/manifest-releaser.md?plain=1#L258C9-L260

That package name is required for  python type releases