### PR TITLE
chore: clean unused imports

### DIFF
--- a/justfile
+++ b/justfile
@@ -27,14 +27,14 @@ check-format:
 
 # check import ordering | fix with `just fix-imports`
 check-imports:
-    poetry run ruff check --select I
+    poetry run ruff check --select I --select F401
 
 # run all static analysis checks
 check: check-format check-types check-imports
 
 # fixes out-of-order imports (note: mutates the code)
 fix-imports:
-    poetry run ruff check --select I --fix
+    poetry run ruff check --select I --select F401 --fix
 
 # fixes code formatting (note: mutates the code)
 fix-format:

--- a/nominal/core/_conjure_utils.py
+++ b/nominal/core/_conjure_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from nominal._api.combined import scout_units_api, timeseries_logicalseries_api
+from nominal._api.combined import timeseries_logicalseries_api
 from nominal.core._clientsbunch import ClientsBunch
 from nominal.core.unit import Unit
 

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -19,7 +19,6 @@ from nominal._api.combined import (
     ingest_api,
     scout_catalog,
     scout_run_api,
-    scout_units_api,
     scout_video_api,
     timeseries_logicalseries_api,
 )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,7 +5,6 @@ from unittest import mock
 
 import pytest
 
-import nominal as nm
 from nominal.core import NominalClient
 
 


### PR DESCRIPTION
we might want to consider moving this inside the pyproject.toml for some more organization, and adding many of the other supported ruff rules