### PR TITLE
feat: update nominal_url for checklists and datareviews

### DIFF
--- a/nominal/core/checklist.py
+++ b/nominal/core/checklist.py
@@ -147,6 +147,16 @@ class Checklist(HasRid):
             self._clients.auth_header, scout_checks_api.UnarchiveChecklistsRequest(rids=[self.rid])
         )
 
+    @property
+    def nominal_url(self) -> str:
+        """Returns a link to the page for this checklist in the Nominal app"""
+        return f"{self._clients.app_base_url}/checklists/{self.rid}"
+
+    def preview_for_run_url(self, run: Run | str) -> str:
+        """Returns a link to the page for previewing this checklist on a given run in the Nominal app"""
+        run_rid = rid_from_instance_or_string(run)
+        return f"{self.nominal_url}?previewRunRid={run_rid}"
+
 
 Priority = Literal[0, 1, 2, 3, 4]
 

--- a/nominal/core/data_review.py
+++ b/nominal/core/data_review.py
@@ -116,7 +116,7 @@ class DataReview(HasRid):
     def nominal_url(self) -> str:
         """Returns a link to the page for this Data Review in the Nominal app"""
         run = self._clients.run.get_run(self._clients.auth_header, self.run_rid)
-        return f"{self._clients.app_base_url}/runs/{run.run_number}/?tab=checklist-executions&openChecklistDetails={self.rid}&openCheckExecutionErrorReview=&checklistExecution={self.rid}"  # noqa: E501
+        return f"{self._clients.app_base_url}/runs/{run.run_number}/?tab=checklist-executions&checklist_execution={self.rid}&openCheckExecutionErrorReview="  # noqa: E501
 
 
 @dataclass(frozen=True)

--- a/uv.lock
+++ b/uv.lock
@@ -1512,7 +1512,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.74.0"
+version = "1.76.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

* There is a simpler URL to use for data reviews-- as shown in this pr
* Add nominal_url to Checklist
* Add `preview_for_run_url` to see a checklist preview for a given run