### PR TITLE
feat: uniformly expose channel prefix tree delimiter in all create dataset methods

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -387,7 +387,7 @@ class NominalClient:
             where {unit} is one of: nanoseconds | microseconds | milliseconds | seconds | minutes | hours | days
 
         Args:
-            dataset: Binary file-like MCAP stream
+            dataset: Binary file-like tabular data stream
             name: Name of the dataset to create
             timestamp_column: Column of data containing timestamp information for all other columns
             timestamp_type: Type of timestamps contained within timestamp_column


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

PR also adds misc. documentation along the way.

If I have channels named:

```
left_wing.roll
left_wing.pitch
left_wing.yaw
right_wing.roll
right_wing.yaw
right_wing.pitch
```

and I ingest with a channel prefix tree delimiter of `.`, then when I put the channel viewer in tree-mode, it'll represent them logically like:

```
left_wing
  |-- roll
  |-- pitch
  |-- yaw

right_wing
  |-- roll
  |-- pitch
  |-- yaw
```