### PR TITLE
feat: new yaml config to support profile -> (url, token) instead of url -> token

### DIFF
--- a/nominal/_config.py
+++ b/nominal/_config.py
@@ -9,17 +9,30 @@ from typing_extensions import Self  # typing.Self in 3.11+
 from nominal.exceptions import NominalConfigError
 
 _DEFAULT_NOMINAL_CONFIG_PATH = Path("~/.nominal.yml").expanduser().resolve()
+_DEFAULT_NOMINAL_PROFILE_CONFIG_PATH = Path("~/.nominal_profile.yml").expanduser().resolve()
+
+
+@dataclass
+class ProfileConfig:
+    url: str
+    token: str
 
 
 @dataclass
 class NominalConfig:
-    environments: dict[str, str]
-    """environments map base_urls (with no scheme) to auth tokens"""
+    environments: dict[str, str] = None
+    """environments map base_urls (with no scheme) to auth tokens (legacy support)"""
+    profiles: dict[str, ProfileConfig] = None
+    """profiles map profile names to profile configurations"""
+    
+    def __post_init__(self):
+        self.environments = self.environments or {}
+        self.profiles = self.profiles or {}
 
     @classmethod
     def from_yaml(cls, path: Path = _DEFAULT_NOMINAL_CONFIG_PATH) -> Self:
         if not path.exists():
-            return cls(environments={})
+            return cls(environments={}, profiles={})
         with open(path) as f:
             obj = yaml.safe_load(f)
         return cls(**obj)
@@ -30,19 +43,44 @@ class NominalConfig:
         with open(path, "w") as f:
             yaml.dump(asdict(self), f)
 
-    def set_token(self, url: str, token: str, save: bool = True) -> None:
+    def set_profile(self, name: str, url: str, token: str, save: bool = True) -> None:
+        """Set a named profile with URL and token"""
         if url.startswith("http"):
-            raise ValueError("url {url!r} must not include the http:// or https:// scheme")
+            raise ValueError(f"url {url!r} must not include the http:// or https:// scheme")
+        self.profiles[name] = ProfileConfig(url=url, token=token)
+        if save:
+            self.to_yaml(_DEFAULT_NOMINAL_PROFILE_CONFIG_PATH)
+
+    def get_profile(self, name: str) -> ProfileConfig:
+        """Get a profile configuration by name"""
+        if name in self.profiles:
+            return self.profiles[name]
+        raise NominalConfigError(f"profile {name!r} not found in config: set a profile with `nom auth set-profile`")
+
+    def set_token(self, url: str, token: str, save: bool = True) -> None:
+        """Legacy method for backward compatibility"""
+        if url.startswith("http"):
+            raise ValueError(f"url {url!r} must not include the http:// or https:// scheme")
         self.environments[url] = token
         if save:
             self.to_yaml()
 
     def get_token(self, url: str) -> str:
+        """Legacy method for backward compatibility"""
         if url.startswith("http"):
-            raise ValueError("url {url!r} must not include the http:// or https:// scheme")
+            raise ValueError(f"url {url!r} must not include the http:// or https:// scheme")
         if url in self.environments:
             return self.environments[url]
         raise NominalConfigError(f"url {url!r} not found in config: set a token with `nom auth set-token`")
+
+
+def get_profile(name: str, config_path: Path = _DEFAULT_NOMINAL_PROFILE_CONFIG_PATH) -> ProfileConfig:
+    return NominalConfig.from_yaml(path=config_path).get_profile(name)
+
+
+def set_profile(name: str, url: str, token: str) -> None:
+    cfg = NominalConfig.from_yaml(path=_DEFAULT_NOMINAL_PROFILE_CONFIG_PATH)
+    cfg.set_profile(name, _strip_scheme(url), token)
 
 
 def get_token(url: str, config_path: Path = _DEFAULT_NOMINAL_CONFIG_PATH) -> str:

--- a/nominal/_config.py
+++ b/nominal/_config.py
@@ -20,14 +20,18 @@ class ProfileConfig:
 
 @dataclass
 class NominalConfig:
