### PR TITLE
fix: video conversion when there is no audio

### DIFF
--- a/nominal/experimental/video_processing/video_conversion.py
+++ b/nominal/experimental/video_processing/video_conversion.py
@@ -87,7 +87,6 @@ def normalize_video(
     # Run ffmpeg in subprocess
     video_in = ffmpeg.input(str(input_path), **input_kwargs)
     video_out = video_in.output(str(output_path), **output_kwargs)
-    print(shlex.join(video_out.compile()))
     logger.info(f"Running command: '{shlex.join(video_out.compile())}'")
     video_out.run()
 

--- a/nominal/experimental/video_processing/video_conversion.py
+++ b/nominal/experimental/video_processing/video_conversion.py
@@ -80,13 +80,14 @@ def normalize_video(
 
     # If the video does not have an audio track, add an empty track by default
     if not has_audio_track(input_path):
+        input_kwargs["f"] = "lavfi"
         input_kwargs["i"] = "anullsrc=channel_layout=stereo:sample_rate=44100"
-        output_kwargs["f"] = "lavfi"
         output_kwargs["shortest"] = None
 
     # Run ffmpeg in subprocess
     video_in = ffmpeg.input(str(input_path), **input_kwargs)
     video_out = video_in.output(str(output_path), **output_kwargs)
+    print(shlex.join(video_out.compile()))
     logger.info(f"Running command: '{shlex.join(video_out.compile())}'")
     video_out.run()
 


### PR DESCRIPTION
`anullsrc` won't be recognized if `-f lavfi` flag doesn't occur prior to `-i anullsrc...`.
