### PR TITLE
feat: make gzip level a global constant

### DIFF
--- a/nominal/core/_networking.py
+++ b/nominal/core/_networking.py
@@ -13,6 +13,7 @@ T = TypeVar("T")
 
 GZIP_COMPRESSION_LEVEL = 1
 
+
 class GzipRequestsAdapter(TransportAdapter):
     """Adapter used with `requests` library for sending gzip-compressed data.
 


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Without wanting to robustly flush through the gzip compression level to be used by a client from click decorator => profiles => client creation, allow a moderately hacky but configurable way of setting the gzip level used by conjure encoding while we experiment with which levels work best for which data-intensive endpoints.