### PR TITLE
feat: massively expand functionality on assets and runs

### DIFF
--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -404,7 +404,15 @@ class Asset(HasRid, RefreshableMixin[scout_asset_api.Asset]):
             yield Attachment._from_conjure(self._clients, a)
 
     def list_attachments(self) -> Sequence[Attachment]:
-        return list(self._iter_list_attachments())
+    def list_runs(self) -> Sequence[Run]:
+        return [
+            Run._from_conjure(self._clients, run)
+            for run in search_runs_by_asset_paginated(
+                self._clients.run,
+                self._clients.auth_header,
+                self.rid,
+            )
+        ]
 
     def remove_attachments(self, attachments: Iterable[Attachment] | Iterable[str]) -> None:
         """Remove attachments from this asset.

--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -16,17 +16,30 @@ from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils.api_tools import HasRid, Link, RefreshableMixin, create_links, rid_from_instance_or_string
 from nominal.core.attachment import Attachment, _iter_get_attachments
 from nominal.core.connection import Connection, _get_connections
-from nominal.core.dataset import Dataset, _create_dataset, _get_datasets
+from nominal.core.dataset import Dataset, _create_dataset, _DatasetWrapper, _get_dataset, _get_datasets
 from nominal.core.datasource import DataSource
 from nominal.core.event import Event, EventType, _create_event
 from nominal.core.video import Video, _create_video, _get_video
 from nominal.ts import IntegralNanosecondsDuration, IntegralNanosecondsUTC, _SecondsNanos
 
 ScopeType: TypeAlias = Connection | Dataset | Video
+ScopeTypeSpecifier: TypeAlias = Literal["connection", "dataset", "video"]
+def _filter_scopes(
+    scopes: Sequence[scout_asset_api.DataScope], scope_type: ScopeTypeSpecifier
+) -> Sequence[scout_asset_api.DataScope]:
+    return [scope for scope in scopes if scope.data_source.type.lower() == scope_type]
+
+
+def _filter_scope_rids(
+    scopes: Sequence[scout_asset_api.DataScope], scope_type: ScopeTypeSpecifier
+) -> Mapping[str, str]:
+    return {
+        scope.data_scope_name: getattr(scope.data_source, scope_type) for scope in _filter_scopes(scopes, scope_type)
+    }
 
 
 @dataclass(frozen=True)
-class Asset(HasRid, RefreshableMixin[scout_asset_api.Asset]):
+class Asset(_DatasetWrapper, HasRid, RefreshableMixin[scout_asset_api.Asset]):
     rid: str
     name: str
     description: str | None
@@ -102,12 +115,21 @@ class Asset(HasRid, RefreshableMixin[scout_asset_api.Asset]):
             logger.warning("Not promoting asset %s-- already promoted!", self.rid)
 
         return self
+    def _get_dataset_scope(self, data_scope_name: str) -> tuple[Dataset, Mapping[str, str]]:
         asset = self._get_latest_api()
-        return {
-            scope.data_scope_name: cast(str, getattr(scope.data_source, stype))
-            for scope in asset.data_scopes
-            if scope.data_source.type.lower() == stype
-        }
+        ds_scopes = {scope.data_scope_name: scope for scope in _filter_scopes(asset.data_scopes, "dataset")}
+
+        data_scope = ds_scopes.get(data_scope_name)
+        if data_scope is None:
+            raise ValueError(f"No such data scope found on asset {self.rid} with data_scope_name {data_scope_name}")
+        elif data_scope.data_source.dataset is None:
+            raise ValueError(f"Datascope {data_scope_name} on asset {self.rid} is not a dataset!")
+
+        dataset = Dataset._from_conjure(
+            self._clients,
+            _get_dataset(self._clients.auth_header, self._clients.catalog, data_scope.data_source.dataset),
+        )
+        return dataset, data_scope.series_tags
 
     def get_data_scope(self, data_scope_name: str) -> ScopeType:
         """Retrieve a datascope by data scope name, or raise ValueError if one is not found."""

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -651,6 +651,10 @@ class NominalClient:
             )
         )
 
+    @deprecated(
+        "NominalClient.search_runs_by_asset is deprecated and will be removed in a future version. "
+        "Use Asset.list_runs() instead."
+    )
     def search_runs_by_asset(self, asset: Asset | str) -> Sequence[Run]:
         """Search for all runs associated with a given asset:
 

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -107,7 +107,6 @@ from nominal.core.workspace import Workspace
 from nominal.ts import (
     IntegralNanosecondsDuration,
     IntegralNanosecondsUTC,
-    _SecondsNanos,
     _to_typed_timestamp_type,
 )
 

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -93,7 +93,7 @@ from nominal.core.dataset import (
     _get_datasets,
 )
 from nominal.core.datasource import DataSource
