### PR TITLE
feat: validate login flow for new users

### DIFF
--- a/nominal/cli/auth.py
+++ b/nominal/cli/auth.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import warnings
-
 import click
-import requests
 from conjure_python_client import ConjureHTTPError
 
 from nominal import NominalClient, _config

--- a/nominal/cli/auth.py
+++ b/nominal/cli/auth.py
@@ -6,6 +6,7 @@ import click
 import requests
 
 from .. import _config
+from ..nominal import get_user
 from .util.global_decorators import global_options
 
 
@@ -18,16 +19,16 @@ def _validate_token_url(token: str, base_url: str) -> None:
     """Ensure the user sets a valid configuration before letting them import the client."""
     token_link = "https://app.gov.nominal.io/settings/user?tab=tokens"
     r = requests.get(f"{base_url}/openapi", headers={"Authorization": f"Bearer {token}"})
+    err_msg = ""
     if r.status_code == 401:
-        raise ValueError(
-            f"Your authorization token seems to be incorrect. Please recreate one here: {token_link}"
-        ) from None
-    if r.status_code == 404:
-        raise ValueError(f"Your base_url is not correct. Ensure it points to the API and not the app.") from None
-    if r.status_code != 200:
-        raise ValueError(
-            f"There is a misconfiguration between your base_url and token. Ensure you use the API url, and create a new token: {token_link}"
-        ) from None
+        err_msg = f"Your authorization token seems to be incorrect. Please recreate one here: {token_link}"
+    elif r.status_code == 404:
+        err_msg = f"Your base_url is not correct. Ensure it points to the API and not the app."
+    elif r.status_code != 200:
+        err_msg = f"There is a misconfiguration between your base_url and token. Ensure you use the API url, and create a new token: {token_link} {r.status_code}"
+    if err_msg:
+        click.secho(err_msg, err=True, fg="red")
+        raise click.ClickException("Failed to authenticate. See above for details")
 
 
 @auth_cmd.command()


### PR DESCRIPTION
As a new user, i ran into issues where i put in the wrong api for nominal, but since the auth flow didnt throw any issues, I didn't realize. Then, working through the docs examples, i ran into erroneous errors since my auth was misconfigured.

This eagerly checks the auth and url provided so users don't go down the path of and get frustrated.


invalid base_url
<img width="612" alt="image" src="https://github.com/user-attachments/assets/31a16a82-d9cd-430c-bef2-6d9a98b8f356">


invalid token
<img width="959" alt="image" src="https://github.com/user-attachments/assets/7db60bf4-216a-4876-b4e2-1d0adfd301a2">


everything correct
![image](https://github.com/user-attachments/assets/cf03b73a-4310-4865-ad3e-5ea02891ad56)
