### PR TITLE
chore: bump setup-just version

### DIFF
--- a/.github/workflows/build-check-test.yml
+++ b/.github/workflows/build-check-test.yml
@@ -27,7 +27,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
           python-version: ${{ matrix.python-version }}
       - name: Install just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@v3
       - name: Install dependencies
         run: |
           just install

--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -32,7 +32,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
           python-version: "3.12"
       - name: Install just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@v3
       - name: Install dependencies
         run: |
           just install


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

This step was periodically failing in CI/CD with an error that it cannot find the specified just version (which is weird, as we don't specify a version)... anyways, bumping to the latest version of the action to see if it makes things more stable.