### PR TITLE
feat: allow default_args in nominal log handler

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1512,7 +1512,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.79.0"
+version = "1.80.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

This allows me to specify args that should be present on all log messages streamed, such as the current hostname, or current user, etc.