### PR TITLE
fix: suppress nested exception traceback for Conjure exceptions

### DIFF
--- a/nominal/cli/util/verify_connection.py
+++ b/nominal/cli/util/verify_connection.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import click
-from conjure_python_client import ConjureHTTPError
 
 from nominal.core.client import NominalClient
+from nominal.core.exceptions import NominalAPIError
 
 
 def validate_token_url(token: str, base_url: str, workspace_rid: str | None) -> None:
@@ -17,8 +17,8 @@ def validate_token_url(token: str, base_url: str, workspace_rid: str | None) -> 
     # current user using the api key
     try:
         client.get_user()
-    except ConjureHTTPError as err:
-        status_code = err.response.status_code
+    except NominalAPIError as err:
+        status_code = err.status_code
         if status_code == 401:
             err_msg = f"The authorization token may be invalid. Read the docs on how to get a new token: {docs_link}"
         elif status_code == 404:
@@ -40,8 +40,8 @@ def validate_token_url(token: str, base_url: str, workspace_rid: str | None) -> 
         client.get_workspace(workspace_rid)
     except RuntimeError:
         err_msg = "Workspace not provided, but there is no default workspace for the user."
-    except ConjureHTTPError as err:
-        status_code = err.response.status_code
+    except NominalAPIError as err:
+        status_code = err.status_code
         if status_code == 404:
             err_msg = "The base_url may be incorrect. Ensure the url subdomain begins with 'api' (not 'app')."
         elif status_code != 200:

--- a/nominal/core/_utils/networking.py
+++ b/nominal/core/_utils/networking.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import gzip
 import logging
 import os
@@ -10,15 +11,17 @@ from typing import Any, Callable, Mapping, Type, TypeVar
 import requests
 import truststore
 import typing_extensions
-from conjure_python_client import ServiceConfiguration
+from conjure_python_client import ConjureHTTPError, Service, ServiceConfiguration
 from conjure_python_client._http.requests_client import KEEP_ALIVE_SOCKET_OPTIONS, RetryWithJitter
 from requests.adapters import DEFAULT_POOLSIZE, CaseInsensitiveDict, HTTPAdapter
 from urllib3.connection import HTTPConnection
 from urllib3.util.retry import Retry
 
+from nominal.core.exceptions import NominalAPIError
+
 logger = logging.getLogger(__name__)
 
-T = TypeVar("T")
+T = TypeVar("T", bound=Service)
 
 GZIP_COMPRESSION_LEVEL = 1
 
