### PR TITLE
feat: e2e testing for migration

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -66,7 +66,6 @@ jobs:
             --base-url https://api.nominal.io/api \
             --workspace-rid ${NOMINAL_E2E_WORKSPACE_RID} \
             --token ${NOMINAL_E2E_TOKEN} \
-            --validate \
             -vv
 
       - name: Run e2e tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -50,6 +50,10 @@ jobs:
           NOMINAL_E2E_TOKEN: ${{ secrets.E2E_NOMINAL_STAGING_API_KEY }}
           NOMINAL_E2E_WORKSPACE_RID: ${{ secrets.E2E_NOMINAL_STAGING_WORKSPACE_RID }}
         run: |
+          if [[ -z "${NOMINAL_E2E_TOKEN}" ]]; then
+            echo "::error::E2E_NOMINAL_STAGING_API_KEY secret is not configured"
+            exit 1
+          fi
           uv run nom config profile add staging-e2e \
             --base-url https://api-staging.gov.nominal.io/api \
             --workspace-rid ${NOMINAL_E2E_WORKSPACE_RID} \
@@ -62,6 +66,10 @@ jobs:
           NOMINAL_E2E_TOKEN: ${{ secrets.E2E_NOMINAL_PRODUCTION_API_KEY }}
           NOMINAL_E2E_WORKSPACE_RID: ${{ secrets.E2E_NOMINAL_PRODUCTION_WORKSPACE_RID }}
         run: |
+          if [[ -z "${NOMINAL_E2E_TOKEN}" ]]; then
+            echo "::error::E2E_NOMINAL_PRODUCTION_API_KEY secret is not configured"
+            exit 1
+          fi
           uv run nom config profile add production-e2e \
             --base-url https://api.gov.nominal.io/api \
             --workspace-rid ${NOMINAL_E2E_WORKSPACE_RID} \

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,7 +37,7 @@ jobs:
           version: "0.8.x"
           enable-cache: false
           cache-dependency-glob: "uv.lock"
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install just
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -63,9 +63,10 @@ jobs:
           NOMINAL_E2E_WORKSPACE_RID: ${{ secrets.E2E_NOMINAL_PRODUCTION_WORKSPACE_RID }}
         run: |
           uv run nom config profile add production-e2e \
-            --base-url https://api.nominal.io/api \
+            --base-url https://api.gov.nominal.io/api \
             --workspace-rid ${NOMINAL_E2E_WORKSPACE_RID} \
             --token ${NOMINAL_E2E_TOKEN} \
+            --validate \
             -vv
 
       - name: Run e2e tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,6 +61,57 @@ jobs:
             --validate \
             -vv
 
+      - name: Run e2e tests
+        run: |
+          uv run pytest tests/e2e \
+            --ignore=tests/e2e/migration \
+            --profile staging-e2e \
+            --no-cov \
+            -v
+
+  migration-e2e-tests:
+    name: Migration E2E Tests
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 15
+
+    # Fork PRs don't have access to secrets — skip gracefully.
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+        with:
+          version: "0.8.x"
+          enable-cache: false
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.13"
+
+      - name: Install just
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
+
+      - name: Install dependencies
+        run: just install
+
+      - name: Write staging profile
+        env:
+          NOMINAL_E2E_TOKEN: ${{ secrets.E2E_NOMINAL_STAGING_API_KEY }}
+          NOMINAL_E2E_WORKSPACE_RID: ${{ secrets.E2E_NOMINAL_STAGING_WORKSPACE_RID }}
+        run: |
+          if [[ -z "${NOMINAL_E2E_TOKEN}" ]]; then
+            echo "::error::E2E_NOMINAL_STAGING_API_KEY secret is not configured"
+            exit 1
+          fi
+          uv run nom config profile add staging-e2e \
+            --base-url https://api-staging.gov.nominal.io/api \
+            --workspace-rid ${NOMINAL_E2E_WORKSPACE_RID} \
+            --token ${NOMINAL_E2E_TOKEN} \
+            --validate \
+            -vv
+
       - name: Write production profile
         env:
           NOMINAL_E2E_TOKEN: ${{ secrets.E2E_NOMINAL_PRODUCTION_API_KEY }}
@@ -77,18 +128,10 @@ jobs:
             --validate \
             -vv
 
-      - name: Run e2e tests
-        run: |
-          uv run pytest tests/e2e \
-            --ignore=tests/e2e/migration \
-            --profile staging-e2e \
-            --no-cov \
-            -v
-
       - name: Run migration e2e tests
         run: |
           uv run pytest tests/e2e/migration \
-            --profile staging-e2e \
+            --dest-profile staging-e2e \
             --source-profile production-e2e \
             --no-cov \
             -v

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Run e2e tests
         run: |
           uv run pytest tests/e2e \
+            --ignore=tests/e2e/migration \
             --profile staging-e2e \
             --no-cov \
             -v

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: just install
 
-      - name: Write Nominal profile
+      - name: Write staging profile
         env:
           NOMINAL_E2E_TOKEN: ${{ secrets.E2E_NOMINAL_STAGING_API_KEY }}
           NOMINAL_E2E_WORKSPACE_RID: ${{ secrets.E2E_NOMINAL_STAGING_WORKSPACE_RID }}
@@ -57,9 +57,29 @@ jobs:
             --validate \
             -vv
 
+      - name: Write production profile
+        env:
+          NOMINAL_E2E_TOKEN: ${{ secrets.E2E_NOMINAL_PRODUCTION_API_KEY }}
+          NOMINAL_E2E_WORKSPACE_RID: ${{ secrets.E2E_NOMINAL_PRODUCTION_WORKSPACE_RID }}
+        run: |
+          uv run nom config profile add production-e2e \
+            --base-url https://api.nominal.io/api \
+            --workspace-rid ${NOMINAL_E2E_WORKSPACE_RID} \
+            --token ${NOMINAL_E2E_TOKEN} \
+            --validate \
+            -vv
+
       - name: Run e2e tests
         run: |
           uv run pytest tests/e2e \
             --profile staging-e2e \
+            --no-cov \
+            -v
+
+      - name: Run migration e2e tests
+        run: |
+          uv run pytest tests/e2e/migration \
+            --profile staging-e2e \
+            --source-profile production-e2e \
             --no-cov \
             -v

--- a/justfile
+++ b/justfile
@@ -28,6 +28,13 @@ test-e2e profile:
 test-e2e-token token:
     uv run pytest tests/e2e --auth-token {{token}} --no-cov -v
 
+# run migration e2e tests using named Nominal profiles (source is prod, dest is staging)
+test-e2e-migration source-profile dest-profile:
+    uv run pytest tests/e2e/migration \
+        --source-profile {{source-profile}} \
+        --dest-profile {{dest-profile}} \
+        --no-cov -v
+
 # check static typing
 check-types:
     uv run mypy

--- a/tests/e2e/migration/conftest.py
+++ b/tests/e2e/migration/conftest.py
@@ -19,7 +19,8 @@ for cleanup (archive) after each test, even on failure.
 from __future__ import annotations
 
 from io import BytesIO
-from typing import Callable
+from typing import Callable, Iterator
+from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -85,6 +86,17 @@ def dest_client(pytestconfig) -> NominalClient:
     base_url = pytestconfig.getoption("dest_base_url") or pytestconfig.getoption("base_url")
     print(f"Using dest NominalClient.create(base_url={base_url!r})")
     return NominalClient.create(base_url=base_url, token=auth_token)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_connection(dest_client: NominalClient) -> Iterator[None]:
+    """Override the parent conftest's set_connection to use dest_client.
+
+    The parent fixture requires ``--profile`` which migration tests don't supply;
+    this shadows it so the module-level default client points at the destination env.
+    """
+    with mock.patch("nominal.nominal.get_default_client", return_value=dest_client):
+        yield
 
 
 @pytest.fixture

--- a/tests/e2e/migration/conftest.py
+++ b/tests/e2e/migration/conftest.py
@@ -39,13 +39,13 @@ def pytest_addoption(parser):
     parser.addoption("--source-profile", default=None, help="Source Nominal profile name (e.g. production)")
     parser.addoption("--source-auth-token", default=None, help="Source auth token (used with --source-base-url)")
     parser.addoption(
-        "--source-base-url", default="https://api.gov.nominal.io", help="Source base URL (default: production)"
+        "--source-base-url", default="https://api.gov.nominal.io/api", help="Source base URL (default: production)"
     )
     parser.addoption("--dest-profile", default=None, help="Destination Nominal profile name (e.g. staging)")
     parser.addoption("--dest-auth-token", default=None, help="Destination auth token (used with --dest-base-url)")
     parser.addoption(
         "--dest-base-url",
-        default="https://api-staging.gov.nominal.io",
+        default="https://api-staging.gov.nominal.io/api",
         help="Destination base URL (default: staging)",
     )
 

--- a/tests/e2e/migration/conftest.py
+++ b/tests/e2e/migration/conftest.py
@@ -37,7 +37,7 @@ def pytest_addoption(parser):
     parser.addoption("--source-profile", default=None, help="Source Nominal profile name (e.g. production)")
     parser.addoption("--source-auth-token", default=None, help="Source auth token (used with --source-base-url)")
     parser.addoption(
-        "--source-base-url", default="https://api.nominal.io", help="Source base URL (default: production)"
+        "--source-base-url", default="https://api.gov.nominal.io", help="Source base URL (default: production)"
     )
 
 

--- a/tests/e2e/migration/conftest.py
+++ b/tests/e2e/migration/conftest.py
@@ -50,7 +50,9 @@ def source_client(pytestconfig) -> NominalClient:
         return NominalClient.from_profile(profile)
     auth_token = pytestconfig.getoption("source_auth_token")
     if auth_token is None:
-        raise pytest.UsageError("Either --source-profile or --source-auth-token must be provided")
+        raise pytest.UsageError(
+            "Either --source-profile or --source-auth-token must be provided for migration source environment"
+        )
     base_url = pytestconfig.getoption("source_base_url")
     print(f"Using source NominalClient.create(base_url={base_url!r})")
     return NominalClient.create(base_url=base_url, token=auth_token)
@@ -69,7 +71,9 @@ def dest_client(pytestconfig) -> NominalClient:
         return NominalClient.from_profile(profile)
     auth_token = pytestconfig.getoption("auth_token")
     if auth_token is None:
-        raise pytest.UsageError("Either --profile or --auth-token must be provided")
+        raise pytest.UsageError(
+            "Either --profile or --auth-token must be provided for migration destination environment"
+        )
     base_url = pytestconfig.getoption("base_url")
     print(f"Using dest NominalClient.create(base_url={base_url!r})")
     return NominalClient.create(base_url=base_url, token=auth_token)

--- a/tests/e2e/migration/conftest.py
+++ b/tests/e2e/migration/conftest.py
@@ -6,8 +6,9 @@ Migration tests require two Nominal clients:
 - ``source_client``: the environment to migrate *from* (e.g. production).
   Configured via ``--source-profile`` or ``--source-auth-token`` + ``--source-base-url``.
 - ``dest_client``: the environment to migrate *to* (e.g. staging).
-  Reuses the existing ``--profile`` / ``--auth-token`` + ``--base-url`` options from
-  ``tests/e2e/conftest.py`` — same environment as the rest of the e2e suite.
+  Configured via ``--dest-profile`` or ``--dest-auth-token`` + ``--dest-base-url``.
+  Falls back to the global ``--profile`` / ``--auth-token`` + ``--base-url`` options for
+  backwards compatibility.
 
 Teardown helpers
 ----------------
@@ -33,11 +34,18 @@ ArchiveFn = Callable[[object], None]
 
 
 def pytest_addoption(parser):
