### PR TITLE
fix(cli): add `nominal` entrypoint to deconflict with `nix-output-monitor`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ tdms = ["nptdms>=1.9.0,<2"]
 
 [project.scripts]
 nom = 'nominal.cli:nom'
+nominal = 'nominal.cli:nom'
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

This change allows me to directly call the module with `nominal` instead of `python -m nominal` because I use `nix-output-monitor` which has a higher priority on the `nom` CLI keyword.