### PR TITLE
feat: expose trust store path for client_options decorator

### DIFF
--- a/nominal/cli/util/global_decorators.py
+++ b/nominal/cli/util/global_decorators.py
@@ -123,8 +123,8 @@ def client_options(func: typing.Callable[Param, T]) -> typing.Callable[..., T]:
         "--trust-store",
         type=click.Path(dir_okay=False, exists=True, resolve_path=True, path_type=pathlib.Path),
         help=(
-            "Path to a trust store CA root file to initial SSL connections."
-            "If not provided, defaults to certifi's trust store"
+            "Path to a trust store CA root file to initiate SSL connections."
+            "If not provided, defaults to certifi's trust store."
         ),
     )
 


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

When using scripts meant for our standard multi-tenant deployment in offline (on-prem) contexts, we need to be able to modify the `trust_store_path` when creating the nominal Client. This exposes the option in the standard `@client_options` decorator.