### PR TITLE
chore: allow untyped defs in test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,11 @@ ignore_missing_imports = true
 module = "ffmpeg"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "tests.*"
+disable_error_code = ["no-untyped-def"]
+
+
 [tool.pytest.ini_options]
 filterwarnings = [
     "error", # transform all warnings into errors, except ignore: ones.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,6 @@ ignore_missing_imports = true
 module = "tests.*"
 disable_error_code = ["no-untyped-def"]
 
-
 [tool.pytest.ini_options]
 filterwarnings = [
     "error", # transform all warnings into errors, except ignore: ones.


### PR DESCRIPTION
This avoids MyPy complaining about `def test_foo(): ...` not being annotated with `-> None`.