-from nominal.core.event import Event, EventType
+from nominal.core.event import Event, EventType, _create_event
 from nominal.core.exceptions import NominalConfigError, NominalError, NominalIngestError, NominalMethodRemovedError
 from nominal.core.filetype import FileType, FileTypes
 from nominal.core.run import Run, _create_run
@@ -108,7 +108,6 @@ from nominal.ts import (
     IntegralNanosecondsDuration,
     IntegralNanosecondsUTC,
     _SecondsNanos,
-    _to_api_duration,
     _to_typed_timestamp_type,
 )
 
@@ -1198,19 +1197,17 @@ class NominalClient:
         properties: Mapping[str, str] | None = None,
         labels: Iterable[str] = (),
     ) -> Event:
-        request = event.CreateEvent(
+        return _create_event(
+            clients=self._clients,
             name=name,
+            type=type,
+            start=start,
+            duration=duration,
             description=description,
-            asset_rids=[rid_from_instance_or_string(asset) for asset in assets],
-            timestamp=_SecondsNanos.from_flexible(start).to_api(),
-            duration=_to_api_duration(duration),
-            origins=[],
-            properties=dict(properties) if properties else {},
-            labels=list(labels),
-            type=type._to_api_event_type(),
+            assets=assets,
+            properties=properties,
+            labels=labels,
         )
-        response = self._clients.event.create_event(self._clients.auth_header, request)
-        return Event._from_conjure(self._clients, response)
 
     def get_event(self, rid: str) -> Event:
         events = self.get_events([rid])

--- a/nominal/core/event.py
+++ b/nominal/core/event.py
@@ -9,9 +9,9 @@ from typing import Iterable, Mapping, Protocol, Sequence
 from nominal_api import event
 from typing_extensions import Self
 
+import nominal.core.asset as core_asset
 from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils.api_tools import HasRid, RefreshableMixin, rid_from_instance_or_string
-from nominal.core.asset import Asset
 from nominal.ts import IntegralNanosecondsDuration, IntegralNanosecondsUTC, _SecondsNanos, _to_api_duration
 
 
@@ -50,7 +50,7 @@ class Event(HasRid, RefreshableMixin[event.Event]):
         *,
         name: str | None = None,
         description: str | None = None,
-        assets: Iterable[Asset | str] | None = None,
+        assets: Iterable[core_asset.Asset | str] | None = None,
         start: datetime | IntegralNanosecondsUTC | None = None,
         duration: timedelta | IntegralNanosecondsDuration | None = None,
         properties: Mapping[str, str] | None = None,
@@ -154,3 +154,30 @@ class EventType(Enum):
             return event.EventType.SUCCESS
         else:
             return event.EventType.UNKNOWN
+
+
+def _create_event(
+    clients: Event._Clients,
+    *,
+    name: str,
+    type: EventType,
+    start: datetime | IntegralNanosecondsUTC,
+    duration: timedelta | IntegralNanosecondsDuration,
+    description: str | None,
+    assets: Iterable[core_asset.Asset | str],
+    properties: Mapping[str, str] | None,
+    labels: Iterable[str],
+) -> Event:
+    request = event.CreateEvent(
+        name=name,
+        description=description,
+        asset_rids=[rid_from_instance_or_string(asset) for asset in assets],
+        timestamp=_SecondsNanos.from_flexible(start).to_api(),
+        duration=_to_api_duration(duration),
+        origins=[],
+        properties=dict(properties or {}),
+        labels=list(labels),
+        type=type._to_api_event_type(),
+    )
+    response = clients.event.create_event(clients.auth_header, request)
+    return Event._from_conjure(clients, response)

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -351,3 +351,34 @@ class Run(HasRid, RefreshableMixin[scout_run_api.Run]):
             created_at=_SecondsNanos.from_flexible(run.created_at).to_nanoseconds(),
             _clients=clients,
         )
