### PR TITLE
feat: expose more parameters in top-level `create_run`

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -94,8 +94,8 @@ class NominalClient:
     def create_run(
         self,
         name: str,
-        start: str | datetime | IntegralNanosecondsUTC,
-        end: str | datetime | IntegralNanosecondsUTC | None,
+        start: datetime | IntegralNanosecondsUTC,
+        end: datetime | IntegralNanosecondsUTC | None,
         description: str | None = None,
         *,
         properties: Mapping[str, str] | None = None,

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -94,8 +94,8 @@ class NominalClient:
     def create_run(
         self,
         name: str,
-        start: datetime | IntegralNanosecondsUTC,
-        end: datetime | IntegralNanosecondsUTC | None,
+        start: str | datetime | IntegralNanosecondsUTC,
+        end: str | datetime | IntegralNanosecondsUTC | None,
         description: str | None = None,
         *,
         properties: Mapping[str, str] | None = None,

--- a/nominal/nominal.py
+++ b/nominal/nominal.py
@@ -269,6 +269,10 @@ def create_run(
     start: datetime | str | ts.IntegralNanosecondsUTC,
     end: datetime | str | ts.IntegralNanosecondsUTC | None,
     description: str | None = None,
+    *,
+    properties: Mapping[str, str] | None = None,
+    labels: Sequence[str] = (),
+    attachments: Iterable[Attachment] | Iterable[str] = ()
 ) -> Run:
     """Create a run in the Nominal platform.
 
@@ -279,9 +283,12 @@ def create_run(
     conn = get_default_client()
     return conn.create_run(
         name,
-        start=ts._SecondsNanos.from_flexible(start).to_nanoseconds(),
-        end=None if end is None else ts._SecondsNanos.from_flexible(end).to_nanoseconds(),
+        start=start,
+        end=end,
         description=description,
+        properties=properties,
+        labels=labels,
+        attachments=attachments,
     )
 
 

--- a/nominal/nominal.py
+++ b/nominal/nominal.py
@@ -283,8 +283,8 @@ def create_run(
     conn = get_default_client()
     return conn.create_run(
         name,
-        start=start,
-        end=end,
+        start=ts._SecondsNanos.from_flexible(start).to_nanoseconds(),
+        end=None if end is None else ts._SecondsNanos.from_flexible(end).to_nanoseconds(),
         description=description,
         properties=properties,
         labels=labels,

--- a/nominal/nominal.py
+++ b/nominal/nominal.py
@@ -272,7 +272,7 @@ def create_run(
     *,
     properties: Mapping[str, str] | None = None,
     labels: Sequence[str] = (),
-    attachments: Iterable[Attachment] | Iterable[str] = ()
+    attachments: Iterable[Attachment] | Iterable[str] = (),
 ) -> Run:
     """Create a run in the Nominal platform.
 


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

I noticed that the free function for `create_run` doesn't allow specifying `properties`, `labels`, or `attachments`, although the method defined on the client object does, which means that users have to call `get_default_client` if they want to create a run with any of these values.