### PR TITLE
feat: extend as_user impersonation to more create endpoints

### DIFF
--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import time
 from dataclasses import dataclass, field
-from typing import Mapping, Protocol
+from typing import Mapping, Protocol, TypeVar
 
 from conjure_python_client import Service, ServiceConfiguration
 from nominal_api import (
@@ -38,6 +38,7 @@ from nominal.core.exceptions import NominalConfigError
 from nominal.ts import IntegralNanosecondsUTC
 
 ON_BEHALF_OF_USER_RID_HEADER = "X-Nominal-On-Behalf-Of-User"
+TService = TypeVar("TService", bound=Service)
 
 
 @dataclass(frozen=True)
@@ -255,7 +256,7 @@ class ClientsBunch:
     ) -> Self:
         app_base_url = api_base_url_to_app_base_url(base_url)
 
-        def client_factory(service_class: type[Service]) -> Service:
+        def client_factory(service_class: type[TService]) -> TService:
             return create_conjure_client_factory(
                 user_agent=agent,
                 service_config=cfg,

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -159,14 +159,14 @@ class ClientsBunch:
     containerized_extractors: ingest_api.ContainerizedExtractorService
     secrets: secrets_api.SecretService
 
-    def with_service_request_headers(self, service_headers: Mapping[str, Mapping[str, str]]) -> Self:
+    def with_default_request_headers(self, headers: Mapping[str, str]) -> Self:
         return type(self).from_config(
             self._service_config,
             self._api_base_url,
             self._user_agent,
             self._token,
             self.workspace_rid,
-            service_default_headers=service_headers,
+            default_headers=headers,
         )
 
     def _fetch_default_workspace(self) -> security_api_workspace.Workspace:
@@ -252,7 +252,7 @@ class ClientsBunch:
         token: str,
         workspace_rid: str | None,
         *,
-        service_default_headers: Mapping[str, Mapping[str, str]] | None = None,
+        default_headers: Mapping[str, str] | None = None,
     ) -> Self:
         app_base_url = api_base_url_to_app_base_url(base_url)
 
@@ -260,9 +260,7 @@ class ClientsBunch:
             return create_conjure_client_factory(
                 user_agent=agent,
                 service_config=cfg,
-                default_headers=service_default_headers.get(service_class.__name__, {})
-                if service_default_headers is not None
-                else None,
+                default_headers=default_headers,
             )(service_class)
 
         return cls(

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -158,14 +158,14 @@ class ClientsBunch:
     containerized_extractors: ingest_api.ContainerizedExtractorService
     secrets: secrets_api.SecretService
 
-    def with_catalog_request_headers(self, headers: Mapping[str, str]) -> Self:
+    def with_service_request_headers(self, service_headers: Mapping[str, Mapping[str, str]]) -> Self:
         return type(self).from_config(
             self._service_config,
             self._api_base_url,
             self._user_agent,
             self._token,
             self.workspace_rid,
-            catalog_default_headers=headers,
+            service_default_headers=service_headers,
         )
 
     def _fetch_default_workspace(self) -> security_api_workspace.Workspace:
@@ -251,15 +251,18 @@ class ClientsBunch:
         token: str,
         workspace_rid: str | None,
         *,
-        catalog_default_headers: Mapping[str, str] | None = None,
+        service_default_headers: Mapping[str, Mapping[str, str]] | None = None,
     ) -> Self:
         app_base_url = api_base_url_to_app_base_url(base_url)
