### PR TITLE
fix: sanitize PR title before use

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -13,8 +13,10 @@ jobs:
         # After they fix the config-conventional package we can upgrade.
         run: npm install -g @commitlint/cli@18 @commitlint/config-conventional@18.6.0
       - name: lint pr name
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo "${{ github.event.pull_request.title }}" | commitlint --config .github/commitlint.config.js
+          echo "$TITLE" | commitlint --config .github/commitlint.config.js
       - name: display helpful error message
         if: failure()
         run: |


### PR DESCRIPTION
See https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable

<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->
