### PR TITLE
fix: tie to a specific version of nominal-api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "pyyaml>=0.0.0",
     "requests>=0.0.0",
     "ffmpeg-python>=0.2.0",
-    "nominal-api>=0.621.0",
+    "nominal-api==0.621.0",
 ]
 
 


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

We should use `==` to avoid weird disconnect state between `nominal-api` and `nominal-client`