### PR TITLE
feat: add workspace rids

### DIFF
--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -108,6 +108,7 @@ class ProtoWriteService(Service):
 @dataclass(frozen=True)
 class ClientsBunch:
     auth_header: str
+    workspace_rid: str
 
     assets: scout_assets.AssetService
     attachment: attachments_api.AttachmentService
@@ -136,11 +137,12 @@ class ClientsBunch:
     channel_metadata: timeseries_channelmetadata.ChannelMetadataService
 
     @classmethod
-    def from_config(cls, cfg: ServiceConfiguration, agent: str, token: str) -> Self:
+    def from_config(cls, cfg: ServiceConfiguration, agent: str, token: str, workspace_rid: str) -> Self:
         client_factory = partial(RequestsClient.create, user_agent=agent, service_config=cfg)
 
         return cls(
             auth_header=f"Bearer {token}",
+            workspace_rid=workspace_rid,
             assets=client_factory(scout_assets.AssetService),
             attachment=client_factory(attachments_api.AttachmentService),
             authentication=client_factory(authentication_api.AuthenticationServiceV2),
@@ -169,6 +171,8 @@ class ClientsBunch:
         )
 
 
-class HasAuthHeader(Protocol):
+class HasScoutParams(Protocol):
     @property
     def auth_header(self) -> str: ...
+    @property
+    def workspace_rid(self) -> str: ...

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -108,7 +108,7 @@ class ProtoWriteService(Service):
 @dataclass(frozen=True)
 class ClientsBunch:
     auth_header: str
-    workspace_rid: str
+    workspace_rid: str | None
 
     assets: scout_assets.AssetService
     attachment: attachments_api.AttachmentService
@@ -137,7 +137,7 @@ class ClientsBunch:
     channel_metadata: timeseries_channelmetadata.ChannelMetadataService
 
     @classmethod
