### PR TITLE
fix: cleanup streaming shutdown

### DIFF
--- a/nominal/experimental/stream_v2/_serializer.py
+++ b/nominal/experimental/stream_v2/_serializer.py
@@ -25,7 +25,7 @@ class BatchSerializer:
 
     def close(self) -> None:
         self.pool.shutdown(cancel_futures=True)
-        
+
     @classmethod
     def create(cls, max_workers: int) -> Self:
         pool = ProcessPoolExecutor(max_workers=max_workers)

--- a/nominal/experimental/stream_v2/_serializer.py
+++ b/nominal/experimental/stream_v2/_serializer.py
@@ -25,15 +25,15 @@ class BatchSerializer:
 
     def close(self) -> None:
         self.pool.shutdown(cancel_futures=True)
-        processes = getattr(self.pool, "_processes", None)
-        if processes is not None:
-            for pid, proc in processes.items():
-                if proc.is_alive():
-                    logger.info("Force terminating process %s", pid)
-                    proc.terminate()
-                    proc.join()
-        else:
-            logger.warning("ProcessPoolExecutor._processes is unavailable; unable to force terminate processes.")
+        # processes = getattr(self.pool, "_processes", None)
+        # if processes is not None:
+        #     for pid, proc in processes.items():
+        #         if proc.is_alive():
+        #             logger.info("Force terminating process %s", pid)
+        #             proc.terminate()
+        #             proc.join()
+        # else:
+        #     logger.warning("ProcessPoolExecutor._processes is unavailable; unable to force terminate processes.")
 
     @classmethod
     def create(cls, max_workers: int) -> Self:

--- a/nominal/experimental/stream_v2/_serializer.py
+++ b/nominal/experimental/stream_v2/_serializer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from concurrent.futures import Future, ProcessPoolExecutor
 from dataclasses import dataclass
 from types import TracebackType
@@ -10,8 +9,6 @@ from typing_extensions import Self
 
 from nominal.core._batch_processor_proto import SerializedBatch, serialize_batch
 from nominal.core._queueing import Batch
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)

--- a/nominal/experimental/stream_v2/_serializer.py
+++ b/nominal/experimental/stream_v2/_serializer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from concurrent.futures import Future, ProcessPoolExecutor
 from dataclasses import dataclass
 from types import TracebackType
@@ -9,6 +10,8 @@ from typing_extensions import Self
 
 from nominal.core._batch_processor_proto import SerializedBatch, serialize_batch
 from nominal.core._queueing import Batch
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -22,6 +25,15 @@ class BatchSerializer:
 
     def close(self) -> None:
         self.pool.shutdown(cancel_futures=True)
+        processes = getattr(self.pool, "_processes", None)
+        if processes is not None:
+            for pid, proc in processes.items():
+                if proc.is_alive():
+                    logger.info("Force terminating process %s", pid)
+                    proc.terminate()
+                    proc.join()
+        else:
+            logger.warning("ProcessPoolExecutor._processes is unavailable; unable to force terminate processes.")
 
     @classmethod
     def create(cls, max_workers: int) -> Self:

--- a/nominal/experimental/stream_v2/_serializer.py
+++ b/nominal/experimental/stream_v2/_serializer.py
@@ -25,16 +25,7 @@ class BatchSerializer:
 
     def close(self) -> None:
         self.pool.shutdown(cancel_futures=True)
-        # processes = getattr(self.pool, "_processes", None)
-        # if processes is not None:
-        #     for pid, proc in processes.items():
-        #         if proc.is_alive():
-        #             logger.info("Force terminating process %s", pid)
-        #             proc.terminate()
-        #             proc.join()
-        # else:
-        #     logger.warning("ProcessPoolExecutor._processes is unavailable; unable to force terminate processes.")
-
+        
     @classmethod
     def create(cls, max_workers: int) -> Self:
         pool = ProcessPoolExecutor(max_workers=max_workers)

--- a/nominal/experimental/stream_v2/_write_stream.py
+++ b/nominal/experimental/stream_v2/_write_stream.py
@@ -190,6 +190,9 @@ def _write_serialized_batch(
             serialized.newest_timestamp,
         )
         write_future.add_done_callback(write_callback)
+    except KeyboardInterrupt:
+        logger.warning("KeyboardInterrupt caught in _write_serialized_batch; aborting batch write.")
+        return
     except Exception as e:
         logger.error(f"Error processing batch: {e}", exc_info=True)
         raise e

--- a/nominal/experimental/stream_v2/_write_stream.py
+++ b/nominal/experimental/stream_v2/_write_stream.py
@@ -98,10 +98,10 @@ class WriteStreamV2:
     def close(self) -> None:
         self._item_queue.put(QueueShutdown())
         self._batch_thread.join()
-        
+
         self._serializer.close()
         self._write_pool.shutdown(cancel_futures=True)
-        
+
         self._batch_serialize_thread.join()
 
     def enqueue(

--- a/nominal/experimental/stream_v2/_write_stream.py
+++ b/nominal/experimental/stream_v2/_write_stream.py
@@ -98,9 +98,11 @@ class WriteStreamV2:
     def close(self) -> None:
         self._item_queue.put(QueueShutdown())
         self._batch_thread.join()
-        self._batch_serialize_thread.join()
+        
         self._serializer.close()
         self._write_pool.shutdown(cancel_futures=True)
+        
+        self._batch_serialize_thread.join()
 
     def enqueue(
         self,


### PR DESCRIPTION
after creating the write stream context manager we do not shutdown cleanly after keyboard interrupt

the goal of this pr is to fix ^