### PR TITLE
chore: indicate that client is compatible with Python 3.13

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,6 +30,7 @@ check-types:
 
 # check static typing across all supported python versions
 check-types-all:
+    uv run mypy --python-version 3.13
     uv run mypy --python-version 3.12
     uv run mypy --python-version 3.11
     uv run mypy --python-version 3.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 requires-python = ">=3.9,<4"


### PR DESCRIPTION
I've been running it under 3.13 for a while now without any issues.

3.9 is EOL October 2025, FWIW, around the same time 3.14 is being released.