### PR TITLE
fix: make dataframe actually use timestamps as the index column in datasource_to_dataframe

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1732,7 +1732,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.55.0"
+version = "1.57.0"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -1790,12 +1790,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8,<9" },
-    { name = "conjure-python-client", specifier = ">=2.8.0" },
+    { name = "conjure-python-client", specifier = ">=2.8.0,<3" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.0.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "h5py", marker = "extra == 'hdf5'", specifier = ">=3.0" },
     { name = "nominal-api", specifier = "==0.703.0" },
-    { name = "nominal-api-protos", marker = "extra == 'protos'", specifier = ">=0.549.0" },
+    { name = "nominal-api-protos", marker = "extra == 'protos'", specifier = ">=0.703.0" },
     { name = "nptdms", marker = "extra == 'tdms'", specifier = ">=1.9.0,<2" },
     { name = "pandas", specifier = ">=0.0.0" },
     { name = "python-dateutil", specifier = ">=0.0.0" },


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

As title, it used to return the timestamps duplicated n/20 times given n channels (once per batch of 20 columns) as a "timestamp" column if the data comes in at different times / rates.
It is unclear to me if this works if the user has a column named "timestamp" already in the data, though, I'm guessing this is rare for a channel name that isn't used as the timestamp column during ingest.

For some random dataset in staging as of this PR, the only difference other than this fix is that the index changes:

```python
import nominal
from nominal.thirdparty.pandas import datasource_to_dataframe

client = nominal.NominalClient.from_profile("staging")
dataset = client.get_dataset("...")

data = datasource_to_dataframe(
    datasource = dataset,
    start=dataset.bounds.start,
    end=dataset.bounds.end,
)
data.head(n=20), data.shape
```

```
(                      vibration_level  torque_nm  error_count  temperature_c
 timestamp                                                                   
 2025-06-03T19:24:21Z        22.103693  28.092199    21.553773      28.282380
 2025-06-03T19:24:21Z        22.789283  28.092199    21.553773      29.449322
 2025-06-03T19:24:21Z        21.344826  28.092199    21.553773      25.112573
 2025-06-03T19:24:22Z        27.762567  24.114644    24.363259      29.394682
 2025-06-03T19:24:22Z        29.815108  24.114644    24.363259      20.849847
 2025-06-03T19:24:22Z        27.891486  24.114644    24.363259      22.365354
 2025-06-03T19:24:24Z        24.010258  28.712219    23.400385      25.473874
 2025-06-03T19:24:24Z        24.980114  28.712219    23.400385      27.525588
 2025-06-03T19:24:24Z        25.080638  28.712219    23.400385      23.780603
 2025-06-03T19:24:25Z        29.638016  28.500876    26.805086      21.827278
 2025-06-03T19:24:25Z        24.494213  28.500876    26.805086      23.391632
 2025-06-03T19:24:25Z        27.096542  28.500876    26.805086      28.673263
 2025-06-03T19:24:26Z        28.833139  21.521625    21.133054      25.151692
 2025-06-03T19:24:26Z        25.971623  21.521625    21.133054      24.539892
 2025-06-03T19:24:26Z        27.812179  21.521625    21.133054      22.730495
 2025-06-03T19:24:28Z        20.431979  25.458704    20.901033      22.819757
 2025-06-03T19:24:28Z        26.569536  25.458704    20.901033      25.788348
 2025-06-03T19:24:28Z        24.498899  25.458704    20.901033      24.229030
 2025-06-03T19:24:29Z        29.409901  22.020460    28.723547      23.607342
 2025-06-03T19:24:29Z        21.498487  22.020460    28.723547      22.089284,
 (10992, 4))
```

before, it would return this

``` 
(               timestamp  vibration_level  torque_nm  error_count  \
 0   2025-06-03T19:24:21Z        22.103693  28.092199    21.553773   
 1   2025-06-03T19:24:21Z        22.789283  28.092199    21.553773   
 2   2025-06-03T19:24:21Z        21.344826  28.092199    21.553773   
 3   2025-06-03T19:24:22Z        27.762567  24.114644    24.363259   
 4   2025-06-03T19:24:22Z        29.815108  24.114644    24.363259   
 5   2025-06-03T19:24:22Z        27.891486  24.114644    24.363259   
 6   2025-06-03T19:24:24Z        24.010258  28.712219    23.400385   
 7   2025-06-03T19:24:24Z        24.980114  28.712219    23.400385   
 8   2025-06-03T19:24:24Z        25.080638  28.712219    23.400385   
 9   2025-06-03T19:24:25Z        29.638016  28.500876    26.805086   
 10  2025-06-03T19:24:25Z        24.494213  28.500876    26.805086   
 11  2025-06-03T19:24:25Z        27.096542  28.500876    26.805086   
 12  2025-06-03T19:24:26Z        28.833139  21.521625    21.133054   
 13  2025-06-03T19:24:26Z        25.971623  21.521625    21.133054   
 14  2025-06-03T19:24:26Z        27.812179  21.521625    21.133054   
 15  2025-06-03T19:24:28Z        20.431979  25.458704    20.901033   
 16  2025-06-03T19:24:28Z        26.569536  25.458704    20.901033   
 17  2025-06-03T19:24:28Z        24.498899  25.458704    20.901033   
 18  2025-06-03T19:24:29Z        29.409901  22.020460    28.723547   
 19  2025-06-03T19:24:29Z        21.498487  22.020460    28.723547   
 
     temperature_c  
 0       28.282380  
 1       29.449322  
 2       25.112573  
 3       29.394682  
 4       20.849847  
 5       22.365354  
 6       25.473874  
 7       27.525588  
 8       23.780603  
 9       21.827278  
 10      23.391632  
 11      28.673263  
 12      25.151692  
 13      24.539892  
 14      22.730495  
 15      22.819757  
 16      25.788348  
 17      24.229030  
 18      23.607342  
 19      22.089284  ,
 (10992, 5))
```

For a dataset with 365 channels being read at the same refresh rates, the output goes from 

```
>>> data.shape, list(sorted(data.isna().sum().to_list(), reverse=True))[:25]
((131689, 365),
 [124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758,
  124758])
```

Which is a disturbing output given that:
```
>>> data.timestamp.unique()
array(['2024-12-20T09:52:41.7Z', '2024-12-20T09:52:41.710000128Z',
       '2024-12-20T09:52:41.72Z', ..., '2024-12-20T09:53:50.98Z',
       '2024-12-20T09:53:50.990000128Z', '2024-12-20T09:53:51Z'],
      shape=(6931,), dtype=object)
```

to 

```
>>> data.shape, list(sorted(data.isna().sum().to_list(), reverse=True))[:25]
((6931, 364),
 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
```