-    def from_config(cls, cfg: ServiceConfiguration, agent: str, token: str, workspace_rid: str) -> Self:
+    def from_config(cls, cfg: ServiceConfiguration, agent: str, token: str, workspace_rid: str | None) -> Self:
         client_factory = partial(RequestsClient.create, user_agent=agent, service_config=cfg)
 
         return cls(
@@ -175,4 +175,4 @@ class HasScoutParams(Protocol):
     @property
     def auth_header(self) -> str: ...
     @property
-    def workspace_rid(self) -> str: ...
+    def workspace_rid(self) -> str | None: ...

--- a/nominal/core/_multipart.py
+++ b/nominal/core/_multipart.py
@@ -73,7 +73,7 @@ def path_upload_name(path: pathlib.Path, file_type: FileType) -> str:
 
 def put_multipart_upload(
     auth_header: str,
-    workspace_rid: str,
+    workspace_rid: str | None,
     f: BinaryIO,
     filename: str,
     mimetype: str,
@@ -159,7 +159,7 @@ def put_multipart_upload(
 
 def upload_multipart_io(
     auth_header: str,
-    workspace_rid: str,
+    workspace_rid: str | None,
     f: BinaryIO,
     name: str,
     file_type: FileType,
@@ -200,7 +200,7 @@ def upload_multipart_io(
 
 def upload_multipart_file(
     auth_header: str,
-    workspace_rid: str,
+    workspace_rid: str | None,
     file: pathlib.Path,
     upload_client: upload_api.UploadService,
     file_type: FileType | None = None,

--- a/nominal/core/_multipart.py
+++ b/nominal/core/_multipart.py
@@ -171,6 +171,7 @@ def upload_multipart_io(
 
     Args:
         auth_header: Nominal authorization token
+        workspace_rid: Nominal workspace rid
         f: Binary IO to upload
         name: Name of the file to create in S3
             NOTE: does not need to be URL Safe
@@ -211,6 +212,7 @@ def upload_multipart_file(
 
     Args:
         auth_header: Nominal authorization token
+        workspace_rid: Nominal workspace rid
         file: File to upload to S3
         upload_client: Conjure upload client
         file_type: Manually override inferred file type for the given file

--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -11,7 +11,7 @@ from nominal_api import (
 )
 from typing_extensions import Self, TypeAlias, deprecated
 
-from nominal.core._clientsbunch import HasAuthHeader
+from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._conjure_utils import Link, _build_links
 from nominal.core._utils import HasRid, rid_from_instance_or_string, update_dataclass
 from nominal.core.attachment import Attachment, _iter_get_attachments
@@ -39,7 +39,7 @@ class Asset(HasRid):
         Video._Clients,
         LogSet._Clients,
         Attachment._Clients,
-        HasAuthHeader,
+        HasScoutParams,
         Protocol,
     ):
         @property

--- a/nominal/core/attachment.py
+++ b/nominal/core/attachment.py
@@ -9,7 +9,7 @@ from typing import BinaryIO, Iterable, Mapping, Protocol, Sequence, cast
 from nominal_api import attachments_api
 from typing_extensions import Self
 
-from nominal.core._clientsbunch import HasAuthHeader
+from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils import HasRid, update_dataclass
 
 
@@ -22,7 +22,7 @@ class Attachment(HasRid):
     labels: Sequence[str]
     _clients: _Clients = field(repr=False)
 
-    class _Clients(HasAuthHeader, Protocol):
+    class _Clients(HasScoutParams, Protocol):
         @property
         def attachment(self) -> attachments_api.AttachmentService: ...
 

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -18,7 +18,7 @@ from nominal_api import (
 )
 from typing_extensions import Self
 
-from nominal.core._clientsbunch import HasAuthHeader
+from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils import update_dataclass
 from nominal.core.unit import UnitLike, _build_unit_update
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
@@ -58,7 +58,7 @@ class Channel:
         warnings.warn("Accessing Channel.rid is deprecated and now returns an empty string.", UserWarning, stacklevel=2)
         return self._rid
 
-    class _Clients(HasAuthHeader, Protocol):
+    class _Clients(HasScoutParams, Protocol):
         @property
         def dataexport(self) -> scout_dataexport_api.DataExportService: ...
         @property

--- a/nominal/core/checklist.py
+++ b/nominal/core/checklist.py
@@ -13,7 +13,7 @@ from nominal_api import (
 )
 from typing_extensions import Self
 
-from nominal.core._clientsbunch import HasAuthHeader
+from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils import HasRid, rid_from_instance_or_string
 from nominal.core.asset import Asset
 from nominal.core.data_review import DataReview
@@ -29,7 +29,7 @@ class Checklist(HasRid):
     labels: Sequence[str]
     _clients: _Clients = field(repr=False)
 
-    class _Clients(DataReview._Clients, HasAuthHeader, Protocol):
+    class _Clients(DataReview._Clients, HasScoutParams, Protocol):
         @property
         def checklist(self) -> scout_checks_api.ChecklistService: ...
         @property

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -82,7 +82,7 @@ class NominalClient:
         trust_store_path: str | None = None,
         connect_timeout: float = 30,
         *,
-        workspace_rid: str = "",
+        workspace_rid: str | None = None,
     ) -> Self:
         """Create a connection to the Nominal platform.
 
@@ -90,6 +90,9 @@ class NominalClient:
         token: An API token to authenticate with. By default, the token will be looked up in ~/.nominal.yml.
         trust_store_path: path to a trust store CA root file to initiate SSL connections. If not provided,
             certifi's trust store is used.
+        connect_timeout: Timeout for any single request to the Nominal API.
+        workspace_rid: The workspace RID to use for all API calls that require it. If not provided, the default
+            workspace will be used (if one is configured for the tenant).
         """
         if token is None:
             token = _config.get_token(base_url)

--- a/nominal/core/data_review.py
+++ b/nominal/core/data_review.py
@@ -15,7 +15,7 @@ from nominal_api import (
 from typing_extensions import Self
 
 from nominal.core import checklist
-from nominal.core._clientsbunch import HasAuthHeader
+from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils import HasRid
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
 
@@ -30,7 +30,7 @@ class DataReview(HasRid):
 
     _clients: _Clients = field(repr=False)
 
-    class _Clients(HasAuthHeader, Protocol):
+    class _Clients(HasScoutParams, Protocol):
         @property
         def datareview(self) -> scout_datareview_api.DataReviewService: ...
         @property

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -197,6 +197,7 @@ class Dataset(DataSource):
         file_type = FileType(*file_type)
         s3_path = upload_multipart_io(
             self._clients.auth_header,
+            self._clients.workspace_rid,
             dataset,
             file_name,
             file_type,
@@ -228,6 +229,7 @@ class Dataset(DataSource):
         file_type = FileType.from_path_journal_json(log_path)
         s3_path = upload_multipart_file(
             self._clients.auth_header,
+            self._clients.workspace_rid,
             log_path,
             self._clients.upload,
             file_type=file_type,
@@ -298,6 +300,7 @@ class Dataset(DataSource):
 
         s3_path = upload_multipart_io(
             self._clients.auth_header,
+            self._clients.workspace_rid,
             mcap,
             file_name,
             file_type=FileTypes.MCAP,
@@ -322,6 +325,7 @@ class Dataset(DataSource):
         dataflash_path = Path(path)
         s3_path = upload_multipart_file(
             self._clients.auth_header,
+            self._clients.workspace_rid,
             dataflash_path,
             self._clients.upload,
             file_type=FileTypes.DATAFLASH,

--- a/nominal/core/datasource.py
+++ b/nominal/core/datasource.py
@@ -25,7 +25,7 @@ from nominal_api import (
 
 from nominal._utils import warn_on_deprecated_argument
 from nominal.core._batch_processor import process_batch_legacy
-from nominal.core._clientsbunch import HasAuthHeader, ProtoWriteService
+from nominal.core._clientsbunch import HasScoutParams, ProtoWriteService
 from nominal.core._utils import HasRid, batched
 from nominal.core.channel import Channel, ChannelDataType
 from nominal.core.stream import WriteStream
@@ -43,7 +43,7 @@ class DataSource(HasRid):
     rid: str
     _clients: _Clients = field(repr=False)
 
-    class _Clients(Channel._Clients, HasAuthHeader, Protocol):
+    class _Clients(Channel._Clients, HasScoutParams, Protocol):
         @property
         def catalog(self) -> scout_catalog.CatalogService: ...
         @property

--- a/nominal/core/log.py
+++ b/nominal/core/log.py
@@ -6,7 +6,7 @@ from typing import Iterable, Protocol
 from nominal_api import datasource, datasource_logset, datasource_logset_api
 from typing_extensions import Self
 
-from nominal.core._clientsbunch import HasAuthHeader
+from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils import HasRid
 from nominal.ts import IntegralNanosecondsUTC, LogTimestampType, _SecondsNanos
 
@@ -19,7 +19,7 @@ class LogSet(HasRid):
     description: str | None
     _clients: _Clients = field(repr=False)
 
-    class _Clients(HasAuthHeader, Protocol):
+    class _Clients(HasScoutParams, Protocol):
         @property
         def logset(self) -> datasource_logset.LogSetService: ...
 

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -11,7 +11,7 @@ from nominal_api import (
 )
 from typing_extensions import Self
 
-from nominal.core._clientsbunch import HasAuthHeader
+from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._conjure_utils import Link, _build_links
 from nominal.core._utils import HasRid, rid_from_instance_or_string, update_dataclass
 from nominal.core.asset import Asset
@@ -39,7 +39,7 @@ class Run(HasRid):
 
     class _Clients(
         Asset._Clients,
-        HasAuthHeader,
+        HasScoutParams,
         Protocol,
     ):
         @property

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -312,7 +312,7 @@ class Video(HasRid):
 
 def _upload_frame_timestamps(
     auth_header: str,
-    workspace_rid: str,
+    workspace_rid: str | None,
     upload_client: upload_api.UploadService,
     frame_timestamps: Sequence[IntegralNanosecondsUTC],
 ) -> str:
@@ -337,7 +337,7 @@ def _upload_frame_timestamps(
 
 def _build_video_file_timestamp_manifest(
     auth_header: str,
-    workspace_rid: str,
+    workspace_rid: str | None,
     upload_client: upload_api.UploadService,
     start: datetime | IntegralNanosecondsUTC | None = None,
     frame_timestamps: Sequence[IntegralNanosecondsUTC] | None = None,

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -13,7 +13,7 @@ from typing import BinaryIO, Mapping, Protocol, Sequence
 from nominal_api import api, ingest_api, scout_video, scout_video_api, upload_api
 from typing_extensions import Self
 
-from nominal.core._clientsbunch import HasAuthHeader
+from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._multipart import path_upload_name, upload_multipart_io
 from nominal.core._utils import HasRid, update_dataclass
 from nominal.core.filetype import FileType, FileTypes
@@ -33,7 +33,7 @@ class Video(HasRid):
     labels: Sequence[str]
     _clients: _Clients = field(repr=False)
 
-    class _Clients(HasAuthHeader, Protocol):
+    class _Clients(HasScoutParams, Protocol):
         @property
         def video(self) -> scout_video.VideoService: ...
         @property
@@ -178,10 +178,12 @@ class Video(HasRid):
             raise TypeError(f"video {video} must be open in binary mode, rather than text mode")
 
         timestamp_manifest = _build_video_file_timestamp_manifest(
-            self._clients.auth_header, self._clients.upload, start, frame_timestamps
+            self._clients.auth_header, self._clients.workspace_rid, self._clients.upload, start, frame_timestamps
         )
         file_type = FileType(*file_type)
-        s3_path = upload_multipart_io(self._clients.auth_header, video, name, file_type, self._clients.upload)
+        s3_path = upload_multipart_io(
+            self._clients.auth_header, self._clients.workspace_rid, video, name, file_type, self._clients.upload
+        )
         request = ingest_api.IngestRequest(
             ingest_api.IngestOptions(
                 video=ingest_api.VideoOpts(
@@ -259,7 +261,9 @@ class Video(HasRid):
             raise TypeError(f"dataset {mcap} must be open in binary mode, rather than text mode")
 
         file_type = FileType(*file_type)
-        s3_path = upload_multipart_io(self._clients.auth_header, mcap, name, file_type, self._clients.upload)
+        s3_path = upload_multipart_io(
+            self._clients.auth_header, self._clients.workspace_rid, mcap, name, file_type, self._clients.upload
+        )
         request = ingest_api.IngestRequest(
             options=ingest_api.IngestOptions(
                 video=ingest_api.VideoOpts(
@@ -307,7 +311,10 @@ class Video(HasRid):
 
 
 def _upload_frame_timestamps(
-    auth_header: str, upload_client: upload_api.UploadService, frame_timestamps: Sequence[IntegralNanosecondsUTC]
+    auth_header: str,
+    workspace_rid: str,
+    upload_client: upload_api.UploadService,
+    frame_timestamps: Sequence[IntegralNanosecondsUTC],
 ) -> str:
     """Uploads per-frame video timestamps to S3 and provides a path to the uploaded resource."""
     # Dump timestamp array into an in-memory file-like IO object
@@ -320,6 +327,7 @@ def _upload_frame_timestamps(
     logger.debug("Uploading timestamp manifests to s3")
     return upload_multipart_io(
         auth_header,
+        workspace_rid,
         json_io,
         "timestamp_manifest",
         FileTypes.JSON,
@@ -329,6 +337,7 @@ def _upload_frame_timestamps(
 
 def _build_video_file_timestamp_manifest(
     auth_header: str,
+    workspace_rid: str,
     upload_client: upload_api.UploadService,
     start: datetime | IntegralNanosecondsUTC | None = None,
     frame_timestamps: Sequence[IntegralNanosecondsUTC] | None = None,
@@ -336,7 +345,7 @@ def _build_video_file_timestamp_manifest(
     if None not in (start, frame_timestamps):
         raise ValueError("Only one of 'start' or 'frame_timestamps' are allowed")
     elif frame_timestamps is not None:
-        manifest_s3_path = _upload_frame_timestamps(auth_header, upload_client, frame_timestamps)
+        manifest_s3_path = _upload_frame_timestamps(auth_header, workspace_rid, upload_client, frame_timestamps)
         return scout_video_api.VideoFileTimestampManifest(s3path=manifest_s3_path)
     elif start is not None:
         # TODO(drake): expose scale parameter to users

--- a/nominal/core/video_file.py
+++ b/nominal/core/video_file.py
@@ -9,7 +9,7 @@ from typing import Protocol
 from nominal_api import scout_video, scout_video_api
 from typing_extensions import Self
 
-from nominal.core._clientsbunch import HasAuthHeader
+from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils import HasRid, update_dataclass
 from nominal.exceptions import NominalIngestError, NominalIngestFailed
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
@@ -24,7 +24,7 @@ class VideoFile(HasRid):
     description: str | None
     _clients: _Clients = field(repr=False)
 
-    class _Clients(HasAuthHeader, Protocol):
+    class _Clients(HasScoutParams, Protocol):
         @property
         def video_file(self) -> scout_video.VideoFileService: ...
 

--- a/nominal/core/workbook.py
+++ b/nominal/core/workbook.py
@@ -6,7 +6,7 @@ from typing import Protocol
 from nominal_api import scout, scout_notebook_api
 from typing_extensions import Self
 
-from nominal.core._clientsbunch import HasAuthHeader
+from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils import HasRid
 
 
@@ -18,7 +18,7 @@ class Workbook(HasRid):
     run_rid: str | None
     _clients: _Clients = field(repr=False)
 
-    class _Clients(HasAuthHeader, Protocol):
+    class _Clients(HasScoutParams, Protocol):
         @property
         def notebook(self) -> scout.NotebookService: ...
 

--- a/nominal/experimental/stream_v2/_write_stream.py
+++ b/nominal/experimental/stream_v2/_write_stream.py
@@ -15,7 +15,7 @@ from typing import Callable, Protocol, Sequence, Type
 from typing_extensions import Self
 
 from nominal.core._batch_processor_proto import SerializedBatch
-from nominal.core._clientsbunch import HasAuthHeader, ProtoWriteService, RequestMetrics
+from nominal.core._clientsbunch import HasScoutParams, ProtoWriteService, RequestMetrics
 from nominal.core._queueing import Batch, QueueShutdown, ReadQueue, iter_queue, spawn_batching_thread
 from nominal.core.stream import BatchItem
 from nominal.experimental.stream_v2._serializer import BatchSerializer
@@ -35,7 +35,7 @@ class WriteStreamV2:
     _track_metrics: bool
     _add_metric: Callable[[str, int, float], None]
 
-    class _Clients(HasAuthHeader, Protocol):
+    class _Clients(HasScoutParams, Protocol):
         @property
         def proto_write(self) -> ProtoWriteService: ...
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ requires-python = ">=3.9,<4"
 dependencies = [
     "click>=8,<9",
     "conjure-python-client>=2.8.0,<3",
-    "nominal-api==0.618.0",
     "nptdms>=1.9.0,<2",
     "tabulate>=0.9.0,<0.10",
     "typing-extensions>=4,<5",
@@ -36,6 +35,7 @@ dependencies = [
     "pyyaml>=0.0.0",
     "requests>=0.0.0",
     "ffmpeg-python>=0.2.0",
+    "nominal-api>=0.621.0",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1578,7 +1578,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.45.2"
+version = "1.46.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -1632,7 +1632,7 @@ requires-dist = [
     { name = "conjure-python-client", specifier = ">=2.8.0,<3" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "h5py", marker = "extra == 'hdf5'", specifier = ">=3.0" },
-    { name = "nominal-api", specifier = "==0.618.0" },
+    { name = "nominal-api", specifier = ">=0.621.0" },
     { name = "nominal-api-protos", marker = "extra == 'protos'", specifier = ">=0.549.0" },
     { name = "nptdms", specifier = ">=1.9.0,<2" },
     { name = "pandas", specifier = ">=0.0.0" },
@@ -1671,15 +1671,15 @@ dev = [
 
 [[package]]
 name = "nominal-api"
-version = "0.618.0"
+version = "0.621.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "conjure-python-client" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/16/52536f18f610fbea52b198ee531446aaaaf89566f993c604eabc56d14ed5/nominal_api-0.618.0.tar.gz", hash = "sha256:aa7905cfa320d8933fbe0fd12a8a3877282ae5fa8d4a09c82aa574af3c6f6d55", size = 316147 }
+sdist = { url = "https://files.pythonhosted.org/packages/61/5a/80f2f6941d35f2a47efbd350ed5c538cf7c76e3422896f555c57b036f7db/nominal_api-0.621.0.tar.gz", hash = "sha256:ef8acba54b67bef46778ffad6a7b263f499051bbc71410908c528991e5bb186e", size = 317051 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/8a/d24d782e842ddc893bf43cea6f56ca9d429ed397c13ad8bbdbb097cfc13c/nominal_api-0.618.0-py3-none-any.whl", hash = "sha256:aa51fd7e36f97d189ac61671975a91d7223e8bc9b5dc6687d66eaf93dae68e0c", size = 337683 },
+    { url = "https://files.pythonhosted.org/packages/0b/2b/a68833a5d7b00e04658f67d32f4f144e344106aaa656c82b2081f2537973/nominal_api-0.621.0-py3-none-any.whl", hash = "sha256:7547206eac56875ad44055092f434b7fc8bc21b13229de2ecc784656947b7f91", size = 338615 },
 ]
 
 [[package]]


### PR DESCRIPTION
Subsumes #278 

This PR adds basic support for workspaces. Workspace RIDs (not their name/ID) are specified when you construct the client. All API calls that depend on workspace as a parameter have the workspace passed in. Backwards compatibility is supported as it is in the APIs currently, by leaving the workspace param optional, defaulting to the org's default workspace.

Note that you can only use workspaces with `NominalClient.create(..., workspace_rid)` currently---the global "default" client will have no workspace set.

To find all of the places where workspace _could_ be provided, I generated conjure types locally where I changed all instances of `optional<rids.WorkspaceRid>` to `rids.WorkspaceRid` so the type checker could find them all. After all instances were found, I then fell back to the newer public APIs.

Intentionally left out of this PR for now:
- customizing list/search with workspaces
- ability to specify workspaces with the global client