### PR TITLE
fix: incorrect warning in datasource to dataframe when specifying channels

### DIFF
--- a/nominal/thirdparty/pandas/_pandas.py
+++ b/nominal/thirdparty/pandas/_pandas.py
@@ -254,8 +254,8 @@ def _get_renamed_timestamp_column(channels: list[Channel]) -> str:
 
 def datasource_to_dataframe(
     datasource: DataSource,
-    channel_exact_match: Sequence[str] = (),
-    channel_fuzzy_search_text: str = "",
+    channel_exact_match: Sequence[str] | None = None,
+    channel_fuzzy_search_text: str | None = None,
     start: str | datetime | ts.IntegralNanosecondsUTC | None = None,
     end: str | datetime | ts.IntegralNanosecondsUTC | None = None,
     tags: Mapping[str, str] | None = None,
@@ -319,8 +319,8 @@ def datasource_to_dataframe(
     if channels is None:
         channels = list(
             datasource.search_channels(
-                exact_match=channel_exact_match,
-                fuzzy_search_text=channel_fuzzy_search_text,
+                exact_match=channel_exact_match or (),
+                fuzzy_search_text=channel_fuzzy_search_text or "",
             )
         )
     elif channel_exact_match is not None or channel_fuzzy_search_text is not None:


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

We changed the defaults at some point to not be `None`, but all of the logic in the function for logging a warning was predicated on the defaults being `None`. This makes the appropriate change to silent the warning when not needed.