### PR TITLE
fix: remove available_tag_values from create streaming connection and expose get connection

### DIFF
--- a/nominal/__init__.py
+++ b/nominal/__init__.py
@@ -49,6 +49,7 @@ __all__ = [
     "download_attachment",
     "get_attachment",
     "create_streaming_connection",
+    "get_connection",
     "get_checklist",
     "get_dataset",
     "get_default_client",

--- a/nominal/__init__.py
+++ b/nominal/__init__.py
@@ -23,6 +23,7 @@ from nominal.nominal import (
     download_attachment,
     get_attachment,
     get_checklist,
+    get_connection,
     get_dataset,
     get_default_client,
     get_log_set,

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -761,6 +761,7 @@ class NominalClient:
                         nominal_data_source_rid=datasource_response.rid
                     ),
                 ),
+                metadata={},
                 scraping=scout_datasource_connection_api.ScrapingConfig(
                     nominal=scout_datasource_connection_api.NominalScrapingConfig(
                         channel_name_components=[
@@ -768,13 +769,12 @@ class NominalClient:
                                 channel=scout_datasource_connection_api.Empty()
                             )
                         ],
-                        separator='.'
+                        separator="."
                     )
                 ),
-                available_tag_values={},
-                should_scrape=True,
-                metadata={},
                 required_tag_names=required_tag_names or [],
+                available_tag_values={},
+                should_scrape=True
             ),
         )
         return Connection._from_conjure(self._clients, connection_response)

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -743,11 +743,7 @@ class NominalClient:
         datasource_description: str | None = None,
         *,
         required_tag_names: list[str] | None = None,
-        available_tag_values: dict[str, list[str]] | None = None,
     ) -> Connection:
-        if required_tag_names:
-            if not available_tag_values or not all(key in available_tag_values for key in required_tag_names):
-                raise ValueError("available_tag_values contain all required_tag_names")
         datasource_response = self._clients.storage.create(
             self._clients.auth_header,
             storage_datasource_api.CreateNominalDataSourceRequest(
@@ -765,19 +761,7 @@ class NominalClient:
                     ),
                 ),
                 metadata={},
-                scraping=scout_datasource_connection_api.ScrapingConfig(
-                    nominal=scout_datasource_connection_api.NominalScrapingConfig(
-                        channel_name_components=[
-                            scout_datasource_connection_api.NominalChannelNameComponent(
-                                channel=scout_datasource_connection_api.Empty()
-                            )
-                        ],
-                        separator=".",
-                    )
-                ),
                 required_tag_names=required_tag_names or [],
-                available_tag_values=available_tag_values or {},
-                should_scrape=True,
             ),
         )
         return Connection._from_conjure(self._clients, connection_response)

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -769,12 +769,12 @@ class NominalClient:
                                 channel=scout_datasource_connection_api.Empty()
                             )
                         ],
-                        separator="."
+                        separator=".",
                     )
                 ),
                 required_tag_names=required_tag_names or [],
                 available_tag_values={},
-                should_scrape=True
+                should_scrape=True,
             ),
         )
         return Connection._from_conjure(self._clients, connection_response)

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -761,8 +761,18 @@ class NominalClient:
                         nominal_data_source_rid=datasource_response.rid
                     ),
                 ),
+                scraping=scout_datasource_connection_api.ScrapingConfig(
+                    nominal=scout_datasource_connection_api.NominalScrapingConfig(
+                        channel_name_components=[
+                            scout_datasource_connection_api.NominalChannelNameComponent(
+                                channel=scout_datasource_connection_api.Empty()
+                            )
+                        ],
+                        separator='.'
+                    )
+                ),
                 available_tag_values={},
-                should_scrape=False,
+                should_scrape=True,
                 metadata={},
                 required_tag_names=required_tag_names or [],
             ),

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -760,6 +760,8 @@ class NominalClient:
                         nominal_data_source_rid=datasource_response.rid
                     ),
                 ),
+                available_tag_values={},
+                should_scrape=False,
                 metadata={},
                 required_tag_names=required_tag_names or [],
             ),

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -774,7 +774,7 @@ class NominalClient:
                 ),
                 required_tag_names=required_tag_names or [],
                 available_tag_values={},
-                should_scrape=True,
+                should_scrape=False,
             ),
         )
         return Connection._from_conjure(self._clients, connection_response)

--- a/nominal/nominal.py
+++ b/nominal/nominal.py
@@ -570,8 +570,7 @@ def create_streaming_connection(
     connection_name: str,
     datasource_description: str | None = None,
     *,
-    required_tag_names: list[str] | None = None,
-    available_tag_values: dict[str, list[str]] | None = None,
+    required_tag_names: list[str] | None = None
 ) -> Connection:
     """Creates a new datasource and a new connection.
 
@@ -582,8 +581,7 @@ def create_streaming_connection(
         datasource_id,
         connection_name,
         datasource_description,
-        required_tag_names=required_tag_names,
-        available_tag_values=available_tag_values,
+        required_tag_names=required_tag_names
     )
 
 

--- a/nominal/nominal.py
+++ b/nominal/nominal.py
@@ -570,7 +570,7 @@ def create_streaming_connection(
     connection_name: str,
     datasource_description: str | None = None,
     *,
-    required_tag_names: list[str] | None = None
+    required_tag_names: list[str] | None = None,
 ) -> Connection:
     """Creates a new datasource and a new connection.
 
@@ -578,10 +578,7 @@ def create_streaming_connection(
     """
     conn = get_default_client()
     return conn.create_streaming_connection(
-        datasource_id,
-        connection_name,
-        datasource_description,
-        required_tag_names=required_tag_names
+        datasource_id, connection_name, datasource_description, required_tag_names=required_tag_names
     )
 
 


### PR DESCRIPTION
connection should start with a blank slate of tags.