### PR TITLE
feat: remove 3mo+ deprecations

### DIFF
--- a/nominal/_utils.py
+++ b/nominal/_utils.py
@@ -6,33 +6,15 @@ import os
 import warnings
 from contextlib import contextmanager
 from functools import wraps
-from typing import Any, BinaryIO, Callable, Iterator, TypeVar
+from typing import BinaryIO, Callable, Iterator, TypeVar
 
 from typing_extensions import ParamSpec
-
-from nominal.core import filetype
 
 logger = logging.getLogger(__name__)
 
 
 Param = ParamSpec("Param")
 T = TypeVar("T")
-
-
-def __getattr__(attr: str) -> Any:
-    import warnings
-
-    deprecated_attrs = {"FileType": filetype.FileType, "FileTypes": filetype.FileTypes}
-    if attr in deprecated_attrs:
-        warnings.warn(
-            (
-                f"nominal._utils.{attr} is deprecated and will be removed in a future version, use "
-                f"nominal.core.{attr} instead."
-            ),
-            UserWarning,
-            stacklevel=2,
-        )
-        return deprecated_attrs[attr]
 
 
 @contextmanager

--- a/nominal/_utils.py
+++ b/nominal/_utils.py
@@ -66,28 +66,6 @@ def warn_on_deprecated_argument(
     return decorator
 
 
-def deprecate_keyword_argument(new_name: str, old_name: str) -> Callable[[Callable[Param, T]], Callable[Param, T]]:
-    def _deprecate_keyword_argument_decorator(f: Callable[Param, T]) -> Callable[Param, T]:
-        def wrapper(*args: Param.args, **kwargs: Param.kwargs) -> T:
-            if old_name in kwargs:
-                import warnings
-
-                warnings.warn(
-                    (
-                        f"The '{old_name}' keyword argument is deprecated and will be removed in a "
-                        f"future version, use '{new_name}' instead."
-                    ),
-                    UserWarning,
-                    stacklevel=2,
-                )
-                kwargs[new_name] = kwargs.pop(old_name)
-            return f(*args, **kwargs)
-
-        return wrapper
-
-    return _deprecate_keyword_argument_decorator
-
-
 def deprecate_arguments(
     deprecated_args: list[str], new_kwarg: str, new_method: Callable[..., T]
 ) -> Callable[[Callable[Param, T]], Callable[Param, T]]:

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -167,7 +167,6 @@ class NominalClient:
         for run in self._search_runs_paginated(request):
             yield Run._from_conjure(self._clients, run)
 
-    @deprecate_keyword_argument("name_substring", "exact_name")
     def search_runs(
         self,
         start: str | datetime | IntegralNanosecondsUTC | None = None,

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -31,7 +31,6 @@ from nominal_api import (
 from typing_extensions import Self, deprecated
 
 from nominal import _config
-from nominal._utils import deprecate_keyword_argument
 from nominal.core._clientsbunch import ClientsBunch
 from nominal.core._conjure_utils import _available_units, _build_unit_update
 from nominal.core._multipart import path_upload_name, upload_multipart_file, upload_multipart_io

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -173,8 +173,6 @@ class NominalClient:
         start: str | datetime | IntegralNanosecondsUTC | None = None,
         end: str | datetime | IntegralNanosecondsUTC | None = None,
         name_substring: str | None = None,
-        label: str | None = None,
-        property: tuple[str, str] | None = None,
         *,
         labels: Sequence[str] | None = None,
         properties: Mapping[str, str] | None = None,
@@ -186,22 +184,12 @@ class NominalClient:
             start: Inclusive start time for filtering runs.
             end: Inclusive end time for filtering runs.
             name_substring: Searches for a (case-insensitive) substring in the name.
-            label: Deprecated, use labels instead.
-            property: Deprecated, use properties instead.
             labels: A sequence of labels that must ALL be present on a run to be included.
             properties: A mapping of key-value pairs that must ALL be present on a run to be included.
 
         Returns:
             All runs which match all of the provided conditions
         """
-        labels, properties = _handle_deprecated_labels_properties(
-            "search_runs",
-            label,
-            labels,
-            property,
-            properties,
-        )
-
         return list(self._iter_search_runs(start, end, name_substring, labels, properties))
 
     def create_dataset(
@@ -1185,8 +1173,6 @@ class NominalClient:
     def search_assets(
         self,
         search_text: str | None = None,
-        label: str | None = None,
-        property: tuple[str, str] | None = None,
         *,
         labels: Sequence[str] | None = None,
         properties: Mapping[str, str] | None = None,
@@ -1196,22 +1182,12 @@ class NominalClient:
 
         Args:
             search_text: case-insensitive search for any of the keywords in all string fields
-            label: Deprecated, use labels instead.
-            property: Deprecated, use properties instead.
             labels: A sequence of labels that must ALL be present on a asset to be included.
             properties: A mapping of key-value pairs that must ALL be present on a asset to be included.
 
         Returns:
             All assets which match all of the provided conditions
         """
-        labels, properties = _handle_deprecated_labels_properties(
-            "search_assets",
-            label,
-            labels,
-            property,
-            properties,
-        )
-
         return list(self._iter_search_assets(search_text, labels, properties))
 
     def list_streaming_checklists(self, asset: Asset | str | None = None) -> Iterable[str]:
@@ -1372,37 +1348,3 @@ def _create_search_checklists_query(
             queries.append(scout_checks_api.ChecklistSearchQuery(property=api.Property(prop_key, prop_value)))
 
     return scout_checks_api.ChecklistSearchQuery(and_=queries)
-
-
-def _handle_deprecated_labels_properties(
-    function_name: str,
-    label: str | None,
-    labels: Sequence[str] | None,
-    property: tuple[str, str] | None,
-    properties: Mapping[str, str] | None,
-) -> tuple[Sequence[str], Mapping[str, str]]:
-    if all([label, labels]):
-        raise ValueError(f"Cannot use both label and labels for {function_name}.")
-    elif label:
-        warnings.warn(
-            f"parameter 'label' of {function_name} is deprecated, use 'labels' instead",
-            UserWarning,
-            stacklevel=2,
-        )
-        labels = [label]
-    elif labels is None:
-        labels = []
-
-    if all([property, properties]):
-        raise ValueError(f"Cannot use both property and propertiess for {function_name}.")
-    elif property:
-        warnings.warn(
-            f"parameter 'property' of {function_name} is deprecated, use 'properties' instead",
-            UserWarning,
-            stacklevel=2,
-        )
-        properties = {property[0]: property[1]}
-    elif properties is None:
-        properties = {}
-
-    return labels, properties

--- a/nominal/core/connection.py
+++ b/nominal/core/connection.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import itertools
-import warnings
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Literal, Mapping, Sequence
@@ -57,16 +55,6 @@ class Connection(DataSource):
 @dataclass(frozen=True)
 class StreamingConnection(Connection):
     nominal_data_source_rid: str
-
-    # Deprecated methods for backward compatibility
-    def get_nominal_write_stream(self, batch_size: int = 50_000, max_wait_sec: int = 1) -> WriteStream:
-        warnings.warn(
-            "get_nominal_write_stream is deprecated and will be removed in a future version. "
-            "use get_write_stream instead.",
-            UserWarning,
-            stacklevel=2,
-        )
-        return self.get_write_stream(batch_size, timedelta(seconds=max_wait_sec))
 
     def get_write_stream(
         self,
@@ -132,9 +120,3 @@ def _get_connections(
     clients: Connection._Clients, connection_rids: Sequence[str]
 ) -> Sequence[scout_datasource_connection_api.Connection]:
     return [clients.connection.get_connection(clients.auth_header, rid) for rid in connection_rids]
-
-
-def _tag_product(tags: Mapping[str, Sequence[str]]) -> list[dict[str, str]]:
-    # {color: [red, green], size: [S, M, L]} -> [{color: red, size: S}, {color: red, size: M}, ...,
-    #                                            {color: green, size: L}]
-    return [dict(zip(tags.keys(), values)) for values in itertools.product(*tags.values())]

--- a/nominal/core/stream.py
+++ b/nominal/core/stream.py
@@ -4,27 +4,14 @@ import concurrent.futures
 import logging
 import threading
 import time
-import warnings
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from types import TracebackType
-from typing import Any, Callable, Sequence, Type
+from typing import Callable, Sequence, Type
 
 from typing_extensions import Self
 
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
-
-
-def __getattr__(name: str) -> Any:
-    if name == "NominalWriteStream":
-        warnings.warn(
-            "NominalWriteStream is deprecated, use WriteStream instead",
-            UserWarning,
-            stacklevel=2,
-        )
-        return WriteStream
-    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
-
 
 logger = logging.getLogger(__name__)
 

--- a/nominal/nominal.py
+++ b/nominal/nominal.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
 import typing_extensions
 
 from nominal import Connection, _config, ts
-from nominal._utils import deprecate_keyword_argument
 from nominal.core import (
     Asset,
     Attachment,
@@ -300,42 +299,29 @@ def get_run(rid: str) -> Run:
     return conn.get_run(rid)
 
 
-@deprecate_keyword_argument("name_substring", "exact_name")
 def search_runs(
     *,
     start: str | datetime | ts.IntegralNanosecondsUTC | None = None,
     end: str | datetime | ts.IntegralNanosecondsUTC | None = None,
     name_substring: str | None = None,
-    label: str | None = None,
     labels: Sequence[str] | None = None,
-    property: tuple[str, str] | None = None,
     properties: Mapping[str, str] | None = None,
 ) -> Sequence[Run]:
     """Search for runs meeting the specified filters.
-    Filters are ANDed together, e.g. `(run.label == label) AND (run.end <= end)`
+    Filters are ANDed together, e.g. `(labels in run.labels) AND (run.end <= end)`
 
     Args:
         start: Inclusive start time for filtering runs.
         end: Inclusive end time for filtering runs.
         name_substring: Searches for a (case-insensitive) substring in the name
-        label: Deprecated, use labels instead.
         labels: A sequence of labels that must ALL be present on a run to be included.
-        property: Deprecated, use properties instead.
         properties: A mapping of key-value pairs that must ALL be present on a run to be included.
 
     Returns:
         All runs which match all of the provided conditions
     """
     conn = get_default_client()
-    return conn.search_runs(
-        start=start,
-        end=end,
-        name_substring=name_substring,
-        label=label,
-        labels=labels,
-        property=property,
-        properties=properties,
-    )
+    return conn.search_runs(start=start, end=end, name_substring=name_substring, labels=labels, properties=properties)
 
 
 def upload_attachment(
@@ -411,14 +397,10 @@ def get_asset(rid: str) -> Asset:
     return conn.get_asset(rid)
 
 
-@deprecate_keyword_argument("properties", "property")
-@deprecate_keyword_argument("labels", "label")
 def search_assets(
     *,
     search_text: str | None = None,
-    label: str | None = None,
     labels: Sequence[str] | None = None,
-    property: tuple[str, str] | None = None,
     properties: Mapping[str, str] | None = None,
 ) -> Sequence[Asset]:
     """Search for assets meeting the specified filters.
@@ -426,22 +408,14 @@ def search_assets(
 
     Args:
         search_text: case-insensitive search for any of the keywords in all string fields
-        label: Deprecated, use labels instead.
         labels: A sequence of labels that must ALL be present on a asset to be included.
-        property: Deprecated, use properties instead.
         properties: A mapping of key-value pairs that must ALL be present on a asset to be included.
 
     Returns:
         All assets which match all of the provided conditions
     """
     conn = get_default_client()
-    return conn.search_assets(
-        search_text=search_text,
-        label=label,
-        property=property,
-        labels=labels,
-        properties=properties,
-    )
+    return conn.search_assets(search_text=search_text, labels=labels, properties=properties)
 
 
 def list_streaming_checklists(asset: Asset | str | None = None) -> Iterable[str]:

--- a/nominal/ts.py
+++ b/nominal/ts.py
@@ -197,7 +197,6 @@ nm.upload_csv("temperature.csv", "Exterior Temps", "timestamp",
 from __future__ import annotations
 
 import abc
-import warnings
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from types import MappingProxyType
@@ -336,19 +335,10 @@ _LiteralAbsolute: TypeAlias = Literal[
     "epoch_hours",
 ]
 
-_LiteralRelativeDeprecated: TypeAlias = Literal[
-    "relative_nanoseconds",
-    "relative_microseconds",
-    "relative_milliseconds",
-    "relative_seconds",
-    "relative_minutes",
-    "relative_hours",
-]
-
 TypedTimestampType: TypeAlias = Union[Iso8601, Epoch, Relative, Custom]
 """Type alias for all of the strongly typed timestamp types."""
 
-_AnyTimestampType: TypeAlias = Union[TypedTimestampType, _LiteralAbsolute, _LiteralRelativeDeprecated]
+_AnyTimestampType: TypeAlias = Union[TypedTimestampType, _LiteralAbsolute]
 """Type alias for all of the allowable timestamp types, including string representations."""
 
 
@@ -357,14 +347,6 @@ def _to_typed_timestamp_type(type_: _AnyTimestampType) -> TypedTimestampType:
         return type_
     if not isinstance(type_, str):
         raise TypeError(f"timestamp type {type_} must be a string or an instance of one of: {TypedTimestampType}")
-    if type_.startswith("relative_"):
-        # until this is completely removed, we implicitly assume offset=1970-01-01 in the APIs
-        warnings.warn(
-            "specifying 'relative_{unit}' as a string is deprecated and will be removed in a future version: "
-            "use `nm.ts.Relative` instead. "
-            "for example: instead of 'relative_seconds', use `nm.ts.Relative('seconds', start=datetime.now())`. ",
-            UserWarning,
-        )
     if type_ not in _str_to_type:
         raise ValueError(f"string timestamp types must be one of: {_str_to_type.keys()}")
     return _str_to_type[type_]
@@ -374,7 +356,7 @@ def _time_unit_to_conjure(unit: _LiteralTimeUnit) -> api.TimeUnit:
     return api.TimeUnit[unit.upper()]
 
 
-_str_to_type: Mapping[_LiteralAbsolute | _LiteralRelativeDeprecated, Iso8601 | Epoch | Relative] = MappingProxyType(
+_str_to_type: Mapping[_LiteralAbsolute, Iso8601 | Epoch | Relative] = MappingProxyType(
     {
         "iso_8601": ISO_8601,
         "epoch_nanoseconds": EPOCH_NANOSECONDS,
@@ -383,12 +365,6 @@ _str_to_type: Mapping[_LiteralAbsolute | _LiteralRelativeDeprecated, Iso8601 | E
         "epoch_seconds": EPOCH_SECONDS,
         "epoch_minutes": EPOCH_MINUTES,
         "epoch_hours": EPOCH_HOURS,
-        "relative_nanoseconds": Relative("nanoseconds", start=0),
-        "relative_microseconds": Relative("microseconds", start=0),
-        "relative_milliseconds": Relative("milliseconds", start=0),
-        "relative_seconds": Relative("seconds", start=0),
-        "relative_minutes": Relative("minutes", start=0),
-        "relative_hours": Relative("hours", start=0),
     }
 )
 

--- a/tests/e2e/test_toplevel.py
+++ b/tests/e2e/test_toplevel.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 
 import pandas as pd
 import polars as pl
-import pytest
 
 import nominal as nm
 from nominal import _utils
@@ -188,21 +187,6 @@ def test_search_runs_substring():
     start, end = _create_random_start_end()
     run = nm.create_run(name, start, end, desc)
     runs = nm.search_runs(name_substring=name[4:])
-    assert len(runs) == 1
-    run2 = runs[0]
-
-    assert run2.rid == run.rid != ""
-    assert run2.name == run.name == name
-
-
-def test_search_runs_substring_deprecated():
-    name = f"run-{uuid4()}"
-    desc = f"top-level test to search for a run by name {uuid4()}"
-    start, end = _create_random_start_end()
-    run = nm.create_run(name, start, end, desc)
-
-    with pytest.warns(UserWarning):
-        runs = nm.search_runs(exact_name=name[4:])
     assert len(runs) == 1
     run2 = runs[0]
 


### PR DESCRIPTION
🪓 Removing members, args, etc that have been deprecated (i.e., `UserWarning` with a recommended alternative) for at least 90 days

❌ `nominal._utils.FileType`
✅ `nominal.core.FileType`

❌ `nominal._utils.FileTypes`
✅ `nominal.core.FileTypes`

❌ `nominal.core.NominalWriteStream`
✅ `nominal.core.WriteStream`

❌ `NominalClient.search_runs(exact_name="...")`
✅ `NominalClient.search_runs(name_substring="...")` 

❌ `NominalClient.search_runs(label="label")`
✅ `NominalClient.search_runs(labels=["label"])` 

❌ `NominalClient.search_runs(property=("key", "value"))` 
✅ `NominalClient.search_runs(properties={"key": "value")`

❌ `NominalClient.search_assets(label="label")`
✅ `NominalClient.search_assets(labels=["label"])` 

❌ `NominalClient.search_assets(property=("key", "value"))` 
✅ `NominalClient.search_assets(properties={"key": "value")`

❌ `StreamingConnection.get_nominal_write_stream(...)`
✅ `StreamingConnection.get_write_stream(...)`

❌ `nominal.search_runs(exact_name="...")`
✅ `nominal.search_runs(name_substring="...")` 

❌ `nominal.search_runs(label="label")`
✅ `nominal.search_runs(labels=["label"])` 

❌ `nominal.search_runs(property=("key", "value"))` 
✅ `nominal.search_runs(properties={"key": "value")`

❌ `nominal.search_assets(label="label")`
✅ `nominal.search_assets(labels=["label"])` 

❌ `nominal.search_assets(property=("key", "value"))` 
✅ `nominal.search_assets(properties={"key": "value")`

❌ `"relative_{unit}"` for timestamp type specification
✅ `nominal.ts.Relative("{unit}", start=timestamp)`