### PR TITLE
fix: list and remove various types of data sources

### DIFF
--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Iterable, Literal, Mapping, Protocol, Sequence, TypeAlias, cast
+from typing import Iterable, Literal, Mapping, Protocol, Sequence, cast
 
 from nominal_api import (
     attachments_api,
@@ -11,7 +11,7 @@ from nominal_api import (
     scout_catalog,
     scout_run_api,
 )
-from typing_extensions import Self
+from typing_extensions import Self, TypeAlias
 
 from nominal.core._clientsbunch import HasAuthHeader
 from nominal.core._conjure_utils import Link, _build_links
@@ -22,9 +22,9 @@ from nominal.core.dataset import Dataset, _get_datasets
 from nominal.core.log import LogSet, _get_log_set
 from nominal.core.video import Video, _get_video
 
-ScopeTupleList: TypeAlias = list[tuple[str, Connection | Dataset | LogSet | Video]]
-ScopeList: TypeAlias = list[Connection | Dataset | LogSet | Video | str]
-ScopeSequence: TypeAlias = Sequence[Connection | Dataset | LogSet | Video | str]
+ScopeTupleList: TypeAlias = "list[tuple[str, Connection | Dataset | LogSet | Video]]"
+ScopeList: TypeAlias = "list[Connection | Dataset | LogSet | Video | str]"
+ScopeSequence: TypeAlias = "Sequence[Connection | Dataset | LogSet | Video | str]"
 
 
 @dataclass(frozen=True)

--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
-from collections import defaultdict
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Iterable, Literal, Mapping, Protocol, Sequence, cast, TypeAlias
+from typing import Iterable, Literal, Mapping, Protocol, Sequence, TypeAlias, cast
 
-from nominal_api import attachments_api, scout_asset_api, scout_assets, scout_datasource_connection, scout_run_api, scout_catalog
+from nominal_api import (
+    attachments_api,
+    scout_asset_api,
+    scout_assets,
+    scout_catalog,
+    scout_run_api,
+)
 from typing_extensions import Self
 
 from nominal.core._clientsbunch import HasAuthHeader
@@ -16,7 +21,6 @@ from nominal.core.connection import Connection, _get_connections
 from nominal.core.dataset import Dataset, _get_datasets
 from nominal.core.log import LogSet, _get_log_set
 from nominal.core.video import Video, _get_video
-
 
 ScopeTupleList: TypeAlias = list[tuple[str, Connection | Dataset | LogSet | Video]]
 ScopeList: TypeAlias = list[Connection | Dataset | LogSet | Video | str]
@@ -109,14 +113,9 @@ class Asset(HasRid):
             raise ValueError(f"multiple assets found with RID {self.rid!r}: {response!r}")
         return response[self.rid]
 
-    def _scope_rid(self, stype : Literal['dataset', 'video', 'connection', 'logset']) -> dict[str, str]:
+    def _scope_rid(self, stype: Literal["dataset", "video", "connection", "logset"]) -> dict[str, str]:
         asset = self._get_asset()
-        rid_attrib = {
-            "dataset": "dataset",
-            "logset": "log_set",
-            "connection": "connection",
-            "video": "video"
-        }
+        rid_attrib = {"dataset": "dataset", "logset": "log_set", "connection": "connection", "video": "video"}
         return {
             scope.data_scope_name: cast(str, getattr(scope.data_source, rid_attrib[stype]))
             for scope in asset.data_scopes
@@ -127,21 +126,11 @@ class Asset(HasRid):
         """List the datasets associated with this asset.
         Returns (data_scope_name, dataset) pairs for each dataset.
         """
-        scope_rid = self._scope_rid(stype='dataset')
+        scope_rid = self._scope_rid(stype="dataset")
         _clients = cast(Dataset._Clients, self._clients)
-        datasets_meta = _get_datasets(
-            _clients.auth_header,
-            _clients.catalog,
-            scope_rid.values()
-        )
+        datasets_meta = _get_datasets(_clients.auth_header, _clients.catalog, scope_rid.values())
         return [
-            (
-                scope,
-                Dataset._from_conjure(
-                    cast(Dataset._Clients, self._clients),
-                    ds
-                )
-            )
+            (scope, Dataset._from_conjure(cast(Dataset._Clients, self._clients), ds))
             for (scope, ds) in zip(scope_rid.keys(), datasets_meta)
         ]
 
@@ -149,19 +138,11 @@ class Asset(HasRid):
         """List the connections associated with this asset.
         Returns (data_scope_name, connection) pairs for each connection.
         """
-        scope_rid = self._scope_rid(stype='connection')
+        scope_rid = self._scope_rid(stype="connection")
         _clients = cast(Connection._Clients, self._clients)
-        connections_meta = _get_connections(
-            _clients,
-            list(scope_rid.values())
-        )
+        connections_meta = _get_connections(_clients, list(scope_rid.values()))
         return [
-            (
-                scope,
-                Connection._from_conjure(
-                    cast(Connection._Clients, self._clients), connection
-                )
-            )
+            (scope, Connection._from_conjure(cast(Connection._Clients, self._clients), connection))
             for (scope, connection) in zip(scope_rid.keys(), connections_meta)
         ]
 
@@ -169,34 +150,18 @@ class Asset(HasRid):
         """List the videos associated with this asset.
         Returns (data_scope_name, dataset) pairs for each video.
         """
-        scope_rid = self._scope_rid(stype='video')
+        scope_rid = self._scope_rid(stype="video")
         _clients = cast(Video._Clients, self._clients)
-        return [
-            (
-                scope,
-                Video._from_conjure(
-                    _clients,
-                    _get_video(_clients, rid)
-                )
-            )
-            for (scope, rid) in scope_rid.items()
-        ]
+        return [(scope, Video._from_conjure(_clients, _get_video(_clients, rid))) for (scope, rid) in scope_rid.items()]
 
     def list_logsets(self) -> list[tuple[str, LogSet]]:
         """List the logsets associated with this asset.
         Returns (data_scope_name, logset) pairs for each logset.
         """
-        scope_rid = self._scope_rid(stype='logset')
+        scope_rid = self._scope_rid(stype="logset")
         _clients = cast(LogSet._Clients, self._clients)
         return [
-            (
-                scope,
-                LogSet._from_conjure(
-                    _clients,
-                    _get_log_set(_clients, rid)
-                )
-            )
-            for (scope, rid) in scope_rid.items()
+            (scope, LogSet._from_conjure(_clients, _get_log_set(_clients, rid))) for (scope, rid) in scope_rid.items()
         ]
 
     def list_data_scopes(self) -> ScopeTupleList:
@@ -205,10 +170,10 @@ class Asset(HasRid):
         a dataset, connection, video, or logset.
         """
         return (
-            cast(ScopeTupleList, self.list_datasets()) +
-            cast(ScopeTupleList, self.list_connections()) +
-            cast(ScopeTupleList, self.list_logsets()) +
-            cast(ScopeTupleList, self.list_videos())
+            cast(ScopeTupleList, self.list_datasets())
+            + cast(ScopeTupleList, self.list_connections())
+            + cast(ScopeTupleList, self.list_logsets())
+            + cast(ScopeTupleList, self.list_videos())
         )
 
     def add_log_set(self, data_scope_name: str, log_set: LogSet | str) -> None:
@@ -319,7 +284,7 @@ class Asset(HasRid):
         Scopes can be specified either by their names, their rids, or the
         scope objects themselves.
         """
-        data_sources : ScopeList = []
+        data_sources: ScopeList = []
         if rids is not None:
             if isinstance(rids, str):
                 data_sources.extend([rids])
@@ -329,8 +294,7 @@ class Asset(HasRid):
             data_sources.extend(list(scopes))
 
         self.remove_data_sources(
-            data_scope_names=[names] if isinstance(names, str) else names,
-            data_sources=data_sources
+            data_scope_names=[names] if isinstance(names, str) else names, data_sources=data_sources
         )
 
     def add_connection(

--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -122,7 +122,7 @@ class Asset(HasRid):
             if scope.data_source.type.lower() == stype
         }
 
-    def list_datasets(self) -> list[tuple[str, Dataset]]:
+    def list_datasets(self) -> Sequence[tuple[str, Dataset]]:
         """List the datasets associated with this asset.
         Returns (data_scope_name, dataset) pairs for each dataset.
         """
@@ -132,7 +132,7 @@ class Asset(HasRid):
             (scope, Dataset._from_conjure(self._clients, ds)) for (scope, ds) in zip(scope_rid.keys(), datasets_meta)
         ]
 
-    def list_connections(self) -> list[tuple[str, Connection]]:
+    def list_connections(self) -> Sequence[tuple[str, Connection]]:
         """List the connections associated with this asset.
         Returns (data_scope_name, connection) pairs for each connection.
         """
@@ -143,7 +143,7 @@ class Asset(HasRid):
             for (scope, connection) in zip(scope_rid.keys(), connections_meta)
         ]
 
