### PR TITLE
fix: value in enum classes check for python < 3.12

### DIFF
--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -29,7 +29,7 @@ class ChannelDataType(enum.Enum):
     def _from_conjure(
         cls, data_type: datasource_api.SeriesDataType | timeseries_logicalseries_api.SeriesDataType
     ) -> Self:
-        if data_type.value in cls:
+        if data_type.value in cls.__members__:
             return cls(data_type.value)
         else:
             return cls("UNKNOWN")


### PR DESCRIPTION
`value in EnumClass` only works on Python 3.12+, we should check `value in EnumClass.__members__` instead for earlier versions!

3.11 gives this information:

```
<stdin>:1: DeprecationWarning: in 3.12 __contains__ will no longer raise TypeError, but will return True or
False depending on whether the value is a member or the value of a member
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/nix/store/kcm5282kss1mnil624lccr7y8wqg75vk-python3-3.11.9/lib/python3.11/enum.py", line 742, in __contains__
    raise TypeError(
TypeError: unsupported operand type(s) for 'in': 'str' and 'EnumType'
```