### PR TITLE
fix: disable typechecking from pylance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,3 +173,6 @@ addopts = "--cov=nominal --cov-branch --cov-report=html --cov-report=term"
 
 [tool.coverage.run]
 omit = ["tests/*", "*__init__*", "nominal/__main__.py"]
+
+[tool.pyright]
+typeCheckingMode = "off"


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Within VSCode, it's useful to have `pylance` running-- it enables cmd + click to navigate, etc.. 
HOWEVER, within this repo, we use `ruff` for all of our linting and formatting needs.

One problem that has recently started occurring with modern versions of our api package, extensions, etc., is that `pylance` now reports all usages of `@builtins.property` and `@builtins.classmethod` incorrectly, giving red squigglies any time we use any conjure properties. This has been observed on mac and windows. This is because the complexity of the file breaches some hardcoded maximum in pyright/pylance.

To fix this, we can simply turn off pylance typechecking-- again, covered by mypy and ruff already.

In addition, here are my relevant VSCode settings:

```json
{
    "editor.defaultFormatter": "charliermarsh.ruff",
    "isort.check": true,
    "notebook.defaultFormatter": "charliermarsh.ruff",
    "python.analysis.inlayHints.callArgumentNames": "partial",
    "python.analysis.inlayHints.functionReturnTypes": true,
    "python.analysis.regenerateStdLibIndices": true,
    "python.languageServer": "Default",
    "python.missingPackage.severity": "Error",
    "python.REPL.enableREPLSmartSend": false,
    "python.REPL.provideVariables": false,
    "pythonIndent.trimLinesWithOnlyWhitespace": true,
    "ruff.lint.enable": true,
    "ruff.lint.preview": false
}
```

Now, the type is still incorrect when I hover it with pylance, but it doesn't give me a red sqiggly:

**before**
<img width="1412" height="299" alt="image" src="https://github.com/user-attachments/assets/a7c59d50-a0e0-4b2b-ac26-46de8d04647c" />

**after**
<img width="932" height="299" alt="image" src="https://github.com/user-attachments/assets/0402f101-f707-47ba-914d-bcce2789c7f6" />

This should be a safe change, because:
* this affects any pylance/pyright version released in the last 6 months (based on which version of extension is installed)
* we don't actually use / want pylance / pyright to do our type checking-- mypy works great within the IDE and CLI.
