### PR TITLE
chore: make docstrings clearer

### DIFF
--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -47,8 +47,8 @@ class Dataset(DataSource):
         return f"https://app.gov.nominal.io/data-sources/{self.rid}"
 
     def poll_until_ingestion_completed(self, interval: timedelta = timedelta(seconds=1)) -> Self:
-        """Block until dataset ingestion has completed.
-        This method polls Nominal for ingest status after uploading a dataset on an interval.
+        """Block until dataset file ingestion has completed.
+        This method polls Nominal for ingest status after uploading a file to a dataset on an interval.
 
         Raises:
         ------

--- a/nominal/core/stream.py
+++ b/nominal/core/stream.py
@@ -117,7 +117,7 @@ class WriteStream(WriteStreamBase):
         Args:
         ----
             wait: If true, wait for the batch to complete uploading before returning
-            timeout: If wait is true, the time to wait for flush completion.
+            timeout: If wait is true, the time to wait for flush completion in seconds.
                      NOTE: If none, waits indefinitely.
 
         """


### PR DESCRIPTION
now that datasets can be streamed to, users can erroneously think that poll_until_ingestion_completed also applies to streaming