### PR TITLE
feat: add log streaming, deprecate LogSets

### DIFF
--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -7,7 +7,7 @@ from nominal.core.connection import Connection
 from nominal.core.data_review import CheckViolation, DataReview, DataReviewBuilder
 from nominal.core.dataset import Dataset, poll_until_ingestion_completed
 from nominal.core.filetype import FileType, FileTypes
-from nominal.core.log import Log, LogSet
+from nominal.core.log import Log, LogPoint, LogSet
 from nominal.core.run import Run
 from nominal.core.stream import WriteStream
 from nominal.core.user import User
@@ -19,20 +19,21 @@ __all__ = [
     "Attachment",
     "Channel",
     "Checklist",
+    "CheckViolation",
     "Connection",
+    "DataReview",
+    "DataReviewBuilder",
     "Dataset",
     "FileType",
     "FileTypes",
     "Log",
+    "LogPoint",
     "LogSet",
     "NominalClient",
     "Run",
     "User",
     "Video",
-    "poll_until_ingestion_completed",
     "Workbook",
-    "DataReview",
-    "CheckViolation",
-    "DataReviewBuilder",
     "WriteStream",
+    "poll_until_ingestion_completed",
 ]

--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -205,10 +205,17 @@ class Asset(HasRid):
             for (scope, rid) in scope_rid.items()
         ]
 
+    @deprecated(
+        "LogSets are deprecated and will be removed in a future version. "
+        "Logs should be stored as a log channel in a Nominal datasource instead."
+    )
     def list_logsets(self) -> Sequence[tuple[str, LogSet]]:
         """List the logsets associated with this asset.
         Returns (data_scope_name, logset) pairs for each logset.
         """
