### PR TITLE
feat: allow using truststore for ssl bypass

### DIFF
--- a/nominal/core/_utils/networking.py
+++ b/nominal/core/_utils/networking.py
@@ -1,20 +1,69 @@
 from __future__ import annotations
 
 import gzip
+import logging
 import os
+import ssl
 from typing import Any, Callable, Mapping, Type, TypeVar
 
 import requests
+import truststore
 from conjure_python_client import ServiceConfiguration
-from conjure_python_client._http.requests_client import RetryWithJitter, TransportAdapter
-from requests.adapters import CaseInsensitiveDict
+from conjure_python_client._http.requests_client import KEEP_ALIVE_SOCKET_OPTIONS, RetryWithJitter
+from requests.adapters import DEFAULT_POOLSIZE, CaseInsensitiveDict, HTTPAdapter
+from urllib3.connection import HTTPConnection
+from urllib3.util.retry import Retry
+
+logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
 GZIP_COMPRESSION_LEVEL = 1
 
 
-class GzipRequestsAdapter(TransportAdapter):
+class SslBypassRequestsAdapter(HTTPAdapter):
+    """Transport adapter that allows customizing SSL options and forwarding host truststore.
+
+    NOTE: based on a combination of injecting `truststore.SSLContext` into
+        `conjure_python_client._http.requests_client.TransportAdapter`.
+    """
+
+    ENABLE_KEEP_ALIVE_ATTR = "_enable_keep_alive"
+    __attrs__ = [*HTTPAdapter.__attrs__, ENABLE_KEEP_ALIVE_ATTR]
+
+    def __init__(self, *args: Any, enable_keep_alive: bool = False, **kwargs: Any):
+        self._enable_keep_alive = enable_keep_alive
+        super().__init__(*args, **kwargs)
+
+    def init_poolmanager(
+        self,
+        connections: int,
+        maxsize: int,
+        block: bool = False,
+        **pool_kwargs: Mapping[str, Any],
+    ) -> None:
+        """Wrapper around the standard init_poolmanager from HTTPAdapter with modifications
+        to support keep-alive settings and injecting SSL context.
+        """
+        if self._enable_keep_alive:
+            keep_alive_kwargs: dict[str, Any] = {
+                "socket_options": [
+                    *HTTPConnection.default_socket_options,
+                    *KEEP_ALIVE_SOCKET_OPTIONS,
+                ]
+            }
+            pool_kwargs = {**pool_kwargs, **keep_alive_kwargs}
+
+        pool_kwargs["ssl_context"] = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+        super().init_poolmanager(connections, maxsize, block, **pool_kwargs)  # type: ignore[no-untyped-call]
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        state[self.ENABLE_KEEP_ALIVE_ATTR] = state.get(self.ENABLE_KEEP_ALIVE_ATTR, False)
+        super().__setstate__(state)  # type: ignore[misc]
+
+
+class NominalRequestsAdapter(SslBypassRequestsAdapter):
     """Adapter used with `requests` library for sending gzip-compressed data.
 
     Based on: https://github.com/psf/requests/issues/1753#issuecomment-417806737
@@ -69,7 +118,7 @@ class GzipRequestsAdapter(TransportAdapter):
         return super().send(request, stream=stream, timeout=timeout, verify=verify, cert=cert, proxies=proxies)
 
 
-def create_gzip_service_client(
+def create_conjure_service_client(
     service_class: Type[T],
     user_agent: str,
     service_config: ServiceConfiguration,
@@ -104,7 +153,7 @@ def create_gzip_service_client(
         status_forcelist=[308, 429, 503],
         backoff_factor=float(service_config.backoff_slot_size) / 1000,
     )
-    transport_adapter = GzipRequestsAdapter(max_retries=retry)
+    transport_adapter = NominalRequestsAdapter(max_retries=retry)
     # create a session, for shared connection polling, user agent, etc
     session = requests.Session()
     session.headers = CaseInsensitiveDict({"User-Agent": user_agent})
@@ -131,11 +180,11 @@ def create_conjure_client_factory(
 ) -> Callable[[Type[T]], T]:
     """Create factory method for creating conjure clients given the respective conjure service type
 
