### PR TITLE
feat: allow directly retrieving a given dataset file by id

### DIFF
--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -481,7 +481,9 @@ class Dataset(DataSource):
             raw_file = self._clients.catalog.get_dataset_file(self._clients.auth_header, self.rid, dataset_file_id)
             return DatasetFile._from_conjure(self._clients, raw_file)
         except Exception as ex:
-            raise FileNotFoundError(f"Failed to retrieve dataset file {dataset_file_id} from dataset {self.rid}: {ex}")
+            raise FileNotFoundError(
+                f"Failed to retrieve dataset file {dataset_file_id} from dataset {self.rid}"
+            ) from ex
 
     def get_log_stream(
         self,


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

I'm so tired of writing

```
dataset_file_id ="..."
dataset_rid="..."
dataset_file = nominal.DatasetFile._from_conjure(
    client._clients.auth_header, 
    client._clients.catalog.get_dataset_file(client._clients.auth_header, dataset_file_id, dataset_rid)
)
```

so i'm exposing this convenience accessor for when you don't want to have to iteratively fetch _all_ dataset files...
