### PR TITLE
feat: allow --token when default token path doesn't exist in CLI

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1547,7 +1547,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.26.0"
+version = "1.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

When CLI methods used `@nominal.cli.utils.client_options`, if the user does not yet have a `~/.nominal.yml` and instead provides a `--token` manually, it would error out. Now, we allow the file to not exist at the click level, and instead manually verify that the path exists _if_ the user also did not pass in an auth token.