-    See `create_gzip_service_client` for documentation on parameters.
+    See `create_conjure_service_client` for documentation on parameters.
     """
 
     def factory(service_class: Type[T]) -> T:
-        return create_gzip_service_client(
+        return create_conjure_service_client(
             service_class,
             user_agent=user_agent,
             service_config=service_config,
@@ -143,3 +192,19 @@ def create_conjure_client_factory(
         )
 
     return factory
+
+
+def create_multipart_request_session(
+    *,
+    pool_size: int = DEFAULT_POOLSIZE,
+    num_retries: int = 5,
+) -> requests.Session:
+    retries = Retry(
+        total=num_retries,
+        backoff_factor=0.5,
+        status_forcelist=(429, 500, 502, 503, 504),
+    )
+    session = requests.Session()
+    adapter = SslBypassRequestsAdapter(max_retries=retries, pool_maxsize=pool_size)
+    session.mount("https://", adapter)
+    return session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "nominal-streaming==0.5.8",
     "rich>=14.1.0",
     "tabulate>=0.9.0,<0.10",
+    "truststore>=0.10.4",
     "types-cachetools>=6.0.0.20250525",
     "typing-extensions>=4,<5",
     # Any version is okay for these dependencies

--- a/uv.lock
+++ b/uv.lock
@@ -1011,6 +1011,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "tabulate" },
+    { name = "truststore" },
     { name = "types-cachetools" },
     { name = "typing-extensions" },
 ]
@@ -1064,6 +1065,7 @@ requires-dist = [
     { name = "requests", specifier = ">=0.0.0" },
     { name = "rich", specifier = ">=14.1.0" },
     { name = "tabulate", specifier = ">=0.9.0,<0.10" },
+    { name = "truststore", specifier = ">=0.10.4" },
     { name = "types-cachetools", specifier = ">=6.0.0.20250525" },
     { name = "typing-extensions", specifier = ">=4,<5" },
 ]
@@ -1950,6 +1952,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

I had chatgpt describe the context & solution proposed by this PR

# Why Python Does Not Use the Operating System Trust Store by Default

This document explains:
- what the original problem was,
- why Python behaves this way by default (with historical context),
- how the `truststore` library works, and
- why using `truststore.SSLContext` is the correct solution in a corporate network.

---

## What the Problem Was

Our corporate network sits in the middle of secure (TLS/HTTPS) connections in order to inspect and secure traffic.  
As a result, applications are not talking directly to external services; they are talking through a company-managed security system.

The operating system is configured to trust this system via installed root certificates.  
Most software—browsers in particular—automatically uses the operating system’s trust store and therefore works without issue.

Python, by default, does not.

When a Python program attempts to make a secure connection, it evaluates the connection using its own list of trusted certificate authorities. Since the corporate root certificate is not included in that list, Python rejects the connection as untrusted.

Nothing is actually wrong with the network or the service—Python is simply unaware of the organization’s trust decisions.

---

## Historical Context: Why Python Works This Way

Python’s TLS behavior is the result of early design decisions made when:

- Operating systems did not expose stable, portable APIs for accessing trusted certificates
- Certificate storage locations varied widely across Linux distributions
- Windows and macOS certificate APIs were complex, inconsistent, or poorly documented
- Python prioritized portability and deterministic behavior across platforms

To avoid platform-specific complexity, Python chose to ship and rely on its own certificate authority (CA) bundle rather than depend on the operating system.

This approach provided:
- consistent behavior across machines,
- reproducible results in different environments, and
- fewer platform-specific bugs.

At the time, this was a conservative and reasonable security decision.

---

## Why Browsers Behave Differently

Web browsers evolved under different constraints:

- They are deeply integrated with the operating system
- They explicitly support enterprise security policies
- They synchronize with system trust stores by design

As corporate TLS interception became widespread, browsers adapted.  
Python, as a general-purpose runtime rather than a managed client application, did not.

This difference explains why browsers typically work seamlessly behind corporate firewalls while Python applications often require additional configuration.

---

## The Modern Mismatch

In modern corporate environments:

- TLS interception is intentional and sanctioned
- Custom root certificates are installed at the OS level
- Trust policy is centrally managed

Python, however:
- continues to rely on a bundled CA list (often via `certifi`),
- ignores OS-installed enterprise certificates by default, and
- has no built-in awareness of corporate trust policy.

From Python’s perspective, intercepted connections genuinely appear unsafe.  
This is not a bug—it is a legacy design assumption colliding with modern infrastructure.

---

## How `truststore.SSLContext` Works

The `truststore` library provides an explicit, opt-in mechanism for Python to use the operating system’s trust store.

Instead of globally modifying Python’s SSL behavior, `truststore.SSLContext` creates an SSL context that:

- On Windows, consults the Windows Certificate Store
- On macOS, consults the system Keychain
- On Linux, consults the system trust store (e.g. `/etc/ssl/certs`)

Only connections that explicitly use this context inherit the operating system’s trust decisions.

This makes the trust relationship:
- explicit,
- scoped, and
- easy to reason about.

Example usage:

```python
import truststore
import ssl

ssl_context = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
```