### PR TITLE
fix: fix function argument overwrite (propagate exception)

### DIFF
--- a/nominal/core/_multipart.py
+++ b/nominal/core/_multipart.py
@@ -249,4 +249,4 @@ def _abort(upload_client: upload_api.UploadService, auth_header: str, key: str, 
         upload_client.abort_multipart_upload(auth_header, key, upload_id)
     except Exception as exc:
         logger.critical("multipart upload abort failed", exc_info=exc, extra={"key": key, "upload_id": upload_id})
-        raise e
+        raise exc from e

--- a/nominal/core/_multipart.py
+++ b/nominal/core/_multipart.py
@@ -247,6 +247,6 @@ def _abort(upload_client: upload_api.UploadService, auth_header: str, key: str, 
     )
     try:
         upload_client.abort_multipart_upload(auth_header, key, upload_id)
-    except Exception as e:
-        logger.critical("multipart upload abort failed", exc_info=e, extra={"key": key, "upload_id": upload_id})
+    except Exception as exc:
+        logger.critical("multipart upload abort failed", exc_info=exc, extra={"key": key, "upload_id": upload_id})
         raise e


### PR DESCRIPTION
I noticed that we have a few ruff failures, so will address each of those in a separate PR.

This one prevents overriding the `e` argument to the function the `try/except` clause, also avoiding confusion as to *which* e we are referring to when logging the error.