-    def list_videos(self) -> list[tuple[str, Video]]:
+    def list_videos(self) -> Sequence[tuple[str, Video]]:
         """List the videos associated with this asset.
         Returns (data_scope_name, dataset) pairs for each video.
         """
@@ -153,7 +153,7 @@ class Asset(HasRid):
             for (scope, rid) in scope_rid.items()
         ]
 
-    def list_logsets(self) -> list[tuple[str, LogSet]]:
+    def list_logsets(self) -> Sequence[tuple[str, LogSet]]:
         """List the logsets associated with this asset.
         Returns (data_scope_name, logset) pairs for each logset.
         """
@@ -228,7 +228,7 @@ class Asset(HasRid):
         self,
         *,
         data_scope_names: Sequence[str] | None = None,
-        data_sources: Sequence[Connection | Dataset | LogSet | Video | str] | None = None,
+        data_sources: Sequence[ScopeType | str] | None = None,
     ) -> None:
         data_scope_names = data_scope_names or []
         data_sources = data_sources or []
@@ -268,7 +268,7 @@ class Asset(HasRid):
         self,
         *,
         data_scope_names: Sequence[str] | None = None,
-        data_sources: Sequence[Connection | Dataset | LogSet | Video | str] | None = None,
+        data_sources: Sequence[ScopeType | str] | None = None,
     ) -> None:
         """Remove data sources from this asset.
 

--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -238,6 +238,9 @@ class Asset(HasRid):
         The list data_sources can contain Connection, Dataset, Video instances, or rids as string.
         """
         data_scope_names = data_scope_names or []
