### PR TITLE
chore: remove unused available tags field from connection object

### DIFF
--- a/nominal/core/connection.py
+++ b/nominal/core/connection.py
@@ -14,7 +14,6 @@ from nominal.core.write_stream_base import WriteStreamBase
 class Connection(DataSource):
     name: str
     description: str | None
-    _tags: Mapping[str, Sequence[str]]
 
     @classmethod
     def _from_conjure(
@@ -26,7 +25,6 @@ class Connection(DataSource):
                 rid=response.rid,
                 name=response.display_name,
                 description=response.description,
-                _tags=response.available_tag_values,
                 _clients=clients,
                 nominal_data_source_rid=response.connection_details.nominal.nominal_data_source_rid,
             )
@@ -34,7 +32,6 @@ class Connection(DataSource):
             rid=response.rid,
             name=response.display_name,
             description=response.description,
-            _tags=response.available_tag_values,
             _clients=clients,
         )
 

--- a/nominal/core/connection.py
+++ b/nominal/core/connection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Literal, Mapping, Sequence
+from typing import Literal, Sequence
 
 from nominal_api import scout_datasource_connection_api
 

--- a/tests/test_write_stream.py
+++ b/tests/test_write_stream.py
@@ -37,7 +37,6 @@ def mock_connection(mock_clients):
         rid="test-connection-rid",
         name="Test Connection",
         description="A connection for testing",
-        _tags={},
         _clients=mock_clients,
         nominal_data_source_rid="test-datasource-rid",
     )


### PR DESCRIPTION
Getting tags for a connection have been moved to DataSourceService#getTagValuesForDataSource

<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->
