### PR TITLE
feat: allow streaming ints with vanilla streaming

### DIFF
--- a/nominal/core/_batch_processor.py
+++ b/nominal/core/_batch_processor.py
@@ -31,6 +31,15 @@ def make_points(api_batch: Sequence[BatchItem]) -> storage_writer_api.PointsExte
                 for item in api_batch
             ]
         )
+    elif isinstance(api_batch[0].value, int):
+        return storage_writer_api.PointsExternal(
+            int_=[
+                storage_writer_api.IntPoint(
+                    timestamp=_SecondsNanos.from_flexible(item.timestamp).to_api(), value=cast(int, item.value)
+                )
+                for item in api_batch
+            ]
+        )
     else:
         raise ValueError("only float and string are supported types for value")
 

--- a/nominal/core/stream.py
+++ b/nominal/core/stream.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 class BatchItem:
     channel_name: str
     timestamp: IntegralNanosecondsUTC
-    value: float | str
+    value: float | int | str
     tags: Mapping[str, str] | None = None
 
 


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

This does not add support for protobuf or experimental streaming, as both rely upon protobuf API which does _not_ support ints.

tested on staging 