### PR TITLE
feat: forward client CA cert bundle to requests when pushing artifacts to storage

### DIFF
--- a/nominal/core/_multipart.py
+++ b/nominal/core/_multipart.py
@@ -36,9 +36,9 @@ def _sign_and_upload_part_job(
             extra={"key": key, "part": part, "upload_id": upload_id, "response.url": response.url},
         )
         put_response = requests.put(
-            response.url, 
-            data=data, 
-            headers=response.headers, 
+            response.url,
+            data=data,
+            headers=response.headers,
             verify=upload_client._verify,
         )
         logger.debug(


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Forward client verify path (ca cert) to requests library when pushing to cloud storage. This is done within conjure, however, needs to similarly be done when we directly use the `requests` library to upload multipart files to storage (s3, minio, etc.)
