### PR TITLE
feat: expose index_channel_prefix_tree for datasets

### DIFF
--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -274,6 +274,15 @@ class Dataset(HasRid):
         request = timeseries_logicalseries_api.BatchUpdateLogicalSeriesRequest(update_requests)
         self._clients.logical_series.batch_update_logical_series(self._clients.auth_header, request)
 
+    def set_channel_prefix_tree(self, delimiter: str = ".") -> None:
+        """Index channels hierarchically by a given delimiter.
+
+        Primarily, the result of this operation is to prompt the frontend to represent channels
+        in a tree-like manner that allows folding channels by common roots.
+        """
+        request = datasource_api.IndexChannelPrefixTreeRequest(self.rid, delimiter=delimiter)
+        self._clients.datasource.index_channel_prefix_tree(self._clients.auth_header, request)
+
     @classmethod
     def _from_conjure(cls, clients: ClientsBunch, dataset: scout_catalog.EnrichedDataset) -> Self:
         return cls(


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

In order to view channels in a hierarchical manner in the nominal UI, one must first submit a request to set the `channel_prefix_tree` for the dataset. 

In the past, when we ingested via single file == single dataset, the old `TriggerIngest` endpoint used to expose this as part of the initial ingest request, though, this is notably present on the `TriggerFileIngest` endpoint.

This should be considered essential for datasets with thousands of columns to help improve page load times and searchability of channels.