-    """Register source-environment CLI options (dest reuses the existing e2e options)."""
+    """Register source and destination environment CLI options."""
     parser.addoption("--source-profile", default=None, help="Source Nominal profile name (e.g. production)")
     parser.addoption("--source-auth-token", default=None, help="Source auth token (used with --source-base-url)")
     parser.addoption(
         "--source-base-url", default="https://api.gov.nominal.io", help="Source base URL (default: production)"
+    )
+    parser.addoption("--dest-profile", default=None, help="Destination Nominal profile name (e.g. staging)")
+    parser.addoption("--dest-auth-token", default=None, help="Destination auth token (used with --dest-base-url)")
+    parser.addoption(
+        "--dest-base-url",
+        default="https://api-staging.gov.nominal.io",
+        help="Destination base URL (default: staging)",
     )
 
 
@@ -62,19 +70,19 @@ def source_client(pytestconfig) -> NominalClient:
 def dest_client(pytestconfig) -> NominalClient:
     """Build a NominalClient for the migration destination environment (e.g. staging).
 
-    Reuses the same ``--profile`` / ``--auth-token`` / ``--base-url`` options as the
-    rest of the e2e suite (registered in ``tests/e2e/conftest.py``).
+    ``--dest-profile`` takes precedence; falls back to the global ``--profile`` for
+    backwards compatibility with existing invocations.
     """
-    profile = pytestconfig.getoption("profile")
+    profile = pytestconfig.getoption("dest_profile") or pytestconfig.getoption("profile")
     if profile is not None:
         print(f"Using dest NominalClient.from_profile({profile!r})")
         return NominalClient.from_profile(profile)
-    auth_token = pytestconfig.getoption("auth_token")
+    auth_token = pytestconfig.getoption("dest_auth_token") or pytestconfig.getoption("auth_token")
     if auth_token is None:
         raise pytest.UsageError(
-            "Either --profile or --auth-token must be provided for migration destination environment"
+            "Either --dest-profile or --dest-auth-token must be provided for migration destination environment"
         )
-    base_url = pytestconfig.getoption("base_url")
+    base_url = pytestconfig.getoption("dest_base_url") or pytestconfig.getoption("base_url")
     print(f"Using dest NominalClient.create(base_url={base_url!r})")
     return NominalClient.create(base_url=base_url, token=auth_token)
 

--- a/tests/e2e/migration/conftest.py
+++ b/tests/e2e/migration/conftest.py
@@ -1,0 +1,113 @@
+"""Shared fixtures for migration e2e tests.
+
+Connection setup
+----------------
+Migration tests require two Nominal clients:
+- ``source_client``: the environment to migrate *from* (e.g. production).
+  Configured via ``--source-profile`` or ``--source-auth-token`` + ``--source-base-url``.
+- ``dest_client``: the environment to migrate *to* (e.g. staging).
+  Reuses the existing ``--profile`` / ``--auth-token`` + ``--base-url`` options from
+  ``tests/e2e/conftest.py`` — same environment as the rest of the e2e suite.
+
+Teardown helpers
+----------------
+``source_archive`` / ``dest_archive`` — function-scoped helpers that register objects
+for cleanup (archive) after each test, even on failure.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Callable
+from uuid import uuid4
+
+import pytest
+
+from nominal.core import NominalClient
+from nominal.core.dataset import Dataset
+from nominal.experimental.migration.migration_state import MigrationState
+from nominal.experimental.migration.migrator.context import MigrationContext
+from tests.e2e import POLL_INTERVAL
+
+ArchiveFn = Callable[[object], None]
+
+
+def pytest_addoption(parser):
+    """Register source-environment CLI options (dest reuses the existing e2e options)."""
+    parser.addoption("--source-profile", default=None, help="Source Nominal profile name (e.g. production)")
+    parser.addoption("--source-auth-token", default=None, help="Source auth token (used with --source-base-url)")
+    parser.addoption(
+        "--source-base-url", default="https://api.nominal.io", help="Source base URL (default: production)"
+    )
+
+
+@pytest.fixture(scope="session")
+def source_client(pytestconfig) -> NominalClient:
+    """Build a NominalClient for the migration source environment (e.g. production)."""
+    profile = pytestconfig.getoption("source_profile")
+    if profile is not None:
+        print(f"Using source NominalClient.from_profile({profile!r})")
+        return NominalClient.from_profile(profile)
+    auth_token = pytestconfig.getoption("source_auth_token")
+    if auth_token is None:
+        raise pytest.UsageError("Either --source-profile or --source-auth-token must be provided")
+    base_url = pytestconfig.getoption("source_base_url")
+    print(f"Using source NominalClient.create(base_url={base_url!r})")
+    return NominalClient.create(base_url=base_url, token=auth_token)
+
+
+@pytest.fixture(scope="session")
+def dest_client(pytestconfig) -> NominalClient:
+    """Build a NominalClient for the migration destination environment (e.g. staging).
+
+    Reuses the same ``--profile`` / ``--auth-token`` / ``--base-url`` options as the
+    rest of the e2e suite (registered in ``tests/e2e/conftest.py``).
+    """
+    profile = pytestconfig.getoption("profile")
+    if profile is not None:
+        print(f"Using dest NominalClient.from_profile({profile!r})")
+        return NominalClient.from_profile(profile)
+    auth_token = pytestconfig.getoption("auth_token")
+    if auth_token is None:
+        raise pytest.UsageError("Either --profile or --auth-token must be provided")
+    base_url = pytestconfig.getoption("base_url")
+    print(f"Using dest NominalClient.create(base_url={base_url!r})")
+    return NominalClient.create(base_url=base_url, token=auth_token)
+
+
+@pytest.fixture
+def source_archive(request) -> ArchiveFn:
+    """Register source-environment objects for cleanup after each test."""
+
+    def _register(obj):
+        request.addfinalizer(obj.archive)
+
+    return _register
+
+
+@pytest.fixture
+def dest_archive(request) -> ArchiveFn:
+    """Register destination-environment objects for cleanup after each test."""
+
+    def _register(obj):
+        request.addfinalizer(obj.archive)
+
+    return _register
+
+
+@pytest.fixture
+def migration_ctx(dest_client: NominalClient) -> MigrationContext:
+    """A fresh MigrationContext with an empty MigrationState for each test."""
+    return MigrationContext(
+        destination_client=dest_client,
+        migration_state=MigrationState(rid_mapping={}),
+    )
+
+
+@pytest.fixture
+def ingested_source_dataset(source_client: NominalClient, csv_data: bytes, source_archive: ArchiveFn) -> Dataset:
+    """A dataset on the source client, fully ingested from csv_data."""
+    ds = source_client.create_dataset(f"migration-e2e-source-{uuid4().hex[:8]}")
+    source_archive(ds)
+    ds.add_from_io(BytesIO(csv_data), "timestamp", "iso_8601").poll_until_ingestion_completed(interval=POLL_INTERVAL)
+    return ds

--- a/tests/e2e/migration/conftest.py
+++ b/tests/e2e/migration/conftest.py
@@ -12,8 +12,14 @@ Migration tests require two Nominal clients:
 
 Teardown helpers
 ----------------
-``source_archive`` / ``dest_archive`` — function-scoped helpers that register objects
-for cleanup (archive) after each test, even on failure.
+``register_cleanup`` — a function-scoped fixture that schedules a callable for execution
+after each test, even on failure. Pass any no-arg callable (typically ``obj.archive``) to
+register it::
+
+    register_cleanup(obj.archive)
+
+See https://docs.pytest.org/en/stable/reference/reference.html#request for details on the
+underlying pytest ``request`` fixture.
 """
 
 from __future__ import annotations
@@ -31,7 +37,7 @@ from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.migrator.context import MigrationContext
 from tests.e2e import POLL_INTERVAL
 
-ArchiveFn = Callable[[object], None]
+RegisterCleanup = Callable[[Callable[[], None]], None]
 
 
 def pytest_addoption(parser):
@@ -100,21 +106,16 @@ def set_connection(dest_client: NominalClient) -> Iterator[None]:
 
 
 @pytest.fixture
-def source_archive(request) -> ArchiveFn:
-    """Register source-environment objects for cleanup after each test."""
+def register_cleanup(request) -> RegisterCleanup:
+    """Schedule a callable to run after the current test, even on failure.
 
-    def _register(obj):
-        request.addfinalizer(obj.archive)
+    Usage::
 
-    return _register
+        register_cleanup(obj.archive)
+    """
 
-
-@pytest.fixture
-def dest_archive(request) -> ArchiveFn:
-    """Register destination-environment objects for cleanup after each test."""
-
-    def _register(obj):
-        request.addfinalizer(obj.archive)
+    def _register(fn: Callable[[], None]) -> None:
+        request.addfinalizer(fn)
 
     return _register
 
@@ -129,9 +130,11 @@ def migration_ctx(dest_client: NominalClient) -> MigrationContext:
 
 
 @pytest.fixture
-def ingested_source_dataset(source_client: NominalClient, csv_data: bytes, source_archive: ArchiveFn) -> Dataset:
+def ingested_source_dataset(
+    source_client: NominalClient, csv_data: bytes, register_cleanup: RegisterCleanup
+) -> Dataset:
     """A dataset on the source client, fully ingested from csv_data."""
     ds = source_client.create_dataset(f"migration-e2e-source-{uuid4().hex[:8]}")
-    source_archive(ds)
+    register_cleanup(ds.archive)
     ds.add_from_io(BytesIO(csv_data), "timestamp", "iso_8601").poll_until_ingestion_completed(interval=POLL_INTERVAL)
     return ds

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -189,8 +189,9 @@ def _assert_event_fields(source: Event, dest: Event, dest_asset: Asset) -> None:
     assert dest.description == source.description
     assert set(dest.labels) == set(source.labels)
     assert dest.properties == source.properties
-    # Linkage: event is associated with the destination asset.
+    # Linkage: event is associated with exactly the destination asset (no others).
     assert dest.rid in {e.rid for e in dest_asset.search_events()}
+    assert set(dest.asset_rids) == {dest_asset.rid}
 
 
 def _assert_run_fields(source: Run, dest: Run, dest_asset: Asset) -> None:
@@ -200,9 +201,9 @@ def _assert_run_fields(source: Run, dest: Run, dest_asset: Asset) -> None:
     assert dest.properties == source.properties
     assert dest.start == source.start
     assert dest.end == source.end
-    # Linkage: bidirectional — run appears on the destination asset and the run references it.
+    # Linkage: bidirectional — run appears on the destination asset and references exactly it.
     assert dest.rid in {r.rid for r in dest_asset.list_runs()}
-    assert dest_asset.rid in dest.assets
+    assert set(dest.assets) == {dest_asset.rid}
 
 
 def _assert_checklist_fields(source: Checklist, dest: Checklist) -> None:
