### PR TITLE
feat: allow gzipping during pandas export

### DIFF
--- a/nominal/core/datasource.py
+++ b/nominal/core/datasource.py
@@ -266,6 +266,7 @@ def _construct_export_request(
     start: api.Timestamp,
     end: api.Timestamp,
     tags: dict[str, str] | None,
+    enable_gzip: bool,
 ) -> scout_dataexport_api.ExportDataRequest:
     export_channels = []
 
@@ -334,6 +335,7 @@ def _construct_export_request(
         resolution=scout_dataexport_api.ResolutionOption(
             undecimated=scout_dataexport_api.UndecimatedResolution(),
         ),
+        compression=scout_dataexport_api.CompressionFormat.GZIP if enable_gzip else None,
     )
     return request
 

--- a/uv.lock
+++ b/uv.lock
@@ -1732,7 +1732,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.57.0"
+version = "1.57.1"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Combined with parallel processing, this allows us to go from ~250k points/second exported => 7.5m points/second on a 200mbps connection.