### PR TITLE
feat: Add a a cli for processing an instrumentation spreadsheet

### DIFF
--- a/nominal/cli/__init__.py
+++ b/nominal/cli/__init__.py
@@ -1,7 +1,7 @@
 import click
 
 import nominal
-from nominal.cli import attachment, auth, config, dataset, run
+from nominal.cli import attachment, auth, config, dataset, mis, run
 
 
 @click.group(context_settings={"show_default": True, "help_option_names": ("-h", "--help")})
@@ -15,3 +15,4 @@ nom.add_command(auth.auth_cmd)
 nom.add_command(dataset.dataset_cmd)
 nom.add_command(run.run_cmd)
 nom.add_command(config.config_cmd)
+nom.add_command(mis.mis_cmd)

--- a/nominal/cli/mis.py
+++ b/nominal/cli/mis.py
@@ -1,0 +1,62 @@
+"""This CLI processes an MIS and turns it into unit assignments and chennel descriptions on a dataset
+MIS must be in the format of a CSV with the following columns:
+- Channel Name
+- Channel Description
+- UCUM Unit
+"""
+
+import csv
+from pathlib import Path
+from typing import Tuple
+
+import click
+
+from nominal.core import NominalClient
+
+
+def process_mis_csv(mis_path: Path) -> dict[str, Tuple[str, str]]:
+    """Read the MIS CSV and return a dictionary of channel names and their descriptions and units.
+
+    Args:
+        mis_path: The path to the MIS CSV file containing channel information
+
+    Returns:
+        dict[str, Tuple[str, str]]: Dictionary mapping channel names to tuples of (description, unit)
+    """
+    with open(mis_path, "r") as f:
+        reader = csv.reader(f)
+        next(reader)
+        return {row[0]: (row[1], row[2]) for row in reader}
+
+
+class Channel_Updater:
+    def __init__(self, dataset_rid: str, profile: str):
+        self.dataset_rid = dataset_rid
+        self.client = NominalClient.from_profile(profile)
+        self.dataset = self.client.get_dataset(dataset_rid)
+        self.channel_list = self.dataset.get_channels()
+        # Create a mapping of channel names to channel objects for O(1) lookups
+        # dictionary comprehension
+        self.channel_map = {channel.name: channel for channel in self.channel_list}
+
+    def update_channels(self, mis_data: dict):
+        """Update channels using dictionary lookup instead of nested loops."""
+        for channel_name, (description, unit) in mis_data.items():
+            channel = self.channel_map.get(channel_name)
+            if channel:
+                channel.update(description=description, unit=unit)
+
+
+@click.group()
+def mis_cmd():
+    pass
+
+
+@mis_cmd.command()
+@click.argument("mis_path", type=click.Path(exists=True))
+@click.option("--dataset-rid", type=str, required=True)
+@click.option("--profile", type=str, required=True)
+def process(mis_path: Path, dataset_rid: str, profile: str):
+    mis_data = process_mis_csv(mis_path)
+    channel_updater = Channel_Updater(dataset_rid, profile)
+    channel_updater.update_channels(mis_data)

--- a/nominal/cli/mis.py
+++ b/nominal/cli/mis.py
@@ -35,8 +35,6 @@ class Channel_Updater:
         self.client = NominalClient.from_profile(profile)
         self.dataset = self.client.get_dataset(dataset_rid)
         self.channel_list = self.dataset.get_channels()
-        # Create a mapping of channel names to channel objects for O(1) lookups
-        # dictionary comprehension
         self.channel_map = {channel.name: channel for channel in self.channel_list}
 
     def update_channels(self, mis_data: dict):


### PR DESCRIPTION
This add an addition to the CLI to parse an instrumentation spreadsheet to populate description and unit fields. The workflow is built around the following steps:
- The sheet has been exported to a CSV with 3 cols, param_id, param_description, UCUM_unit as headers, in that order left to right
- The dataset has existing channels that match with the sheet

The following work remains
- Validate against dataset


