### PR TITLE
feat: make ffmpeg-python a standard dependency instead of extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "python-dateutil>=0.0.0",
     "pyyaml>=0.0.0",
     "requests>=0.0.0",
+    "ffmpeg-python>=0.2.0",
 ]
 
 
@@ -77,7 +78,6 @@ nominal = { workspace = true }
 [project.optional-dependencies]
 hdf5 = ["h5py>=3.0", "tables>=3.7"]
 protos = ["nominal-api-protos>=0.549.0"]
-video = ["ffmpeg-python>=0.2.0"]
 
 [project.scripts]
 nom = 'nominal.cli:nom'

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9, <4"
 resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'darwin'",
@@ -1582,6 +1583,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "conjure-python-client" },
+    { name = "ffmpeg-python" },
     { name = "nominal-api" },
     { name = "nptdms" },
     { name = "pandas" },
@@ -1600,9 +1602,6 @@ hdf5 = [
 ]
 protos = [
     { name = "nominal-api-protos" },
-]
-video = [
-    { name = "ffmpeg-python" },
 ]
 
 [package.dev-dependencies]
@@ -1631,7 +1630,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8,<9" },
     { name = "conjure-python-client", specifier = ">=2.8.0,<3" },
-    { name = "ffmpeg-python", marker = "extra == 'video'", specifier = ">=0.2.0" },
+    { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "h5py", marker = "extra == 'hdf5'", specifier = ">=3.0" },
     { name = "nominal-api", specifier = "==0.584.3" },
     { name = "nominal-api-protos", marker = "extra == 'protos'", specifier = ">=0.549.0" },
@@ -1645,6 +1644,7 @@ requires-dist = [
     { name = "tabulate", specifier = ">=0.9.0,<0.10" },
     { name = "typing-extensions", specifier = ">=4,<5" },
 ]
+provides-extras = ["hdf5", "protos"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Was typing out instructions to a customer on how to install and use this function, and realized, since `ffmpeg-python` doesn't include ffmpeg and is just a thin wrapper around a system-installed ffmpeg, we don't need to hide it in extras-- it's small enough to just have as a main dependency and simplify things for users.