### PR TITLE
chore: format code before fixing imports

### DIFF
--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ fix-format:
     poetry run ruff format
 
 # fix imports and formatting
-fix: fix-imports fix-format
+fix: fix-format fix-imports
 
 # run all tests and checks, except e2e tests
 verify: install test check


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

In the justfile recipe for `fix`, we fix imports before formatting the code. As a result, if we have issues like extra whitespace at the end of lines (or in empty lines), the recipe errors out and doesn't format the code. 

Tangibly, if I have this erroneous docstring:

```python
def download_attachment(rid: str, file: Path | str) -> None:
    """Retrieve an attachment from the Nominal platform and save it to `file`.
    
    
    """
```

The current `just fix` errors out with:

``` shell
$ just fix
poetry run ruff check --fix
nominal/nominal.py:366:5: D200 One-line docstring should fit on one line
nominal/nominal.py:367:1: W293 Blank line contains whitespace
nominal/nominal.py:368:1: W293 Blank line contains whitespace
Found 3 errors.
No fixes available (3 hidden fixes can be enabled with the `--unsafe-fixes` option).
error: Recipe `fix-imports` failed on line 37 with exit code 1
```

but swapping `fix-imports` and `fix-format` passes:

``` shell
$ just fix
poetry run ruff format
1 file reformatted, 47 files left unchanged
poetry run ruff check --fix
All checks passed!
```

And formats my code as expected

``` python
def download_attachment(rid: str, file: Path | str) -> None:
    """Retrieve an attachment from the Nominal platform and save it to `file`."""
```