### PR TITLE
fix: stop using channel delimiter as channel prefix

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -447,7 +447,6 @@ class NominalClient:
                         timestamp_type=_to_typed_timestamp_type(timestamp_type)._to_conjure_ingest_api(),
                     ),
                     additional_file_tags=None,
-                    channel_prefix=prefix_tree_delimiter,
                     tag_keys_from_columns=None,
                 )
             )


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->
