### PR TITLE
feat: add `nominal.__version__` and `nom --version`

### DIFF
--- a/nominal/__init__.py
+++ b/nominal/__init__.py
@@ -1,3 +1,5 @@
+import importlib.metadata
+
 from nominal import ts
 from nominal.core import (
     Asset,
@@ -107,4 +109,12 @@ __all__ = [
     "CheckViolation",
     "DataReviewBuilder",
     "WriteStream",
+    "__version__",
 ]
+
+
+try:
+    __version__ = importlib.metadata.version("nominal")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = ""
+del importlib

--- a/nominal/__init__.py
+++ b/nominal/__init__.py
@@ -116,5 +116,5 @@ __all__ = [
 try:
     __version__ = importlib.metadata.version("nominal")
 except importlib.metadata.PackageNotFoundError:
-    __version__ = ""
+    __version__ = "unknown"
 del importlib

--- a/nominal/cli/__init__.py
+++ b/nominal/cli/__init__.py
@@ -1,9 +1,11 @@
 import click
 
+import nominal
 from nominal.cli import attachment, auth, dataset, run
 
 
 @click.group(context_settings={"show_default": True, "help_option_names": ("-h", "--help")})
+@click.version_option(nominal.__version__)
 def nom() -> None:
     pass
 


### PR DESCRIPTION
There are various ways to do this; this method relies on the distribution version, which means, as a dev, if you have an editable install and the pyproject.toml changes, it won't be picked up. An alternative is to define `__version__` in the `__init__.py`, and to extract it from there. Hatchling [makes that easy](https://hatch.pypa.io/1.9/version/), it's just a matter of taste.