### PR TITLE
fix: make token default None for NominalClient.create

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -78,7 +78,7 @@ class NominalClient:
     def create(
         cls,
         base_url: str,
-        token: str | None,
+        token: str | None = None,
         trust_store_path: str | None = None,
         connect_timeout: float = 30,
         *,


### PR DESCRIPTION
Currently, if you'd like to manually instantiate a `NominalClient` via `.create(...)`, you need to pass in at a minimum `NominalClient.create(<api base url>, <token>)`.

There is convenient, documented behavior where `token` can be `None`, in which case it'll be pulled from the local config file. However, to leverage that behavior you need to explicitly pass in `None` rather than just omitting it. This PR just sets a default for that positional argument in order to be able to create the client by just passing in the `base_url`