### PR TITLE
fix: create_event() functions reject EventType.UNKNOWN

### DIFF
--- a/nominal/core/event.py
+++ b/nominal/core/event.py
@@ -71,6 +71,8 @@ class Event(HasRid, RefreshableMixin[event.Event]):
                 new_labels.append(old_label)
             event = event.update(labels=new_labels)
         """
+        if type == EventType.UNKNOWN:
+            raise ValueError("Events with EventType.UNKNOWN cannot be updated")
         request = event.BatchUpdateEventRequest(
             requests=[
                 event.UpdateEventRequest(
@@ -130,6 +132,9 @@ def _create_event(
     properties: Mapping[str, str] | None,
     labels: Iterable[str] | None,
 ) -> Event:
+    if type == EventType.UNKNOWN:
+        raise ValueError("Events with EventType.UNKNOWN cannot be created")
+
     request = event.CreateEvent(
         name=name,
         description=description,

--- a/tests/e2e/test_core.py
+++ b/tests/e2e/test_core.py
@@ -173,6 +173,9 @@ def test_update_event_rejects_unknown_type(client: NominalClient, archive: Archi
     event = client.create_event(f"event-{uuid4()}", EventType.INFO, start, assets=[asset])
     archive(event)
 
+    event.update(type=EventType.ERROR)
+    assert event.type == EventType.ERROR
+
     with pytest.raises(ValueError, match="EventType.UNKNOWN cannot be updated"):
         event.update(type=EventType.UNKNOWN)
 

--- a/tests/e2e/test_core.py
+++ b/tests/e2e/test_core.py
@@ -25,7 +25,7 @@ from uuid import uuid4
 import pandas as pd
 import pytest
 
-from nominal.core import NominalClient
+from nominal.core import EventType, NominalClient
 from nominal.core.channel import ChannelDataType
 from nominal.core.dataset import Dataset
 from nominal.core.dataset_file import wait_for_files_to_ingest
@@ -155,6 +155,26 @@ def test_update_attachment(client: NominalClient, csv_data, archive: ArchiveFn):
     assert at.description == new_desc
     assert at.properties == new_props
     assert at.labels == tuple(new_labels)
+
+
+def test_create_event_rejects_unknown_type(client: NominalClient):
+    """Creating an event with event type EventType.UNKNOWN raises"""
+    start, _ = _create_random_start_end()
+    with pytest.raises(ValueError, match="EventType.UNKNOWN cannot be created"):
+        client.create_event(f"event-{uuid4()}", EventType.UNKNOWN, start)
+
+
+def test_update_event_rejects_unknown_type(client: NominalClient, archive: ArchiveFn):
+    """Updating an event to have event type EventType.UNKNOWN raises"""
+    asset = client.create_asset(f"asset-{uuid4()}")
+    archive(asset)
+
+    start, _ = _create_random_start_end()
+    event = client.create_event(f"event-{uuid4()}", EventType.INFO, start, assets=[asset])
+    archive(event)
+
+    with pytest.raises(ValueError, match="EventType.UNKNOWN cannot be updated"):
+        event.update(type=EventType.UNKNOWN)
 
 
 def test_add_attachment_to_run_and_list_attachments(client: NominalClient, csv_data, archive: ArchiveFn):


### PR DESCRIPTION
Instead of waiting for the server to reject the event with an 'Invalid Argument' error, fail fast with a ValueError.

<details><summary>Exception Before:</summary>
<p>

```
400 Client Error: Bad Request for url: <URL>. ErrorCode: 'INVALID_ARGUMENT'. ErrorName: 'Default:InvalidArgument'. ErrorInstanceId: '<ID>'. TraceId: '<ID>'. Parameters: {}
======================================================================
ERROR: test_2 (__main__.WorkflowExample.test_2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "path/to/.venv/lib/python3.13/site-packages/conjure_python_client/_http/requests_client.py", line 120, in _request
    _response.raise_for_status()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "path/to/.venv/lib/python3.13/site-packages/requests/models.py", line 1026, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: <URL>

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "path/to/user_app.py", line 39, in test_2
    core_client.create_event(
    ~~~~~~~~~~~~~~~~~~~~~~~~^
        name=self._testMethodName,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
        assets=[asset],
        ^^^^^^^^^^^^^^^
    )
    ^
  File "path/to/.venv/lib/python3.13/site-packages/nominal/core/client.py", line 1221, in create_event
    return _create_event(
        clients=self._clients,
    ...<7 lines>...
        labels=labels,
    )
  File "path/to/.venv/lib/python3.13/site-packages/nominal/core/event.py", line 152, in _create_event
    response = clients.event.create_event(clients.auth_header, request)
  File "path/to/.venv/lib/python3.13/site-packages/nominal_api/_impl.py", line 7142, in create_event
    _response: Response = self._request(
                          ~~~~~~~~~~~~~^
        'POST',
        ^^^^^^^
    ...<2 lines>...
        headers=_headers,
        ^^^^^^^^^^^^^^^^^
        json=_json)
        ^^^^^^^^^^^
  File "path/to/.venv/lib/python3.13/site-packages/conjure_python_client/_http/requests_client.py", line 123, in _request
    raise ConjureHTTPError(e) from e
conjure_python_client._http.requests_client.ConjureHTTPError: 400 Client Error: Bad Request for url: <URL>. ErrorCode: 'INVALID_ARGUMENT'. ErrorName: 'Default:InvalidArgument'. ErrorInstanceId: '<ID>'. TraceId: '<ID>'. Parameters: {}

----------------------------------------------------------------------
Ran 2 tests in 3.685s

FAILED (errors=1)
```

</p>
</details> 

<details><summary>Exception After:</summary>
<p>

```Unknown event type can not be created
======================================================================
ERROR: test_2 (__main__.WorkflowExample.test_2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "user_app.py", line 39, in test_2
    core_client.create_event(
    ~~~~~~~~~~~~~~~~~~~~~~~~^
        name=self._testMethodName,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
        assets=[asset],
        ^^^^^^^^^^^^^^^
    )
    ^
  File "path/to/nominal/core/client.py", line 1272, in create_event
    return _create_event(
        clients=self._clients,
    ...<7 lines>...
        labels=labels,
    )
  File "path/to/nominal/core/event.py", line 142, in _create_event
    raise ValueError("Unknown event type can not be created")
ValueError: Unknown event type can not be created

----------------------------------------------------------------------
Ran 1 test in 1.358s

FAILED (errors=1)
```

</p>
</details> 