-    environments: dict[str, str] = None
+    environments: dict[str, str]
     """environments map base_urls (with no scheme) to auth tokens (legacy support)"""
-    profiles: dict[str, ProfileConfig] = None
+    profiles: dict[str, ProfileConfig]
     """profiles map profile names to profile configurations"""
-    
-    def __post_init__(self):
-        self.environments = self.environments or {}
-        self.profiles = self.profiles or {}
+
+    def __init__(
+        self,
+        environments: dict[str, str] | None = None,
+        profiles: dict[str, ProfileConfig] | None = None,
+    ) -> None:
+        self.environments = environments or {}
+        self.profiles = profiles or {}
 
     @classmethod
     def from_yaml(cls, path: Path = _DEFAULT_NOMINAL_CONFIG_PATH) -> Self:

--- a/nominal/cli/auth.py
+++ b/nominal/cli/auth.py
@@ -35,15 +35,71 @@ def _validate_token_url(token: str, base_url: str) -> None:
         raise click.ClickException("Failed to authenticate. See above for details")
 
 
-@auth_cmd.command()
+@auth_cmd.command(deprecated=True)
 @click.option("-u", "--base-url", default="https://api.gov.nominal.io/api", prompt=True)
 @click.option(
     "-t", "--token", required=True, prompt=True, help="access token, can be found in /sandbox on your Nominal instance"
 )
 @global_options
 def set_token(token: str, base_url: str) -> None:
-    """Update the token for a given URL in the Nominal config file"""
+    """[Deprecated] Update the token for a given URL in the Nominal config file.
+    
+    This command is deprecated. Please use 'auth set-profile' instead, which provides
+    better profile management and configuration options.
+    """
+    click.secho(
+        "Warning: 'set-token' is deprecated and will be removed in a future version. "
+        "Please use 'auth set-profile' instead.",
+        fg="yellow",
+        err=True,
+    )
     path = _config._DEFAULT_NOMINAL_CONFIG_PATH
     _validate_token_url(token, base_url)
     _config.set_token(base_url, token)
     click.secho(f"Successfully set token for '{base_url}' in {path}", fg="green")
+
+
+@auth_cmd.command()
+@click.argument("profile-name")
+@click.option("-u", "--base-url", default="https://api.gov.nominal.io/api", prompt=True)
+@click.option(
+    "-t", "--token", required=True, prompt=True, help="access token, can be found in /sandbox on your Nominal instance"
+)
+@global_options
+def set_profile(profile_name: str, token: str, base_url: str) -> None:
+    """Create or update a named profile in the Nominal config file"""
+    path = _config._DEFAULT_NOMINAL_PROFILE_CONFIG_PATH
+    _validate_token_url(token, base_url)
+    _config.set_profile(profile_name, base_url, token)
+    click.secho(f"Successfully set profile '{profile_name}' for '{base_url}' in {path}", fg="green")
+
+
+@auth_cmd.command(name="list-profiles")
+@global_options
+def list_profiles() -> None:
+    """List all configured profiles"""
+    cfg = _config.NominalConfig.from_yaml(path=_config._DEFAULT_NOMINAL_PROFILE_CONFIG_PATH)
+    if not cfg.profiles:
+        click.secho("No profiles configured", fg="yellow")
+        return
+    
+    click.secho("Configured profiles:", fg="green")
+    for name, profile in cfg.profiles.items():
+        click.echo(f"  {name}:")
+        click.echo(f"    URL: {profile.url}")
+        click.echo(f"    Token: {'*' * 8}{profile.token[-4:]}")
+
+
+@auth_cmd.command()
+@click.argument("profile-name")
+@global_options
+def get_profile(profile_name: str) -> None:
+    """Show details for a specific profile"""
+    try:
+        profile = _config.get_profile(profile_name)
+        click.secho(f"Profile: {profile_name}", fg="green")
+        click.echo(f"  URL: {profile.url}")
+        click.echo(f"  Token: {'*' * 8}{profile.token[-4:]}")
+    except ValueError as e:
+        click.secho(str(e), fg="red", err=True)
+        raise click.ClickException("Profile not found")