+        return self._list_logsets()
+
+    def _list_logsets(self) -> Sequence[tuple[str, LogSet]]:
         scope_rid = self._scope_rid(stype="logset")
         return [
             (scope, LogSet._from_conjure(self._clients, _get_log_set(self._clients, rid)))
@@ -220,7 +227,7 @@ class Asset(HasRid):
         Returns (data_scope_name, scope) pairs, where scope can be
         a dataset, connection, video, or logset.
         """
-        return (*self.list_datasets(), *self.list_connections(), *self.list_logsets(), *self.list_videos())
+        return (*self.list_datasets(), *self.list_connections(), *self._list_logsets(), *self.list_videos())
 
     def get_data_scope(self, data_scope_name: str) -> ScopeType:
         """Retrieve a datascope by data scope name, or raise ValueError if one is not found."""

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -705,6 +705,10 @@ class NominalClient:
             raise NominalIngestError("error ingesting video: no video created")
         return self.get_video(response.details.video.video_rid)
 
+    @deprecated(
+        "LogSets are deprecated and will be removed in a future version. "
+        "Add logs to an existing datasource with datasource.write_logs instead."
+    )
     def create_log_set(
         self,
         name: str,
@@ -752,6 +756,7 @@ class NominalClient:
         response = _get_dataset(self._clients.auth_header, self._clients.catalog, rid)
         return Dataset._from_conjure(self._clients, response)
 
+    @deprecated("LogSets are deprecated and will be removed in a future version.")
     def get_log_set(self, log_set_rid: str) -> LogSet:
         """Retrieve a log set along with its metadata given its RID."""
         response = _get_log_set(self._clients, log_set_rid)

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -707,7 +707,7 @@ class NominalClient:
 
     @deprecated(
         "LogSets are deprecated and will be removed in a future version. "
-        "Add logs to an existing datasource with datasource.write_logs instead."
+        "Add logs to an existing dataset with dataset.write_logs instead."
     )
     def create_log_set(
         self,

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -20,6 +20,7 @@ from nominal.core.channel import Channel
 from nominal.core.dataset_file import DatasetFile
 from nominal.core.datasource import DataSource
 from nominal.core.filetype import FileType, FileTypes
+from nominal.core.log import LogPoint, _write_logs
 from nominal.exceptions import NominalIngestError, NominalIngestFailed, NominalIngestMultiError
 from nominal.ts import (
     _AnyTimestampType,
@@ -425,6 +426,42 @@ class Dataset(DataSource):
                 break
             else:
                 next_page_token = files_page.next_page
+
+    def write_logs(self, logs: Iterable[LogPoint], channel_name: str = "logs", batch_size: int = 1000) -> None:
+        r"""Stream logs to the datasource.
+
+        This method executes synchronously, i.e. it blocks until all logs are sent to the API.
+        Logs are sent in batches. The logs can be any iterable of LogPoints, including a generator.
+
+        Args:
+            logs: LogPoints to stream to Nominal.
+            channel_name: Name of the channel to stream logs to.
+            batch_size: Number of logs to send to the API at a time.
+
+        Example:
+            ```python
+            from nominal.core import LogPoint
+
+            def parse_logs_from_file(file_path: str) -> Iterable[LogPoint]:
+                # 2025-04-08T14:26:28.679052Z [INFO] Sent ACTUATE_MOTOR command
+                with open(file_path, "r") as f:
+                    for line in f:
+                        timestamp, message = line.removesuffix("\n").split(maxsplit=1)
+                        yield LogPoint.create(timestamp, message)
+
+            dataset = client.get_dataset("dataset_rid")
+            logs = parse_logs_from_file("logs.txt")
+            dataset.write_logs(logs)
+            ```
+        """
+        _write_logs(
+            auth_header=self._clients.auth_header,
+            client=self._clients.storage_writer,
+            data_source_rid=self.rid,
+            logs=logs,
+            channel_name=channel_name,
+            batch_size=batch_size,
+        )
 
 
 def poll_until_ingestion_completed(datasets: Iterable[Dataset], interval: timedelta = timedelta(seconds=1)) -> None:

--- a/nominal/core/datasource.py
+++ b/nominal/core/datasource.py
@@ -28,7 +28,7 @@ from nominal.core._batch_processor import process_batch_legacy
 from nominal.core._clientsbunch import HasAuthHeader, ProtoWriteService
 from nominal.core._utils import HasRid, batched
 from nominal.core.channel import Channel, ChannelDataType
-from nominal.core.log import LogPoint, _stream_write_logs_batched
+from nominal.core.log import LogPoint, _write_logs
 from nominal.core.stream import WriteStream
 from nominal.core.unit import UnitMapping, _build_unit_update, _error_on_invalid_units
 from nominal.core.write_stream_base import WriteStreamBase
@@ -260,7 +260,7 @@ class DataSource(HasRid):
         request = datasource_api.IndexChannelPrefixTreeRequest(self.rid, delimiter=delimiter)
         self._clients.datasource.index_channel_prefix_tree(self._clients.auth_header, request)
 
-    def stream_logs(self, logs: Iterable[LogPoint], channel_name: str = "logs", batch_size: int = 1000) -> None:
+    def write_logs(self, logs: Iterable[LogPoint], channel_name: str = "logs", batch_size: int = 1000) -> None:
         """Stream logs to the datasource.
 
         This method executes synchronously, i.e. it blocks until all logs are sent to the API.
@@ -284,10 +284,10 @@ class DataSource(HasRid):
 
             dataset = client.get_dataset("dataset_rid")
             logs = parse_logs_from_file("logs.txt")
-            dataset.stream_logs(logs)
+            dataset.write_logs(logs)
             ```
         """
-        _stream_write_logs_batched(
+        _write_logs(
             auth_header=self._clients.auth_header,
             client=self._clients.storage_writer,
             data_source_rid=self.rid,

--- a/nominal/core/datasource.py
+++ b/nominal/core/datasource.py
@@ -261,7 +261,7 @@ class DataSource(HasRid):
         self._clients.datasource.index_channel_prefix_tree(self._clients.auth_header, request)
 
     def write_logs(self, logs: Iterable[LogPoint], channel_name: str = "logs", batch_size: int = 1000) -> None:
-        """Stream logs to the datasource.
+        r"""Stream logs to the datasource.
 
         This method executes synchronously, i.e. it blocks until all logs are sent to the API.
         Logs are sent in batches. The logs can be any iterable of LogPoints, including a generator.

--- a/nominal/core/datasource.py
+++ b/nominal/core/datasource.py
@@ -28,7 +28,6 @@ from nominal.core._batch_processor import process_batch_legacy
 from nominal.core._clientsbunch import HasAuthHeader, ProtoWriteService
 from nominal.core._utils import HasRid, batched
 from nominal.core.channel import Channel, ChannelDataType
-from nominal.core.log import LogPoint, _write_logs
 from nominal.core.stream import WriteStream
 from nominal.core.unit import UnitMapping, _build_unit_update, _error_on_invalid_units
 from nominal.core.write_stream_base import WriteStreamBase
@@ -259,42 +258,6 @@ class DataSource(HasRid):
         """
         request = datasource_api.IndexChannelPrefixTreeRequest(self.rid, delimiter=delimiter)
         self._clients.datasource.index_channel_prefix_tree(self._clients.auth_header, request)
-
-    def write_logs(self, logs: Iterable[LogPoint], channel_name: str = "logs", batch_size: int = 1000) -> None:
-        r"""Stream logs to the datasource.
-
-        This method executes synchronously, i.e. it blocks until all logs are sent to the API.
-        Logs are sent in batches. The logs can be any iterable of LogPoints, including a generator.
-
-        Args:
-            logs: LogPoints to stream to Nominal.
-            channel_name: Name of the channel to stream logs to.
-            batch_size: Number of logs to send to the API at a time.
-
-        Example:
-            ```python
-            from nominal.core import LogPoint
-
-            def parse_logs_from_file(file_path: str) -> Iterable[LogPoint]:
-                # 2025-04-08T14:26:28.679052Z [INFO] Sent ACTUATE_MOTOR command
-                with open(file_path, "r") as f:
-                    for line in f:
-                        timestamp, message = line.removesuffix("\n").split(maxsplit=1)
-                        yield LogPoint.create(timestamp, message)
-
-            dataset = client.get_dataset("dataset_rid")
-            logs = parse_logs_from_file("logs.txt")
-            dataset.write_logs(logs)
-            ```
-        """
-        _write_logs(
-            auth_header=self._clients.auth_header,
-            client=self._clients.storage_writer,
-            data_source_rid=self.rid,
-            logs=logs,
-            channel_name=channel_name,
-            batch_size=batch_size,
-        )
 
 
 def _construct_export_request(

--- a/nominal/core/log.py
+++ b/nominal/core/log.py
@@ -50,7 +50,7 @@ class LogPoint:
         )
 
 
-def _stream_write_logs_batched(
+def _write_logs(
     auth_header: str,
     client: storage_writer_api.NominalChannelWriterService,
     data_source_rid: str,

--- a/nominal/core/log.py
+++ b/nominal/core/log.py
@@ -8,10 +8,9 @@ from typing import Iterable, Mapping, Protocol
 from nominal_api import datasource, datasource_logset, datasource_logset_api, storage_writer_api
 from typing_extensions import Self
 
-from nominal.core._clientsbunch import ClientsBunch, HasAuthHeader
+from nominal.core._clientsbunch import HasAuthHeader
 from nominal.core._utils import HasRid, batched
 from nominal.ts import IntegralNanosecondsUTC, LogTimestampType, _SecondsNanos
-
 
 _EMTPY_MAP: Mapping[str, str] = MappingProxyType({})
 

--- a/nominal/core/log.py
+++ b/nominal/core/log.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from types import MappingProxyType
 from typing import Iterable, Mapping, Protocol
 
 from nominal_api import datasource, datasource_logset, datasource_logset_api, storage_writer_api
 from typing_extensions import Self
 
-from nominal.core._clientsbunch import HasAuthHeader
-from nominal.core._utils import HasRid
+from nominal.core._clientsbunch import ClientsBunch, HasAuthHeader
+from nominal.core._utils import HasRid, batched
 from nominal.ts import IntegralNanosecondsUTC, LogTimestampType, _SecondsNanos
+
+
+_EMTPY_MAP: Mapping[str, str] = MappingProxyType({})
 
 
 @dataclass(frozen=True)
@@ -19,12 +23,47 @@ class LogPoint:
     args: Mapping[str, str]
 
     @classmethod
+    def create(
+        cls, timestamp: str | datetime | IntegralNanosecondsUTC, message: str, args: Mapping[str, str] | None
+    ) -> Self:
+        return cls(
+            timestamp=_SecondsNanos.from_flexible(timestamp).to_nanoseconds(),
+            message=message,
+            args=_EMTPY_MAP if args is None else MappingProxyType(args),
+        )
+
+    @classmethod
     def _from_conjure(cls, point: storage_writer_api.LogPoint) -> Self:
         return cls(
             timestamp=_SecondsNanos.from_api(point.timestamp).to_nanoseconds(),
             message=point.value.message,
             args=MappingProxyType(point.value.args),
         )
+
+    def _to_conjure(self) -> storage_writer_api.LogPoint:
+        return storage_writer_api.LogPoint(
+            timestamp=_SecondsNanos.from_nanoseconds(self.timestamp).to_api(),
+            value=storage_writer_api.LogValue(
+                message=self.message,
+                args=dict(self.args),
+            ),
+        )
+
+
+def _stream_write_logs_batched(
+    auth_header: str,
+    client: storage_writer_api.NominalChannelWriterService,
+    data_source_rid: str,
+    logs: Iterable[LogPoint],
+    channel_name: str,
+    batch_size: int,
+) -> None:
+    for batch in batched(logs, batch_size):
+        request = storage_writer_api.WriteLogsRequest(
+            logs=[log._to_conjure() for log in batch],
+            channel=channel_name,
+        )
+        client.write_logs(auth_header, data_source_rid, request)
 
 
 @dataclass(frozen=True)

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -69,7 +69,7 @@ class Run(HasRid):
 
     @deprecated(
         "LogSets are deprecated and will be removed in a future version. "
-        "Add logs to an existing datasource with datasource.write_logs instead."
+        "Add logs to an existing dataset with dataset.write_logs instead."
     )
     def add_log_set(self, ref_name: str, log_set: LogSet | str) -> None:
         """Add a log set to this run.
@@ -80,7 +80,7 @@ class Run(HasRid):
 
     @deprecated(
         "LogSets are deprecated and will be removed in a future version. "
-        "Add logs to an existing datasource with datasource.write_logs instead."
+        "Add logs to an existing dataset with dataset.write_logs instead."
     )
     def add_log_sets(self, log_sets: Mapping[str, LogSet | str]) -> None:
         """Add multiple log sets to this run.

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -9,7 +9,7 @@ from nominal_api import (
     scout,
     scout_run_api,
 )
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 from nominal.core._clientsbunch import HasAuthHeader
 from nominal.core._conjure_utils import Link, _build_links
@@ -67,6 +67,10 @@ class Run(HasRid):
 
         return datasource_rids_by_ref_name
 
+    @deprecated(
+        "LogSets are deprecated and will be removed in a future version. "
+        "Add logs to an existing datasource with datasource.write_logs instead."
+    )
     def add_log_set(self, ref_name: str, log_set: LogSet | str) -> None:
         """Add a log set to this run.
 
@@ -74,6 +78,10 @@ class Run(HasRid):
         """
         self.add_log_sets({ref_name: log_set})
 
+    @deprecated(
+        "LogSets are deprecated and will be removed in a future version. "
+        "Add logs to an existing datasource with datasource.write_logs instead."
+    )
     def add_log_sets(self, log_sets: Mapping[str, LogSet | str]) -> None:
         """Add multiple log sets to this run.
 
@@ -102,6 +110,10 @@ class Run(HasRid):
             log_set = log_sets_by_rids[rid]
             yield (ref_name, log_set)
 
+    @deprecated(
+        "LogSets are deprecated and will be removed in a future version. "
+        "Logs should be stored as a log channel in a Nominal datasource instead."
+    )
     def list_log_sets(self) -> Sequence[tuple[str, LogSet]]:
         """List the log_sets associated with this run.
         Returns (ref_name, logset) pairs for each logset.


### PR DESCRIPTION
Nominal is deprecating the "LogSet" data source type in favor of log channels on any existing or new datasets. As a result, we're deprecating the client lib functions for getting or creating LogSets, and we're adding the ability to stream logs up to Nominal with `datasource.write_logs`. Unlike the previous log set API which needed to serialize the entire log set in a single JSON object, the new API allows for batch writing and can be continuously appended to.

Not yet implemented: reading a log channel.