-        client_factory = create_conjure_client_factory(user_agent=agent, service_config=cfg)
-        catalog_client_factory = create_conjure_client_factory(
-            user_agent=agent,
-            service_config=cfg,
-            default_headers=catalog_default_headers,
-        )
+
+        def client_factory(service_class: type[Service]) -> Service:
+            return create_conjure_client_factory(
+                user_agent=agent,
+                service_config=cfg,
+                default_headers=service_default_headers.get(service_class.__name__, {})
+                if service_default_headers is not None
+                else None,
+            )(service_class)
 
         return cls(
             auth_header=f"Bearer {token}",
@@ -272,7 +275,7 @@ class ClientsBunch:
             assets=client_factory(scout_assets.AssetService),
             attachment=client_factory(attachments_api.AttachmentService),
             authentication=client_factory(authentication_api.AuthenticationServiceV2),
-            catalog=catalog_client_factory(scout_catalog.CatalogService),
+            catalog=client_factory(scout_catalog.CatalogService),
             checklist=client_factory(scout_checks_api.ChecklistService),
             connection=client_factory(scout_datasource_connection.ConnectionService),
             dataexport=client_factory(scout_dataexport_api.DataExportService),

--- a/nominal/experimental/impersonation/__init__.py
+++ b/nominal/experimental/impersonation/__init__.py
@@ -7,15 +7,7 @@ from nominal.core.client import NominalClient
 def as_user(client: NominalClient, user_rid: str) -> NominalClient:
     """Return an experimental derived client for user impersonation.
 
-    The returned client injects the on-behalf-of header for dataset, asset, run, and workbook creation endpoints.
+    The returned client injects the on-behalf-of header for all service requests.
     """
-    header = {ON_BEHALF_OF_USER_RID_HEADER: user_rid}
-    clients = client._clients.with_service_request_headers(
-        {
-            "CatalogService": header,
-            "AssetService": header,
-            "RunService": header,
-            "NotebookService": header,
-        }
-    )
+    clients = client._clients.with_default_request_headers({ON_BEHALF_OF_USER_RID_HEADER: user_rid})
     return NominalClient(_clients=clients, _profile=client._profile)

--- a/nominal/experimental/impersonation/__init__.py
+++ b/nominal/experimental/impersonation/__init__.py
@@ -7,7 +7,15 @@ from nominal.core.client import NominalClient
 def as_user(client: NominalClient, user_rid: str) -> NominalClient:
     """Return an experimental derived client for user impersonation.
 
-    The returned client currently injects the on-behalf-of header only for catalog-backed operations.
+    The returned client injects the on-behalf-of header for dataset, asset, run, and workbook creation endpoints.
     """
-    clients = client._clients.with_catalog_request_headers({ON_BEHALF_OF_USER_RID_HEADER: user_rid})
+    header = {ON_BEHALF_OF_USER_RID_HEADER: user_rid}
+    clients = client._clients.with_service_request_headers(
+        {
+            "CatalogService": header,
+            "AssetService": header,
+            "RunService": header,
+            "NotebookService": header,
+        }
+    )
     return NominalClient(_clients=clients, _profile=client._profile)

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -66,24 +66,26 @@ class _FakeCatalogService:
         self._requests_session = _FakeSession(headers)
 
 
-class _FakeAssetService:
-    def __init__(self, headers: dict[str, str] | None = None) -> None:
-        self._requests_session = _FakeSession(headers)
-
-
-class _FakeRunService:
-    def __init__(self, headers: dict[str, str] | None = None) -> None:
-        self._requests_session = _FakeSession(headers)
-
-
-class _FakeNotebookService:
-    def __init__(self, headers: dict[str, str] | None = None) -> None:
-        self._requests_session = _FakeSession(headers)
-
-
 class _FakeService:
     def __init__(self, headers: dict[str, str] | None = None) -> None:
         self._requests_session = _FakeSession(headers)
+
+
+def _fake_create_conjure_client_factory(
+    *,
+    user_agent,
+    service_config,
+    return_none_for_unknown_union_types=False,
+    default_headers=None,
+):
+    del user_agent, service_config, return_none_for_unknown_union_types
+
+    def factory(service_class):
+        if service_class.__name__ == "CatalogService":
+            return _FakeCatalogService(default_headers)
+        return _FakeService(default_headers)
+
+    return factory
 
 
 def test_api_app_url_conversion():
@@ -209,29 +211,7 @@ def test_resolve_workspace_reuses_the_cached_configured_default_workspace_object
 
 
 def test_with_default_request_headers_recreates_clients_from_config(monkeypatch):
-    def fake_create_conjure_client_factory(
-        *,
-        user_agent,
-        service_config,
-        return_none_for_unknown_union_types=False,
-        default_headers=None,
-    ):
-        del user_agent, service_config, return_none_for_unknown_union_types
-
-        def factory(service_class):
-            if service_class.__name__ == "CatalogService":
-                return _FakeCatalogService(default_headers)
-            if service_class.__name__ == "AssetService":
-                return _FakeAssetService(default_headers)
-            if service_class.__name__ == "RunService":
-                return _FakeRunService(default_headers)
-            if service_class.__name__ == "NotebookService":
-                return _FakeNotebookService(default_headers)
-            return _FakeService(default_headers)
-
-        return factory
-
-    monkeypatch.setattr("nominal.core._clientsbunch.create_conjure_client_factory", fake_create_conjure_client_factory)
+    monkeypatch.setattr("nominal.core._clientsbunch.create_conjure_client_factory", _fake_create_conjure_client_factory)
 
     clients = ClientsBunch.from_config(
         ServiceConfiguration(uris=["https://api.nominal.test"]),
@@ -245,44 +225,14 @@ def test_with_default_request_headers_recreates_clients_from_config(monkeypatch)
 
     assert cloned is not clients
     assert cloned.catalog is not clients.catalog
-    assert cloned.assets is not clients.assets
-    assert cloned.run is not clients.run
-    assert cloned.notebook is not clients.notebook
     assert ON_BEHALF_OF_USER_RID_HEADER not in clients.catalog._requests_session.headers
-    assert ON_BEHALF_OF_USER_RID_HEADER not in clients.assets._requests_session.headers
-    assert ON_BEHALF_OF_USER_RID_HEADER not in clients.run._requests_session.headers
-    assert ON_BEHALF_OF_USER_RID_HEADER not in clients.notebook._requests_session.headers
     assert cloned.catalog._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
     assert cloned.assets._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
-    assert cloned.run._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
-    assert cloned.notebook._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
     assert cloned.attachment._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
 
 
 def test_experimental_as_user_returns_derived_nominal_client(monkeypatch):
-    def fake_create_conjure_client_factory(
-        *,
-        user_agent,
-        service_config,
-        return_none_for_unknown_union_types=False,
-        default_headers=None,
-    ):
-        del user_agent, service_config, return_none_for_unknown_union_types
-
-        def factory(service_class):
-            if service_class.__name__ == "CatalogService":
-                return _FakeCatalogService(default_headers)
-            if service_class.__name__ == "AssetService":
-                return _FakeAssetService(default_headers)
-            if service_class.__name__ == "RunService":
-                return _FakeRunService(default_headers)
-            if service_class.__name__ == "NotebookService":
-                return _FakeNotebookService(default_headers)
-            return _FakeService(default_headers)
-
-        return factory
-
-    monkeypatch.setattr("nominal.core._clientsbunch.create_conjure_client_factory", fake_create_conjure_client_factory)
+    monkeypatch.setattr("nominal.core._clientsbunch.create_conjure_client_factory", _fake_create_conjure_client_factory)
 
     client = NominalClient(
         _clients=ClientsBunch.from_config(
@@ -299,18 +249,9 @@ def test_experimental_as_user_returns_derived_nominal_client(monkeypatch):
     assert isinstance(impersonated, NominalClient)
     assert impersonated is not client
     assert ON_BEHALF_OF_USER_RID_HEADER not in client._clients.catalog._requests_session.headers
-    assert ON_BEHALF_OF_USER_RID_HEADER not in client._clients.assets._requests_session.headers
-    assert ON_BEHALF_OF_USER_RID_HEADER not in client._clients.run._requests_session.headers
-    assert ON_BEHALF_OF_USER_RID_HEADER not in client._clients.notebook._requests_session.headers
     assert impersonated._clients.catalog._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
         "ri.authn.dev.user.target"
     )
     assert impersonated._clients.assets._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
-        "ri.authn.dev.user.target"
-    )
-    assert impersonated._clients.run._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
-        "ri.authn.dev.user.target"
-    )
-    assert impersonated._clients.notebook._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
         "ri.authn.dev.user.target"
     )

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -66,6 +66,21 @@ class _FakeCatalogService:
         self._requests_session = _FakeSession(headers)
 
 
