### PR TITLE
feat: add nominal_url property to dataset

### DIFF
--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -64,6 +64,7 @@ class Dataset(HasRid):
     @property
     def nominal_url(self) -> str:
         """Returns a URL to the page in the nominal app containing this dataset"""
+        # TODO (drake): move logic into _from_conjure() factory function to accomodate different URL schemes
         return f"https://app.gov.nominal.io/data-sources/{self.rid}"
 
     def poll_until_ingestion_completed(self, interval: timedelta = timedelta(seconds=1)) -> None:


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Within customers' scripts, some find it useful to print a link to the created dataset after it has been ingested for them to ctrl+click and view on the app. This exposes a property that may be used to quickly get that URL. The alternative is customer scripts hackily making the assumption that our URL scheme won't change-- this allows us to change the scheme of our URLs without breaking customer scripts. 