### PR TITLE
feat: allow users to select the number of threads used by ffmpeg in normalize_video

### DIFF
--- a/nominal/experimental/video_processing/video_conversion.py
+++ b/nominal/experimental/video_processing/video_conversion.py
@@ -91,11 +91,12 @@ def normalize_video(
     if resolution is not None:
         output_kwargs["vf"] = scale_factor_from_resolution(resolution)
 
+    input_kwargs = {}
     if num_threads is not None:
-        output_kwargs["-threads:v"] = str(num_threads)
+        input_kwargs["threads"] = str(num_threads)
 
     # Run ffmpeg in subprocess
-    video_in = ffmpeg.input(str(input_path))
+    video_in = ffmpeg.input(str(input_path), **input_kwargs)
     video_out = video_in.output(str(output_path), **output_kwargs)
     logger.info(f"Running command: '{shlex.join(video_out.compile())}'")
     video_out.run()


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Several users complained that ffmpeg used 100% of their CPU during normalize_video, and requested a way to lower the amount utilized.

Before using a 1gb h265 file (83s):
<img width="1320" height="798" alt="image" src="https://github.com/user-attachments/assets/bec4d7b9-e044-4c65-b405-0534a3fd1bb9" />

After setting `num_threads=1` (503s):
<img width="1320" height="798" alt="image" src="https://github.com/user-attachments/assets/52fdc84d-5d1f-47a6-9e15-3957f3d7ecac" />
