### PR TITLE
feat: un-deprecate creating streaming connections

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -1225,10 +1225,6 @@ class NominalClient:
             raise NominalIngestError("error ingesting mcap video: no video created")
         return self.get_video(response.details.video.video_rid)
 
-    @deprecated(
-        "`NominalClient.create_streaming_connection` is deprecated and will be removed in a future version. "
-        "Instead, create a dataset with `create_dataset` and use `Dataset.get_write_stream` to stream data."
-    )
     def create_streaming_connection(
         self,
         datasource_id: str,

--- a/nominal/core/connection.py
+++ b/nominal/core/connection.py
@@ -50,10 +50,9 @@ class Connection(DataSource):
 class StreamingConnection(Connection):
     """A `StreamingConnection` is used to stream telemetry data to Nominal.
 
-    This is now largely an antiquated mechanism for ingesting data into Nominal.
-    It is instead recommended that users simply retrieve a write stream to an existing
-    dataset using `Dataset.get_write_stream`, which has the same overall semantics of using
-    a `StreamingConnection`.
+    This method of streaming is being phased out in favor of streaming to a dataset.
+    However, it is still available while we complete adding the same level of tag
+    support to datasets, and for backwards compatibility.
     """
 
     nominal_data_source_rid: str

--- a/nominal/nominal.py
+++ b/nominal/nominal.py
@@ -479,10 +479,6 @@ def upload_mcap_video(
     return video
 
 
-@typing_extensions.deprecated(
-    "`nominal.create_streaming_connection` is deprecated, use `nominal.create_dataset` "
-    "and then `Dataset.get_write_stream` instead."
-)
 def create_streaming_connection(
     datasource_id: str,
     connection_name: str,


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Undoes the parts of #296 that deprecated StreamingConnection. This is on the roadmap but tag support is not yet at parity with datasets, so we'll have both hanging around for a bit longer.