+class _FakeAssetService:
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self._requests_session = _FakeSession(headers)
+
+
+class _FakeRunService:
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self._requests_session = _FakeSession(headers)
+
+
+class _FakeNotebookService:
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self._requests_session = _FakeSession(headers)
+
+
 class _FakeService:
     def __init__(self, headers: dict[str, str] | None = None) -> None:
         self._requests_session = _FakeSession(headers)
@@ -193,7 +208,7 @@ def test_resolve_workspace_reuses_the_cached_configured_default_workspace_object
     workspace_service.get_default_workspace.assert_not_called()
 
 
-def test_with_catalog_request_headers_recreates_clients_from_config(monkeypatch):
+def test_with_service_request_headers_recreates_clients_from_config(monkeypatch):
     def fake_create_conjure_client_factory(
         *,
         user_agent,
@@ -206,6 +221,12 @@ def test_with_catalog_request_headers_recreates_clients_from_config(monkeypatch)
         def factory(service_class):
             if service_class.__name__ == "CatalogService":
                 return _FakeCatalogService(default_headers)
+            if service_class.__name__ == "AssetService":
+                return _FakeAssetService(default_headers)
+            if service_class.__name__ == "RunService":
+                return _FakeRunService(default_headers)
+            if service_class.__name__ == "NotebookService":
+                return _FakeNotebookService(default_headers)
             return _FakeService(default_headers)
 
         return factory
@@ -220,14 +241,30 @@ def test_with_catalog_request_headers_recreates_clients_from_config(monkeypatch)
         None,
     )
 
-    cloned = clients.with_catalog_request_headers({ON_BEHALF_OF_USER_RID_HEADER: "ri.authn.dev.user.target"})
+    header = {ON_BEHALF_OF_USER_RID_HEADER: "ri.authn.dev.user.target"}
+    cloned = clients.with_service_request_headers(
+        {
+            "CatalogService": header,
+            "AssetService": header,
+            "RunService": header,
+            "NotebookService": header,
+        }
+    )
 
     assert cloned is not clients
     assert cloned.catalog is not clients.catalog
