### PR TITLE
fix: remove subscript type specification for inheritance, not supported in <=3.10

### DIFF
--- a/nominal/cli/util/click_log_handler.py
+++ b/nominal/cli/util/click_log_handler.py
@@ -6,7 +6,7 @@ import typing
 import click
 
 
-class ClickLogHandler(logging.StreamHandler[typing.TextIO]):
+class ClickLogHandler(logging.StreamHandler):  # type: ignore[type-arg]
     """Logging stream handler that routes and styles log messages through click
     instead of directly routing to stderr.
 


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

With our current mypy settings, it is not allowed to inherit from a genericly type-hinted class. HOWEVER, this fails in python <=3.10 with a runtime error that is _not_ found by mypy. The fix is simple-- tell mypy to ignore this line and write code in a version agnostic way 