### PR TITLE
feat: support multifile containerized in python client

### DIFF
--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -412,28 +412,6 @@ class Dataset(DataSource, RefreshableMixin[scout_catalog.EnrichedDataset]):
     # Backward compatibility
     add_ardupilot_dataflash_to_dataset = add_ardupilot_dataflash
 
-    @overload
-    def add_containerized(
-        self,
-        extractor: str | ContainerizedExtractor,
-        sources: Mapping[str, PathLike],
-        tag: str | None = None,
-        *,
-        arguments: Mapping[str, str] | None = None,
-        tags: Mapping[str, str] | None = None,
-    ) -> DatasetFile: ...
-    @overload
-    def add_containerized(
-        self,
-        extractor: str | ContainerizedExtractor,
-        sources: Mapping[str, PathLike],
-        tag: str | None = None,
-        *,
-        arguments: Mapping[str, str] | None = None,
-        tags: Mapping[str, str] | None = None,
-        timestamp_column: str,
-        timestamp_type: _AnyTimestampType,
-    ) -> DatasetFile: ...
     def _ingest_containerized(
         self,
         extractor: str | ContainerizedExtractor,
@@ -505,6 +483,28 @@ class Dataset(DataSource, RefreshableMixin[scout_catalog.EnrichedDataset]):
             ),
         )
 
+    @overload
+    def add_containerized(
+        self,
+        extractor: str | ContainerizedExtractor,
+        sources: Mapping[str, PathLike],
+        tag: str | None = None,
+        *,
+        arguments: Mapping[str, str] | None = None,
+        tags: Mapping[str, str] | None = None,
+    ) -> DatasetFile: ...
+    @overload
+    def add_containerized(
+        self,
+        extractor: str | ContainerizedExtractor,
+        sources: Mapping[str, PathLike],
+        tag: str | None = None,
+        *,
+        arguments: Mapping[str, str] | None = None,
+        tags: Mapping[str, str] | None = None,
+        timestamp_column: str,
+        timestamp_type: _AnyTimestampType,
+    ) -> DatasetFile: ...
     def add_containerized(
         self,
         extractor: str | ContainerizedExtractor,

--- a/uv.lock
+++ b/uv.lock
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.104.1"
+version = "1.104.2"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
currently the add_conttainerized method needs to return a `DatasetFile`. This is not possible in the multi-file ingest world we need to make methods that return the IngestJobRid instead