+    assert cloned.assets is not clients.assets
+    assert cloned.run is not clients.run
+    assert cloned.notebook is not clients.notebook
     assert ON_BEHALF_OF_USER_RID_HEADER not in clients.catalog._requests_session.headers
+    assert ON_BEHALF_OF_USER_RID_HEADER not in clients.assets._requests_session.headers
+    assert ON_BEHALF_OF_USER_RID_HEADER not in clients.run._requests_session.headers
+    assert ON_BEHALF_OF_USER_RID_HEADER not in clients.notebook._requests_session.headers
     assert cloned.catalog._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
-    assert cloned.catalog._requests_session.headers["User-Agent"] == "test-agent"
-    assert ON_BEHALF_OF_USER_RID_HEADER not in cloned.assets._requests_session.headers
+    assert cloned.assets._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
+    assert cloned.run._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
+    assert cloned.notebook._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
+    assert ON_BEHALF_OF_USER_RID_HEADER not in cloned.attachment._requests_session.headers
 
 
 def test_experimental_as_user_returns_derived_nominal_client(monkeypatch):
@@ -243,6 +280,12 @@ def test_experimental_as_user_returns_derived_nominal_client(monkeypatch):
         def factory(service_class):
             if service_class.__name__ == "CatalogService":
                 return _FakeCatalogService(default_headers)
+            if service_class.__name__ == "AssetService":
+                return _FakeAssetService(default_headers)
+            if service_class.__name__ == "RunService":
+                return _FakeRunService(default_headers)
+            if service_class.__name__ == "NotebookService":
+                return _FakeNotebookService(default_headers)
             return _FakeService(default_headers)
 
         return factory
@@ -264,6 +307,18 @@ def test_experimental_as_user_returns_derived_nominal_client(monkeypatch):
     assert isinstance(impersonated, NominalClient)
     assert impersonated is not client
     assert ON_BEHALF_OF_USER_RID_HEADER not in client._clients.catalog._requests_session.headers
+    assert ON_BEHALF_OF_USER_RID_HEADER not in client._clients.assets._requests_session.headers
+    assert ON_BEHALF_OF_USER_RID_HEADER not in client._clients.run._requests_session.headers
+    assert ON_BEHALF_OF_USER_RID_HEADER not in client._clients.notebook._requests_session.headers
     assert impersonated._clients.catalog._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
+        "ri.authn.dev.user.target"
+    )
+    assert impersonated._clients.assets._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
+        "ri.authn.dev.user.target"
+    )
+    assert impersonated._clients.run._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
+        "ri.authn.dev.user.target"
+    )
+    assert impersonated._clients.notebook._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
         "ri.authn.dev.user.target"
     )

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -208,7 +208,7 @@ def test_resolve_workspace_reuses_the_cached_configured_default_workspace_object
     workspace_service.get_default_workspace.assert_not_called()
 
 
-def test_with_service_request_headers_recreates_clients_from_config(monkeypatch):
+def test_with_default_request_headers_recreates_clients_from_config(monkeypatch):
     def fake_create_conjure_client_factory(
         *,
         user_agent,
@@ -241,15 +241,7 @@ def test_with_service_request_headers_recreates_clients_from_config(monkeypatch)
         None,
     )
 
-    header = {ON_BEHALF_OF_USER_RID_HEADER: "ri.authn.dev.user.target"}
-    cloned = clients.with_service_request_headers(
-        {
-            "CatalogService": header,
-            "AssetService": header,
-            "RunService": header,
-            "NotebookService": header,
-        }
-    )
+    cloned = clients.with_default_request_headers({ON_BEHALF_OF_USER_RID_HEADER: "ri.authn.dev.user.target"})
 
     assert cloned is not clients
     assert cloned.catalog is not clients.catalog
@@ -264,7 +256,7 @@ def test_with_service_request_headers_recreates_clients_from_config(monkeypatch)
     assert cloned.assets._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
     assert cloned.run._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
     assert cloned.notebook._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
-    assert ON_BEHALF_OF_USER_RID_HEADER not in cloned.attachment._requests_session.headers
+    assert cloned.attachment._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
 
 
 def test_experimental_as_user_returns_derived_nominal_client(monkeypatch):


### PR DESCRIPTION
## Summary
- extend `nominal.experimental.as_user(...)` so the derived client injects the on-behalf-of header for assets, runs, and workbooks in addition to datasets
- generalize `ClientsBunch` header overrides from a catalog-only path to per-service default headers during client reconstruction
- add focused unit coverage for header isolation across catalog, asset, run, and notebook services

## Testing
- `uv run pytest tests/core/test_clientsbunch.py`
- `uv run ruff check nominal/core/_utils/networking.py nominal/core/_clientsbunch.py nominal/experimental/__init__.py nominal/experimental/impersonation/__init__.py tests/core/test_clientsbunch.py`
