### PR TITLE
feat: add deprecation notices to consolidate dataset creation / addition methods

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -28,7 +28,7 @@ from nominal_api import (
     storage_datasource_api,
     timeseries_logicalseries_api,
 )
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 from nominal import _config
 from nominal._utils import deprecate_keyword_argument
@@ -242,6 +242,10 @@ class NominalClient:
 
         return dataset
 
+    @deprecated(
+        "Creating a dataset from a file via the client is deprecated and will be removed in a future version. "
+        "Use `create_dataset`, `get_dataset`, or `search_datasets` and add data to an existing dataset instead."
+    )
     def create_csv_dataset(
         self,
         path: Path | str,
@@ -273,6 +277,10 @@ class NominalClient:
             channel_prefix=channel_prefix,
         )
 
+    @deprecated(
+        "Creating a dataset from a file via the client is deprecated and will be removed in a future version. "
+        "Use `create_dataset`, `get_dataset`, or `search_datasets` and add data to an existing dataset instead."
+    )
     def create_ardupilot_dataflash_dataset(
         self,
         path: Path | str,
@@ -310,6 +318,10 @@ class NominalClient:
             raise NominalIngestError("error ingesting dataflash: no dataset created")
         return self.get_dataset(response.details.dataset.dataset_rid)
 
+    @deprecated(
+        "Creating a dataset from a file via the client is deprecated and will be removed in a future version. "
+        "Use `create_dataset`, `get_dataset`, or `search_datasets` and add data to an existing dataset instead."
+    )
     def create_tabular_dataset(
         self,
         path: Path | str,
@@ -352,6 +364,10 @@ class NominalClient:
                 channel_prefix=channel_prefix,
             )
 
+    @deprecated(
+        "Creating a dataset from a file via the client is deprecated and will be removed in a future version. "
+        "Use `create_dataset`, `get_dataset`, or `search_datasets` and add data to an existing dataset instead."
+    )
     def create_journal_json_dataset(
         self,
         path: Path | str,
@@ -400,6 +416,10 @@ class NominalClient:
             raise NominalIngestError("error ingesting journal json: no dataset created")
         return self.get_dataset(response.details.dataset.dataset_rid)
 
+    @deprecated(
+        "Creating a dataset from a file via the client is deprecated and will be removed in a future version. "
+        "Use `create_dataset`, `get_dataset`, or `search_datasets` and add data to an existing dataset instead."
+    )
     def create_dataset_from_io(
         self,
         dataset: BinaryIO,
@@ -480,6 +500,10 @@ class NominalClient:
             raise NominalIngestError("error ingesting dataset: no dataset created")
         return self.get_dataset(response.details.dataset.dataset_rid)
 
+    @deprecated(
+        "Creating a dataset from a file via the client is deprecated and will be removed in a future version. "
+        "Use `create_dataset`, `get_dataset`, or `search_datasets` and add data to an existing dataset instead."
+    )
     def create_mcap_dataset(
         self,
         path: Path | str,
@@ -515,6 +539,10 @@ class NominalClient:
                 file_name=path_upload_name(mcap_path, FileTypes.MCAP),
             )
 
+    @deprecated(
+        "Creating a dataset from a file via the client is deprecated and will be removed in a future version. "
+        "Use `create_dataset`, `get_dataset`, or `search_datasets` and add data to an existing dataset instead."
+    )
     def create_dataset_from_mcap_io(
         self,
         dataset: BinaryIO,

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -10,7 +10,7 @@ from types import MappingProxyType
 from typing import BinaryIO, Iterable, Mapping, Sequence
 
 from nominal_api import api, datasource_api, ingest_api, scout_catalog
-from typing_extensions import Self, TypeAlias
+from typing_extensions import Self, TypeAlias, deprecated
 
 from nominal._utils import deprecate_arguments
 from nominal.core._multipart import path_upload_name, upload_multipart_file, upload_multipart_io
@@ -118,11 +118,25 @@ class Dataset(DataSource):
 
         return self.refresh()
 
+    @deprecated(
+        "`Dataset.add_csv_to_dataset` is deprecated and will be removed in a future version. "
+        "Use `Dataset.add_tabular_data_to_dataset` instead."
+    )
     def add_csv_to_dataset(self, path: Path | str, timestamp_column: str, timestamp_type: _AnyTimestampType) -> None:
         """Append to a dataset from a csv on-disk."""
-        self.add_data_to_dataset(path, timestamp_column, timestamp_type)
+        self.add_tabular_data_to_dataset(path, timestamp_column, timestamp_type)
 
+    @deprecated(
+        "`Dataset.add_data_to_dataset` is deprecated and will be removed in a future version. "
+        "Use `Dataset.add_tabular_data_to_dataset` instead."
+    )
     def add_data_to_dataset(self, path: Path | str, timestamp_column: str, timestamp_type: _AnyTimestampType) -> None:
+        """Append to a dataset from a tabular data file on-disk."""
+        self.add_tabular_data_to_dataset(path, timestamp_column, timestamp_type)
+
+    def add_tabular_data_to_dataset(
+        self, path: Path | str, timestamp_column: str, timestamp_type: _AnyTimestampType
+    ) -> None:
         """Append to a dataset from tabular data on-disk.
 
         Currently, the supported filetypes are:

--- a/nominal/nominal.py
+++ b/nominal/nominal.py
@@ -157,6 +157,35 @@ def upload_polars(
     )
 
 
+def create_dataset(
+    name: str,
+    description: str | None = None,
+    labels: Sequence[str] = (),
+    properties: Mapping[str, str] | None = None,
+    prefix_tree_delimiter: str | None = None,
+) -> Dataset:
+    """Create an empty dataset.
+
+    Args:
+        name: Name of the dataset to create in Nominal.
+        description: Human readable description of the dataset.
+        labels: Text labels to apply to the created dataset
+        properties: Key-value properties to apply to the cleated dataset
+        prefix_tree_delimiter: If present, the delimiter to represent tiers when viewing channels hierarchically.
+
+    Returns:
+        Reference to the created dataset in Nominal.
+    """
+    conn = get_default_client()
+    return conn.create_dataset(
+        name, description=description, labels=labels, properties=properties, prefix_tree_delimiter=prefix_tree_delimiter
+    )
+
+
+@typing_extensions.deprecated(
+    "`nominal.upload_csv` is deprecated and will be removed in a future version. "
+    "Use `nominal.create_dataset` or `nominal.get_dataset`, add data to an existing dataset instead."
+)
 def upload_csv(
     file: Path | str,
     name: str | None,

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9, <4"
 resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'darwin'",
@@ -1577,7 +1578,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.45.0"
+version = "1.45.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1643,6 +1644,7 @@ requires-dist = [
     { name = "tabulate", specifier = ">=0.9.0,<0.10" },
     { name = "typing-extensions", specifier = ">=4,<5" },
 ]
+provides-extras = ["hdf5", "protos"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Consolidating all of the parallel codepaths for creating a dataset using deprecation notices so that we don't have the same logic 10 different places in the code in a near future version of the client.