### PR TITLE
fix: pass workspace rid when creating empty video

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -781,6 +781,7 @@ class NominalClient:
             labels=list(labels),
             properties={} if properties is None else {**properties},
             description=description,
+            workspace=self._clients.workspace_rid,
         )
         raw_video = self._clients.video.create(self._clients.auth_header, request)
         return Video._from_conjure(self._clients, raw_video)


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->