+
+
+def _create_run(
+    clients: Run._Clients,
+    *,
+    name: str,
+    start: datetime | IntegralNanosecondsUTC,
+    end: datetime | IntegralNanosecondsUTC | None,
+    description: str | None,
+    properties: Mapping[str, str] | None,
+    labels: Sequence[str],
+    links: Sequence[str | Link | LinkDict],
+    attachments: Iterable[Attachment] | Iterable[str],
+    asset_rids: Sequence[str],
+) -> Run:
+    """Create a run."""
+    request = scout_run_api.CreateRunRequest(
+        attachments=[rid_from_instance_or_string(a) for a in attachments],
+        data_sources={},
+        description=description or "",
+        labels=list(labels),
+        links=create_links(links),
+        properties={} if properties is None else dict(properties),
+        start_time=_SecondsNanos.from_flexible(start).to_scout_run_api(),
+        title=name,
+        end_time=None if end is None else _SecondsNanos.from_flexible(end).to_scout_run_api(),
+        assets=list(asset_rids),
+        workspace=clients.workspace_rid,
+    )
+    response = clients.run.create_run(clients.auth_header, request)
+    return Run._from_conjure(clients, response)

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -24,6 +24,7 @@ from nominal.core.asset import Asset
 from nominal.core.attachment import Attachment, _iter_get_attachments
 from nominal.core.connection import Connection, _get_connections
 from nominal.core.dataset import Dataset, _get_datasets
+from nominal.core.event import Event, EventType, _create_event
 from nominal.core.video import Video, _get_video
 from nominal.ts import IntegralNanosecondsDuration, IntegralNanosecondsUTC, _SecondsNanos, _to_api_duration
 
@@ -46,6 +47,7 @@ class Run(HasRid, RefreshableMixin[scout_run_api.Run]):
 
     class _Clients(
         Asset._Clients,
+        Event._Clients,
         HasScoutParams,
         Protocol,
     ):
@@ -149,6 +151,29 @@ class Run(HasRid, RefreshableMixin[scout_run_api.Run]):
             self.rid,
         )
         self._refresh_from_api(updated_run)
+
+    def create_event(
+        self,
+        name: str,
+        type: EventType,
+        start: datetime | IntegralNanosecondsUTC,
+        duration: timedelta | IntegralNanosecondsDuration = 0,
+        *,
+        description: str | None = None,
+        properties: Mapping[str, str] | None = None,
+        labels: Iterable[str] = (),
+    ) -> Event:
+        return _create_event(
+            self._clients,
+            name=name,
+            type=type,
+            start=start,
+            duration=duration,
+            description=description,
+            assets=self.assets,
+            properties=properties,
+            labels=labels,
+        )
 
     def add_dataset(
         self,

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -20,17 +20,17 @@ from nominal.core._utils.api_tools import (
     create_links,
     rid_from_instance_or_string,
 )
-from nominal.core.asset import Asset
+from nominal.core.asset import Asset, ScopeTypeSpecifier, _filter_scope_rids, _filter_scopes
 from nominal.core.attachment import Attachment, _iter_get_attachments
 from nominal.core.connection import Connection, _get_connections
-from nominal.core.dataset import Dataset, _get_datasets
+from nominal.core.dataset import Dataset, _create_dataset, _DatasetWrapper, _get_dataset, _get_datasets
 from nominal.core.event import Event, EventType, _create_event
 from nominal.core.video import Video, _get_video
 from nominal.ts import IntegralNanosecondsDuration, IntegralNanosecondsUTC, _SecondsNanos, _to_api_duration
 
 
 @dataclass(frozen=True)
-class Run(HasRid, RefreshableMixin[scout_run_api.Run]):
+class Run(HasRid, RefreshableMixin[scout_run_api.Run], _DatasetWrapper):
     rid: str
     name: str
     description: str
@@ -51,8 +51,7 @@ class Run(HasRid, RefreshableMixin[scout_run_api.Run]):
         HasScoutParams,
         Protocol,
     ):
-        @property
-        def run(self) -> scout.RunService: ...
+        pass
 
     @property
     def nominal_url(self) -> str:
