### PR TITLE
chore: cli cleanup

### DIFF
--- a/nominal/__main__.py
+++ b/nominal/__main__.py
@@ -1,4 +1,0 @@
-from nominal.cli import nom
-
-if __name__ == "__main__":
-    nom()

--- a/nominal/cli/__init__.py
+++ b/nominal/cli/__init__.py
@@ -12,3 +12,6 @@ nom.add_command(attachment.attachment_cmd)
 nom.add_command(auth.auth_cmd)
 nom.add_command(dataset.dataset_cmd)
 nom.add_command(run.run_cmd)
+
+if __name__ == "__main__":
+    nom()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/nominal-io/nominal-client"
 include = ["README.md", "LICENSE", "CHANGELOG.md"]
 
 [tool.poetry.scripts]
-nom = 'nominal.cli:nom'
+nom = "nominal.cli:nom"
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
this is the proper setup for the CLI and enforces using the actual script, which we weren't using.

`poetry run nom auth set-token`

We were doing `poetry run python nominal auth set-token` which is why the `__main__` was needed