@@ -186,14 +189,28 @@ def create_conjure_service_client(
         verify = None
     for uri in service_config.uris:
         session.mount(uri, transport_adapter)
-    return service_class(  # type: ignore
+    service = service_class(
         session,
         service_config.uris,
         service_config.connect_timeout,
         service_config.read_timeout,
-        verify,
+        verify,  # type: ignore[arg-type]
         return_none_for_unknown_union_types,
     )
+
+    # Wrap _request to convert ConjureHTTPError -> NominalAPIError
+    # This avoids propagating nested exceptions to the caller
+    original_request = service._request
+
+    @functools.wraps(original_request)
+    def wrapped_request(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return original_request(*args, **kwargs)
+        except ConjureHTTPError as e:
+            raise NominalAPIError._from_conjure_error(e) from None
+
+    service._request = wrapped_request  # type: ignore[method-assign]
+    return service
 
 
 def create_conjure_client_factory(

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -89,7 +89,7 @@ from nominal.core.dataset import (
 from nominal.core.dataset_file import DatasetFile
 from nominal.core.datasource import DataSource
 from nominal.core.event import Event, _create_event, _search_events
-from nominal.core.exceptions import NominalConfigError, NominalError, NominalMethodRemovedError
+from nominal.core.exceptions import NominalAPIError, NominalConfigError, NominalError, NominalMethodRemovedError
 from nominal.core.filetype import FileType, FileTypes
 from nominal.core.run import Run, _create_run
 from nominal.core.secret import Secret
@@ -976,7 +976,7 @@ class NominalClient:
         try:
             api_unit = self._clients.units.get_unit(self._clients.auth_header, unit_symbol)
             return None if api_unit is None else Unit._from_conjure(api_unit)
-        except conjure_python_client.ConjureHTTPError as ex:
+        except NominalAPIError as ex:
             logger.debug("Error getting unit '%s': '%s'", unit_symbol, ex)
             return None
 

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import BinaryIO, Iterable, Mapping, Sequence, overload
 
 import certifi
-import conjure_python_client
 from conjure_python_client import ServiceConfiguration, SslConfiguration
 from nominal_api import (
     api,

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -272,7 +272,7 @@ class NominalClient:
         Raises:
             NominalConfigError: Raises a NominalConfigError if no workspace provided and there is no configured
                 default workspace for the user.
-            conjure_python_client.ConjureHTTPError: Requested workspace is unavailable to the user.
+            NominalAPIError: Requested workspace is unavailable to the user.
         """
         if workspace_rid is None:
             raw_workspace = self._clients.workspace.get_default_workspace(self._clients.auth_header)
@@ -599,7 +599,7 @@ class NominalClient:
 
         Raises:
             ValueError: both `asset` and `assets` provided
-            ConjureHTTPError: error making request
+            NominalAPIError: error making request
 
         """
         if asset and assets:

--- a/nominal/core/datasource.py
+++ b/nominal/core/datasource.py
@@ -245,7 +245,7 @@ class DataSource(HasRid):
         Raises:
         ------
             ValueError: Unsupported unit symbol provided
-            conjure_python_client.ConjureHTTPError: Error completing requests.
+            NominalAPIError: Error completing requests.
         """
         channel_names = set(channel.name for channel in self.get_channels())
 
@@ -312,7 +312,7 @@ class DataSource(HasRid):
             The created Channel object.
 
         Raises:
-            conjure_python_client.ConjureHTTPError: If a channel with this name already exists
+            NominalAPIError: If a channel with this name already exists
                 or if there's an error creating the channel.
         """
         nominal_data_type = data_type._to_nominal_data_type()

--- a/nominal/core/exceptions.py
+++ b/nominal/core/exceptions.py
@@ -1,8 +1,36 @@
 from typing import Mapping
 
+from conjure_python_client import ConjureHTTPError
+from typing_extensions import Self
+
 
 class NominalError(Exception):
     """Base class for Nominal exceptions."""
+
+
+class NominalAPIError(NominalError):
+    """A Conjure HTTP error occurred.
+
+    Attributes:
+        status_code: HTTP status code of the response.
+        error_name: The Conjure error name (e.g. 'Scout:MissingAssetRid').
+        error_code: The Conjure error code (e.g. 'INVALID_ARGUMENT').
+    """
+
+    def __init__(self, message: str, *, status_code: int, error_name: str, error_code: str) -> None:
+        """Initialize error with HTTP status and Conjure error details."""
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_name = error_name
+        self.error_code = error_code
+
+    @classmethod
+    def _from_conjure_error(cls, e: ConjureHTTPError) -> Self:
+        status_code = e.response.status_code if e.response is not None else 0
+        error_name = getattr(e, "error_name", "Unknown")
+        error_code = getattr(e, "error_code", "Unknown")
+        message = f"{error_name}: {e}" if error_name else str(e)
+        return cls(message, status_code=status_code, error_name=error_name, error_code=error_code)
 
 
 class NominalIngestError(NominalError):

--- a/tests/core/test_event.py
+++ b/tests/core/test_event.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from nominal.core._event_types import EventType
+from nominal.core.event import _create_event
+from nominal.core.exceptions import NominalAPIError
+
+
+def _make_nominal_api_error(*, status_code: int = 400, error_name: str = "", error_code: str = "") -> NominalAPIError:
+    """Create a NominalAPIError with the given attributes."""
+    message = f"{error_name}: {status_code} Client Error" if error_name else f"{status_code} Client Error"
+    return NominalAPIError(message, status_code=status_code, error_name=error_name, error_code=error_code)
+
+
+class TestCreateEventErrorHandling:
+    def test_api_error_propagates_with_details(self):
+        clients = MagicMock()
+        clients.event.create_event.side_effect = _make_nominal_api_error(
+            status_code=400,
+            error_name="Scout:MissingAssetRid",
+            error_code="INVALID_ARGUMENT",
+        )
+
+        with pytest.raises(NominalAPIError) as exc_info:
+            _create_event(
+                clients,
+                name="test",
+                type=EventType.INFO,
+                start=0,
+                duration=0,
+                assets=None,
+                description=None,
+                properties=None,
+                labels=None,
+            )
+
+        err = exc_info.value
+        assert err.status_code == 400
+        assert err.error_name == "Scout:MissingAssetRid"
+        assert err.error_code == "INVALID_ARGUMENT"
+        assert "Scout:MissingAssetRid" in str(err)
+
+    def test_api_error_does_not_have_chained_traceback(self):
+        clients = MagicMock()
+        clients.event.create_event.side_effect = _make_nominal_api_error(
+            status_code=400,
+            error_name="Scout:MissingAssetRid",
+            error_code="INVALID_ARGUMENT",
+        )
+
+        with pytest.raises(NominalAPIError) as exc_info:
+            _create_event(
+                clients,
+                name="test",
+                type=EventType.INFO,
+                start=0,
+                duration=0,
+                assets=None,
+                description=None,
+                properties=None,
+                labels=None,
+            )
+
+        assert exc_info.value.__cause__ is None

--- a/uv.lock
+++ b/uv.lock
@@ -1142,7 +1142,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.118.0"
+version = "1.119.1"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
This PR uses inline monkey-patching to capture Conjure exceptions and suppress tracebacks from within the conjure_python_client library.

Specifically, it wraps the Conjure `Service`'s `_request()` method to catch any `ConjureHTTPError` and re-raise it as `NominalAPIError`, suppressing the internal traceback in the process.
