### PR TITLE
feat: deprecate create_streaming_connection

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -1085,7 +1085,7 @@ class NominalClient:
 
     @deprecated(
         "NominalClient.create_streaming_connection is deprecated and will be removed in a future version. "
-        "Create the datasource and connection separately instead."
+        "Use NominalClient.create_dataset instead."
     )
     def create_streaming_connection(
         self,

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -1083,6 +1083,10 @@ class NominalClient:
         video.add_mcap_from_io(mcap, file_name or name, topic, description, file_type)
         return video
 
+    @deprecated(
+        "NominalClient.create_streaming_connection is deprecated and will be removed in a future version. "
+        "Create the datasource and connection separately instead."
+    )
     def create_streaming_connection(
         self,
         datasource_id: str,


### PR DESCRIPTION
## Summary
- mark \ as deprecated
- align the client method with the existing deprecated top-level wrapper

## Testing
- python3 -m compileall nominal/core/client.py