### PR TITLE
feat: make polling for io completion update dataset metadata

### DIFF
--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -157,11 +157,9 @@ class Dataset(HasRid):
             name=name,
             properties=None if properties is None else dict(properties),
         )
-        response = self._clients.catalog.update_dataset_metadata(self._clients.auth_header, self.rid, request)
+        self._clients.catalog.update_dataset_metadata(self._clients.auth_header, self.rid, request)
 
-        dataset = self.__class__._from_conjure(self._clients, response)
-        update_dataclass(self, dataset, fields=self.__dataclass_fields__)
-        return self
+        return self.refresh()
 
     def add_csv_to_dataset(self, path: Path | str, timestamp_column: str, timestamp_type: _AnyTimestampType) -> None:
         """Append to a dataset from a csv on-disk."""

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -120,6 +120,9 @@ class Dataset(HasRid):
             time.sleep(interval.total_seconds())
 
         # Update metadata now that data has successfully ingested
+        return self.refresh()
+
+    def refresh(self) -> Self:
         updated_dataset = self.__class__._from_conjure(
             self._clients,
             _get_dataset(self._clients.auth_header, self._clients.catalog, self.rid),

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -35,11 +35,11 @@ def mock_dataset(mock_clients):
         labels=[],
         _clients=mock_clients,
     )
-    
+
     spy = MagicMock(wraps=ds.refresh)
     object.__setattr__(ds, "refresh", spy)
     ds.refresh.return_value = ds
-    
+
     return ds
 
 

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -26,7 +26,7 @@ def mock_clients():
 
 @pytest.fixture
 def mock_dataset(mock_clients):
-    return Dataset(
+    ds = Dataset(
         rid="test-rid",
         name="Test Dataset",
         description="A dataset for testing",
@@ -35,6 +35,12 @@ def mock_dataset(mock_clients):
         labels=[],
         _clients=mock_clients,
     )
+    
+    spy = MagicMock(wraps=ds.refresh)
+    object.__setattr__(ds, "refresh", spy)
+    ds.refresh.return_value = ds
+    
+    return ds
 
 
 @patch("nominal.core.dataset._available_units", return_value=UNITS)
@@ -124,7 +130,6 @@ def test_poll_until_ingestion_completed_success(mock_sleep: MagicMock, mock_data
     )
 
     mock_dataset.poll_until_ingestion_completed(interval=timedelta(seconds=1))
-
     mock_dataset._clients.catalog.get_ingest_progress_v2.assert_called()
 
 


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Removes the need for this antipattern:

```
client = nominal.get_default_client()
dataset = client.create_csv_dataset(...)
dataset.poll_for_io_completion()
dataset = client.get_dataset(dataset.rid)
```

and replace with 

```
client = nominal.get_default_client()
dataset = client.create_csv_dataset(...)
dataset.poll_for_io_completion()
```