### PR TITLE
feat: add run number to nominal Run class

### DIFF
--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -40,6 +40,7 @@ class Run(HasRid):
     @property
     def nominal_url(self) -> str:
         """Returns a link to the page for this Run in the Nominal app"""
+        # TODO (drake): move logic into _from_conjure() factory function to accomodate different URL schemes
         return f"https://app.gov.nominal.io/runs/{self.run_number}"
 
     def add_dataset(self, ref_name: str, dataset: Dataset | str) -> None:


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Within scripts, it is incredibly useful to be able to get the run number for a run for presenting a link to a created / existing run for displaying to the user. 

We have shipped the following lines of code to several customers as a quick workaround to the missing metadata:

```python
run = create_run_from_dataset(dataset, input_file.stem, run_name, run_description)
enhanced_run = client._clients.run.get_run(client._clients.auth_header, run.rid)
click.echo("Uploaded run to nominal! See here: " + click.style(f"https://app.gov.nominal.io/runs/{enhanced_run.run_number}", fg="cyan"))
```

And it would be vastly preferred to expose things in our public API instead:

```python
run = create_run_from_dataset(dataset, input_file.stem, run_name, run_description)
click.echo("Uploaded run to nominal! See here: " + click.style(run.nominal_url, fg="cyan"))
```