### PR TITLE
feat: use less restrictive io type for file ingest

### DIFF
--- a/nominal/_utils.py
+++ b/nominal/_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 from contextlib import contextmanager
-from typing import Any, BinaryIO, Callable, Iterator, TypeVar
+from typing import Any, BinaryIO, Callable, Iterator, Protocol, TypeVar
 
 from typing_extensions import ParamSpec
 
@@ -64,3 +64,7 @@ def deprecate_keyword_argument(new_name: str, old_name: str) -> Callable[[Callab
         return wrapper
 
     return _deprecate_keyword_argument_decorator
+
+
+class HasBinaryRead(Protocol):
+    def read(self, length: int = ..., /) -> bytes: ...

--- a/nominal/core/_multipart.py
+++ b/nominal/core/_multipart.py
@@ -6,11 +6,12 @@ import pathlib
 import urllib.parse
 from functools import partial
 from queue import Queue
-from typing import BinaryIO, Iterable
+from typing import Iterable
 
 import requests
 
 from nominal._api.scout_service_api import ingest_api, upload_api
+from nominal._utils import HasBinaryRead
 from nominal.core.filetype import FileType
 from nominal.exceptions import NominalMultipartUploadFailed
 
@@ -49,14 +50,14 @@ def _sign_and_upload_part_job(
         q.task_done()
 
 
-def _iter_chunks(f: BinaryIO, chunk_size: int) -> Iterable[bytes]:
+def _iter_chunks(f: HasBinaryRead, chunk_size: int) -> Iterable[bytes]:
     while (data := f.read(chunk_size)) != b"":
         yield data
 
 
 def put_multipart_upload(
     auth_header: str,
-    f: BinaryIO,
+    f: HasBinaryRead,
     filename: str,
     mimetype: str,
     upload_client: upload_api.UploadService,
@@ -138,7 +139,7 @@ def put_multipart_upload(
 
 def upload_multipart_io(
     auth_header: str,
-    f: BinaryIO,
+    f: HasBinaryRead,
     name: str,
     file_type: FileType,
     upload_client: upload_api.UploadService,

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from io import BytesIO, TextIOBase, TextIOWrapper
 from pathlib import Path
-from typing import BinaryIO, Iterable, Mapping, Sequence
+from typing import Iterable, Mapping, Sequence
 
 import certifi
 from conjure_python_client import ServiceConfiguration, SslConfiguration
@@ -28,7 +28,7 @@ from nominal._api.scout_service_api import (
     storage_datasource_api,
     timeseries_logicalseries_api,
 )
-from nominal._utils import deprecate_keyword_argument
+from nominal._utils import HasBinaryRead, deprecate_keyword_argument
 from nominal.core._clientsbunch import ClientsBunch
 from nominal.core._conjure_utils import _available_units, _build_unit_update
 from nominal.core._multipart import upload_multipart_file, upload_multipart_io
@@ -284,7 +284,7 @@ class NominalClient:
 
     def create_dataset_from_io(
         self,
-        dataset: BinaryIO,
+        dataset: HasBinaryRead,
         name: str,
         timestamp_column: str,
         timestamp_type: _AnyTimestampType,
@@ -367,7 +367,7 @@ class NominalClient:
 
     def create_video_from_io(
         self,
-        video: BinaryIO,
+        video: HasBinaryRead,
         name: str,
         start: datetime | IntegralNanosecondsUTC | None = None,
         frame_timestamps: Sequence[IntegralNanosecondsUTC] | None = None,
@@ -567,7 +567,7 @@ class NominalClient:
 
     def create_attachment_from_io(
         self,
-        attachment: BinaryIO,
+        attachment: HasBinaryRead,
         name: str,
         file_type: tuple[str, str] | FileType = FileTypes.BINARY,
         description: str | None = None,
@@ -689,7 +689,7 @@ class NominalClient:
 
     def create_video_from_mcap_io(
         self,
-        mcap: BinaryIO,
+        mcap: HasBinaryRead,
         topic: str,
         name: str,
         description: str | None = None,

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from io import TextIOBase
 from pathlib import Path
 from types import MappingProxyType
-from typing import BinaryIO, Iterable, Mapping, Protocol, Sequence
+from typing import Iterable, Mapping, Protocol, Sequence
 
 import pandas as pd
 from typing_extensions import Self
@@ -23,6 +23,7 @@ from nominal._api.scout_service_api import (
     timeseries_logicalseries_api,
     upload_api,
 )
+from nominal._utils import HasBinaryRead
 from nominal.core._clientsbunch import HasAuthHeader
 from nominal.core._conjure_utils import _available_units, _build_unit_update
 from nominal.core._multipart import upload_multipart_io
@@ -173,7 +174,7 @@ class Dataset(HasRid):
 
     def add_to_dataset_from_io(
         self,
-        dataset: BinaryIO,
+        dataset: HasBinaryRead,
         timestamp_column: str,
         timestamp_type: _AnyTimestampType,
         file_type: tuple[str, str] | FileType = FileTypes.CSV,


### PR DESCRIPTION
Request's data param has type `_Data | None` [as annotated](https://github.com/python/typeshed/blob/bba068c8a1f08a16dee4dab83117804291706553/stubs/requests/requests/api.pyi#L16), where `_Data` is [defined](https://github.com/python/typeshed/blob/bba068c8a1f08a16dee4dab83117804291706553/stubs/requests/requests/sessions.pyi#L62-L80) as a union including `SupportsRead[str | bytes]` from [typeshed](https://github.com/python/typeshed/blob/bba068c8a1f08a16dee4dab83117804291706553/stdlib/_typeshed/__init__.pyi#L254-L255). Since we don't need to parameterize by the string type (we already require binary file), I just copied over the impl from

```py
class SupportsRead(Protocol[_T_co]):
    def read(self, length: int = ..., /) -> _T_co: ...
```

to

```py
class HasBinaryRead(Protocol):
    def read(self, length: int = ..., /) -> bytes: ...
```

(and renamed to be in line with our other protocols)