--- a/nominal/cli/auth.py
+++ b/nominal/cli/auth.py
@@ -43,7 +43,7 @@ def _validate_token_url(token: str, base_url: str) -> None:
 @global_options
 def set_token(token: str, base_url: str) -> None:
     """[Deprecated] Update the token for a given URL in the Nominal config file.
-    
+
     This command is deprecated. Please use 'auth set-profile' instead, which provides
     better profile management and configuration options.
     """
@@ -82,7 +82,7 @@ def list_profiles() -> None:
     if not cfg.profiles:
         click.secho("No profiles configured", fg="yellow")
         return
-    
+
     click.secho("Configured profiles:", fg="green")
     for name, profile in cfg.profiles.items():
         click.echo(f"  {name}:")

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -98,11 +98,10 @@ class NominalClient:
         Returns:
             A new NominalClient instance configured with the profile settings
         """
-        config = _config.get_profile_config(profile_name)
+        config = _config.get_profile(profile_name)
         return cls.create(
-            base_url=config.base_url,
+            base_url=config.url,
             token=config.token,
-            trust_store_path=config.trust_store_path,
             connect_timeout=connect_timeout,
         )
 

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -87,6 +87,25 @@ class NominalClient:
         agent = construct_user_agent_string()
         return cls(_clients=ClientsBunch.from_config(cfg, agent, token))
 
+    @classmethod
+    def from_profile(cls, profile_name: str, connect_timeout: float = 30) -> Self:
+        """Create a connection to the Nominal platform using a named profile.
+
+        Args:
+            profile_name: Name of the profile to use from ~/.nominal.yml
+            connect_timeout: Connection timeout in seconds
+
+        Returns:
+            A new NominalClient instance configured with the profile settings
+        """
+        config = _config.get_profile_config(profile_name)
+        return cls.create(
+            base_url=config.base_url,
+            token=config.token,
+            trust_store_path=config.trust_store_path,
+            connect_timeout=connect_timeout,
+        )
+
     def get_user(self) -> User:
         """Retrieve the user associated with this client."""
         return _get_user(self._clients.auth_header, self._clients.authentication)

--- a/nominal/nominal.py
+++ b/nominal/nominal.py
@@ -48,16 +48,17 @@ def set_base_url(base_url: str) -> None:
     For staging environments: "https://api-staging.gov.nominal.io/api".
     For local development: "https://api.nominal.test".
     """
-    _config.get_token(base_url) # @vtupuri - why is this needed? error checking?
+    _config.get_token(base_url)  # @vtupuri - why is this needed? error checking?
 
     global _global_base_url
     _global_base_url = base_url
 
+
 def set_profile(name: str, url: str, token: str) -> None:
     """Set a named profile configuration.
-    
+
     Use in conjunction with `get_client_from_profile()`.
-    
+
     Args:
         name: Name of the profile configuration
         url: Base URL for the Nominal API (e.g. "https://api.gov.nominal.io/api")
@@ -73,13 +74,15 @@ def set_token(base_url: str, token: str) -> None:
     """
     _config.set_token(base_url, token)
 
+
 def get_client_from_profile(profile_name: str) -> NominalClient:
     """Get a client using a named profile configuration.
-    
+
     Profiles can be set using `nom auth set-profile` or programmatically with `nominal.set_profile()`.
     """
     profile = _config.get_profile(profile_name)
     return _get_or_create_connection(f"https://{profile.url}", profile.token)
+
 
 def get_default_client() -> NominalClient:
     """Retrieve the default client to the Nominal platform."""
@@ -89,17 +92,19 @@ def get_default_client() -> NominalClient:
 
 def get_user(*, profile: str | None = None) -> User:
     """Retrieve the user associated with the client.
-    
+
     Args:
         profile: Optional profile name to use for authentication. If None, uses the default client.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
     return conn.get_user()
 
+
 def get_user_from_profile(profile_name: str) -> User:
     """Retrieve the user associated with a named profile configuration."""
     conn = get_client_from_profile(profile_name)
     return conn.get_user()
+
 
 def upload_tdms(
     file: Path | str,
@@ -207,8 +212,15 @@ def upload_polars(
     """Create a dataset in the Nominal platform from a polars.DataFrame.
 
     Args:
-        profile: Optional profile name to use for authentication. If None, uses the default client.
-        
+        df: The polars DataFrame to upload
+        name: Name for the dataset
+        timestamp_column: Name of the column containing timestamps
+        timestamp_type: Type of the timestamp values
+        description: Optional description for the dataset
+        channel_name_delimiter: Optional delimiter for channel name hierarchy
+        wait_until_complete: If True, wait for ingestion to complete before returning
+        profile: Optional profile name to use for authentication. If None, uses the default client
+
     If `wait_until_complete=True` (the default), this function waits until the dataset has completed ingestion before
         returning. If you are uploading many datasets, set `wait_until_complete=False` instead and call
         `wait_until_ingestions_complete()` after uploading all datasets to allow for parallel ingestion.
@@ -252,8 +264,15 @@ def upload_csv(
     """Create a dataset in the Nominal platform from a .csv or .csv.gz file.
 
     Args:
-        profile: Optional profile name to use for authentication. If None, uses the default client.
-        
+        file: Path to the CSV file
+        name: Name for the dataset. If None, uses the filename
+        timestamp_column: Name of the column containing timestamps
+        timestamp_type: Type of the timestamp values
+        description: Optional description for the dataset
+        channel_name_delimiter: Optional delimiter for channel name hierarchy
+        wait_until_complete: If True, wait for ingestion to complete before returning
+        profile: Optional profile name to use for authentication. If None, uses the default client
+
     If `name` is None, the dataset is created with the name of the file.
 
     If `wait_until_complete=True` (the default), this function waits until the dataset has completed ingestion before
@@ -299,8 +318,9 @@ def _upload_csv(
 
 def get_dataset(rid: str, *, profile: str | None = None) -> Dataset:
     """Retrieve a dataset from the Nominal platform by its RID.
-    
+
     Args:
+        rid: Resource ID of the dataset to retrieve
         profile: Optional profile name to use for authentication. If None, uses the default client.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
@@ -318,8 +338,12 @@ def create_run(
     """Create a run in the Nominal platform.
 
     Args:
+        name: Name of the run
+        start: Start time of the run
+        end: End time of the run, or None if ongoing
+        description: Optional description for the run
         profile: Optional profile name to use for authentication. If None, uses the default client.
-        
+
     If the run has no end (for example, if it is ongoing), use `end=None`.
 
     To add a dataset to the run, use `run.add_dataset()`.
@@ -345,8 +369,13 @@ def create_run_csv(
     """Create a dataset from a CSV file, and create a run based on it.
 
     Args:
+        file: Path to the CSV file
+        name: Name for the run
+        timestamp_column: Name of the column containing timestamps
+        timestamp_type: Type of the timestamp values
+        description: Optional description for the run
         profile: Optional profile name to use for authentication. If None, uses the default client.
-        
+
     This is a convenience function that combines `upload_csv()` and `create_run()` and can only be used with absolute
     timestamps. For relative timestamps or custom formats, use `upload_dataset()` and `create_run()` separately.
 
@@ -371,8 +400,9 @@ def create_run_csv(
 
 def get_run(rid: str, *, profile: str | None = None) -> Run:
     """Retrieve a run from the Nominal platform by its RID.
-    
+
     Args:
+        rid: Resource ID of the run to retrieve
         profile: Optional profile name to use for authentication. If None, uses the default client.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
@@ -395,7 +425,7 @@ def search_runs(
 
     Args:
         profile: Optional profile name to use for authentication. If None, uses the default client.
-        
+
     Filters are ANDed together, e.g. `(run.label == label) AND (run.end <= end)`
 
     Args:
@@ -430,8 +460,11 @@ def upload_attachment(
     profile: str | None = None,
 ) -> Attachment:
     """Upload an attachment to the Nominal platform.
-    
+
     Args:
+        file: Path to the file to upload
+        name: Name for the attachment
+        description: Optional description for the attachment
         profile: Optional profile name to use for authentication. If None, uses the default client.
     """
     path = Path(file)
@@ -443,8 +476,9 @@ def upload_attachment(
 
 def get_attachment(rid: str, *, profile: str | None = None) -> Attachment:
     """Retrieve an attachment from the Nominal platform by its RID.
-    
+
     Args:
+        rid: Resource ID of the attachment to retrieve
         profile: Optional profile name to use for authentication. If None, uses the default client.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
@@ -453,8 +487,9 @@ def get_attachment(rid: str, *, profile: str | None = None) -> Attachment:
 
 def get_log_set(rid: str, *, profile: str | None = None) -> LogSet:
     """Retrieve a log set from the Nominal platform by its RID.
-    
+
     Args:
+        rid: Resource ID of the log set to retrieve
         profile: Optional profile name to use for authentication. If None, uses the default client.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
@@ -463,8 +498,10 @@ def get_log_set(rid: str, *, profile: str | None = None) -> LogSet:
 
 def download_attachment(rid: str, file: Path | str, *, profile: str | None = None) -> None:
     """Retrieve an attachment from the Nominal platform and save it to `file`.
-    
+
     Args:
+        rid: Resource ID of the attachment to retrieve
+        file: Path where the attachment should be saved
         profile: Optional profile name to use for authentication. If None, uses the default client.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
@@ -481,8 +518,12 @@ def upload_video(
     profile: str | None = None,
 ) -> Video:
     """Upload a video to Nominal from a file.
-    
+
     Args:
+        file: Path to the video file
+        name: Name for the video
+        start: Start time of the video
+        description: Optional description for the video
         profile: Optional profile name to use for authentication. If None, uses the default client.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
@@ -500,8 +541,9 @@ def upload_video(
 
 def get_video(rid: str, *, profile: str | None = None) -> Video:
     """Retrieve a video from the Nominal platform by its RID.
-    
+
     Args:
+        rid: Resource ID of the video to retrieve
         profile: Optional profile name to use for authentication. If None, uses the default client.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
@@ -517,8 +559,12 @@ def create_asset(
     profile: str | None = None,
 ) -> Asset:
     """Create an asset.
-    
+
     Args:
+        name: Name of the asset
+        description: Optional description for the asset
+        properties: Optional key-value properties to attach to the asset
+        labels: Optional sequence of labels to attach to the asset
         profile: Optional profile name to use for authentication. If None, uses the default client.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
@@ -527,8 +573,9 @@ def create_asset(
 
 def get_asset(rid: str, *, profile: str | None = None) -> Asset:
     """Retrieve an asset by its RID.
-    
+
     Args:
+        rid: Resource ID of the asset to retrieve
         profile: Optional profile name to use for authentication. If None, uses the default client.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
@@ -550,7 +597,7 @@ def search_assets(
 
     Args:
         profile: Optional profile name to use for authentication. If None, uses the default client.
-        
+
     Filters are ANDed together, e.g. `(asset.label == label) AND (asset.search_text =~ field)`
 
     Args:
@@ -640,8 +687,12 @@ def checklist_builder(
     """Create a checklist builder to add checks and variables, and publish the checklist to Nominal.
 
     Args:
+        name: Name of the checklist
+        description: Optional description for the checklist
+        assignee_email: Email of the user to assign the checklist to
+        default_ref_name: Optional default reference name for the checklist
         profile: Optional profile name to use for authentication. If None, uses the default client.
-        
+
     If assignee_email is None, the checklist is assigned to the user executing the code.
 
     Example:
@@ -667,9 +718,10 @@ def checklist_builder(
 
 
 def get_checklist(checklist_rid: str, *, profile: str | None = None) -> Checklist:
-    """Retrieve a checklist by its RID.
-    
+    """Retrieve a checklist from the Nominal platform by its RID.
+
     Args:
+        checklist_rid: Resource ID of the checklist to retrieve
         profile: Optional profile name to use for authentication. If None, uses the default client.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
@@ -688,8 +740,13 @@ def upload_mcap_video(
     """Create a video in the Nominal platform from a topic in a mcap file.
 
     Args:
+        file: Path to the mcap file
+        topic: Topic name containing the video data
+        name: Name for the video. If None, uses the filename
+        description: Optional description for the video
+        wait_until_complete: If True, wait for ingestion to complete before returning
         profile: Optional profile name to use for authentication. If None, uses the default client.
-        
+
     If `name` is None, the video is created with the name of the file.
 
     If `wait_until_complete=True` (the default), this function waits until the video has completed ingestion before
@@ -726,9 +783,11 @@ def create_streaming_connection(
     """Creates a new datasource and a new connection.
 
     Args:
+        datasource_id: A human readable identifier. Must be unique within an organization
+        connection_name: Name for the connection
+        datasource_description: Optional description for the datasource
+        required_tag_names: Optional list of required tag names
         profile: Optional profile name to use for authentication. If None, uses the default client.
-        
-    datasource_id: A human readable identifier. Must be unique within an organization.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
     return conn.create_streaming_connection(
@@ -738,8 +797,9 @@ def create_streaming_connection(
 
 def get_connection(rid: str, *, profile: str | None = None) -> Connection:
     """Retrieve a connection from the Nominal platform by its RID.
-    
+
     Args:
+        rid: Resource ID of the connection to retrieve
         profile: Optional profile name to use for authentication. If None, uses the default client.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
@@ -758,10 +818,12 @@ def create_workbook_from_template(
     """Creates a new workbook from a template.
 
     Args:
+        template_rid: The template to use for the workbook
+        run_rid: The run to associate the workbook with
+        title: Optional title for the workbook
+        description: Optional description for the workbook
+        is_draft: If True, create as a draft workbook
         profile: Optional profile name to use for authentication. If None, uses the default client.
-        
-    template_rid: The template to use for the workbook.
-    run_rid: The run to associate the workbook with.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
     return conn.create_workbook_from_template(template_rid, run_rid, title, description, is_draft)
@@ -778,8 +840,12 @@ def create_log_set(
     """Create an immutable log set with the given logs.
 
     Args:
+        name: Name for the log set
+        logs: Collection of logs to include
+        timestamp_type: Type of timestamps in the logs ('absolute' or 'relative')
+        description: Optional description for the log set
         profile: Optional profile name to use for authentication. If None, uses the default client.
-        
+
     The logs are attached during creation and cannot be modified afterwards. Logs can either be of type `Log`
     or a tuple of a timestamp and a string. Timestamp type must be either 'absolute' or 'relative'.
     """
@@ -792,7 +858,7 @@ def data_review_builder(*, profile: str | None = None) -> DataReviewBuilder:
 
     Args:
         profile: Optional profile name to use for authentication. If None, uses the default client.
-        
+
     Example:
     -------
     ```python
@@ -812,10 +878,10 @@ def data_review_builder(*, profile: str | None = None) -> DataReviewBuilder:
 
 def get_data_review(rid: str, *, profile: str | None = None) -> DataReview:
     """Retrieve a data review from the Nominal platform by its RID.
-    
+
     Args:
+        rid: Resource ID of the data review to retrieve
         profile: Optional profile name to use for authentication. If None, uses the default client.
     """
     conn = get_client_from_profile(profile) if profile else get_default_client()
     return conn.get_data_review(rid)
- 

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -5,8 +5,7 @@ from click.testing import CliRunner
 from conjure_python_client import ConjureHTTPError
 from requests import HTTPError
 
-from nominal.cli.auth import auth_cmd, get_profile, list_profiles, set_profile, set_token
-from nominal._config import NominalConfig, ProfileConfig
+from nominal.cli.auth import set_token
 
 
 @pytest.fixture()

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -5,7 +5,8 @@ from click.testing import CliRunner
 from conjure_python_client import ConjureHTTPError
 from requests import HTTPError
 
-from nominal.cli.auth import set_token
+from nominal.cli.auth import auth_cmd, get_profile, list_profiles, set_profile, set_token
+from nominal._config import NominalConfig, ProfileConfig
 
 
 @pytest.fixture()

--- a/tests/test_toplevel.py
+++ b/tests/test_toplevel.py
@@ -5,9 +5,30 @@ from conjure_python_client import ConjureEncoder
 from nominal_api.attachments_api import Attachment as _Attachment
 
 import nominal as nm
+from nominal._config import ProfileConfig
 
 
 class MockGetAttachmentResponse(requests.Response):
+    text = ConjureEncoder().encode(
+        _Attachment(
+            created_at="",
+            created_by="",
+            description="",
+            file_type="",
+            is_archived=False,
+            labels=[],
+            properties={},
+            rid="",
+            s3_path="",
+            title="",
+        )
+    )
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class MockGetAttachmentResponseWithProfile(requests.Response):
     text = ConjureEncoder().encode(
         _Attachment(
             created_at="",
@@ -55,3 +76,23 @@ def test_default_connection(mock_get: mock.Mock, token: str) -> None:
         assert call.kwargs["headers"]["Authorization"].endswith("test-token")
     finally:
         nm.nominal._global_base_url = original_base_url
+
+
+@mock.patch("nominal._config.get_profile", return_value=ProfileConfig(url="test-profile-url", token="test-profile-token"))
+@mock.patch("requests.Session.request", return_value=MockGetAttachmentResponseWithProfile())
+def test_profile_connection(mock_get: mock.Mock, mock_profile: mock.Mock) -> None:
+    """Test that using a profile correctly sets the connection parameters.
+
+    Similar to test_default_connection, but verifies that when using a profile:
+    1. The profile configuration is retrieved
+    2. The URL is correctly constructed with https:// prefix
+    3. The token from the profile is used in the Authorization header
+    """
+    _ = nm.get_attachment("", profile="test-profile")
+    assert mock_get.call_count == 1
+    assert len(mock_get.call_args_list) == 1
+    call = mock_get.call_args_list[0]
+    assert call.args[0] == "GET"
+    assert call.args[1].startswith("https://test-profile-url")
+    assert call.kwargs["headers"]["Authorization"].endswith("test-profile-token")
+

--- a/tests/test_toplevel.py
+++ b/tests/test_toplevel.py
@@ -78,7 +78,9 @@ def test_default_connection(mock_get: mock.Mock, token: str) -> None:
         nm.nominal._global_base_url = original_base_url
 
 
-@mock.patch("nominal._config.get_profile", return_value=ProfileConfig(url="test-profile-url", token="test-profile-token"))
+@mock.patch(
+    "nominal._config.get_profile", return_value=ProfileConfig(url="test-profile-url", token="test-profile-token")
+)
 @mock.patch("requests.Session.request", return_value=MockGetAttachmentResponseWithProfile())
 def test_profile_connection(mock_get: mock.Mock, mock_profile: mock.Mock) -> None:
     """Test that using a profile correctly sets the connection parameters.
@@ -95,4 +97,3 @@ def test_profile_connection(mock_get: mock.Mock, mock_profile: mock.Mock) -> Non
     assert call.args[0] == "GET"
     assert call.args[1].startswith("https://test-profile-url")
     assert call.kwargs["headers"]["Authorization"].endswith("test-profile-token")
-


### PR DESCRIPTION
current client creation
```python
import nominal as nm
nm.set_token(some_url, some_token)
client = nm.get_default_client()
```

now supported client creation (lets you have multiple tokens for one url)
```python
import nominal as nm
nm.set_profile(p1, url1, some_token_1)
nm.set_profile(p2, url1, some_token_2)

client_one = nm.get_client_from_profile(p1)
client_two = nm.get_client_from_profile(p2)

```

can still use both of the above methods but deprecating `set_token`

updated a bunch of methods in `nominal.py` to not just always use the get_default_client() but have the option to use a profile as well