### PR TITLE
fix: fix name of argument for trust store cert

### DIFF
--- a/nominal/cli/util/global_decorators.py
+++ b/nominal/cli/util/global_decorators.py
@@ -120,7 +120,7 @@ def client_options(func: typing.Callable[Param, T]) -> typing.Callable[..., T]:
         ),
     )
     trust_store_option = click.option(
-        "--trust-store",
+        "--trust-store-path",
         type=click.Path(dir_okay=False, exists=True, resolve_path=True, path_type=pathlib.Path),
         help=(
             "Path to a trust store CA root file to initiate SSL connections."


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

My previous PR introduced a bug in the `--trust-store` commandline arg-- there was a mismatch between the parameter name and the click arg name.