+
+        if isinstance(data_sources, str):
+            data_sources = [data_sources]
         data_source_rids = {rid_from_instance_or_string(ds) for ds in data_sources or []}
 
         conjure_asset = self._get_asset()

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -6,9 +6,7 @@ from types import MappingProxyType
 from typing import Iterable, Mapping, Protocol, Sequence, cast
 
 from nominal_api import (
-    attachments_api,
     scout,
-    scout_catalog,
     scout_run_api,
 )
 from typing_extensions import Self
@@ -40,19 +38,10 @@ class Run(HasRid):
     _clients: _Clients = field(repr=False)
 
     class _Clients(
-        Attachment._Clients,
         Asset._Clients,
-        Connection._Clients,
-        Dataset._Clients,
-        LogSet._Clients,
-        Video._Clients,
         HasAuthHeader,
         Protocol,
     ):
-        @property
-        def attachment(self) -> attachments_api.AttachmentService: ...
-        @property
-        def catalog(self) -> scout_catalog.CatalogService: ...
         @property
         def run(self) -> scout.RunService: ...
 


### PR DESCRIPTION
- Adds the `list_data_sources` function which, unlike `list_datasets`, fetches all types of sources (Videos, LogSets, Datasets, Connections)
- Fixes a bug whereby LogSets were excluded from removal by `remove_data_sources`
- Allows for a single rid to be passed to `remove_data_sources`:
```
drone.remove_data_sources(
    data_sources='ri.data-source.cerulean-staging.log-set.2f768ee8-c071-41b6-8239-73b3686ef7f7'
)
```
 