### PR TITLE
fix: handle case where data file has extra extension prefixes

### DIFF
--- a/nominal/core/filetype.py
+++ b/nominal/core/filetype.py
@@ -23,8 +23,12 @@ class FileType(NamedTuple):
         for file_type in FileTypes.__dict__.values():
             if not isinstance(file_type, cls):
                 continue
+            elif not file_type.extension:
+                continue
 
-            if file_type.extension.endswith(ext_str):
+            # If the file ends with the given file extension, regardless of other suffixes it may have
+            # preceeding, then return the file type.
+            if ext_str.endswith(file_type.extension):
                 return file_type
 
         # Infer mimetype from filepath


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Say I had an input file `test.random.parquet`, which is actually a parquet file. Previously, we would fail to match this as a `FileTypes.PARQUET`, as `.random.parquet` was not a suffix we prepared for. This fix would correctly match it as a parquet file.