@@ -100,21 +99,25 @@ class Run(HasRid, RefreshableMixin[scout_run_api.Run]):
         updated_run = self._clients.run.update_run(self._clients.auth_header, request, self.rid)
         return self._refresh_from_api(updated_run)
 
-    def _list_datasource_rids(
-        self, datasource_type: str | None = None, property_name: str | None = None
-    ) -> Mapping[str, str]:
-        enriched_run = self._get_latest_api()
-        datasource_rids_by_ref_name = {}
-        for ref_name, source in enriched_run.data_sources.items():
-            if datasource_type is not None and source.data_source.type != datasource_type:
-                continue
 
-            rid = cast(
-                str, getattr(source.data_source, source.data_source.type if property_name is None else property_name)
-            )
-            datasource_rids_by_ref_name[ref_name] = rid
+    def _get_dataset_scope(self, data_scope_name: str) -> tuple[Dataset, Mapping[str, str]]:
+        if len(self.assets) > 1:
+            raise RuntimeError("Can't retrieve dataset scopes on multi-asset runs")
 
-        return datasource_rids_by_ref_name
+        run = self._get_latest_api()
+        ds_scopes = {scope.data_scope_name: scope for scope in _filter_scopes(run.asset_data_scopes, "dataset")}
+
+        data_scope = ds_scopes.get(data_scope_name)
+        if data_scope is None:
+            raise ValueError(f"No such data scope found on asset {self.rid} with data_scope_name {data_scope_name}")
+        elif data_scope.data_source.dataset is None:
+            raise ValueError(f"Datascope {data_scope_name} on asset {self.rid} is not a dataset!")
+
+        dataset = Dataset._from_conjure(
+            self._clients,
+            _get_dataset(self._clients.auth_header, self._clients.catalog, data_scope.data_source.dataset),
+        )
+        return dataset, data_scope.series_tags
 
     def remove_data_sources(
         self,

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.97.0"
+version = "1.98.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

# Overview

Make assets and runs way more powerful. Instead of needing to handle runs and asset objects, or even think about dataset objects, now users can work with mostly just assets. A typical ingestion flow would now look like:

```
asset = client.get_or_create_asset_by_properties(...)
asset.get_or_create_dataset("data_scope", ...)

dataset_file = asset.add_tabular_data("data_scope", "path/to.csv", ...)
dataset_file.poll_until_ingestion_completed()

run = asset.create_run("run name", start=dataset_file.start, end=dataset_file.end)
run.create_workbook(client.get_workbook_template("rid..."))
```

A future change I want to make is to allow users to pass a `Run` into `add_tabular_data` so that `ingest` will update the run bounds upon ingestion completion. I also want to allow users to `poll_until_ingestion_completed()` on both an `Asset` and `Run`-- also left as future work. 

Another future change I would like to make is exposing a `as_completed()` variant for dataset files, and to also make it easier to retrieve dataset files for runs, assets (e.g. `get_dataset_files("data_scope_name", start_time=..., end_time=...)`). 

## Deprecations

*  `NominalClient.search_runs_by_asset` => `Asset.search_runs`

## Addditions to NominalClient

* Can now create a run with exactly one of {no asset, 1 asset, or many assets}. New keyword argument `assets` should be preferred over `asset`, with the former potentially deserving deprecation.

## Additions to Asset

* `add_data` utilities that take in datascope name & parameters that would normally be passed to their equivalents in the Dataset class:
  * `add_tabular_data`
  * `add_journal_json`
  * `add_mcap`
  * `add_ardupilot_dataflash`
  * `add_containerized`
  * `add_from_io`
* `promote`: promote an implicitly created asset from a run into a full on asset
* `create_run`
* `create_event`
* `create_workbook`
* `list_runs`

## Additions to Run

* `add_data` utilities that take in datascope name & parameters that would normally be passed to their equivalents in the Dataset class:
  * `add_tabular_data`
  * `add_journal_json`
  * `add_mcap`
  * `add_ardupilot_dataflash`
  * `add_containerized`
  * `add_from_io`
* `get_or_create_dataset`
* `get_or_create_video`
* `create_event`: targets all assets present on a run
* `create_workbook`
* `get_dataset`
* `get_video`
* `get_connection`
* `unarchive`