### PR TITLE
feat: add channel name delimiter to file ingest

### DIFF
--- a/nominal/cli/dataset.py
+++ b/nominal/cli/dataset.py
@@ -43,6 +43,12 @@ def dataset_cmd() -> None:
     help="interpretation the primary timestamp column",
 )
 @click.option("-d", "--desc")
+@click.option(
+    "--channel-name-delimiter",
+    default=".",
+    show_default=True,
+    help="the character used to delimit the hierarchy in the channel name",
+)
 @click.option("--wait/--no-wait", default=True, help="wait until the upload is complete")
 @client_options
 @global_options
@@ -52,6 +58,7 @@ def upload_csv(
     timestamp_column: str,
     timestamp_type: _LiteralAbsolute,
     desc: str | None,
+    channel_name_delimiter: str | None,
     wait: bool,
     client: NominalClient,
 ) -> None:
@@ -64,6 +71,7 @@ def upload_csv(
         timestamp_column=timestamp_column,
         timestamp_type=timestamp_type,
         description=desc,
+        prefix_tree_delimiter=channel_name_delimiter,
     )
 
     # block until ingestion completed, if requested

--- a/nominal/nominal.py
+++ b/nominal/nominal.py
@@ -125,6 +125,7 @@ def upload_pandas(
     timestamp_column: str,
     timestamp_type: ts._AnyTimestampType,
     description: str | None = None,
+    channel_name_delimiter: str | None = None,
     *,
     wait_until_complete: bool = True,
 ) -> Dataset:
@@ -153,6 +154,7 @@ def upload_pandas(
             timestamp_type=timestamp_type,
             file_type=FileTypes.CSV,
             description=description,
+            prefix_tree_delimiter=channel_name_delimiter,
         )
         t.join()
     if wait_until_complete:
@@ -166,6 +168,7 @@ def upload_polars(
     timestamp_column: str,
     timestamp_type: ts._AnyTimestampType,
     description: str | None = None,
+    channel_name_delimiter: str | None = None,
     *,
     wait_until_complete: bool = True,
 ) -> Dataset:
@@ -192,6 +195,7 @@ def upload_polars(
             timestamp_type=timestamp_type,
             file_type=FileTypes.CSV,
             description=description,
+            prefix_tree_delimiter=channel_name_delimiter,
         )
         t.join()
     if wait_until_complete:
@@ -205,6 +209,7 @@ def upload_csv(
     timestamp_column: str,
     timestamp_type: ts._AnyTimestampType,
     description: str | None = None,
+    channel_name_delimiter: str | None = None,
     *,
     wait_until_complete: bool = True,
 ) -> Dataset:
@@ -218,7 +223,14 @@ def upload_csv(
     """
     conn = get_default_client()
     return _upload_csv(
-        conn, file, name, timestamp_column, timestamp_type, description, wait_until_complete=wait_until_complete
+        conn,
+        file,
+        name,
+        timestamp_column,
+        timestamp_type,
+        description,
+        channel_name_delimiter,
+        wait_until_complete=wait_until_complete,
     )
 
 
@@ -229,6 +241,7 @@ def _upload_csv(
     timestamp_column: str,
     timestamp_type: ts._AnyTimestampType,
     description: str | None = None,
+    channel_name_delimiter: str | None = None,
     *,
     wait_until_complete: bool = True,
 ) -> Dataset:
@@ -238,6 +251,7 @@ def _upload_csv(
         timestamp_column=timestamp_column,
         timestamp_type=timestamp_type,
         description=description,
+        prefix_tree_delimiter=channel_name_delimiter,
     )
     if wait_until_complete:
         dataset.poll_until_ingestion_completed()


### PR DESCRIPTION
Channel names may have a hierarchical structure, with a delimiter separating the levels. For example, `vehicle.assembly.sensor` is a period-delimited channel name. This change allows users to define the delimiter used in their channel names.