### PR TITLE
feat: clean up DataReview API usage

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -23,6 +23,7 @@ from nominal_api import (
     scout_notebook_api,
     scout_run_api,
     scout_video_api,
+    scout_workbookcommon_api,
     secrets_api,
     storage_datasource_api,
 )
@@ -794,15 +795,11 @@ class NominalClient:
         request = scout_notebook_api.CreateNotebookRequest(
             title=title if title is not None else f"Workbook from {template.metadata.title}",
             description=description or "",
-            notebook_type=None,
             is_draft=is_draft,
             state_as_json="{}",
-            charts=None,
-            run_rid=run_rid,
-            data_scope=None,
+            data_scope=scout_notebook_api.NotebookDataScope(run_rids=[run_rid]),
             layout=template.layout,
-            content=template.content,
-            content_v2=None,
+            content_v2=scout_workbookcommon_api.UnifiedWorkbookContent(workbook=template.content),
             event_refs=[],
             workspace=self._clients.workspace_rid,
         )

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -803,7 +803,6 @@ class NominalClient:
             layout=template.layout,
             content=template.content,
             content_v2=None,
-            check_alert_refs=[],
             event_refs=[],
             workspace=self._clients.workspace_rid,
         )

--- a/nominal/core/data_review.py
+++ b/nominal/core/data_review.py
@@ -43,19 +43,15 @@ class DataReview(HasRid):
 
     @classmethod
     def _from_conjure(cls, clients: _Clients, data_review: scout_datareview_api.DataReview) -> Self:
-        if data_review.checklist is None:
-            raise Exception("Data review does not have an associated checklist")
         executing_states = [
-            check.automatic_check.state._pending_execution or check.automatic_check.state._executing
-            for check in data_review.checklist.checks
-            if check.automatic_check
+            check.state._pending_execution or check.state._executing for check in data_review.check_evaluations
         ]
         completed = not any(executing_states)
         return cls(
             rid=data_review.rid,
             run_rid=data_review.run_rid,
-            checklist_rid=data_review.checklist.checklist.rid,
-            checklist_commit=data_review.checklist.checklist.commit,
+            checklist_rid=data_review.checklist_ref.rid,
+            checklist_commit=data_review.checklist_ref.commit,
             completed=completed,
             _clients=clients,
         )


### PR DESCRIPTION
See ticket for more details.

Updates client to not use deprecated fields and move away from CheckViolation in favor of Events.