### PR TITLE
feat: allow adding an asset to a run

### DIFF
--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -214,29 +214,29 @@ class Run(HasRid):
 
     def add_to_asset(self, asset: Asset | str, remove_existing: bool = False) -> Self:
         """Add the run to the given Asset.
-        
+
         NOTE: this will unassociate any datasets from the run, which will instead point to the asset,
               which should itself have datasets associated with it.
-              
+
         NOTE: currently, it is not supported for a run to be associated with more than one asset at
               a time. An error will be raised if a run is added to an asset while already being associated
               with another asset unless remove_existing=True is provided
-              
+
         Args:
             asset: Asset (or asset RID) to associate with the run
             remove_existing: If true, remove any existing assets from the run before adding the new asset.
-            
+
         Returns:
             Updated Run object
         """
         asset_rid_to_add = rid_from_instance_or_string(asset)
-        
+
         new_asset_rids = [asset_rid_to_add]
         if not remove_existing:
             # deduplicate rids, in case this run was already associated with the asset its being added to
-            new_asset_rids.extend([asset.rid for asset in self.list_assets()])    
+            new_asset_rids.extend([asset.rid for asset in self.list_assets()])
             new_asset_rids = list(set(new_asset_rids))
-        
+
         return self.update(assets=new_asset_rids)
 
     def _iter_list_assets(self) -> Iterable[Asset]:
@@ -279,7 +279,7 @@ class Run(HasRid):
             for old_label in run.labels:
                 new_labels.append(old_label)
             run = run.update(labels=new_labels)
-            
+
         NOTE: currently, it is only possible to add or change an asset associated with a Run,
               but not yet possible to remove assets altogether from a run by providing an empty list.
               This behavior differs from labels and properties, where empty containers clear the respective
@@ -288,7 +288,7 @@ class Run(HasRid):
         # TODO: update to passing None to the request once this becomes a no-op in the backend
         if assets is None:
             assets = self.list_assets()
-            
+
         request = scout_run_api.UpdateRunRequest(
             description=description,
             labels=None if labels is None else list(labels),


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Allow adding an asset to a Run, and document that you cannot un-add an asset from a run, only change which asset is associated with the run.

A follow-up PR will be prepared for once runs can be disassociated with an asset.