### PR TITLE
fix: broken links to python quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ pip install nominal
 
 ### Usage
 
-Please refer to usage examples in the [documentation](https://docs.nominal.io/python/quickstart).
+Please refer to usage examples in the [documentation](https://docs.nominal.io/core/sdk/python-client/quickstart).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -34,7 +34,7 @@ nav:
         - Video Processing: reference/experimental/video_processing.md
   - Development:
       - Contributing: contributing.md
-  - Documentation: https://docs.nominal.io/python/quickstart
+  - Documentation: https://docs.nominal.io/core/sdk/python-client/quickstart
   - Nominal: https://nominal.io
 
 theme:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,6 +9,6 @@ The main components of the SDK are:
 
 Use the navigation bar above to see examples and reference documentation.
 
-If you are new to Nominal and the Python client, we recommend that you read our [Quickstart guide](https://docs.nominal.io/python/quickstart).
+If you are new to Nominal and the Python client, we recommend that you read our [Quickstart guide](https://docs.nominal.io/core/sdk/python-client/quickstart).
 
 Thereafter, navigate to the [API reference manual](./reference/toplevel.md).

--- a/docs/src/reference/toplevel.md
+++ b/docs/src/reference/toplevel.md
@@ -1,4 +1,4 @@
-Also see the [Python Quickstart guide](https://docs.nominal.io/python/quickstart).
+Also see the [Python Quickstart guide](https://docs.nominal.io/core/sdk/python-client/quickstart). 
 
 [`nominal.core`](./core.md) — platform client<br/>
 [`nominal.ts`](./ts.md) — timestamp utilities<br/>


### PR DESCRIPTION
This PR fixes old links to the python quickstart section of our documentation. 

Old link [broken]: https://docs.nominal.io/python/quickstart
New link [current]: https://docs.nominal.io/core/sdk/python-client/quickstart