### PR TITLE
fix: dataset get_channels()

### DIFF
--- a/nominal/_utils.py
+++ b/nominal/_utils.py
@@ -106,7 +106,7 @@ def deprecate_keyword_argument(new_name: str, old_name: str) -> Callable[[Callab
     return _deprecate_keyword_argument_decorator
 
 
-def deprecate_arguments_on_instance_methods(
+def deprecate_arguments(
     deprecated_args: list[str], new_kwarg: str, new_method: Callable[..., T]
 ) -> Callable[[Callable[Param, T]], Callable[Param, T]]:
     """Decorator to deprecate specific positional and keyword arguments in favor of a keyword-only argument.

--- a/nominal/_utils.py
+++ b/nominal/_utils.py
@@ -106,7 +106,7 @@ def deprecate_keyword_argument(new_name: str, old_name: str) -> Callable[[Callab
     return _deprecate_keyword_argument_decorator
 
 
-def deprecate_arguments(
+def deprecate_arguments_on_instance_methods(
     deprecated_args: list[str], new_kwarg: str, new_method: Callable[..., T]
 ) -> Callable[[Callable[Param, T]], Callable[Param, T]]:
     """Decorator to deprecate specific positional and keyword arguments in favor of a keyword-only argument.
@@ -118,6 +118,7 @@ def deprecate_arguments(
     2. Execute the original method (which contains the legacy logic)
     3. If no deprecated arguments are provided but the new keyword argument is,
        it will call new_method with the new keyword argument.
+    4. If only self is passed (for instance methods), it will call new_method.
 
     Args:
         deprecated_args: List of argument names that are being deprecated
@@ -150,6 +151,9 @@ def deprecate_arguments(
 
             if new_kwarg in kwargs:
                 return new_method(*args, **{new_kwarg: kwargs[new_kwarg]})
+
+            if len(args) == 1 and not kwargs:
+                return new_method(*args)
 
             return method(*args, **kwargs)
 

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -12,7 +12,7 @@ from typing import BinaryIO, Iterable, Mapping, Sequence
 from nominal_api import api, datasource_api, ingest_api, scout_catalog
 from typing_extensions import Self
 
-from nominal._utils import deprecate_arguments_on_instance_methods
+from nominal._utils import deprecate_arguments
 from nominal.core._multipart import upload_multipart_file, upload_multipart_io
 from nominal.core._utils import update_dataclass
 from nominal.core.channel import Channel
@@ -243,7 +243,7 @@ class Dataset(DataSource):
             _clients=clients,
         )
 
-    @deprecate_arguments_on_instance_methods(
+    @deprecate_arguments(
         deprecated_args=["exact_match", "fuzzy_search_text"],
         new_kwarg="names",
         new_method=DataSource.get_channels,

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -12,7 +12,7 @@ from typing import BinaryIO, Iterable, Mapping, Sequence
 from nominal_api import api, datasource_api, ingest_api, scout_catalog
 from typing_extensions import Self
 
-from nominal._utils import deprecate_arguments
+from nominal._utils import deprecate_arguments_on_instance_methods
 from nominal.core._multipart import upload_multipart_file, upload_multipart_io
 from nominal.core._utils import update_dataclass
 from nominal.core.channel import Channel
@@ -243,7 +243,7 @@ class Dataset(DataSource):
             _clients=clients,
         )
 
-    @deprecate_arguments(
+    @deprecate_arguments_on_instance_methods(
         deprecated_args=["exact_match", "fuzzy_search_text"],
         new_kwarg="names",
         new_method=DataSource.get_channels,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.9, <4"
 resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'darwin'",
@@ -1578,7 +1577,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.39.0"
+version = "1.40.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1646,7 +1645,6 @@ requires-dist = [
     { name = "tabulate", specifier = ">=0.9.0,<0.10" },
     { name = "typing-extensions", specifier = ">=4,<5" },
 ]
-provides-extras = ["hdf5", "protos", "video"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
dataset.get_channels() was still calling legacy method when no args were passed in.
- update decorator to properly handle this case