### PR TITLE
fix: remove warning on uploading CSV

### DIFF
--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -609,7 +609,7 @@ def _construct_new_ingest_options(
             )
         )
     else:
-        if file_type.is_csv():
+        if not file_type.is_csv():
             logger.warning("Expected filetype %s to be parquet or csv for creating a dataset from io", file_type)
 
         return ingest_api.IngestOptions(


### PR DESCRIPTION
Presumably, this warning was for the case where filetype was *neither* parquet or csv for a tabular upload. Right now, it shows up when calling `add_tabular_data` with a CSV file.
