### PR TITLE
feat: hide archetype series from channel abstraction

### DIFF
--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -68,18 +68,14 @@ class Channel(HasRid):
 
     @classmethod
     def _from_conjure_datasource_api(cls, clients: ClientsBunch, channel: datasource_api.ChannelMetadata) -> Self:
-        channel_rid = (
-            channel.series_rid.series_archetype
-            if channel.series_rid.series_archetype
-            else channel.series_rid.logical_series
-        )
-        if channel_rid is None:
+        # NOTE: intentionally ignoring archetype RID as it does not correspond to a Channel in the same way that a logical series does
+        if channel.series_rid.logical_series is None:
             raise ValueError(f"Cannot create ChannelMetadata for channel {channel.name}: no defined RID")
 
         channel_unit = channel.unit.symbol if channel.unit else None
         channel_data_type = ChannelDataType._from_conjure(channel.data_type) if channel.data_type else None
         return cls(
-            rid=channel_rid,
+            rid=channel.series_rid.logical_series,
             name=channel.name,
             data_source=channel.data_source,
             unit=channel_unit,

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -174,6 +174,10 @@ class Dataset(HasRid):
             )
             response = self._clients.datasource.search_channels(self._clients.auth_header, query)
             for channel_metadata in response.results:
+                # Skip series archetypes for now-- they aren't handled by the rest of the SDK in a graceful manner
+                if channel_metadata.series_rid.logical_series is None:
+                    continue
+
                 yield Channel._from_conjure_datasource_api(self._clients, channel_metadata)
 
             if response.next_page_token is None:


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Given that the rest of the Channel class fails in the presence of Archetype series (preferring instead only to work with logical series), it is best if we don't expose the ability to get archetypical series at all in the client until the backend improves.