### PR TITLE
feat: add asset via run creation instead

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -99,6 +99,7 @@ class NominalClient:
         properties: Mapping[str, str] | None = None,
         labels: Sequence[str] = (),
         attachments: Iterable[Attachment] | Iterable[str] = (),
+        asset: Asset | str | None = None,
     ) -> Run:
         """Create a run."""
         # TODO(alkasm): support links
@@ -112,7 +113,7 @@ class NominalClient:
             start_time=_SecondsNanos.from_flexible(start).to_scout_run_api(),
             title=name,
             end_time=None if end is None else _SecondsNanos.from_flexible(end).to_scout_run_api(),
-            assets=[],
+            assets=[] if asset is None else [rid_from_instance_or_string(asset)],
         )
         response = self._clients.run.create_run(self._clients.auth_header, request)
         return Run._from_conjure(self._clients, response)

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -212,13 +212,11 @@ class Run(HasRid):
         """List a sequence of Attachments associated with this Run."""
         return list(self._iter_list_attachments())
 
-    def add_asset(self, asset: Asset | str) -> None:
-        """Add an asset to this run.
+    def set_asset(self, asset: Asset | str) -> None:
+        """Sets the asset of this run. If the run is associated with an existing asset, it will be replaced.
 
         `asset` can be an `Asset` instance, or asset RID.
         """
-        if len(self.list_assets()) != 0:
-            raise ValueError("runs cannot have more than one asset")
 
         asset_rid = rid_from_instance_or_string(asset)
         request = scout_run_api.UpdateRunRequest(assets=[asset_rid])

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -212,15 +212,6 @@ class Run(HasRid):
         """List a sequence of Attachments associated with this Run."""
         return list(self._iter_list_attachments())
 
-    def set_asset(self, asset: Asset | str) -> None:
-        """Sets the asset of this run. If the run is associated with an existing asset, it will be replaced.
-
-        `asset` can be an `Asset` instance, or asset RID.
-        """
-        asset_rid = rid_from_instance_or_string(asset)
-        request = scout_run_api.UpdateRunRequest(assets=[asset_rid])
-        self._clients.run.update_run(self._clients.auth_header, request, self.rid)
-
     def _iter_list_assets(self) -> Iterable[Asset]:
         run = self._clients.run.get_run(self._clients.auth_header, self.rid)
         assets = self._clients.assets.get_assets(self._clients.auth_header, run.assets)

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -217,7 +217,6 @@ class Run(HasRid):
 
         `asset` can be an `Asset` instance, or asset RID.
         """
-
         asset_rid = rid_from_instance_or_string(asset)
         request = scout_run_api.UpdateRunRequest(assets=[asset_rid])
         self._clients.run.update_run(self._clients.auth_header, request, self.rid)

--- a/tests/e2e/test_core.py
+++ b/tests/e2e/test_core.py
@@ -160,7 +160,7 @@ def test_add_asset_to_run():
     desc = f"core test to add a asset to a run {uuid4()}"
     start, end = _create_random_start_end()
     run = nm.create_run(title, start, end, desc)
-    run.add_asset(asset.rid)
+    run.set_asset(asset.rid)
 
     assets2 = run.list_assets()
     assert len(assets2) == 1

--- a/tests/e2e/test_core.py
+++ b/tests/e2e/test_core.py
@@ -151,22 +151,6 @@ def test_add_attachment_to_run_and_list_attachments(csv_data):
     assert at2.get_contents().read() == at.get_contents().read() == csv_data
 
 
-def test_add_asset_to_run():
-    asset_name = f"asset-{uuid4()}"
-    asset_desc = f"core test to add a asset to a run {uuid4()}"
-    asset = nm.create_asset(asset_name, asset_desc)
-
-    title = f"run-{uuid4()}"
-    desc = f"core test to add a asset to a run {uuid4()}"
-    start, end = _create_random_start_end()
-    run = nm.create_run(title, start, end, desc)
-    run.set_asset(asset.rid)
-
-    assets2 = run.list_assets()
-    assert len(assets2) == 1
-    assert assets2[0].rid == asset.rid
-
-
 def test_create_get_log_set(client: nm.NominalClient):
     name = f"logset-{uuid4()}"
     desc = f"core test to create & get a log set {uuid4()}"


### PR DESCRIPTION
this PR removes the add_asset endpoint and adds it as an option in create run instead.
The add_asset endpoint is OK to remove because it is currently broken-- it will always fail validation because runs are always associated with an asset by default.