@@ -333,7 +334,9 @@ def test_migrate_asset_with_dataset_files(
 
     source_channels = {ch.name for ch in source_ds.search_channels()}
     dest_channels = {ch.name for ch in dest_ds.search_channels()}
-    assert source_channels.issubset(dest_channels)
+    assert source_channels.issubset(dest_channels), (
+        f"Missing channels in destination dataset. Source channels: {source_channels}, Dest channels: {dest_channels}"
+    )
 
 
 def test_migration_idempotency(

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -97,7 +97,9 @@ def _setup_source_resources(source_client: NominalClient, source_archive: Archiv
     source_run = source_client.create_run(f"migration-e2e-run-{tag}", start, end, assets=[source_asset])
     source_archive(source_run)
 
-    source_checklist = _create_checklist_with_content(source_client, title=f"migration-e2e-checklist-{tag}")
+    source_checklist = _create_checklist_with_content(
+        source_client, title=f"migration-e2e-checklist-{tag}", is_published=True
+    )
     source_archive(source_checklist)
     source_data_review = source_checklist.execute(source_run)
     source_archive(source_data_review)

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -17,15 +17,17 @@ Run with:
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from io import BytesIO
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Mapping
 from uuid import uuid4
 
 from nominal.core import NominalClient
 from nominal.core._event_types import EventType
 from nominal.core.asset import Asset
 from nominal.core.checklist import Checklist
+from nominal.core.data_review import DataReview
 from nominal.core.dataset import Dataset
 from nominal.core.event import Event
 from nominal.core.run import Run
@@ -82,81 +84,128 @@ def _dest_asset(runner: MigrationRunner, source_asset: Asset, dest_client: Nomin
     return dest_client.get_asset(rid)
 
 
-def _setup_source_resources(source_client: NominalClient, source_archive: ArchiveFn, mp4_data: bytes):
-    """Create a source asset with one of every resource type, each populated with labels,
-    properties, and descriptions to exercise full metadata migration fidelity.
-    """
-    start, end = _create_random_start_end()
-    tag = uuid4()
-
-    source_asset = source_client.create_asset(
-        f"migration-e2e-asset-{tag}",
-        description=f"asset-description-{tag}",
+def _create_source_asset(source_client: NominalClient, source_archive: ArchiveFn) -> Asset:
+    asset = source_client.create_asset(
+        f"migration-e2e-asset-{uuid4()}",
+        description="asset description",
         properties={"asset-prop": "asset-val"},
         labels=["migration-e2e"],
     )
-    source_archive(source_asset)
+    source_archive(asset)
+    return asset
 
-    source_ds = source_client.create_dataset(
-        f"migration-e2e-ds-{tag}",
-        description=f"ds-description-{tag}",
+
+def _create_source_dataset(source_client: NominalClient, source_archive: ArchiveFn, source_asset: Asset) -> Dataset:
+    ds = source_client.create_dataset(
+        f"migration-e2e-ds-{uuid4()}",
+        description="dataset description",
         properties={"ds-prop": "ds-val"},
         labels=["migration-e2e"],
     )
-    source_archive(source_ds)
-    source_asset.add_dataset("primary", source_ds)
+    source_archive(ds)
+    source_asset.add_dataset("primary", ds, series_tags={"scope-tag": "scope-val"})
+    return ds
 
+
+def _create_source_events(
+    source_client: NominalClient,
+    source_archive: ArchiveFn,
+    source_asset: Asset,
+    start: datetime,
+) -> tuple[Event, Event]:
     event_a = source_client.create_event(
-        f"migration-e2e-event-a-{tag}",
+        f"migration-e2e-event-a-{uuid4()}",
         EventType.FLAG,
         start,
+        duration=timedelta(minutes=5),
         assets=[source_asset],
-        description=f"event-a-description-{tag}",
+        description="event a description",
         properties={"event-prop": "flag"},
         labels=["migration-e2e"],
     )
     source_archive(event_a)
     event_b = source_client.create_event(
-        f"migration-e2e-event-b-{tag}",
+        f"migration-e2e-event-b-{uuid4()}",
         EventType.INFO,
         start,
+        duration=timedelta(minutes=10),
         assets=[source_asset],
-        description=f"event-b-description-{tag}",
+        description="event b description",
         properties={"event-prop": "info"},
         labels=["migration-e2e"],
     )
     source_archive(event_b)
+    return event_a, event_b
 
-    source_run = source_client.create_run(
-        f"migration-e2e-run-{tag}",
+
+def _create_source_run(
+    source_client: NominalClient,
+    source_archive: ArchiveFn,
+    source_asset: Asset,
+    start: datetime,
+    end: datetime,
+) -> Run:
+    run = source_client.create_run(
+        f"migration-e2e-run-{uuid4()}",
         start,
         end,
         assets=[source_asset],
-        description=f"run-description-{tag}",
+        description="run description",
         properties={"run-prop": "run-val"},
         labels=["migration-e2e"],
     )
-    source_archive(source_run)
+    source_archive(run)
+    return run
 
-    source_checklist = _create_checklist_with_content(
-        source_client, title=f"migration-e2e-checklist-{tag}", is_published=True
+
+def _create_source_checklist_and_review(
+    source_client: NominalClient,
+    source_archive: ArchiveFn,
+    source_run: Run,
+) -> tuple[Checklist, DataReview]:
+    checklist = _create_checklist_with_content(
+        source_client, title=f"migration-e2e-checklist-{uuid4()}", is_published=True
     )
-    source_archive(source_checklist)
-    source_data_review = source_checklist.execute(source_run)
-    source_archive(source_data_review)
+    source_archive(checklist)
+    data_review = checklist.execute(source_run)
+    source_archive(data_review)
+    return checklist, data_review
 
-    source_video = source_client.create_video(
-        f"migration-e2e-video-{tag}",
-        description=f"video-description-{tag}",
+
+def _create_source_video(
+    source_client: NominalClient,
+    source_archive: ArchiveFn,
+    source_asset: Asset,
+    mp4_data: bytes,
+    start: datetime,
+) -> Video:
+    video = source_client.create_video(
+        f"migration-e2e-video-{uuid4()}",
+        description="video description",
         properties={"video-prop": "video-val"},
         labels=["migration-e2e"],
     )
-    source_archive(source_video)
-    source_video.add_from_io(BytesIO(mp4_data), "test.mp4", start=start).poll_until_ingestion_completed(
-        interval=POLL_INTERVAL
-    )
-    source_asset.add_video("camera", source_video)
+    source_archive(video)
+    video.add_from_io(BytesIO(mp4_data), "test.mp4", start=start).poll_until_ingestion_completed(interval=POLL_INTERVAL)
+    source_asset.add_video("camera", video)
+    return video
 
+
+def _setup_source_resources(
+    source_client: NominalClient, source_archive: ArchiveFn, mp4_data: bytes
+) -> tuple[Asset, Dataset, Event, Event, Run, Checklist, DataReview, Video]:
+    """Create a source asset with one of every resource type, each populated with labels,
+    properties, and descriptions to exercise full metadata migration fidelity.
+    """
+    start, end = _create_random_start_end()
+    source_asset = _create_source_asset(source_client, source_archive)
+    source_ds = _create_source_dataset(source_client, source_archive, source_asset)
+    event_a, event_b = _create_source_events(source_client, source_archive, source_asset, start)
+    source_run = _create_source_run(source_client, source_archive, source_asset, start, end)
+    source_checklist, source_data_review = _create_source_checklist_and_review(
+        source_client, source_archive, source_run
+    )
+    source_video = _create_source_video(source_client, source_archive, source_asset, mp4_data, start)
     return source_asset, source_ds, event_a, event_b, source_run, source_checklist, source_data_review, source_video
 
 
@@ -172,7 +221,13 @@ def _assert_asset_fields(source: Asset, dest: Asset) -> None:
     assert dest.properties == source.properties
 
 
-def _assert_dataset_fields(source: Dataset, dest: Dataset, scope_name: str, dest_asset: Asset) -> None:
+def _assert_dataset_fields(
+    source: Dataset,
+    dest: Dataset,
+    scope_name: str,
+    dest_asset: Asset,
+    series_tags: Mapping[str, str] | None = None,
+) -> None:
     assert dest.name == source.name
     assert dest.description == source.description
     assert set(dest.labels) == set(source.labels)
@@ -181,11 +236,17 @@ def _assert_dataset_fields(source: Dataset, dest: Dataset, scope_name: str, dest
     dest_datasets = dict(dest_asset.list_datasets())
     assert scope_name in dest_datasets
     assert dest_datasets[scope_name].rid == dest.rid
+    # series_tags on the scope are preserved — get_or_create_dataset raises on tag mismatch.
+    if series_tags is not None:
+        matched = dest_asset.get_or_create_dataset(scope_name, series_tags=series_tags)
+        assert matched.rid == dest.rid
 
 
 def _assert_event_fields(source: Event, dest: Event, dest_asset: Asset) -> None:
     assert dest.name == source.name
     assert dest.type == source.type
+    assert dest.start == source.start
+    assert dest.duration == source.duration
     assert dest.description == source.description
     assert set(dest.labels) == set(source.labels)
     assert dest.properties == source.properties
@@ -265,7 +326,7 @@ def test_migrate_asset(
     assert dest_ds_rid is not None
     dest_ds = dest_client.get_dataset(dest_ds_rid)
     dest_archive(dest_ds)
-    _assert_dataset_fields(source_ds, dest_ds, "primary", dest_asset)
+    _assert_dataset_fields(source_ds, dest_ds, "primary", dest_asset, series_tags={"scope-tag": "scope-val"})
 
     # --- events ---
     dest_event_a_rid = state.get_mapped_rid(ResourceType.EVENT, event_a.rid)
@@ -298,6 +359,9 @@ def test_migrate_asset(
     dest_video = dest_client.get_video(dest_video_rid)
     dest_archive(dest_video)
     _assert_video_fields(source_video, dest_video, "camera", dest_asset)
+    dest_video_files = list(dest_video.list_files())
+    assert len(dest_video_files) == 1
+    dest_video_files[0].poll_until_ingestion_completed(interval=POLL_INTERVAL)
 
 
 def test_migrate_asset_with_dataset_files(
@@ -358,6 +422,8 @@ def test_migration_idempotency(
     runner.run_migration()
     dest_asset_rid_1 = runner.migration_state.get_mapped_rid(ResourceType.ASSET, source_asset.rid)
     dest_ds_rid_1 = runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds.rid)
+    assert dest_asset_rid_1 is not None
+    assert dest_ds_rid_1 is not None
     dest_archive(dest_client.get_asset(dest_asset_rid_1))
     dest_archive(dest_client.get_dataset(dest_ds_rid_1))
 

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -138,7 +138,9 @@ def _setup_source_resources(source_client: NominalClient, source_archive: Archiv
     )
     source_archive(source_run)
 
-    source_checklist = _create_checklist_with_content(source_client, title=f"migration-e2e-checklist-{tag}")
+    source_checklist = _create_checklist_with_content(
+        source_client, title=f"migration-e2e-checklist-{tag}", is_published=True
+    )
     source_archive(source_checklist)
     source_data_review = source_checklist.execute(source_run)
     source_archive(source_data_review)
@@ -198,8 +200,9 @@ def _assert_run_fields(source: Run, dest: Run, dest_asset: Asset) -> None:
     assert dest.properties == source.properties
     assert dest.start == source.start
     assert dest.end == source.end
-    # Linkage: run appears on the destination asset.
+    # Linkage: bidirectional — run appears on the destination asset and the run references it.
     assert dest.rid in {r.rid for r in dest_asset.list_runs()}
+    assert dest_asset.rid in dest.assets
 
 
 def _assert_checklist_fields(source: Checklist, dest: Checklist) -> None:

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -40,9 +40,9 @@ from nominal.experimental.migration.config.migration_resources import AssetResou
 from nominal.experimental.migration.migration_runner import MigrationRunner
 from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.resource_type import ResourceType
-from tests.e2e import POLL_INTERVAL, _create_random_start_end
+from tests.e2e import POLL_INTERVAL
 
-ArchiveFn = Callable[[object], None]
+RegisterCleanup = Callable[[Callable[[], None]], None]
 
 
 # ---------------------------------------------------------------------------
@@ -86,32 +86,34 @@ def _dest_asset(runner: MigrationRunner, source_asset: Asset, dest_client: Nomin
     return dest_client.get_asset(rid)
 
 
-def _create_source_asset(source_client: NominalClient, source_archive: ArchiveFn) -> Asset:
+def _create_source_asset(source_client: NominalClient, register_cleanup: RegisterCleanup) -> Asset:
     asset = source_client.create_asset(
         f"migration-e2e-asset-{uuid4()}",
         description="asset description",
         properties={"asset-prop": "asset-val"},
         labels=["migration-e2e"],
     )
-    source_archive(asset)
+    register_cleanup(asset.archive)
     return asset
 
 
-def _create_source_dataset(source_client: NominalClient, source_archive: ArchiveFn, source_asset: Asset) -> Dataset:
+def _create_source_dataset(
+    source_client: NominalClient, register_cleanup: RegisterCleanup, source_asset: Asset
+) -> Dataset:
     ds = source_client.create_dataset(
         f"migration-e2e-ds-{uuid4()}",
         description="dataset description",
         properties={"ds-prop": "ds-val"},
         labels=["migration-e2e"],
     )
-    source_archive(ds)
+    register_cleanup(ds.archive)
     source_asset.add_dataset("primary", ds, series_tags={"scope-tag": "scope-val"})
     return ds
 
 
 def _create_source_events(
     source_client: NominalClient,
-    source_archive: ArchiveFn,
+    register_cleanup: RegisterCleanup,
     source_asset: Asset,
     start: datetime,
 ) -> tuple[Event, Event]:
@@ -125,7 +127,7 @@ def _create_source_events(
         properties={"event-prop": "flag"},
         labels=["migration-e2e"],
     )
-    source_archive(event_a)
+    register_cleanup(event_a.archive)
     event_b = source_client.create_event(
         f"migration-e2e-event-b-{uuid4()}",
         EventType.INFO,
@@ -136,13 +138,13 @@ def _create_source_events(
         properties={"event-prop": "info"},
         labels=["migration-e2e"],
     )
-    source_archive(event_b)
+    register_cleanup(event_b.archive)
     return event_a, event_b
 
 
 def _create_source_run(
     source_client: NominalClient,
-    source_archive: ArchiveFn,
+    register_cleanup: RegisterCleanup,
     source_asset: Asset,
     start: datetime,
     end: datetime,
@@ -156,27 +158,27 @@ def _create_source_run(
         properties={"run-prop": "run-val"},
         labels=["migration-e2e"],
     )
-    source_archive(run)
+    register_cleanup(run.archive)
     return run
 
 
 def _create_source_checklist_and_review(
     source_client: NominalClient,
-    source_archive: ArchiveFn,
+    register_cleanup: RegisterCleanup,
     source_run: Run,
 ) -> tuple[Checklist, DataReview]:
     checklist = _create_checklist_with_content(
         source_client, title=f"migration-e2e-checklist-{uuid4()}", is_published=True
     )
-    source_archive(checklist)
+    register_cleanup(checklist.archive)
     data_review = checklist.execute(source_run)
-    source_archive(data_review)
+    register_cleanup(data_review.archive)
     return checklist, data_review
 
 
 def _create_source_video(
     source_client: NominalClient,
-    source_archive: ArchiveFn,
+    register_cleanup: RegisterCleanup,
     source_asset: Asset,
     mp4_data: bytes,
     start: datetime,
@@ -187,7 +189,7 @@ def _create_source_video(
         properties={"video-prop": "video-val"},
         labels=["migration-e2e"],
     )
-    source_archive(video)
+    register_cleanup(video.archive)
     video.add_from_io(BytesIO(mp4_data), "test.mp4", start=start).poll_until_ingestion_completed(interval=POLL_INTERVAL)
     source_asset.add_video("camera", video)
     return video
@@ -195,7 +197,7 @@ def _create_source_video(
 
 def _create_source_workbook(
     source_client: NominalClient,
-    source_archive: ArchiveFn,
+    register_cleanup: RegisterCleanup,
     source_asset: Asset,
 ) -> Workbook:
     """Create a workbook on the source asset.
@@ -210,38 +212,9 @@ def _create_source_workbook(
         properties={"wbt-prop": "wbt-val"},
     )
     workbook = template.create_workbook(asset=source_asset, title=f"migration-e2e-workbook-{uuid4()}")
-    source_archive(workbook)
+    register_cleanup(workbook.archive)
     template.archive()
     return workbook
-
-
-def _setup_source_resources(
-    source_client: NominalClient, source_archive: ArchiveFn, mp4_data: bytes
-) -> tuple[Asset, Dataset, Event, Event, Run, Checklist, DataReview, Video, Workbook]:
-    """Create a source asset with one of every resource type, each populated with labels,
-    properties, and descriptions to exercise full metadata migration fidelity.
-    """
-    start, end = _create_random_start_end()
-    source_asset = _create_source_asset(source_client, source_archive)
-    source_ds = _create_source_dataset(source_client, source_archive, source_asset)
-    event_a, event_b = _create_source_events(source_client, source_archive, source_asset, start)
-    source_run = _create_source_run(source_client, source_archive, source_asset, start, end)
-    source_checklist, source_data_review = _create_source_checklist_and_review(
-        source_client, source_archive, source_run
-    )
-    source_video = _create_source_video(source_client, source_archive, source_asset, mp4_data, start)
-    source_workbook = _create_source_workbook(source_client, source_archive, source_asset)
-    return (
-        source_asset,
-        source_ds,
-        event_a,
-        event_b,
-        source_run,
-        source_checklist,
-        source_data_review,
-        source_video,
-        source_workbook,
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -261,7 +234,6 @@ def _assert_dataset_migrated(
     dest: Dataset,
     scope_name: str,
     dest_asset: Asset,
-    series_tags: Mapping[str, str] | None = None,
 ) -> None:
     assert dest.name == source.name
     assert dest.description == source.description
@@ -271,10 +243,6 @@ def _assert_dataset_migrated(
     dest_datasets = dict(dest_asset.list_datasets())
     assert scope_name in dest_datasets
     assert dest_datasets[scope_name].rid == dest.rid
-    # series_tags on the scope are preserved — get_or_create_dataset raises on tag mismatch.
-    if series_tags is not None:
-        matched = dest_asset.get_or_create_dataset(scope_name, series_tags=series_tags)
-        assert matched.rid == dest.rid
 
 
 def _assert_event_migrated(source: Event, dest: Event, dest_asset: Asset) -> None:
@@ -336,8 +304,7 @@ def _assert_workbook_migrated(source: Workbook, dest: Workbook, dest_asset: Asse
 def test_migrate_asset(
     source_client: NominalClient,
     dest_client: NominalClient,
-    source_archive: ArchiveFn,
-    dest_archive: ArchiveFn,
+    register_cleanup: RegisterCleanup,
     mp4_data: bytes,
     tmp_path: Path,
 ):
@@ -349,17 +316,17 @@ def test_migrate_asset(
     - Resources are correctly linked to the migrated destination asset
     """
     # --- source setup ---
-    (
-        source_asset,
-        source_ds,
-        event_a,
-        event_b,
-        source_run,
-        source_checklist,
-        source_data_review,
-        source_video,
-        source_workbook,
-    ) = _setup_source_resources(source_client, source_archive, mp4_data)
+    start = datetime(2024, 1, 1)
+    end = start + timedelta(hours=1)
+    source_asset = _create_source_asset(source_client, register_cleanup)
+    source_ds = _create_source_dataset(source_client, register_cleanup, source_asset)
+    event_a, event_b = _create_source_events(source_client, register_cleanup, source_asset, start)
+    source_run = _create_source_run(source_client, register_cleanup, source_asset, start, end)
+    source_checklist, source_data_review = _create_source_checklist_and_review(
+        source_client, register_cleanup, source_run
+    )
+    source_video = _create_source_video(source_client, register_cleanup, source_asset, mp4_data, start)
+    source_workbook = _create_source_workbook(source_client, register_cleanup, source_asset)
 
     # --- migrate ---
     runner = _make_runner(_make_resources(source_asset), _no_files_config(), dest_client, tmp_path / "state.json")
@@ -367,7 +334,7 @@ def test_migrate_asset(
     state = runner.migration_state
 
     dest_asset = _dest_asset(runner, source_asset, dest_client)
-    dest_archive(dest_asset)
+    register_cleanup(dest_asset.archive)
 
     # --- asset ---
     _assert_asset_migrated(source_asset, dest_asset)
@@ -376,8 +343,11 @@ def test_migrate_asset(
     dest_ds_rid = state.get_mapped_rid(ResourceType.DATASET, source_ds.rid)
     assert dest_ds_rid is not None
     dest_ds = dest_client.get_dataset(dest_ds_rid)
-    dest_archive(dest_ds)
-    _assert_dataset_migrated(source_ds, dest_ds, "primary", dest_asset, series_tags={"scope-tag": "scope-val"})
+    register_cleanup(dest_ds.archive)
+    _assert_dataset_migrated(source_ds, dest_ds, "primary", dest_asset)
+    # Verify series_tags are preserved: get_or_create_dataset raises on tag mismatch.
+    matched = dest_asset.get_or_create_dataset("primary", series_tags={"scope-tag": "scope-val"})
+    assert matched.rid == dest_ds.rid
 
     # --- events ---
     dest_event_a_rid = state.get_mapped_rid(ResourceType.EVENT, event_a.rid)
@@ -393,14 +363,14 @@ def test_migrate_asset(
     dest_run_rid = state.get_mapped_rid(ResourceType.RUN, source_run.rid)
     assert dest_run_rid is not None
     dest_run = dest_client.get_run(dest_run_rid)
-    dest_archive(dest_run)
+    register_cleanup(dest_run.archive)
     _assert_run_migrated(source_run, dest_run, dest_asset)
 
     # --- checklist + data review ---
     dest_checklist_rid = state.get_mapped_rid(ResourceType.CHECKLIST, source_checklist.rid)
     assert dest_checklist_rid is not None
     dest_checklist = dest_client.get_checklist(dest_checklist_rid)
-    dest_archive(dest_checklist)
+    register_cleanup(dest_checklist.archive)
     _assert_checklist_migrated(source_checklist, dest_checklist)
     assert state.get_mapped_rid(ResourceType.DATA_REVIEW, source_data_review.rid) is not None
 
@@ -408,7 +378,7 @@ def test_migrate_asset(
     dest_video_rid = state.get_mapped_rid(ResourceType.VIDEO, source_video.rid)
     assert dest_video_rid is not None
     dest_video = dest_client.get_video(dest_video_rid)
-    dest_archive(dest_video)
+    register_cleanup(dest_video.archive)
     _assert_video_migrated(source_video, dest_video, "camera", dest_asset)
     dest_video_files = list(dest_video.list_files())
     assert len(dest_video_files) == 1
@@ -418,23 +388,22 @@ def test_migrate_asset(
     dest_workbook_rid = state.get_mapped_rid(ResourceType.WORKBOOK, source_workbook.rid)
     assert dest_workbook_rid is not None
     dest_workbook = dest_client.get_workbook(dest_workbook_rid)
-    dest_archive(dest_workbook)
+    register_cleanup(dest_workbook.archive)
     _assert_workbook_migrated(source_workbook, dest_workbook, dest_asset)
 
 
 def test_migrate_asset_with_dataset_files(
     source_client: NominalClient,
     dest_client: NominalClient,
-    source_archive: ArchiveFn,
-    dest_archive: ArchiveFn,
+    register_cleanup: RegisterCleanup,
     csv_data: bytes,
     tmp_path: Path,
 ):
     """Dataset files are copied and ingested on the destination when include_dataset_files=True."""
     source_asset = source_client.create_asset(f"migration-e2e-files-asset-{uuid4()}")
-    source_archive(source_asset)
+    register_cleanup(source_asset.archive)
     source_ds = source_client.create_dataset(f"migration-e2e-files-ds-{uuid4()}")
-    source_archive(source_ds)
+    register_cleanup(source_ds.archive)
     source_ds.add_from_io(BytesIO(csv_data), "timestamp", "iso_8601").poll_until_ingestion_completed(
         interval=POLL_INTERVAL
     )
@@ -444,11 +413,11 @@ def test_migrate_asset_with_dataset_files(
     runner.run_migration()
 
     dest_asset = _dest_asset(runner, source_asset, dest_client)
-    dest_archive(dest_asset)
+    register_cleanup(dest_asset.archive)
     dest_ds_rid = runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds.rid)
     assert dest_ds_rid is not None
     dest_ds = dest_client.get_dataset(dest_ds_rid)
-    dest_archive(dest_ds)
+    register_cleanup(dest_ds.archive)
 
     dest_files = list(dest_ds.list_files())
     assert len(dest_files) == 1
@@ -464,8 +433,7 @@ def test_migrate_asset_with_dataset_files(
 def test_migrate_standalone_template(
     source_client: NominalClient,
     dest_client: NominalClient,
-    source_archive: ArchiveFn,
-    dest_archive: ArchiveFn,
+    register_cleanup: RegisterCleanup,
     tmp_path: Path,
 ):
     """Standalone workbook templates are cloned to the destination client."""
@@ -475,7 +443,7 @@ def test_migrate_standalone_template(
         labels=["migration-e2e"],
         properties={"wbt-prop": "wbt-val"},
     )
-    source_archive(source_template)
+    register_cleanup(source_template.archive)
 
     resources = MigrationResources(
         source_assets={},
@@ -487,7 +455,7 @@ def test_migrate_standalone_template(
     dest_template_rid = runner.migration_state.get_mapped_rid(ResourceType.WORKBOOK_TEMPLATE, source_template.rid)
     assert dest_template_rid is not None
     dest_template = dest_client.get_workbook_template(dest_template_rid)
-    dest_archive(dest_template)
+    register_cleanup(dest_template.archive)
     assert dest_template.title == source_template.title
     assert dest_template.description == source_template.description
     assert set(dest_template.labels) == set(source_template.labels)
@@ -497,15 +465,14 @@ def test_migrate_standalone_template(
 def test_migration_idempotency(
     source_client: NominalClient,
     dest_client: NominalClient,
-    source_archive: ArchiveFn,
-    dest_archive: ArchiveFn,
+    register_cleanup: RegisterCleanup,
     tmp_path: Path,
 ):
     """Running run_migration() twice on the same runner creates no duplicate resources."""
     source_asset = source_client.create_asset(f"migration-e2e-idempotent-asset-{uuid4()}")
-    source_archive(source_asset)
+    register_cleanup(source_asset.archive)
     source_ds = source_client.create_dataset(f"migration-e2e-idempotent-ds-{uuid4()}")
-    source_archive(source_ds)
+    register_cleanup(source_ds.archive)
     source_asset.add_dataset("primary", source_ds)
 
     runner = _make_runner(_make_resources(source_asset), _no_files_config(), dest_client, tmp_path / "state.json")
@@ -515,8 +482,8 @@ def test_migration_idempotency(
     dest_ds_rid_1 = runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds.rid)
     assert dest_asset_rid_1 is not None
     assert dest_ds_rid_1 is not None
-    dest_archive(dest_client.get_asset(dest_asset_rid_1))
-    dest_archive(dest_client.get_dataset(dest_ds_rid_1))
+    register_cleanup(dest_client.get_asset(dest_asset_rid_1).archive)
+    register_cleanup(dest_client.get_dataset(dest_ds_rid_1).archive)
 
     runner.run_migration()
     assert runner.migration_state.get_mapped_rid(ResourceType.ASSET, source_asset.rid) == dest_asset_rid_1
@@ -526,8 +493,7 @@ def test_migration_idempotency(
 def test_resume_partial_migration(
     source_client: NominalClient,
     dest_client: NominalClient,
-    source_archive: ArchiveFn,
-    dest_archive: ArchiveFn,
+    register_cleanup: RegisterCleanup,
     tmp_path: Path,
 ):
     """Resuming from a partial state completes the migration without duplicating already-migrated resources.
@@ -537,17 +503,17 @@ def test_resume_partial_migration(
     and ds2 fresh, reuse the pre-existing ds1 (no duplicate), and link both to the new asset.
     """
     source_asset = source_client.create_asset(f"migration-e2e-partial-asset-{uuid4()}")
-    source_archive(source_asset)
+    register_cleanup(source_asset.archive)
     source_ds1 = source_client.create_dataset(f"migration-e2e-partial-ds1-{uuid4()}")
-    source_archive(source_ds1)
+    register_cleanup(source_ds1.archive)
     source_ds2 = source_client.create_dataset(f"migration-e2e-partial-ds2-{uuid4()}")
-    source_archive(source_ds2)
+    register_cleanup(source_ds2.archive)
     source_asset.add_dataset("primary", source_ds1)
     source_asset.add_dataset("secondary", source_ds2)
 
     # Simulate a previous run: ds1 already exists on dest, state file was written, then crash.
     pre_dest_ds1 = dest_client.create_dataset(f"migration-e2e-partial-ds1-pre-{uuid4()}")
-    dest_archive(pre_dest_ds1)
+    register_cleanup(pre_dest_ds1.archive)
     partial_state = MigrationState(rid_mapping={ResourceType.DATASET.value: {source_ds1.rid: pre_dest_ds1.rid}})
     state_file = tmp_path / "state.json"
     state_file.write_text(partial_state.to_json(), encoding="utf-8")
@@ -556,10 +522,10 @@ def test_resume_partial_migration(
     runner.run_migration()
 
     dest_asset = _dest_asset(runner, source_asset, dest_client)
-    dest_archive(dest_asset)
+    register_cleanup(dest_asset.archive)
     dest_ds2_rid = runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds2.rid)
     assert dest_ds2_rid is not None
-    dest_archive(dest_client.get_dataset(dest_ds2_rid))
+    register_cleanup(dest_client.get_dataset(dest_ds2_rid).archive)
 
     # ds1 was reused — no duplicate created.
     assert runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds1.rid) == pre_dest_ds1.rid
@@ -574,8 +540,7 @@ def test_resume_partial_migration(
 def test_resume_complete_migration(
     source_client: NominalClient,
     dest_client: NominalClient,
-    source_archive: ArchiveFn,
-    dest_archive: ArchiveFn,
+    register_cleanup: RegisterCleanup,
     tmp_path: Path,
 ):
     """Resuming from a complete state file creates nothing new.
@@ -584,11 +549,11 @@ def test_resume_complete_migration(
     same state file. The second run must return identical RIDs for every resource.
     """
     source_asset = source_client.create_asset(f"migration-e2e-complete-asset-{uuid4()}")
-    source_archive(source_asset)
+    register_cleanup(source_asset.archive)
     source_ds1 = source_client.create_dataset(f"migration-e2e-complete-ds1-{uuid4()}")
-    source_archive(source_ds1)
+    register_cleanup(source_ds1.archive)
     source_ds2 = source_client.create_dataset(f"migration-e2e-complete-ds2-{uuid4()}")
-    source_archive(source_ds2)
+    register_cleanup(source_ds2.archive)
     source_asset.add_dataset("primary", source_ds1)
     source_asset.add_dataset("secondary", source_ds2)
 
@@ -603,9 +568,9 @@ def test_resume_complete_migration(
     dest_ds1_rid = first_runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds1.rid)
     dest_ds2_rid = first_runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds2.rid)
     assert dest_asset_rid and dest_ds1_rid and dest_ds2_rid
-    dest_archive(dest_client.get_asset(dest_asset_rid))
-    dest_archive(dest_client.get_dataset(dest_ds1_rid))
-    dest_archive(dest_client.get_dataset(dest_ds2_rid))
+    register_cleanup(dest_client.get_asset(dest_asset_rid).archive)
+    register_cleanup(dest_client.get_dataset(dest_ds1_rid).archive)
+    register_cleanup(dest_client.get_dataset(dest_ds2_rid).archive)
 
     # Second run: loads the complete state file, should create nothing.
     # MigrationRunner increments the output path to state_v2.json but reuses the loaded state.

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -1,0 +1,344 @@
+r"""End-to-end tests for the migration library via MigrationRunner.
+
+All tests go through MigrationRunner (the top-level entry point), mirroring
+real-world usage. Direct use of AssetMigrator/DatasetMigrator belongs in unit tests.
+
+Tests cover:
+  - Full migration of an asset with datasets, events, a run, a checklist, and a video
+  - Dataset file upload and channel verification
+  - Idempotency: running the same runner twice produces no duplicates
+  - Resumption from a partial state: missing resources are created, existing ones reused
+  - Resumption from a complete state: a fully-recorded state causes the runner to do nothing
+
+Run with:
+    uv run pytest tests/e2e/migration/ \
+        --source-profile=<prod> --profile=<staging> -v
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+from typing import Callable
+from uuid import uuid4
+
+from nominal.core import NominalClient
+from nominal.core._event_types import EventType
+from nominal.core.asset import Asset
+from nominal.experimental.checklist_utils.checklist_utils import _create_checklist_with_content
+from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
+from nominal.experimental.migration.config.migration_resources import AssetResources, MigrationResources
+from nominal.experimental.migration.migration_runner import MigrationRunner
+from nominal.experimental.migration.migration_state import MigrationState
+from nominal.experimental.migration.resource_type import ResourceType
+from tests.e2e import POLL_INTERVAL, _create_random_start_end
+
+ArchiveFn = Callable[[object], None]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_resources(*assets: Asset) -> MigrationResources:
+    """Wrap one or more source assets into a MigrationResources with no standalone templates."""
+    return MigrationResources(
+        source_assets={a.rid: AssetResources(asset=a, source_workbook_templates=[]) for a in assets},
+        source_standalone_templates=[],
+    )
+
+
+def _no_files_config() -> MigrationDatasetConfig:
+    return MigrationDatasetConfig(preserve_dataset_uuid=False, include_dataset_files=False)
+
+
+def _with_files_config() -> MigrationDatasetConfig:
+    return MigrationDatasetConfig(preserve_dataset_uuid=False, include_dataset_files=True)
+
+
+def _make_runner(
+    resources: MigrationResources,
+    config: MigrationDatasetConfig,
+    dest_client: NominalClient,
+    state_path: Path,
+) -> MigrationRunner:
+    return MigrationRunner(
+        migration_resources=resources,
+        dataset_config=config,
+        destination_client=dest_client,
+        migration_state_path=state_path,
+    )
+
+
+def _dest_asset(runner: MigrationRunner, source_asset: Asset, dest_client: NominalClient) -> Asset:
+    rid = runner.migration_state.get_mapped_rid(ResourceType.ASSET, source_asset.rid)
+    assert rid is not None, f"No dest asset RID in migration state for source {source_asset.rid}"
+    return dest_client.get_asset(rid)
+
+
+def _setup_source_resources(source_client: NominalClient, source_archive: ArchiveFn, mp4_data: bytes):
+    """Create a source asset with one of every resource type (dataset, events, run, checklist, video)."""
+    start, end = _create_random_start_end()
+    tag = uuid4()
+
+    source_asset = source_client.create_asset(f"migration-e2e-asset-{tag}")
+    source_archive(source_asset)
+
+    source_ds = source_client.create_dataset(f"migration-e2e-ds-{tag}")
+    source_archive(source_ds)
+    source_asset.add_dataset("primary", source_ds)
+
+    event_a = source_client.create_event(f"migration-e2e-event-a-{tag}", EventType.FLAG, start, assets=[source_asset])
+    source_archive(event_a)
+    event_b = source_client.create_event(f"migration-e2e-event-b-{tag}", EventType.INFO, start, assets=[source_asset])
+    source_archive(event_b)
+
+    source_run = source_client.create_run(f"migration-e2e-run-{tag}", start, end, assets=[source_asset])
+    source_archive(source_run)
+
+    source_checklist = _create_checklist_with_content(source_client, title=f"migration-e2e-checklist-{tag}")
+    source_archive(source_checklist)
+    source_data_review = source_checklist.execute(source_run)
+    source_archive(source_data_review)
+
+    source_video = source_client.create_video(f"migration-e2e-video-{tag}")
+    source_archive(source_video)
+    source_video.add_from_io(BytesIO(mp4_data), "test.mp4", start=start).poll_until_ingestion_completed(
+        interval=POLL_INTERVAL
+    )
+    source_asset.add_video("camera", source_video)
+
+    return source_asset, source_ds, event_a, event_b, source_run, source_checklist, source_data_review, source_video
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_asset(
+    source_client: NominalClient,
+    dest_client: NominalClient,
+    source_archive: ArchiveFn,
+    dest_archive: ArchiveFn,
+    mp4_data: bytes,
+    tmp_path: Path,
+):
+    """Full migration of an asset covering all resource types: dataset, events, run, checklist, and video.
+
+    Verifies that all child resources are present on the destination and that the migration
+    state records a RID mapping for each one.
+    """
+    # --- source setup ---
+    source_asset, source_ds, event_a, event_b, source_run, source_checklist, source_data_review, source_video = (
+        _setup_source_resources(source_client, source_archive, mp4_data)
+    )
+
+    # --- migrate ---
+    runner = _make_runner(_make_resources(source_asset), _no_files_config(), dest_client, tmp_path / "state.json")
+    runner.run_migration()
+    state = runner.migration_state
+
+    dest_asset = _dest_asset(runner, source_asset, dest_client)
+    dest_archive(dest_asset)
+
+    # --- dataset ---
+    dest_ds_rid = state.get_mapped_rid(ResourceType.DATASET, source_ds.rid)
+    assert dest_ds_rid is not None
+    dest_archive(dest_client.get_dataset(dest_ds_rid))
+    assert "primary" in dict(dest_asset.list_datasets())
+
+    # --- events ---
+    dest_event_names = {e.name for e in dest_asset.search_events()}
+    assert event_a.name in dest_event_names
+    assert event_b.name in dest_event_names
+    assert state.get_mapped_rid(ResourceType.EVENT, event_a.rid) is not None
+    assert state.get_mapped_rid(ResourceType.EVENT, event_b.rid) is not None
+
+    # --- run ---
+    dest_run_rid = state.get_mapped_rid(ResourceType.RUN, source_run.rid)
+    assert dest_run_rid is not None
+    dest_run = dest_client.get_run(dest_run_rid)
+    dest_archive(dest_run)
+    assert dest_run.name == source_run.name
+    assert source_run.name in {r.name for r in dest_asset.list_runs()}
+
+    # --- checklist + data review ---
+    dest_checklist_rid = state.get_mapped_rid(ResourceType.CHECKLIST, source_checklist.rid)
+    assert dest_checklist_rid is not None
+    dest_archive(dest_client.get_checklist(dest_checklist_rid))
+    assert state.get_mapped_rid(ResourceType.DATA_REVIEW, source_data_review.rid) is not None
+
+    # --- video ---
+    dest_video_rid = state.get_mapped_rid(ResourceType.VIDEO, source_video.rid)
+    assert dest_video_rid is not None
+    dest_archive(dest_client.get_video(dest_video_rid))
+    dest_videos = dict(dest_asset.list_videos())
+    assert "camera" in dest_videos
+    assert dest_videos["camera"].rid == dest_video_rid
+
+
+def test_migrate_asset_with_dataset_files(
+    source_client: NominalClient,
+    dest_client: NominalClient,
+    source_archive: ArchiveFn,
+    dest_archive: ArchiveFn,
+    csv_data: bytes,
+    tmp_path: Path,
+):
+    """Dataset files are copied and ingested on the destination when include_dataset_files=True."""
+    source_asset = source_client.create_asset(f"migration-e2e-files-asset-{uuid4()}")
+    source_archive(source_asset)
+    source_ds = source_client.create_dataset(f"migration-e2e-files-ds-{uuid4()}")
+    source_archive(source_ds)
+    source_ds.add_from_io(BytesIO(csv_data), "timestamp", "iso_8601").poll_until_ingestion_completed(
+        interval=POLL_INTERVAL
+    )
+    source_asset.add_dataset("primary", source_ds)
+
+    runner = _make_runner(_make_resources(source_asset), _with_files_config(), dest_client, tmp_path / "state.json")
+    runner.run_migration()
+
+    dest_asset = _dest_asset(runner, source_asset, dest_client)
+    dest_archive(dest_asset)
+    dest_ds_rid = runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds.rid)
+    assert dest_ds_rid is not None
+    dest_ds = dest_client.get_dataset(dest_ds_rid)
+    dest_archive(dest_ds)
+
+    dest_files = list(dest_ds.list_files())
+    assert len(dest_files) == 1
+    dest_files[0].poll_until_ingestion_completed(interval=POLL_INTERVAL)
+
+    source_channels = {ch.name for ch in source_ds.search_channels()}
+    dest_channels = {ch.name for ch in dest_ds.search_channels()}
+    assert source_channels.issubset(dest_channels)
+
+
+def test_migration_idempotency(
+    source_client: NominalClient,
+    dest_client: NominalClient,
+    source_archive: ArchiveFn,
+    dest_archive: ArchiveFn,
+    tmp_path: Path,
+):
+    """Running run_migration() twice on the same runner creates no duplicate resources."""
+    source_asset = source_client.create_asset(f"migration-e2e-idempotent-asset-{uuid4()}")
+    source_archive(source_asset)
+    source_ds = source_client.create_dataset(f"migration-e2e-idempotent-ds-{uuid4()}")
+    source_archive(source_ds)
+    source_asset.add_dataset("primary", source_ds)
+
+    runner = _make_runner(_make_resources(source_asset), _no_files_config(), dest_client, tmp_path / "state.json")
+
+    runner.run_migration()
+    dest_asset_rid_1 = runner.migration_state.get_mapped_rid(ResourceType.ASSET, source_asset.rid)
+    dest_ds_rid_1 = runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds.rid)
+    dest_archive(dest_client.get_asset(dest_asset_rid_1))
+    dest_archive(dest_client.get_dataset(dest_ds_rid_1))
+
+    runner.run_migration()
+    assert runner.migration_state.get_mapped_rid(ResourceType.ASSET, source_asset.rid) == dest_asset_rid_1
+    assert runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds.rid) == dest_ds_rid_1
+
+
+def test_resume_partial_migration(
+    source_client: NominalClient,
+    dest_client: NominalClient,
+    source_archive: ArchiveFn,
+    dest_archive: ArchiveFn,
+    tmp_path: Path,
+):
+    """Resuming from a partial state completes the migration without duplicating already-migrated resources.
+
+    Simulates a crash mid-migration: ds1 was already created on the destination and recorded
+    in the state file, but ds2 and the asset itself were not. The runner must create the asset
+    and ds2 fresh, reuse the pre-existing ds1 (no duplicate), and link both to the new asset.
+    """
+    source_asset = source_client.create_asset(f"migration-e2e-partial-asset-{uuid4()}")
+    source_archive(source_asset)
+    source_ds1 = source_client.create_dataset(f"migration-e2e-partial-ds1-{uuid4()}")
+    source_archive(source_ds1)
+    source_ds2 = source_client.create_dataset(f"migration-e2e-partial-ds2-{uuid4()}")
+    source_archive(source_ds2)
+    source_asset.add_dataset("primary", source_ds1)
+    source_asset.add_dataset("secondary", source_ds2)
+
+    # Simulate a previous run: ds1 already exists on dest, state file was written, then crash.
+    pre_dest_ds1 = dest_client.create_dataset(f"migration-e2e-partial-ds1-pre-{uuid4()}")
+    dest_archive(pre_dest_ds1)
+    partial_state = MigrationState(rid_mapping={ResourceType.DATASET.value: {source_ds1.rid: pre_dest_ds1.rid}})
+    state_file = tmp_path / "state.json"
+    state_file.write_text(partial_state.to_json(), encoding="utf-8")
+
+    runner = _make_runner(_make_resources(source_asset), _no_files_config(), dest_client, state_file)
+    runner.run_migration()
+
+    dest_asset = _dest_asset(runner, source_asset, dest_client)
+    dest_archive(dest_asset)
+    dest_ds2_rid = runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds2.rid)
+    assert dest_ds2_rid is not None
+    dest_archive(dest_client.get_dataset(dest_ds2_rid))
+
+    # ds1 was reused — no duplicate created.
+    assert runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds1.rid) == pre_dest_ds1.rid
+
+    # Both scopes are linked on the destination asset.
+    dest_datasets = dict(dest_asset.list_datasets())
+    assert "primary" in dest_datasets
+    assert "secondary" in dest_datasets
+    assert dest_datasets["primary"].rid == pre_dest_ds1.rid
+
+
+def test_resume_complete_migration(
+    source_client: NominalClient,
+    dest_client: NominalClient,
+    source_archive: ArchiveFn,
+    dest_archive: ArchiveFn,
+    tmp_path: Path,
+):
+    """Resuming from a complete state file creates nothing new.
+
+    Runs the full migration with one runner, then creates a second runner pointed at the
+    same state file. The second run must return identical RIDs for every resource.
+    """
+    source_asset = source_client.create_asset(f"migration-e2e-complete-asset-{uuid4()}")
+    source_archive(source_asset)
+    source_ds1 = source_client.create_dataset(f"migration-e2e-complete-ds1-{uuid4()}")
+    source_archive(source_ds1)
+    source_ds2 = source_client.create_dataset(f"migration-e2e-complete-ds2-{uuid4()}")
+    source_archive(source_ds2)
+    source_asset.add_dataset("primary", source_ds1)
+    source_asset.add_dataset("secondary", source_ds2)
+
+    resources = _make_resources(source_asset)
+    config = _no_files_config()
+    state_file = tmp_path / "state.json"
+
+    # First run: full migration.
+    first_runner = _make_runner(resources, config, dest_client, state_file)
+    first_runner.run_migration()
+    dest_asset_rid = first_runner.migration_state.get_mapped_rid(ResourceType.ASSET, source_asset.rid)
+    dest_ds1_rid = first_runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds1.rid)
+    dest_ds2_rid = first_runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds2.rid)
+    assert dest_asset_rid and dest_ds1_rid and dest_ds2_rid
+    dest_archive(dest_client.get_asset(dest_asset_rid))
+    dest_archive(dest_client.get_dataset(dest_ds1_rid))
+    dest_archive(dest_client.get_dataset(dest_ds2_rid))
+
+    # Second run: loads the complete state file, should create nothing.
+    # MigrationRunner increments the output path to state_v2.json but reuses the loaded state.
+    second_runner = _make_runner(resources, config, dest_client, state_file)
+    second_runner.run_migration()
+
+    assert second_runner.migration_state.get_mapped_rid(ResourceType.ASSET, source_asset.rid) == dest_asset_rid
+    assert second_runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds1.rid) == dest_ds1_rid
+    assert second_runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_ds2.rid) == dest_ds2_rid
+
+    dest_asset = dest_client.get_asset(dest_asset_rid)
+    dest_datasets = dict(dest_asset.list_datasets())
+    assert "primary" in dest_datasets
+    assert "secondary" in dest_datasets
+    assert dest_datasets["primary"].rid == dest_ds1_rid
+    assert dest_datasets["secondary"].rid == dest_ds2_rid

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from io import BytesIO
 from pathlib import Path
-from typing import Callable, Mapping
+from typing import Callable
 from uuid import uuid4
 
 from nominal.core import NominalClient
@@ -286,6 +286,10 @@ def _assert_video_migrated(source: Video, dest: Video, scope_name: str, dest_ass
     dest_videos = dict(dest_asset.list_videos())
     assert scope_name in dest_videos
     assert dest_videos[scope_name].rid == dest.rid
+    # File: the migrated video has exactly one file, fully ingested.
+    dest_files = list(dest.list_files())
+    assert len(dest_files) == 1
+    dest_files[0].poll_until_ingestion_completed(interval=POLL_INTERVAL)
 
 
 def _assert_workbook_migrated(source: Workbook, dest: Workbook, dest_asset: Asset) -> None:
@@ -350,10 +354,8 @@ def test_migrate_asset(
     assert matched.rid == dest_ds.rid
 
     # --- events ---
-    dest_event_a_rid = state.get_mapped_rid(ResourceType.EVENT, event_a.rid)
-    dest_event_b_rid = state.get_mapped_rid(ResourceType.EVENT, event_b.rid)
-    assert dest_event_a_rid is not None
-    assert dest_event_b_rid is not None
+    assert (dest_event_a_rid := state.get_mapped_rid(ResourceType.EVENT, event_a.rid)) is not None
+    assert (dest_event_b_rid := state.get_mapped_rid(ResourceType.EVENT, event_b.rid)) is not None
     dest_event_a = dest_client.get_event(dest_event_a_rid)
     dest_event_b = dest_client.get_event(dest_event_b_rid)
     _assert_event_migrated(event_a, dest_event_a, dest_asset)
@@ -380,9 +382,6 @@ def test_migrate_asset(
     dest_video = dest_client.get_video(dest_video_rid)
     register_cleanup(dest_video.archive)
     _assert_video_migrated(source_video, dest_video, "camera", dest_asset)
-    dest_video_files = list(dest_video.list_files())
-    assert len(dest_video_files) == 1
-    dest_video_files[0].poll_until_ingestion_completed(interval=POLL_INTERVAL)
 
     # --- workbook ---
     dest_workbook_rid = state.get_mapped_rid(ResourceType.WORKBOOK, source_workbook.rid)

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -25,6 +25,11 @@ from uuid import uuid4
 from nominal.core import NominalClient
 from nominal.core._event_types import EventType
 from nominal.core.asset import Asset
+from nominal.core.checklist import Checklist
+from nominal.core.dataset import Dataset
+from nominal.core.event import Event
+from nominal.core.run import Run
+from nominal.core.video import Video
 from nominal.experimental.checklist_utils.checklist_utils import _create_checklist_with_content
 from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
 from nominal.experimental.migration.config.migration_resources import AssetResources, MigrationResources
@@ -78,33 +83,72 @@ def _dest_asset(runner: MigrationRunner, source_asset: Asset, dest_client: Nomin
 
 
 def _setup_source_resources(source_client: NominalClient, source_archive: ArchiveFn, mp4_data: bytes):
-    """Create a source asset with one of every resource type (dataset, events, run, checklist, video)."""
+    """Create a source asset with one of every resource type, each populated with labels,
+    properties, and descriptions to exercise full metadata migration fidelity.
+    """
     start, end = _create_random_start_end()
     tag = uuid4()
 
-    source_asset = source_client.create_asset(f"migration-e2e-asset-{tag}")
+    source_asset = source_client.create_asset(
+        f"migration-e2e-asset-{tag}",
+        description=f"asset-description-{tag}",
+        properties={"asset-prop": "asset-val"},
+        labels=["migration-e2e"],
+    )
     source_archive(source_asset)
 
-    source_ds = source_client.create_dataset(f"migration-e2e-ds-{tag}")
+    source_ds = source_client.create_dataset(
+        f"migration-e2e-ds-{tag}",
+        description=f"ds-description-{tag}",
+        properties={"ds-prop": "ds-val"},
+        labels=["migration-e2e"],
+    )
     source_archive(source_ds)
     source_asset.add_dataset("primary", source_ds)
 
-    event_a = source_client.create_event(f"migration-e2e-event-a-{tag}", EventType.FLAG, start, assets=[source_asset])
+    event_a = source_client.create_event(
+        f"migration-e2e-event-a-{tag}",
+        EventType.FLAG,
+        start,
+        assets=[source_asset],
+        description=f"event-a-description-{tag}",
+        properties={"event-prop": "flag"},
+        labels=["migration-e2e"],
+    )
     source_archive(event_a)
-    event_b = source_client.create_event(f"migration-e2e-event-b-{tag}", EventType.INFO, start, assets=[source_asset])
+    event_b = source_client.create_event(
+        f"migration-e2e-event-b-{tag}",
+        EventType.INFO,
+        start,
+        assets=[source_asset],
+        description=f"event-b-description-{tag}",
+        properties={"event-prop": "info"},
+        labels=["migration-e2e"],
+    )
     source_archive(event_b)
 
-    source_run = source_client.create_run(f"migration-e2e-run-{tag}", start, end, assets=[source_asset])
+    source_run = source_client.create_run(
+        f"migration-e2e-run-{tag}",
+        start,
+        end,
+        assets=[source_asset],
+        description=f"run-description-{tag}",
+        properties={"run-prop": "run-val"},
+        labels=["migration-e2e"],
+    )
     source_archive(source_run)
 
-    source_checklist = _create_checklist_with_content(
-        source_client, title=f"migration-e2e-checklist-{tag}", is_published=True
-    )
+    source_checklist = _create_checklist_with_content(source_client, title=f"migration-e2e-checklist-{tag}")
     source_archive(source_checklist)
     source_data_review = source_checklist.execute(source_run)
     source_archive(source_data_review)
 
-    source_video = source_client.create_video(f"migration-e2e-video-{tag}")
+    source_video = source_client.create_video(
+        f"migration-e2e-video-{tag}",
+        description=f"video-description-{tag}",
+        properties={"video-prop": "video-val"},
+        labels=["migration-e2e"],
+    )
     source_archive(source_video)
     source_video.add_from_io(BytesIO(mp4_data), "test.mp4", start=start).poll_until_ingestion_completed(
         interval=POLL_INTERVAL
@@ -112,6 +156,68 @@ def _setup_source_resources(source_client: NominalClient, source_archive: Archiv
     source_asset.add_video("camera", source_video)
 
     return source_asset, source_ds, event_a, event_b, source_run, source_checklist, source_data_review, source_video
+
+
+# ---------------------------------------------------------------------------
+# Per-resource assertion helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_asset_fields(source: Asset, dest: Asset) -> None:
+    assert dest.name == source.name
+    assert dest.description == source.description
+    assert set(dest.labels) == set(source.labels)
+    assert dest.properties == source.properties
+
+
+def _assert_dataset_fields(source: Dataset, dest: Dataset, scope_name: str, dest_asset: Asset) -> None:
+    assert dest.name == source.name
+    assert dest.description == source.description
+    assert set(dest.labels) == set(source.labels)
+    assert dest.properties == source.properties
+    # Linkage: dataset is accessible under the expected scope on the destination asset.
+    dest_datasets = dict(dest_asset.list_datasets())
+    assert scope_name in dest_datasets
+    assert dest_datasets[scope_name].rid == dest.rid
+
+
+def _assert_event_fields(source: Event, dest: Event, dest_asset: Asset) -> None:
+    assert dest.name == source.name
+    assert dest.type == source.type
+    assert dest.description == source.description
+    assert set(dest.labels) == set(source.labels)
+    assert dest.properties == source.properties
+    # Linkage: event is associated with the destination asset.
+    assert dest.rid in {e.rid for e in dest_asset.search_events()}
+
+
+def _assert_run_fields(source: Run, dest: Run, dest_asset: Asset) -> None:
+    assert dest.name == source.name
+    assert dest.description == source.description
+    assert set(dest.labels) == set(source.labels)
+    assert dest.properties == source.properties
+    assert dest.start == source.start
+    assert dest.end == source.end
+    # Linkage: run appears on the destination asset.
+    assert dest.rid in {r.rid for r in dest_asset.list_runs()}
+
+
+def _assert_checklist_fields(source: Checklist, dest: Checklist) -> None:
+    assert dest.name == source.name
+    assert dest.description == source.description
+    assert set(dest.labels) == set(source.labels)
+    assert dest.properties == source.properties
+
+
+def _assert_video_fields(source: Video, dest: Video, scope_name: str, dest_asset: Asset) -> None:
+    assert dest.name == source.name
+    assert dest.description == source.description
+    assert set(dest.labels) == set(source.labels)
+    assert dest.properties == source.properties
+    # Linkage: video is accessible under the expected scope on the destination asset.
+    dest_videos = dict(dest_asset.list_videos())
+    assert scope_name in dest_videos
+    assert dest_videos[scope_name].rid == dest.rid
 
 
 # ---------------------------------------------------------------------------
@@ -129,8 +235,10 @@ def test_migrate_asset(
 ):
     """Full migration of an asset covering all resource types: dataset, events, run, checklist, and video.
 
-    Verifies that all child resources are present on the destination and that the migration
-    state records a RID mapping for each one.
+    Verifies:
+    - All child resources exist on the destination with RID mappings in state
+    - Metadata (name, description, labels, properties) is preserved for each resource
+    - Resources are correctly linked to the migrated destination asset
     """
     # --- source setup ---
     source_asset, source_ds, event_a, event_b, source_run, source_checklist, source_data_review, source_video = (
@@ -145,40 +253,47 @@ def test_migrate_asset(
     dest_asset = _dest_asset(runner, source_asset, dest_client)
     dest_archive(dest_asset)
 
+    # --- asset ---
+    _assert_asset_fields(source_asset, dest_asset)
+
     # --- dataset ---
     dest_ds_rid = state.get_mapped_rid(ResourceType.DATASET, source_ds.rid)
     assert dest_ds_rid is not None
-    dest_archive(dest_client.get_dataset(dest_ds_rid))
-    assert "primary" in dict(dest_asset.list_datasets())
+    dest_ds = dest_client.get_dataset(dest_ds_rid)
+    dest_archive(dest_ds)
+    _assert_dataset_fields(source_ds, dest_ds, "primary", dest_asset)
 
     # --- events ---
-    dest_event_names = {e.name for e in dest_asset.search_events()}
-    assert event_a.name in dest_event_names
-    assert event_b.name in dest_event_names
-    assert state.get_mapped_rid(ResourceType.EVENT, event_a.rid) is not None
-    assert state.get_mapped_rid(ResourceType.EVENT, event_b.rid) is not None
+    dest_event_a_rid = state.get_mapped_rid(ResourceType.EVENT, event_a.rid)
+    dest_event_b_rid = state.get_mapped_rid(ResourceType.EVENT, event_b.rid)
+    assert dest_event_a_rid is not None
+    assert dest_event_b_rid is not None
+    dest_event_a = dest_client.get_event(dest_event_a_rid)
+    dest_event_b = dest_client.get_event(dest_event_b_rid)
+    _assert_event_fields(event_a, dest_event_a, dest_asset)
+    _assert_event_fields(event_b, dest_event_b, dest_asset)
 
     # --- run ---
     dest_run_rid = state.get_mapped_rid(ResourceType.RUN, source_run.rid)
     assert dest_run_rid is not None
     dest_run = dest_client.get_run(dest_run_rid)
     dest_archive(dest_run)
-    assert dest_run.name == source_run.name
-    assert source_run.name in {r.name for r in dest_asset.list_runs()}
+    _assert_run_fields(source_run, dest_run, dest_asset)
 
     # --- checklist + data review ---
     dest_checklist_rid = state.get_mapped_rid(ResourceType.CHECKLIST, source_checklist.rid)
     assert dest_checklist_rid is not None
-    dest_archive(dest_client.get_checklist(dest_checklist_rid))
+    dest_checklist = dest_client.get_checklist(dest_checklist_rid)
+    dest_archive(dest_checklist)
+    _assert_checklist_fields(source_checklist, dest_checklist)
     assert state.get_mapped_rid(ResourceType.DATA_REVIEW, source_data_review.rid) is not None
 
     # --- video ---
     dest_video_rid = state.get_mapped_rid(ResourceType.VIDEO, source_video.rid)
     assert dest_video_rid is not None
-    dest_archive(dest_client.get_video(dest_video_rid))
-    dest_videos = dict(dest_asset.list_videos())
-    assert "camera" in dest_videos
-    assert dest_videos["camera"].rid == dest_video_rid
+    dest_video = dest_client.get_video(dest_video_rid)
+    dest_archive(dest_video)
+    _assert_video_fields(source_video, dest_video, "camera", dest_asset)
 
 
 def test_migrate_asset_with_dataset_files(

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -4,15 +4,16 @@ All tests go through MigrationRunner (the top-level entry point), mirroring
 real-world usage. Direct use of AssetMigrator/DatasetMigrator belongs in unit tests.
 
 Tests cover:
-  - Full migration of an asset with datasets, events, a run, a checklist, and a video
+  - Full migration of an asset with datasets, events, a run, a checklist, a video, and a workbook
   - Dataset file upload and channel verification
+  - Standalone workbook template migration
   - Idempotency: running the same runner twice produces no duplicates
   - Resumption from a partial state: missing resources are created, existing ones reused
   - Resumption from a complete state: a fully-recorded state causes the runner to do nothing
 
 Run with:
     uv run pytest tests/e2e/migration/ \
-        --source-profile=<prod> --profile=<staging> -v
+        --source-profile=<prod> --dest-profile=<staging> -v
 """
 
 from __future__ import annotations
@@ -32,6 +33,7 @@ from nominal.core.dataset import Dataset
 from nominal.core.event import Event
 from nominal.core.run import Run
 from nominal.core.video import Video
+from nominal.core.workbook import Workbook
 from nominal.experimental.checklist_utils.checklist_utils import _create_checklist_with_content
 from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
 from nominal.experimental.migration.config.migration_resources import AssetResources, MigrationResources
@@ -191,9 +193,31 @@ def _create_source_video(
     return video
 
 
+def _create_source_workbook(
+    source_client: NominalClient,
+    source_archive: ArchiveFn,
+    source_asset: Asset,
+) -> Workbook:
+    """Create a workbook on the source asset.
+
+    Creates an ephemeral template to instantiate the workbook, then archives the template
+    immediately since it is only needed for setup.
+    """
+    template = source_client.create_workbook_template(
+        f"migration-e2e-wb-template-{uuid4()}",
+        description="workbook template description",
+        labels=["migration-e2e"],
+        properties={"wbt-prop": "wbt-val"},
+    )
+    workbook = template.create_workbook(asset=source_asset, title=f"migration-e2e-workbook-{uuid4()}")
+    source_archive(workbook)
+    template.archive()
+    return workbook
+
+
 def _setup_source_resources(
     source_client: NominalClient, source_archive: ArchiveFn, mp4_data: bytes
-) -> tuple[Asset, Dataset, Event, Event, Run, Checklist, DataReview, Video]:
+) -> tuple[Asset, Dataset, Event, Event, Run, Checklist, DataReview, Video, Workbook]:
     """Create a source asset with one of every resource type, each populated with labels,
     properties, and descriptions to exercise full metadata migration fidelity.
     """
@@ -206,7 +230,18 @@ def _setup_source_resources(
         source_client, source_archive, source_run
     )
     source_video = _create_source_video(source_client, source_archive, source_asset, mp4_data, start)
-    return source_asset, source_ds, event_a, event_b, source_run, source_checklist, source_data_review, source_video
+    source_workbook = _create_source_workbook(source_client, source_archive, source_asset)
+    return (
+        source_asset,
+        source_ds,
+        event_a,
+        event_b,
+        source_run,
+        source_checklist,
+        source_data_review,
+        source_video,
+        source_workbook,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -214,14 +249,14 @@ def _setup_source_resources(
 # ---------------------------------------------------------------------------
 
 
-def _assert_asset_fields(source: Asset, dest: Asset) -> None:
+def _assert_asset_migrated(source: Asset, dest: Asset) -> None:
     assert dest.name == source.name
     assert dest.description == source.description
     assert set(dest.labels) == set(source.labels)
     assert dest.properties == source.properties
 
 
-def _assert_dataset_fields(
+def _assert_dataset_migrated(
     source: Dataset,
     dest: Dataset,
     scope_name: str,
@@ -242,7 +277,7 @@ def _assert_dataset_fields(
         assert matched.rid == dest.rid
 
 
-def _assert_event_fields(source: Event, dest: Event, dest_asset: Asset) -> None:
+def _assert_event_migrated(source: Event, dest: Event, dest_asset: Asset) -> None:
     assert dest.name == source.name
     assert dest.type == source.type
     assert dest.start == source.start
@@ -255,7 +290,7 @@ def _assert_event_fields(source: Event, dest: Event, dest_asset: Asset) -> None:
     assert set(dest.asset_rids) == {dest_asset.rid}
 
 
-def _assert_run_fields(source: Run, dest: Run, dest_asset: Asset) -> None:
+def _assert_run_migrated(source: Run, dest: Run, dest_asset: Asset) -> None:
     assert dest.name == source.name
     assert dest.description == source.description
     assert set(dest.labels) == set(source.labels)
@@ -267,14 +302,14 @@ def _assert_run_fields(source: Run, dest: Run, dest_asset: Asset) -> None:
     assert set(dest.assets) == {dest_asset.rid}
 
 
-def _assert_checklist_fields(source: Checklist, dest: Checklist) -> None:
+def _assert_checklist_migrated(source: Checklist, dest: Checklist) -> None:
     assert dest.name == source.name
     assert dest.description == source.description
     assert set(dest.labels) == set(source.labels)
     assert dest.properties == source.properties
 
 
-def _assert_video_fields(source: Video, dest: Video, scope_name: str, dest_asset: Asset) -> None:
+def _assert_video_migrated(source: Video, dest: Video, scope_name: str, dest_asset: Asset) -> None:
     assert dest.name == source.name
     assert dest.description == source.description
     assert set(dest.labels) == set(source.labels)
@@ -283,6 +318,14 @@ def _assert_video_fields(source: Video, dest: Video, scope_name: str, dest_asset
     dest_videos = dict(dest_asset.list_videos())
     assert scope_name in dest_videos
     assert dest_videos[scope_name].rid == dest.rid
+
+
+def _assert_workbook_migrated(source: Workbook, dest: Workbook, dest_asset: Asset) -> None:
+    assert dest.title == source.title
+    # Linkage: workbook appears on the destination asset and references exactly it.
+    assert dest.rid in {w.rid for w in dest_asset.search_workbooks(include_drafts=True)}
+    assert dest.asset_rids is not None
+    assert set(dest.asset_rids) == {dest_asset.rid}
 
 
 # ---------------------------------------------------------------------------
@@ -298,7 +341,7 @@ def test_migrate_asset(
     mp4_data: bytes,
     tmp_path: Path,
 ):
-    """Full migration of an asset covering all resource types: dataset, events, run, checklist, and video.
+    """Full migration of an asset covering all resource types: dataset, events, run, checklist, video, and workbook.
 
     Verifies:
     - All child resources exist on the destination with RID mappings in state
@@ -306,9 +349,17 @@ def test_migrate_asset(
     - Resources are correctly linked to the migrated destination asset
     """
     # --- source setup ---
-    source_asset, source_ds, event_a, event_b, source_run, source_checklist, source_data_review, source_video = (
-        _setup_source_resources(source_client, source_archive, mp4_data)
-    )
+    (
+        source_asset,
+        source_ds,
+        event_a,
+        event_b,
+        source_run,
+        source_checklist,
+        source_data_review,
+        source_video,
+        source_workbook,
+    ) = _setup_source_resources(source_client, source_archive, mp4_data)
 
     # --- migrate ---
     runner = _make_runner(_make_resources(source_asset), _no_files_config(), dest_client, tmp_path / "state.json")
@@ -319,14 +370,14 @@ def test_migrate_asset(
     dest_archive(dest_asset)
 
     # --- asset ---
-    _assert_asset_fields(source_asset, dest_asset)
+    _assert_asset_migrated(source_asset, dest_asset)
 
     # --- dataset ---
     dest_ds_rid = state.get_mapped_rid(ResourceType.DATASET, source_ds.rid)
     assert dest_ds_rid is not None
     dest_ds = dest_client.get_dataset(dest_ds_rid)
     dest_archive(dest_ds)
-    _assert_dataset_fields(source_ds, dest_ds, "primary", dest_asset, series_tags={"scope-tag": "scope-val"})
+    _assert_dataset_migrated(source_ds, dest_ds, "primary", dest_asset, series_tags={"scope-tag": "scope-val"})
 
     # --- events ---
     dest_event_a_rid = state.get_mapped_rid(ResourceType.EVENT, event_a.rid)
@@ -335,22 +386,22 @@ def test_migrate_asset(
     assert dest_event_b_rid is not None
     dest_event_a = dest_client.get_event(dest_event_a_rid)
     dest_event_b = dest_client.get_event(dest_event_b_rid)
-    _assert_event_fields(event_a, dest_event_a, dest_asset)
-    _assert_event_fields(event_b, dest_event_b, dest_asset)
+    _assert_event_migrated(event_a, dest_event_a, dest_asset)
+    _assert_event_migrated(event_b, dest_event_b, dest_asset)
 
     # --- run ---
     dest_run_rid = state.get_mapped_rid(ResourceType.RUN, source_run.rid)
     assert dest_run_rid is not None
     dest_run = dest_client.get_run(dest_run_rid)
     dest_archive(dest_run)
-    _assert_run_fields(source_run, dest_run, dest_asset)
+    _assert_run_migrated(source_run, dest_run, dest_asset)
 
     # --- checklist + data review ---
     dest_checklist_rid = state.get_mapped_rid(ResourceType.CHECKLIST, source_checklist.rid)
     assert dest_checklist_rid is not None
     dest_checklist = dest_client.get_checklist(dest_checklist_rid)
     dest_archive(dest_checklist)
-    _assert_checklist_fields(source_checklist, dest_checklist)
+    _assert_checklist_migrated(source_checklist, dest_checklist)
     assert state.get_mapped_rid(ResourceType.DATA_REVIEW, source_data_review.rid) is not None
 
     # --- video ---
@@ -358,10 +409,17 @@ def test_migrate_asset(
     assert dest_video_rid is not None
     dest_video = dest_client.get_video(dest_video_rid)
     dest_archive(dest_video)
-    _assert_video_fields(source_video, dest_video, "camera", dest_asset)
+    _assert_video_migrated(source_video, dest_video, "camera", dest_asset)
     dest_video_files = list(dest_video.list_files())
     assert len(dest_video_files) == 1
     dest_video_files[0].poll_until_ingestion_completed(interval=POLL_INTERVAL)
+
+    # --- workbook ---
+    dest_workbook_rid = state.get_mapped_rid(ResourceType.WORKBOOK, source_workbook.rid)
+    assert dest_workbook_rid is not None
+    dest_workbook = dest_client.get_workbook(dest_workbook_rid)
+    dest_archive(dest_workbook)
+    _assert_workbook_migrated(source_workbook, dest_workbook, dest_asset)
 
 
 def test_migrate_asset_with_dataset_files(
@@ -401,6 +459,39 @@ def test_migrate_asset_with_dataset_files(
     assert source_channels.issubset(dest_channels), (
         f"Missing channels in destination dataset. Source channels: {source_channels}, Dest channels: {dest_channels}"
     )
+
+
+def test_migrate_standalone_template(
+    source_client: NominalClient,
+    dest_client: NominalClient,
+    source_archive: ArchiveFn,
+    dest_archive: ArchiveFn,
+    tmp_path: Path,
+):
+    """Standalone workbook templates are cloned to the destination client."""
+    source_template = source_client.create_workbook_template(
+        f"migration-e2e-standalone-template-{uuid4()}",
+        description="standalone template description",
+        labels=["migration-e2e"],
+        properties={"wbt-prop": "wbt-val"},
+    )
+    source_archive(source_template)
+
+    resources = MigrationResources(
+        source_assets={},
+        source_standalone_templates=[source_template],
+    )
+    runner = _make_runner(resources, _no_files_config(), dest_client, tmp_path / "state.json")
+    runner.run_migration()
+
+    dest_template_rid = runner.migration_state.get_mapped_rid(ResourceType.WORKBOOK_TEMPLATE, source_template.rid)
+    assert dest_template_rid is not None
+    dest_template = dest_client.get_workbook_template(dest_template_rid)
+    dest_archive(dest_template)
+    assert dest_template.title == source_template.title
+    assert dest_template.description == source_template.description
+    assert set(dest_template.labels) == set(source_template.labels)
+    assert dest_template.properties == source_template.properties
 
 
 def test_migration_idempotency(


### PR DESCRIPTION
## Summary

Add end to end testing for the top-level migrator methods.  This covers complete migration from scratch, migration in a partially completed state, and an idempotency check to verify that our continue migration path works as expected.

This testing suite covers assertions of resources created under the hood, their top-level properties, and their linkages with other resources. We don't have extensive testing of specific resource migrators (like DatasetMigrator) but can easily create them as a fast follow reusing the same code to set up / break down resources.

## Testing

CI workflows.