### PR TITLE
feat: improve export batch calculations in polars export handler

### DIFF
--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -5,7 +5,7 @@ from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.core.asset import Asset
 from nominal.core.attachment import Attachment
 from nominal.core.bounds import Bounds
-from nominal.core.channel import Channel, ChannelDataType
+from nominal.core.channel import Channel, ChannelDataType, filter_channels_with_data
 from nominal.core.checklist import Checklist
 from nominal.core.client import NominalClient, WorkspaceSearchType
 from nominal.core.connection import Connection
@@ -42,6 +42,7 @@ __all__ = [
     "Bounds",
     "Channel",
     "ChannelDataType",
+    "filter_channels_with_data",
     "Checklist",
     "CheckViolation",
     "Connection",

--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -6,7 +6,7 @@ from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.core.asset import Asset
 from nominal.core.attachment import Attachment
 from nominal.core.bounds import Bounds
-from nominal.core.channel import Channel, ChannelDataType
+from nominal.core.channel import Channel, ChannelDataType, filter_channels_with_data
 from nominal.core.checklist import Checklist
 from nominal.core.client import NominalClient, WorkspaceSearchType
 from nominal.core.comment import Comment
@@ -45,6 +45,7 @@ __all__ = [
     "Bounds",
     "Channel",
     "ChannelDataType",
+    "filter_channels_with_data",
     "Checklist",
     "CheckViolation",
     "Connection",

--- a/nominal/core/_utils/api_tools.py
+++ b/nominal/core/_utils/api_tools.py
@@ -98,6 +98,31 @@ def create_api_tags(tags: Mapping[str, str] | None = None) -> dict[str, scout_co
     return {key: scout_compute_api.StringConstant(literal=value) for key, value in tags.items()}
 
 
+def build_compute_tag_filter(tags: Mapping[str, str] | None) -> scout_compute_api.TagFilters | None:
+    """Convert a simple tag mapping into the TagFilters union type for the compute API.
+
+    Each {key: value} pair becomes a TagFilter with operator=IN and a single-element value list.
+    Multiple tags are composed with AND semantics.
+    """
+    if not tags:
+        return None
+
+    single_filters = [
+        scout_compute_api.TagFilters(
+            single=scout_compute_api.TagFilter(
+                key=scout_compute_api.StringConstant(literal=key),
+                values=[scout_compute_api.StringConstant(literal=value)],
+                operator=scout_compute_api.TagFilterOperator.IN,
+            )
+        )
+        for key, value in tags.items()
+    ]
+
+    if len(single_filters) == 1:
+        return single_filters[0]
+    return scout_compute_api.TagFilters(and_=single_filters)
+
+
 def filter_scopes(
     scopes: Sequence[scout_asset_api.DataScope], scope_type: ScopeTypeSpecifier
 ) -> Sequence[scout_asset_api.DataScope]:

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import concurrent.futures
 import enum
+import functools
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import BinaryIO, Iterable, Mapping, Protocol, cast, overload
+from typing import BinaryIO, Iterable, Iterator, Mapping, Protocol, Sequence, cast, overload
 
 from nominal_api import (
     api,
@@ -18,8 +20,9 @@ from nominal_api import (
 )
 from typing_extensions import Self
 
+from nominal._utils.iterator_tools import batched
 from nominal.core._clientsbunch import HasScoutParams
-from nominal.core._utils.api_tools import RefreshableMixin, create_api_tags
+from nominal.core._utils.api_tools import RefreshableMixin, build_compute_tag_filter, create_api_tags
 from nominal.core._utils.pagination_tools import paginate_rpc
 from nominal.core.log import LogPoint, _log_filter_operator
 from nominal.core.unit import UnitLike, _build_unit_update
@@ -442,3 +445,147 @@ def _create_series_from_channel(
         return scout_compute_api.Series(log=scout_compute_api.LogSeries(channel=channel_series))
     else:
         raise ValueError(f"Unsupported channel data type: {data_type}")
+
+
+def _batch_check_channels_have_data(
+    clients: Channel._Clients,
+    channels: Sequence[Channel],
+    tag_filters: scout_compute_api.TagFilters | None,
+    start: api.Timestamp,
+    end: api.Timestamp,
+) -> tuple[list[Channel], list[str]]:
+    """Check a batch of channels for data presence via a single batchGetSeriesCount call.
+
+    Returns a tuple of:
+        - channels confirmed to have data (series_count > 0)
+        - names of channels with underconstrained tags (series_count > 1)
+    """
+    time_range = api.Range(start=start, end=end)
+    request = datasource_api.BatchGetSeriesCountRequest(
+        requests=[
+            datasource_api.GetSeriesCountRequest(
+                data_source_rid=channel.data_source,
+                channel=channel.name,
+                range=time_range,
+                tag_filters=tag_filters,
+            )
+            for channel in channels
+        ]
+    )
+    response = clients.datasource.batch_get_series_count(clients.auth_header, request)
+
+    channels_with_data: list[Channel] = []
+    underconstrained: list[str] = []
+    for channel, result in zip(channels, response.responses, strict=True):
+        count = result.series_count
+        if count is not None and count > 0:
+            channels_with_data.append(channel)
+            # Multiple series for a single channel+tags means the tags don't fully
+            # constrain the data — results may contain duplicate timestamps.
+            if count > 1:
+                underconstrained.append(channel.name)
+
+    return channels_with_data, underconstrained
+
+
+def filter_channels_with_data(
+    channels: Sequence[Channel],
+    *,
+    tags: Mapping[str, str] | None = None,
+    start_time: datetime | IntegralNanosecondsUTC,
+    end_time: datetime | IntegralNanosecondsUTC,
+    num_workers: int = 8,
+    batch_size: int = 200,
+) -> Iterator[Channel]:
+    """Yield channels that have data in the given time range, optionally filtered by tags.
+
+    Uses batchGetSeriesCount to query data presence server-side in batched API calls. If a
+    batch call fails, its channels are re-submitted individually into the same pool; a
+    single-channel call that fails is treated as having no data and excluded.
+
+    Args:
+        channels: Channels to check for data presence.
+        tags: If provided, only yield channels matching these tag key-value pairs.
+        start_time: Start of the time range to check for data.
+        end_time: End of the time range to check for data.
+        num_workers: Number of concurrent API requests.
+        batch_size: Max channels per API call.
+
+    Yields:
+        Channel objects for each input channel confirmed to have data in the range.
+    """
+    if not channels:
+        return
+
+    clients = channels[0]._clients
+    api_start = _SecondsNanos.from_flexible(start_time).to_api()
+    api_end = _SecondsNanos.from_flexible(end_time).to_api()
+    tag_filters = build_compute_tag_filter(tags)
+
+    matched_keys: set[tuple[str, str]] = set()
+    all_underconstrained: list[str] = []
+    still_failing: list[Channel] = []
+
+    check_batch = functools.partial(
+        _batch_check_channels_have_data,
+        clients,
+        tag_filters=tag_filters,
+        start=api_start,
+        end=api_end,
+    )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as pool:
+        pending: dict[concurrent.futures.Future[tuple[list[Channel], list[str]]], Sequence[Channel]] = {
+            pool.submit(check_batch, batch): batch for batch in batched(channels, batch_size)
+        }
+
+        while pending:
+            done, _ = concurrent.futures.wait(pending, return_when=concurrent.futures.FIRST_COMPLETED)
+            for future in done:
+                batch = pending.pop(future)
+                try:
+                    matched, underconstrained = future.result()
+                except Exception:
+                    # A single-channel request that failed is already a retry (or was submitted
+                    # that way by the caller via batch_size=1); don't retry indefinitely.
+                    if len(batch) == 1:
+                        still_failing.extend(batch)
+                        continue
+                    logger.warning(
+                        "Batch data-presence check failed for %d channels; retrying individually",
+                        len(batch),
+                    )
+                    for ch in batch:
+                        pending[pool.submit(check_batch, [ch])] = [ch]
+                    continue
+
+                for ch in matched:
+                    matched_keys.add((ch.data_source, ch.name))
+                all_underconstrained.extend(underconstrained)
+
+    if still_failing:
+        # Both the batch and the individual retry failed — we can't verify data exists, so
+        # exclude these channels rather than admitting. Admitting would run expensive PPS
+        # compute downstream on channels the export would likely fail on anyway.
+        logger.warning(
+            "Data-presence check failed for %d channels even after individual retry; "
+            "treating as having no data and excluding from export: %s",
+            len(still_failing),
+            ", ".join(ch.name for ch in still_failing),
+        )
+
+    if all_underconstrained:
+        sample = all_underconstrained[:10]
+        joined = ", ".join(sample)
+        suffix = f", ... ({len(all_underconstrained) - 10} more)" if len(all_underconstrained) > 10 else ""
+        logger.warning(
+            "%d channels have underconstrained tags (multiple series matched): %s%s",
+            len(all_underconstrained),
+            joined,
+            suffix,
+        )
+
+    # Yield in original input order
+    for channel in channels:
+        if (channel.data_source, channel.name) in matched_keys:
+            yield channel

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import concurrent.futures
 import enum
+import functools
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import BinaryIO, Iterable, Mapping, Protocol, cast, overload
+from typing import BinaryIO, Iterable, Iterator, Mapping, Protocol, Sequence, cast, overload
 
 from nominal_api import (
     api,
@@ -18,8 +20,9 @@ from nominal_api import (
 )
 from typing_extensions import Self
 
+from nominal._utils.iterator_tools import batched
 from nominal.core._clientsbunch import HasScoutParams
-from nominal.core._utils.api_tools import RefreshableMixin, create_api_tags
+from nominal.core._utils.api_tools import RefreshableMixin, build_compute_tag_filter, create_api_tags
 from nominal.core._utils.pagination_tools import paginate_rpc
 from nominal.core.log import LogPoint, _log_filter_operator
 from nominal.core.unit import UnitLike, _build_unit_update
@@ -444,3 +447,147 @@ def _create_series_from_channel(
         return scout_compute_api.Series(log=scout_compute_api.LogSeries(channel=channel_series))
     else:
         raise ValueError(f"Unsupported channel data type: {data_type}")
+
+
+def _batch_check_channels_have_data(
+    clients: Channel._Clients,
+    channels: Sequence[Channel],
+    tag_filters: scout_compute_api.TagFilters | None,
+    start: api.Timestamp,
+    end: api.Timestamp,
+) -> tuple[list[Channel], list[str]]:
+    """Check a batch of channels for data presence via a single batchGetSeriesCount call.
+
+    Returns a tuple of:
+        - channels confirmed to have data (series_count > 0)
+        - names of channels with underconstrained tags (series_count > 1)
+    """
+    time_range = api.Range(start=start, end=end)
+    request = datasource_api.BatchGetSeriesCountRequest(
+        requests=[
+            datasource_api.GetSeriesCountRequest(
+                data_source_rid=channel.data_source,
+                channel=channel.name,
+                range=time_range,
+                tag_filters=tag_filters,
+            )
+            for channel in channels
+        ]
+    )
+    response = clients.datasource.batch_get_series_count(clients.auth_header, request)
+
+    channels_with_data: list[Channel] = []
+    underconstrained: list[str] = []
+    for channel, result in zip(channels, response.responses, strict=True):
+        count = result.series_count
+        if count is not None and count > 0:
+            channels_with_data.append(channel)
+            # Multiple series for a single channel+tags means the tags don't fully
+            # constrain the data — results may contain duplicate timestamps.
+            if count > 1:
+                underconstrained.append(channel.name)
+
+    return channels_with_data, underconstrained
+
+
+def filter_channels_with_data(
+    channels: Sequence[Channel],
+    *,
+    tags: Mapping[str, str] | None = None,
+    start_time: datetime | IntegralNanosecondsUTC,
+    end_time: datetime | IntegralNanosecondsUTC,
+    num_workers: int = 8,
+    batch_size: int = 200,
+) -> Iterator[Channel]:
+    """Yield channels that have data in the given time range, optionally filtered by tags.
+
+    Uses batchGetSeriesCount to query data presence server-side in batched API calls. If a
+    batch call fails, its channels are re-submitted individually into the same pool; a
+    single-channel call that fails is treated as having no data and excluded.
+
+    Args:
+        channels: Channels to check for data presence.
+        tags: If provided, only yield channels matching these tag key-value pairs.
+        start_time: Start of the time range to check for data.
+        end_time: End of the time range to check for data.
+        num_workers: Number of concurrent API requests.
+        batch_size: Max channels per API call.
+
+    Yields:
+        Channel objects for each input channel confirmed to have data in the range.
+    """
+    if not channels:
+        return
+
+    clients = channels[0]._clients
+    api_start = _SecondsNanos.from_flexible(start_time).to_api()
+    api_end = _SecondsNanos.from_flexible(end_time).to_api()
+    tag_filters = build_compute_tag_filter(tags)
+
+    matched_keys: set[tuple[str, str]] = set()
+    all_underconstrained: list[str] = []
+    still_failing: list[Channel] = []
+
+    check_batch = functools.partial(
+        _batch_check_channels_have_data,
+        clients,
+        tag_filters=tag_filters,
+        start=api_start,
+        end=api_end,
+    )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as pool:
+        pending: dict[concurrent.futures.Future[tuple[list[Channel], list[str]]], Sequence[Channel]] = {
+            pool.submit(check_batch, batch): batch for batch in batched(channels, batch_size)
+        }
+
+        while pending:
+            done, _ = concurrent.futures.wait(pending, return_when=concurrent.futures.FIRST_COMPLETED)
+            for future in done:
+                batch = pending.pop(future)
+                try:
+                    matched, underconstrained = future.result()
+                except Exception:
+                    # A single-channel request that failed is already a retry (or was submitted
+                    # that way by the caller via batch_size=1); don't retry indefinitely.
+                    if len(batch) == 1:
+                        still_failing.extend(batch)
+                        continue
+                    logger.warning(
+                        "Batch data-presence check failed for %d channels; retrying individually",
+                        len(batch),
+                    )
+                    for ch in batch:
+                        pending[pool.submit(check_batch, [ch])] = [ch]
+                    continue
+
+                for ch in matched:
+                    matched_keys.add((ch.data_source, ch.name))
+                all_underconstrained.extend(underconstrained)
+
+    if still_failing:
+        # Both the batch and the individual retry failed — we can't verify data exists, so
+        # exclude these channels rather than admitting. Admitting would run expensive PPS
+        # compute downstream on channels the export would likely fail on anyway.
+        logger.warning(
+            "Data-presence check failed for %d channels even after individual retry; "
+            "treating as having no data and excluding from export: %s",
+            len(still_failing),
+            ", ".join(ch.name for ch in still_failing),
+        )
+
+    if all_underconstrained:
+        sample = all_underconstrained[:10]
+        joined = ", ".join(sample)
+        suffix = f", ... ({len(all_underconstrained) - 10} more)" if len(all_underconstrained) > 10 else ""
+        logger.warning(
+            "%d channels have underconstrained tags (multiple series matched): %s%s",
+            len(all_underconstrained),
+            joined,
+            suffix,
+        )
+
+    # Yield in original input order
+    for channel in channels:
+        if (channel.data_source, channel.name) in matched_keys:
+            yield channel

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -461,6 +461,10 @@ def _batch_check_channels_have_data(
     Returns a tuple of:
         - channels confirmed to have data (series_count > 0)
         - names of channels with underconstrained tags (series_count > 1)
+
+    NOTE: request may fail if rate limits are breached, too many series are queried, bounds are invalid
+        (such as end < start), timeouts are reached, or otherwise if tag filters are invalid or contradictory.
+        This will raise various ConjureHttpError exceptions.
     """
     time_range = api.Range(start=start, end=end)
     request = datasource_api.BatchGetSeriesCountRequest(
@@ -548,6 +552,7 @@ def filter_channels_with_data(
                 try:
                     matched, underconstrained = future.result()
                 except Exception:
+                    # Series count calculations may fail for a myriad of reasons, such as
                     # A single-channel request that failed is already a retry (or was submitted
                     # that way by the caller via batch_size=1); don't retry indefinitely.
                     if len(batch) == 1:

--- a/nominal/thirdparty/polars/polars_export_handler.py
+++ b/nominal/thirdparty/polars/polars_export_handler.py
@@ -10,11 +10,10 @@ from nominal_api import api, scout_compute_api, scout_dataexport_api
 from typing_extensions import Self
 
 from nominal._utils import LogTiming
-from nominal.core.channel import Channel, ChannelDataType
+from nominal._utils.iterator_tools import batched
+from nominal.core.channel import Channel, ChannelDataType, filter_channels_with_data
 from nominal.core.client import NominalClient
 from nominal.core.datasource import DataSource
-from nominal.experimental.compute import batch_compute_buckets
-from nominal.experimental.compute.dsl import exprs
 from nominal.ts import (
     Epoch,
     IntegralNanosecondsDuration,
@@ -46,66 +45,108 @@ DEFAULT_CHANNELS_PER_REQUEST = 25
 # TODO(drake) raise 1000 limit once backend limit is raised
 MAX_NUM_BUCKETS = 1000
 
+# Channel data types that can be exported as dataframe columns.
+_EXPORTABLE_DATA_TYPES: frozenset[ChannelDataType] = frozenset(
+    [ChannelDataType.DOUBLE, ChannelDataType.INT, ChannelDataType.STRING]
+)
+
 DEFAULT_EXPORTED_TIMESTAMP_COL_NAME = "timestamp"
 _INTERNAL_TS_COL = "__nmnl_ts__"  # internal join key, chosen to avoid collision with channel names
 
 logger = logging.getLogger(__name__)
 
 
-def _group_channels_by_datatype(channels: Sequence[Channel]) -> Mapping[ChannelDataType, Sequence[Channel]]:
-    """Partition the provided channels by data type.
+def _extract_bucket_counts(
+    response: scout_compute_api.ComputeNodeResponse,
+) -> Sequence[tuple[IntegralNanosecondsUTC, int]]:
+    """Extract (timestamp, point_count) pairs from a compute response.
 
-    Channels with no datatype are grouped into the UNKNOWN partition of channels.
-
-    Args:
-        channels: Channels to partition
-    Returns:
-        Mapping of data type to a list of the corresponding channels
+    Works for both numeric and enum series. Handles bucketed (decimated) responses
+    as well as undecimated fallbacks when the data has fewer points than requested buckets.
     """
-    channel_groups = collections.defaultdict(list)
-    for channel in channels:
-        channel_groups[channel.data_type or ChannelDataType.UNKNOWN].append(channel)
-    return {**channel_groups}
+    # Numeric — decimated into buckets with statistics
+    if response.bucketed_numeric is not None:
+        return [
+            (_SecondsNanos.from_api(ts).to_nanoseconds(), bucket.count)
+            for ts, bucket in zip(response.bucketed_numeric.timestamps, response.bucketed_numeric.buckets)
+        ]
+
+    # Numeric — undecimated (fewer points than requested buckets)
+    if response.numeric is not None:
+        return [(_SecondsNanos.from_api(ts).to_nanoseconds(), 1) for ts in response.numeric.timestamps]
+
+    # Numeric — single point
+    if response.numeric_point is not None:
+        return [(_SecondsNanos.from_api(response.numeric_point.timestamp).to_nanoseconds(), 1)]
+
+    # Enum — decimated into buckets with histograms
+    if response.bucketed_enum is not None:
+        return [
+            (_SecondsNanos.from_api(ts).to_nanoseconds(), sum(bucket.histogram.values()))
+            for ts, bucket in zip(response.bucketed_enum.timestamps, response.bucketed_enum.buckets)
+        ]
+
+    # Enum — undecimated (fewer points than requested buckets)
+    if response.enum is not None:
+        return [(_SecondsNanos.from_api(ts).to_nanoseconds(), 1) for ts in response.enum.timestamps]
+
+    logger.warning("Unrecognized compute response type: %s", response.type)
+    return []
 
 
-def _has_data_with_tags(channel: Channel, tags: Mapping[str, str], start_ns: int, end_ns: int) -> bool:
-    available_tags = channel.get_available_tags(start_ns, end_ns, tags)
+def _build_compute_request(
+    series: scout_compute_api.Series,
+    start: api.Timestamp,
+    end: api.Timestamp,
+    num_buckets: int,
+) -> scout_compute_api.ComputeNodeRequest:
+    """Build a decimation compute request for a single series."""
+    return scout_compute_api.ComputeNodeRequest(
+        context=scout_compute_api.Context(variables={}),
+        node=scout_compute_api.ComputableNode(
+            series=scout_compute_api.SummarizeSeries(
+                input=series,
+                numeric_aggregations={},
+                summarization_strategy=scout_compute_api.SummarizationStrategy(
+                    decimate=scout_compute_api.DecimateStrategy(
+                        buckets=scout_compute_api.DecimateWithBuckets(buckets=num_buckets)
+                    )
+                ),
+                buckets=num_buckets,
+            )
+        ),
+        start=start,
+        end=end,
+    )
 
-    # No data matches the given tags
-    if not available_tags:
-        return False
 
-    bad_tag_items = {name: values for name, values in available_tags.items() if len(values) > 1}
-    if bad_tag_items:
-        logger.warning(
-            "Channel %s has underconstrained tags-- results may have duplicate rows: %s", channel.name, bad_tag_items
-        )
-
-    return True
-
-
-def _build_point_rate_expressions(
-    channels: Sequence[Channel],
+def _peak_points_per_second(
+    bucket_counts: Sequence[tuple[IntegralNanosecondsUTC, int]],
     start_ns: IntegralNanosecondsUTC,
     end_ns: IntegralNanosecondsUTC,
-    tags: Mapping[str, str],
-) -> Sequence[tuple[Channel, exprs.NumericExpr | None]]:
-    expressions: list[tuple[Channel, exprs.NumericExpr | None]] = []
-    for channel in channels:
-        if channel.data_type is not ChannelDataType.DOUBLE:
-            logger.warning(
-                "Can only compute points per second on float channels, but %s has type: %s",
-                channel.name,
-                channel.data_type,
-            )
-            expressions.append((channel, None))
-        elif tags and not _has_data_with_tags(channel, tags, start_ns, end_ns):
-            logger.warning("No points found in range for channel '%s'", channel.name)
-            expressions.append((channel, None))
-        else:
-            expressions.append((channel, exprs.NumericExpr.datasource_channel(channel.data_source, channel.name, tags)))
+) -> float:
+    """Compute the peak points-per-second from a sequence of (timestamp, count) bucket data.
 
-    return expressions
+    For a single bucket, uses the full time range as the duration. For multiple buckets,
+    computes PPS between consecutive bucket timestamps and returns the peak.
+    Returns 0.0 if the time range or any bucket interval has zero duration.
+    """
+    if len(bucket_counts) == 0:
+        return 0.0
+    elif len(bucket_counts) == 1:
+        total_duration = (end_ns - start_ns) / 1e9
+        if total_duration <= 0:
+            return 0.0
+        return bucket_counts[0][1] / total_duration
+    else:
+        peak_pps = 0.0
+        for idx in range(1, len(bucket_counts)):
+            ts, count = bucket_counts[idx]
+            prev_ts = bucket_counts[idx - 1][0]
+            duration = (ts - prev_ts) / 1e9
+            if duration > 0:
+                peak_pps = max(peak_pps, count / duration)
+        return peak_pps
 
 
 def _batch_channel_points_per_second(
@@ -115,67 +156,77 @@ def _batch_channel_points_per_second(
     end_ns: IntegralNanosecondsUTC,
     tags: dict[str, str],
     num_buckets: int,
-) -> Mapping[str, float | None]:
-    """For each provided channel, determine the maximum number of points per second in the given range.
+) -> Mapping[tuple[str, str], float | None]:
+    """For each provided channel, determine the peak points per second in the given range.
 
-    NOTE: Not intended for direct use-- see `_channel_points_per_second`
-    NOTE: do not use with more than 300 channels, or 500 concurrently across all requests, or concurrency limits
-          will be breached and the request will fail.
+    Supports all channel data types (DOUBLE, INT, STRING) by building the appropriate
+    compute series for each and submitting a single BatchComputeWithUnitsRequest.
+
+    NOTE: Not intended for direct use — see `_channel_points_per_second`.
+    NOTE: Do not use with more than 300 channels, or 500 concurrently across all requests.
 
     Args:
         client: Nominal request client
-        channels: Channels to query data rates for
+        channels: Channels to query data rates for (must be DOUBLE, INT, or STRING)
         start_ns: Start of the time range to query over
         end_ns: End of the time range to query over
         tags: Key-value pairs of tags to filter data with
-        num_buckets: Number of buckets to use-- more typically leads to better results.
+        num_buckets: Number of buckets to use — more typically leads to better results.
             NOTE: max number of buckets allowed is 1000
 
     Returns:
-        Mapping of channel name to maximum points/second for the respective channels
+        Mapping of (data_source, channel_name) to peak points/second. A value of `None`
+        indicates the backend failed to compute a rate for that channel (e.g. transient
+        error); `0.0` indicates the compute succeeded but returned no buckets.
+
+    Raises:
+        ValueError: If any channel has an unsupported data type (not DOUBLE/INT/STRING).
     """
     if not channels:
-        logger.warning("No channels given!")
         return {}
     elif num_buckets > MAX_NUM_BUCKETS:
         raise ValueError(f"num_buckets ({num_buckets}) must be <= {MAX_NUM_BUCKETS}")
 
-    # For each channel that has data with the given tags within the provided time range, add a
-    # compute expression to later retrieve decimated bucket stats
-    results: dict[str, float | None] = {}
-    expressions = []
-    channels_in_expressions = []
-    for channel, expression in _build_point_rate_expressions(list(channels), start_ns, end_ns, tags):
-        if expression is None:
-            results[channel.name] = None
-        else:
-            expressions.append(expression)
-            channels_in_expressions.append(channel)
+    # _to_compute_series raises ValueError for unsupported types; callers are expected to
+    # pre-filter to DOUBLE/INT/STRING channels (see _compute_export_jobs).
+    series_list = [channel._to_compute_series(tags=tags) for channel in channels]
 
-    # For each channel, compute the number of points across the desired number of buckets.
-    # Compute the approximate average points/second in each bucket, and use the largest
-    # across all buckets as the points per second for that channel.
+    api_start = _SecondsNanos.from_nanoseconds(start_ns).to_api()
+    api_end = _SecondsNanos.from_nanoseconds(end_ns).to_api()
+
     try:
-        batch_buckets = batch_compute_buckets(client, expressions, start_ns, end_ns, buckets=num_buckets)
+        request = scout_compute_api.BatchComputeWithUnitsRequest(
+            requests=[_build_compute_request(s, api_start, api_end, num_buckets) for s in series_list]
+        )
+        resp = client._clients.compute.batch_compute_with_units(
+            auth_header=client._clients.auth_header,
+            request=request,
+        )
     except Exception:
-        logger.exception("Failed to compute buckets for channels: %s", [ch.name for ch in channels_in_expressions])
-        return {ch.name: None for ch in channels}
+        logger.exception("Failed to compute buckets for channels: %s", [ch.name for ch in channels])
+        return {(ch.data_source, ch.name): None for ch in channels}
 
-    for channel, buckets in zip(channels_in_expressions, batch_buckets):
-        if len(buckets) == 0:
+    results: dict[tuple[str, str], float | None] = {}
+    for channel, result in zip(channels, resp.results):
+        key = (channel.data_source, channel.name)
+        compute_result = result.compute_result
+        if compute_result is None or compute_result.error is not None:
+            error_msg = compute_result.error if compute_result else "no result"
+            logger.warning("Failed to compute point rate for channel '%s': %s", channel.name, error_msg)
+            results[key] = None
+            continue
+
+        if compute_result.success is None:
+            logger.warning("Compute succeeded for channel '%s' but response is empty", channel.name)
+            results[key] = None
+            continue
+
+        bucket_counts = _extract_bucket_counts(compute_result.success)
+        if not bucket_counts:
             logger.warning("No points found in range for channel '%s'", channel.name)
-            results[channel.name] = 0
-        elif len(buckets) == 1:
-            results[channel.name] = buckets[0].count / ((end_ns - start_ns) / 1e9)
+            results[key] = 0.0
         else:
-            max_points_per_second = 0.0
-            for idx in range(1, len(buckets)):
-                bucket = buckets[idx]
-                last_bucket = buckets[idx - 1]
-                bucket_duration = (bucket.timestamp - last_bucket.timestamp) / 1e9
-                points_per_second = bucket.count / bucket_duration
-                max_points_per_second = max(max_points_per_second, points_per_second)
-                results[channel.name] = max_points_per_second
+            results[key] = _peak_points_per_second(bucket_counts, start_ns, end_ns)
 
     return results
 
@@ -188,11 +239,11 @@ def _channel_points_per_second(
     tags: Mapping[str, str] | None = None,
     num_buckets: int = 100,
     num_workers: int = DEFAULT_NUM_WORKERS,
-) -> Mapping[str, float | None]:
-    """For each provided channel, determine the maximum number of points per second in the given range.
+) -> Mapping[tuple[str, str], float | None]:
+    """For each provided channel, determine the peak number of points per second in the given range.
 
-    This method will take the list of channels provided, and group them into batches (as determined by
-    `batch_size`) and perform queries in parallel using the provided `Executor`.
+    Splits channels into batches of `DEFAULT_CHANNELS_PER_REQUEST` and queries each batch in parallel
+    via an internally-managed thread pool.
 
     NOTE: may take a long time for large channel counts. Takes approx. 30s for 1000 channels with good internet,
           but varies based on how many points are within the query bounds.
@@ -207,14 +258,15 @@ def _channel_points_per_second(
         num_workers: Number of parallel requests to make
 
     Returns:
-        Mapping of channel name to maximum points/second for the respective channels
+        Mapping of (data_source, channel_name) to peak points/second, or None when the
+        estimation failed. Keying by the tuple keeps same-named channels from different
+        datasources independent.
     """
     start_ns = _SecondsNanos.from_flexible(start).to_nanoseconds()
     end_ns = _SecondsNanos.from_flexible(end).to_nanoseconds()
     with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as pool:
         futures = {}
-        for idx in range(0, len(channels), DEFAULT_CHANNELS_PER_REQUEST):
-            channel_batch = channels[idx : idx + DEFAULT_CHANNELS_PER_REQUEST]
+        for channel_batch in batched(channels, DEFAULT_CHANNELS_PER_REQUEST):
             fut = pool.submit(
                 _batch_channel_points_per_second,
                 client,
@@ -226,69 +278,76 @@ def _channel_points_per_second(
             )
             futures[fut] = channel_batch
 
-        results = {}
+        results: dict[tuple[str, str], float | None] = {}
         num_processed = 0
         for fut in concurrent.futures.as_completed(futures):
             channel_batch = futures[fut]
             num_processed += len(channel_batch)
             logger.debug("Completed querying %d/%d channels for update rate", num_processed, len(channels))
 
-            ex = fut.exception()
-            if ex is not None:
-                logger.error(
+            try:
+                res = fut.result()
+            except Exception:
+                logger.exception(
                     "Failed to extract %d channel sample rates: %s",
                     len(channel_batch),
                     [ch.name for ch in channel_batch],
-                    exc_info=ex,
                 )
                 continue
-
-            res = fut.result()
-            for channel, rate in res.items():
-                results[channel] = rate
+            results.update(res)
 
         return results
 
 
 def _build_channel_groups(
-    points_per_second: Mapping[str, float],
-    channels_by_name: Mapping[str, Channel],
+    points_per_second: Mapping[tuple[str, str], float],
+    channels_by_key: Mapping[tuple[str, str], Channel],
     points_per_request: int,
-    channels_per_request: int,
+    max_channels_per_group: int,
     batch_duration: datetime.timedelta,
 ) -> tuple[list[list[Channel]], list[Channel]]:
-    """Build a tuple of groups of channels to read together, and a list of channels that must be read on their own."""
-    # Channels that can be read entirely in a single export request for a batch
-    channel_groups = []
+    """Bin-pack channels into groups that fit the per-request rate and channel-count budgets.
 
-    # Channels that wouldn't fit in a single export request for a batch
-    large_channels = []
+    Channels whose individual rate exceeds the per-group budget are returned separately as
+    `large_channels` — the caller handles subdividing their time ranges. Groups are built
+    highest-rate-first so any NaN padding from uneven channel lengths sits at the tail of
+    each export.
+    """
+    batch_seconds = batch_duration.total_seconds()
+    if batch_seconds <= 0:
+        raise ValueError(f"batch_duration must be positive, got {batch_duration}")
+    allowed_rate_per_group = points_per_request / batch_seconds
 
-    # Compute channel groups for numeric channels
-    allowed_rate_per_group = points_per_request / batch_duration.total_seconds()
+    # Defensive skip: names in points_per_second should also be in channels_by_key, but
+    # don't raise if the invariant breaks.
+    sorted_pairs = sorted(
+        ((channels_by_key[key], rate) for key, rate in points_per_second.items() if key in channels_by_key),
+        key=lambda pair: pair[1],
+        reverse=True,
+    )
+
+    groups: list[list[Channel]] = []
+    large: list[Channel] = []
     curr_group: list[Channel] = []
     curr_rate = 0.0
-    for channel_name, channel_rate in sorted(points_per_second.items(), key=lambda tup: tup[1], reverse=True):
-        # We build channel groups starting with the highest data rate channels to reduce the number of
-        # NaNs that are provided by the backend during data export
-        channel = channels_by_name[channel_name]
-        if channel_rate > allowed_rate_per_group:
-            large_channels.append(channel)
+    for channel, rate in sorted_pairs:
+        if rate > allowed_rate_per_group:
+            large.append(channel)
             continue
 
-        # If the current group is too big to be able to add the current channel, add to channel groups
-        if curr_rate + channel_rate > allowed_rate_per_group or len(curr_group) >= channels_per_request:
-            channel_groups.append(curr_group)
+        # If the current group is too big to fit the current channel, close it out.
+        if curr_rate + rate > allowed_rate_per_group or len(curr_group) >= max_channels_per_group:
+            groups.append(curr_group)
             curr_group = []
             curr_rate = 0.0
 
         curr_group.append(channel)
-        curr_rate += channel_rate
+        curr_rate += rate
 
     if curr_group:
-        channel_groups.append(curr_group)
+        groups.append(curr_group)
 
-    return channel_groups, large_channels
+    return groups, large
 
 
 @dataclasses.dataclass(frozen=True, unsafe_hash=True, order=True)
@@ -323,9 +382,34 @@ class _TimeRange:
         return self.subdivide_ns(int(duration.total_seconds() * 1e9))
 
 
+def _compute_batch_duration(
+    batch_duration: datetime.timedelta | None,
+    time_range: _TimeRange,
+    points_per_second: Mapping[tuple[str, str], float],
+    points_per_dataframe: int,
+) -> IntegralNanosecondsDuration:
+    """Compute the batch duration for export time slices.
+
+    If no explicit batch_duration is provided, computes one based on the total
+    point rate across all channels and the configured points_per_dataframe limit.
+    """
+    if batch_duration is None:
+        total_point_rate = sum(points_per_second.values())
+        if total_point_rate == 0.0:
+            logger.warning("No data detected in time range, attempting to export in one batch")
+            computed_duration = time_range.duration()
+        else:
+            computed_duration = datetime.timedelta(seconds=points_per_dataframe / total_point_rate)
+
+        # If the computed max batch duration is greater than the requested export duration, truncate
+        return min(int(computed_duration.total_seconds() * 1e9), time_range.duration_ns())
+    else:
+        return int(batch_duration.total_seconds() * 1e9)
+
+
 @dataclasses.dataclass(frozen=True, unsafe_hash=True)
 class _ExportJob:
-    """Represents an individual export task suitable for giving to subprocesses."""
+    """Represents a single CSV export request dispatched to a worker thread."""
 
     datasource_rid: str
     channel_names: list[str]
@@ -510,15 +594,19 @@ def _merge_dfs(dfs: Sequence[pl.DataFrame]) -> pl.DataFrame:
 
 
 class PolarsExportHandler:
-    """Manages streaming data out of Nominal using DataFrames.
+    """Streams data out of Nominal into Polars DataFrames.
 
-    Steps:
-    * If no bucket duration is provided, compute a max duration that fits the configured batch size.
-    * Compute read schedule, channel groupings, and time slices.
-    * For each time slice:
-        * in parallel, fetch each channel group
-        * stitch vertically within groups and then outer-join across groups on timestamp column
-    * Yield merged DataFrame batches
+    Pipeline:
+    * Filter to exportable channel types (DOUBLE/INT/STRING).
+    * Confirm each channel has data in the range (via `filter_channels_with_data`) and
+      estimate per-channel peak points-per-second.
+    * Compute a batch duration such that each DataFrame batch stays under `points_per_dataframe`,
+      unless the caller passes an explicit `batch_duration`.
+    * Bin-pack channels into per-request groups within the `points_per_request` rate budget;
+      channels whose rate exceeds the budget are split across sub-slices of the time range.
+    * For each time slice, fetch channel groups in parallel and stitch the results back into a
+      single DataFrame (via vertical concat within equal-column groups, outer-join across groups
+      on the timestamp column) before yielding.
     """
 
     def __init__(
@@ -537,47 +625,42 @@ class PolarsExportHandler:
 
         self._num_workers = num_workers
 
-    def _compute_channel_points_per_second(
-        self, numeric_channels: Sequence[Channel], time_range: _TimeRange, tags: Mapping[str, str] | None = None
-    ) -> dict[str, float]:
-        all_points_per_second = _channel_points_per_second(
+    def _compute_channel_rates(
+        self,
+        channels: Sequence[Channel],
+        time_range: _TimeRange,
+        tags: Mapping[str, str] | None,
+    ) -> tuple[list[Channel], dict[tuple[str, str], float]]:
+        """Filter by data presence, compute PPS, and fill in 0.0 for unknown/missing rates.
+
+        Returns the filtered channel list (confirmed to have data in the range) and a
+        mapping from (data_source, channel_name) to estimated peak PPS. Channels with
+        failed/degenerate PPS estimation default to 0.0 so they aren't silently dropped
+        downstream.
+        """
+        # Cost gate: PPS compute alone correctly handles empty-data channels, but this filter
+        # avoids running the expensive compute on channels with no data in the range.
+        supported_channels = list(
+            filter_channels_with_data(
+                channels,
+                tags=tags,
+                start_time=time_range.start_time,
+                end_time=time_range.end_time,
+            )
+        )
+        all_pps = _channel_points_per_second(
             client=self._client,
-            channels=numeric_channels,
+            channels=supported_channels,
             start=time_range.start_time,
             end=time_range.end_time,
             tags=tags,
         )
-        return {channel: rate for channel, rate in all_points_per_second.items() if rate}
-
-    def _compute_batch_duration(
-        self,
-        batch_duration: datetime.timedelta | None,
-        enum_channels: Sequence[Channel],
-        time_range: _TimeRange,
-        points_per_second: Mapping[str, float],
-    ) -> IntegralNanosecondsDuration:
-        # If the user has not given us a specific batch duration (expected), compute the duration
-        # that would support the provided batch size parameters (i.e. max points per request)
-        if batch_duration is None:
-            if enum_channels:
-                logger.warning(
-                    "No `batch_duration` provided, but exporting %d enum channels. "
-                    "These will not be accounted for in the computed `batch_duration`",
-                    len(enum_channels),
-                )
-
-            # Compute the theoretical max data rate in an second within the export time range
-            total_point_rate = sum(points_per_second.values())
-            if total_point_rate == 0.0:
-                logger.warning("No data detected in time range, attempting to export in one batch")
-                computed_duration = time_range.duration()
-            else:
-                computed_duration = datetime.timedelta(seconds=self._points_per_dataframe / total_point_rate)
-
-            # If the computed max batch duration is greater than the requested export duration, truncate
-            return min(int(computed_duration.total_seconds() * 1e9), time_range.duration_ns())
-        else:
-            return int(batch_duration.total_seconds() * 1e9)
+        # Drop channels whose rate estimator returned 0.0 or None — either the channel has no
+        # data in range (0.0) or the compute failed (None); either way there's nothing to
+        # export, and keeping them would just waste an export request per channel.
+        points_per_second = {key: rate for key, rate in all_pps.items() if rate}
+        exportable_channels = [ch for ch in supported_channels if (ch.data_source, ch.name) in points_per_second]
+        return exportable_channels, points_per_second
 
     def _compute_export_jobs(
         self,
@@ -589,80 +672,90 @@ class PolarsExportHandler:
         resolution: IntegralNanosecondsDuration | None = None,
         batch_duration: datetime.timedelta | None = None,
     ) -> Mapping[_TimeRange, Sequence[_ExportJob]]:
-        """Compute the mapping of export time slices to the sequence of export jobs to produce data for that range."""
+        """Compute the mapping of export time slices to the sequence of export jobs to produce data for that range.
+
+        `channels` is expected to be already filtered to exportable data types by the caller.
+        """
         if buckets is not None and resolution is not None:
             raise ValueError("Cannot provide `buckets` and `resolution`")
 
-        partitioned_channels = _group_channels_by_datatype(channels)
-        enum_channels = partitioned_channels.get(ChannelDataType.STRING, [])
-
-        numeric_channels = [
-            *partitioned_channels.get(ChannelDataType.DOUBLE, []),
-            *partitioned_channels.get(ChannelDataType.INT, []),
-        ]
-        if batch_duration is None and not numeric_channels:
-            raise ValueError("If no numeric channels are provided, a `batch_duration` must be provided!")
-
-        unknown_channels = partitioned_channels.get(ChannelDataType.UNKNOWN, [])
-        if unknown_channels:
-            logger.warning("Could not determine datatypes of %d channels-- ignoring for export", len(unknown_channels))
-
-        channels_by_name = {channel.name: channel for channel in channels}
-        points_per_second = self._compute_channel_points_per_second(numeric_channels, time_range, tags)
-        batch_duration_ns = self._compute_batch_duration(batch_duration, enum_channels, time_range, points_per_second)
-
-        # group channels by datasource
-        channel_names_by_datasource = collections.defaultdict(set)
-        for channel_group in (numeric_channels, enum_channels):
-            for channel in channel_group:
-                channel_names_by_datasource[channel.data_source].add(channel.name)
-
-        jobs = collections.defaultdict(list)
+        supported_channels, points_per_second = self._compute_channel_rates(channels, time_range, tags)
+        batch_duration_ns = _compute_batch_duration(
+            batch_duration, time_range, points_per_second, self._points_per_dataframe
+        )
         time_slices = time_range.subdivide_ns(batch_duration_ns)
-        for datasource_rid, channel_names in channel_names_by_datasource.items():
-            channel_groups, large_channels = _build_channel_groups(
-                {k: v for k, v in points_per_second.items() if k in channel_names},
-                {k: v for k, v in channels_by_name.items() if k in channel_names},
-                self._points_per_request,
-                self._channels_per_request,
-                datetime.timedelta(seconds=batch_duration_ns / 1e9),
+        batch_timedelta = datetime.timedelta(seconds=batch_duration_ns / 1e9)
+
+        channels_by_datasource: dict[str, list[Channel]] = collections.defaultdict(list)
+        for channel in supported_channels:
+            channels_by_datasource[channel.data_source].append(channel)
+
+        jobs: dict[_TimeRange, list[_ExportJob]] = collections.defaultdict(list)
+        for datasource_rid, ds_channels in channels_by_datasource.items():
+            ds_jobs = self._build_jobs_for_datasource(
+                datasource_rid=datasource_rid,
+                channels=ds_channels,
+                points_per_second=points_per_second,
+                time_slices=time_slices,
+                batch_duration=batch_timedelta,
+                timestamp_type=timestamp_type,
+                tags=tags,
+                buckets=buckets,
+                resolution=resolution,
             )
-            channel_groups.extend([[channel] for channel in enum_channels if channel.name in channel_names])
+            for time_slice, slice_jobs in ds_jobs.items():
+                jobs[time_slice].extend(slice_jobs)
 
-            for slice in time_slices:
-                for channel_group in channel_groups:
-                    jobs[slice].append(
-                        _ExportJob(
-                            datasource_rid=datasource_rid,
-                            channel_names=[ch.name for ch in channel_group],
-                            channel_types={ch.name: ch.data_type for ch in channel_group},
-                            time_slice=slice,
-                            tags=dict(tags or {}),
-                            buckets=buckets,
-                            resolution=resolution,
-                            timestamp_type=timestamp_type,
-                        )
-                    )
+        return jobs
 
-                # Add subdivided slices for large channels that cannot be read in a single export request
-                # For large channels, we need to subdivide the time range based on their data rates
-                for channel in large_channels:
-                    channel_rate = points_per_second[channel.name]
-                    sub_offset = datetime.timedelta(seconds=self._points_per_request / channel_rate)
-                    for sub_slice in slice.subdivide(sub_offset):
-                        jobs[slice].append(
-                            _ExportJob(
-                                datasource_rid=datasource_rid,
-                                channel_names=[channel.name],
-                                channel_types={ch.name: ch.data_type for ch in channel_group},
-                                time_slice=sub_slice,
-                                tags=dict(tags or {}),
-                                buckets=buckets,
-                                resolution=resolution,
-                                timestamp_type=timestamp_type,
-                            )
-                        )
+    def _build_jobs_for_datasource(
+        self,
+        *,
+        datasource_rid: str,
+        channels: Sequence[Channel],
+        points_per_second: Mapping[tuple[str, str], float],
+        time_slices: Sequence[_TimeRange],
+        batch_duration: datetime.timedelta,
+        timestamp_type: _AnyExportableTimestampType,
+        tags: Mapping[str, str] | None,
+        buckets: int | None,
+        resolution: IntegralNanosecondsDuration | None,
+    ) -> Mapping[_TimeRange, list[_ExportJob]]:
+        """Build export jobs for a single datasource's channels, keyed by parent time slice.
 
+        Channels are bin-packed by rate; any channel whose rate exceeds the per-request budget
+        is subdivided across sub-slices of each parent time slice, producing one single-channel
+        job per sub-slice.
+        """
+        channels_by_key = {(ch.data_source, ch.name): ch for ch in channels}
+        ds_pps = {key: points_per_second[key] for key in channels_by_key}
+        channel_groups, large_channels = _build_channel_groups(
+            ds_pps, channels_by_key, self._points_per_request, self._channels_per_request, batch_duration
+        )
+
+        def make_job(group: Sequence[Channel], slice_: _TimeRange) -> _ExportJob:
+            return _ExportJob(
+                datasource_rid=datasource_rid,
+                channel_names=[ch.name for ch in group],
+                channel_types={ch.name: ch.data_type for ch in group},
+                time_slice=slice_,
+                tags=dict(tags or {}),
+                buckets=buckets,
+                resolution=resolution,
+                timestamp_type=timestamp_type,
+            )
+
+        jobs: dict[_TimeRange, list[_ExportJob]] = collections.defaultdict(list)
+        for time_slice in time_slices:
+            for group in channel_groups:
+                jobs[time_slice].append(make_job(group, time_slice))
+            # Large channels exceed the per-request rate budget, so subdivide the slice per
+            # channel so each sub-slice fits. All sub-slice jobs roll up under the parent slice.
+            for channel in large_channels:
+                rate = ds_pps[(channel.data_source, channel.name)]
+                sub_offset = datetime.timedelta(seconds=self._points_per_request / rate)
+                for sub_slice in time_slice.subdivide(sub_offset):
+                    jobs[time_slice].append(make_job([channel], sub_slice))
         return jobs
 
     def export(
@@ -677,7 +770,30 @@ class PolarsExportHandler:
         resolution: IntegralNanosecondsDuration | None = None,
         join_batches: bool = True,
     ) -> Iterator[pl.DataFrame]:
-        """Yield DataFrame slices"""
+        """Yield exported data one DataFrame at a time.
+
+        LOG / UNKNOWN channels are filtered out with a warning; only DOUBLE, INT, and STRING
+        channels flow through the export pipeline.
+
+        Args:
+            channels: Channels to export.
+            start: Start of the export time range (nanoseconds UTC).
+            end: End of the export time range (nanoseconds UTC).
+            tags: Key-value pairs used to filter channel data server-side.
+            batch_duration: Explicit per-batch time window. If omitted, one is computed
+                from total channel rate and `points_per_dataframe`.
+            timestamp_type: Output timestamp representation (`epoch_seconds`, `iso8601`, etc.).
+            buckets: Decimate each channel to at most this many buckets per request. Mutually
+                exclusive with `resolution`.
+            resolution: Decimate each channel to samples at this interval (nanoseconds).
+                Mutually exclusive with `buckets`.
+            join_batches: If True (default), each yielded DataFrame is the outer-joined merge of
+                all channel groups for a single time slice. If False, yields one DataFrame per
+                channel group without merging.
+
+        Yields:
+            Polars DataFrames covering successive time slices of the export range.
+        """
         # Ensure user has selected channels to export
         if not channels:
             logger.warning("No channels requested for export-- returning")
@@ -686,6 +802,12 @@ class PolarsExportHandler:
         # Ensure user has not selected incompatible decimation options
         if None not in (buckets, resolution):
             raise ValueError("Cannot export data decimated with both buckets and resolution")
+
+        # Exclude channels with unsupported data types
+        supported_channels = [ch for ch in channels if ch.data_type in _EXPORTABLE_DATA_TYPES]
+        unsupported = len(channels) - len(supported_channels)
+        if unsupported:
+            logger.warning("Could not determine datatypes of %d channels -- ignoring for export", unsupported)
 
         if resolution is not None:
             # If the batch duration is higher than this number, and data is actually downsampled with the
@@ -710,9 +832,9 @@ class PolarsExportHandler:
 
         # Determine download schedule
         export_jobs = self._compute_export_jobs(
-            channels, _TimeRange(start, end), timestamp_type, tags or {}, buckets, resolution, batch_duration
+            supported_channels, _TimeRange(start, end), timestamp_type, tags or {}, buckets, resolution, batch_duration
         )
-        time_column = _get_exported_timestamp_channel([ch.name for ch in channels])
+        time_column = _get_exported_timestamp_channel([ch.name for ch in supported_channels])
         yield from self._export_dataframes(export_jobs, time_column, join_batches)
 
     def _export_dataframes(

--- a/nominal/thirdparty/polars/polars_export_handler.py
+++ b/nominal/thirdparty/polars/polars_export_handler.py
@@ -10,11 +10,10 @@ from typing_extensions import Self
 
 import polars as pl
 from nominal._utils import LogTiming
-from nominal.core.channel import Channel, ChannelDataType
+from nominal._utils.iterator_tools import batched
+from nominal.core.channel import Channel, ChannelDataType, filter_channels_with_data
 from nominal.core.client import NominalClient
 from nominal.core.datasource import DataSource
-from nominal.experimental.compute import batch_compute_buckets
-from nominal.experimental.compute.dsl import exprs
 from nominal.ts import (
     Epoch,
     IntegralNanosecondsDuration,
@@ -46,66 +45,108 @@ DEFAULT_CHANNELS_PER_REQUEST = 25
 # TODO(drake) raise 1000 limit once backend limit is raised
 MAX_NUM_BUCKETS = 1000
 
+# Channel data types that can be exported as dataframe columns.
+_EXPORTABLE_DATA_TYPES: frozenset[ChannelDataType] = frozenset(
+    [ChannelDataType.DOUBLE, ChannelDataType.INT, ChannelDataType.STRING]
+)
+
 DEFAULT_EXPORTED_TIMESTAMP_COL_NAME = "timestamp"
 _INTERNAL_TS_COL = "__nmnl_ts__"  # internal join key, chosen to avoid collision with channel names
 
 logger = logging.getLogger(__name__)
 
 
-def _group_channels_by_datatype(channels: Sequence[Channel]) -> Mapping[ChannelDataType, Sequence[Channel]]:
-    """Partition the provided channels by data type.
+def _extract_bucket_counts(
+    response: scout_compute_api.ComputeNodeResponse,
+) -> Sequence[tuple[IntegralNanosecondsUTC, int]]:
+    """Extract (timestamp, point_count) pairs from a compute response.
 
-    Channels with no datatype are grouped into the UNKNOWN partition of channels.
-
-    Args:
-        channels: Channels to partition
-    Returns:
-        Mapping of data type to a list of the corresponding channels
+    Works for both numeric and enum series. Handles bucketed (decimated) responses
+    as well as undecimated fallbacks when the data has fewer points than requested buckets.
     """
-    channel_groups = collections.defaultdict(list)
-    for channel in channels:
-        channel_groups[channel.data_type or ChannelDataType.UNKNOWN].append(channel)
-    return {**channel_groups}
+    # Numeric — decimated into buckets with statistics
+    if response.bucketed_numeric is not None:
+        return [
+            (_SecondsNanos.from_api(ts).to_nanoseconds(), bucket.count or 0)
+            for ts, bucket in zip(response.bucketed_numeric.timestamps, response.bucketed_numeric.buckets)
+        ]
+
+    # Numeric — undecimated (fewer points than requested buckets)
+    if response.numeric is not None:
+        return [(_SecondsNanos.from_api(ts).to_nanoseconds(), 1) for ts in response.numeric.timestamps]
+
+    # Numeric — single point
+    if response.numeric_point is not None:
+        return [(_SecondsNanos.from_api(response.numeric_point.timestamp).to_nanoseconds(), 1)]
+
+    # Enum — decimated into buckets with histograms
+    if response.bucketed_enum is not None:
+        return [
+            (_SecondsNanos.from_api(ts).to_nanoseconds(), sum(bucket.histogram.values()))
+            for ts, bucket in zip(response.bucketed_enum.timestamps, response.bucketed_enum.buckets)
+        ]
+
+    # Enum — undecimated (fewer points than requested buckets)
+    if response.enum is not None:
+        return [(_SecondsNanos.from_api(ts).to_nanoseconds(), 1) for ts in response.enum.timestamps]
+
+    logger.warning("Unrecognized compute response type: %s", response.type)
+    return []
 
 
-def _has_data_with_tags(channel: Channel, tags: Mapping[str, str], start_ns: int, end_ns: int) -> bool:
-    available_tags = channel.get_available_tags(start_ns, end_ns, tags)
+def _build_compute_request(
+    series: scout_compute_api.Series,
+    start: api.Timestamp,
+    end: api.Timestamp,
+    num_buckets: int,
+) -> scout_compute_api.ComputeNodeRequest:
+    """Build a decimation compute request for a single series."""
+    return scout_compute_api.ComputeNodeRequest(
+        context=scout_compute_api.Context(dataset_references={}, variables={}),
+        node=scout_compute_api.ComputableNode(
+            series=scout_compute_api.SummarizeSeries(
+                input=series,
+                numeric_aggregations={},
+                summarization_strategy=scout_compute_api.SummarizationStrategy(
+                    decimate=scout_compute_api.DecimateStrategy(
+                        buckets=scout_compute_api.DecimateWithBuckets(buckets=num_buckets)
+                    )
+                ),
+                buckets=num_buckets,
+            )
+        ),
+        start=start,
+        end=end,
+    )
 
-    # No data matches the given tags
-    if not available_tags:
-        return False
 
-    bad_tag_items = {name: values for name, values in available_tags.items() if len(values) > 1}
-    if bad_tag_items:
-        logger.warning(
-            "Channel %s has underconstrained tags-- results may have duplicate rows: %s", channel.name, bad_tag_items
-        )
-
-    return True
-
-
-def _build_point_rate_expressions(
-    channels: Sequence[Channel],
+def _peak_points_per_second(
+    bucket_counts: Sequence[tuple[IntegralNanosecondsUTC, int]],
     start_ns: IntegralNanosecondsUTC,
     end_ns: IntegralNanosecondsUTC,
-    tags: Mapping[str, str],
-) -> Sequence[tuple[Channel, exprs.NumericExpr | None]]:
-    expressions: list[tuple[Channel, exprs.NumericExpr | None]] = []
-    for channel in channels:
-        if channel.data_type is not ChannelDataType.DOUBLE:
-            logger.warning(
-                "Can only compute points per second on float channels, but %s has type: %s",
-                channel.name,
-                channel.data_type,
-            )
-            expressions.append((channel, None))
-        elif tags and not _has_data_with_tags(channel, tags, start_ns, end_ns):
-            logger.warning("No points found in range for channel '%s'", channel.name)
-            expressions.append((channel, None))
-        else:
-            expressions.append((channel, exprs.NumericExpr.datasource_channel(channel.data_source, channel.name, tags)))
+) -> float:
+    """Compute the peak points-per-second from a sequence of (timestamp, count) bucket data.
 
-    return expressions
+    For a single bucket, uses the full time range as the duration. For multiple buckets,
+    computes PPS between consecutive bucket timestamps and returns the peak.
+    Returns 0.0 if the time range or any bucket interval has zero duration.
+    """
+    if len(bucket_counts) == 0:
+        return 0.0
+    elif len(bucket_counts) == 1:
+        total_duration = (end_ns - start_ns) / 1e9
+        if total_duration <= 0:
+            return 0.0
+        return bucket_counts[0][1] / total_duration
+    else:
+        peak_pps = 0.0
+        for idx in range(1, len(bucket_counts)):
+            ts, count = bucket_counts[idx]
+            prev_ts = bucket_counts[idx - 1][0]
+            duration = (ts - prev_ts) / 1e9
+            if duration > 0:
+                peak_pps = max(peak_pps, count / duration)
+        return peak_pps
 
 
 def _batch_channel_points_per_second(
@@ -115,67 +156,77 @@ def _batch_channel_points_per_second(
     end_ns: IntegralNanosecondsUTC,
     tags: dict[str, str],
     num_buckets: int,
-) -> Mapping[str, float | None]:
-    """For each provided channel, determine the maximum number of points per second in the given range.
+) -> Mapping[tuple[str, str], float | None]:
+    """For each provided channel, determine the peak points per second in the given range.
 
-    NOTE: Not intended for direct use-- see `_channel_points_per_second`
-    NOTE: do not use with more than 300 channels, or 500 concurrently across all requests, or concurrency limits
-          will be breached and the request will fail.
+    Supports all channel data types (DOUBLE, INT, STRING) by building the appropriate
+    compute series for each and submitting a single BatchComputeWithUnitsRequest.
+
+    NOTE: Not intended for direct use — see `_channel_points_per_second`.
+    NOTE: Do not use with more than 300 channels, or 500 concurrently across all requests.
 
     Args:
         client: Nominal request client
-        channels: Channels to query data rates for
+        channels: Channels to query data rates for (must be DOUBLE, INT, or STRING)
         start_ns: Start of the time range to query over
         end_ns: End of the time range to query over
         tags: Key-value pairs of tags to filter data with
-        num_buckets: Number of buckets to use-- more typically leads to better results.
+        num_buckets: Number of buckets to use — more typically leads to better results.
             NOTE: max number of buckets allowed is 1000
 
     Returns:
-        Mapping of channel name to maximum points/second for the respective channels
+        Mapping of (data_source, channel_name) to peak points/second. A value of `None`
+        indicates the backend failed to compute a rate for that channel (e.g. transient
+        error); `0.0` indicates the compute succeeded but returned no buckets.
+
+    Raises:
+        ValueError: If any channel has an unsupported data type (not DOUBLE/INT/STRING).
     """
     if not channels:
-        logger.warning("No channels given!")
         return {}
     elif num_buckets > MAX_NUM_BUCKETS:
         raise ValueError(f"num_buckets ({num_buckets}) must be <= {MAX_NUM_BUCKETS}")
 
-    # For each channel that has data with the given tags within the provided time range, add a
-    # compute expression to later retrieve decimated bucket stats
-    results: dict[str, float | None] = {}
-    expressions = []
-    channels_in_expressions = []
-    for channel, expression in _build_point_rate_expressions(list(channels), start_ns, end_ns, tags):
-        if expression is None:
-            results[channel.name] = None
-        else:
-            expressions.append(expression)
-            channels_in_expressions.append(channel)
+    # _to_compute_series raises ValueError for unsupported types; callers are expected to
+    # pre-filter to DOUBLE/INT/STRING channels (see _compute_export_jobs).
+    series_list = [channel._to_compute_series(tags=tags) for channel in channels]
 
-    # For each channel, compute the number of points across the desired number of buckets.
-    # Compute the approximate average points/second in each bucket, and use the largest
-    # across all buckets as the points per second for that channel.
+    api_start = _SecondsNanos.from_nanoseconds(start_ns).to_api()
+    api_end = _SecondsNanos.from_nanoseconds(end_ns).to_api()
+
     try:
-        batch_buckets = batch_compute_buckets(client, expressions, start_ns, end_ns, buckets=num_buckets)
+        request = scout_compute_api.BatchComputeWithUnitsRequest(
+            requests=[_build_compute_request(s, api_start, api_end, num_buckets) for s in series_list]
+        )
+        resp = client._clients.compute.batch_compute_with_units(
+            auth_header=client._clients.auth_header,
+            request=request,
+        )
     except Exception:
-        logger.exception("Failed to compute buckets for channels: %s", [ch.name for ch in channels_in_expressions])
-        return {ch.name: None for ch in channels}
+        logger.exception("Failed to compute buckets for channels: %s", [ch.name for ch in channels])
+        return {(ch.data_source, ch.name): None for ch in channels}
 
-    for channel, buckets in zip(channels_in_expressions, batch_buckets):
-        if len(buckets) == 0:
+    results: dict[tuple[str, str], float | None] = {}
+    for channel, result in zip(channels, resp.results):
+        key = (channel.data_source, channel.name)
+        compute_result = result.compute_result
+        if compute_result is None or compute_result.error is not None:
+            error_msg = compute_result.error if compute_result else "no result"
+            logger.warning("Failed to compute point rate for channel '%s': %s", channel.name, error_msg)
+            results[key] = None
+            continue
+
+        if compute_result.success is None:
+            logger.warning("Compute succeeded for channel '%s' but response is empty", channel.name)
+            results[key] = None
+            continue
+
+        bucket_counts = _extract_bucket_counts(compute_result.success)
+        if not bucket_counts:
             logger.warning("No points found in range for channel '%s'", channel.name)
-            results[channel.name] = 0
-        elif len(buckets) == 1:
-            results[channel.name] = buckets[0].count / ((end_ns - start_ns) / 1e9)
+            results[key] = 0.0
         else:
-            max_points_per_second = 0.0
-            for idx in range(1, len(buckets)):
-                bucket = buckets[idx]
-                last_bucket = buckets[idx - 1]
-                bucket_duration = (bucket.timestamp - last_bucket.timestamp) / 1e9
-                points_per_second = bucket.count / bucket_duration
-                max_points_per_second = max(max_points_per_second, points_per_second)
-                results[channel.name] = max_points_per_second
+            results[key] = _peak_points_per_second(bucket_counts, start_ns, end_ns)
 
     return results
 
@@ -188,11 +239,11 @@ def _channel_points_per_second(
     tags: Mapping[str, str] | None = None,
     num_buckets: int = 100,
     num_workers: int = DEFAULT_NUM_WORKERS,
-) -> Mapping[str, float | None]:
-    """For each provided channel, determine the maximum number of points per second in the given range.
+) -> Mapping[tuple[str, str], float | None]:
+    """For each provided channel, determine the peak number of points per second in the given range.
 
-    This method will take the list of channels provided, and group them into batches (as determined by
-    `batch_size`) and perform queries in parallel using the provided `Executor`.
+    Splits channels into batches of `DEFAULT_CHANNELS_PER_REQUEST` and queries each batch in parallel
+    via an internally-managed thread pool.
 
     NOTE: may take a long time for large channel counts. Takes approx. 30s for 1000 channels with good internet,
           but varies based on how many points are within the query bounds.
@@ -207,14 +258,15 @@ def _channel_points_per_second(
         num_workers: Number of parallel requests to make
 
     Returns:
-        Mapping of channel name to maximum points/second for the respective channels
+        Mapping of (data_source, channel_name) to peak points/second, or None when the
+        estimation failed. Keying by the tuple keeps same-named channels from different
+        datasources independent.
     """
     start_ns = _SecondsNanos.from_flexible(start).to_nanoseconds()
     end_ns = _SecondsNanos.from_flexible(end).to_nanoseconds()
     with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as pool:
         futures = {}
-        for idx in range(0, len(channels), DEFAULT_CHANNELS_PER_REQUEST):
-            channel_batch = channels[idx : idx + DEFAULT_CHANNELS_PER_REQUEST]
+        for channel_batch in batched(channels, DEFAULT_CHANNELS_PER_REQUEST):
             fut = pool.submit(
                 _batch_channel_points_per_second,
                 client,
@@ -226,69 +278,76 @@ def _channel_points_per_second(
             )
             futures[fut] = channel_batch
 
-        results = {}
+        results: dict[tuple[str, str], float | None] = {}
         num_processed = 0
         for fut in concurrent.futures.as_completed(futures):
             channel_batch = futures[fut]
             num_processed += len(channel_batch)
             logger.debug("Completed querying %d/%d channels for update rate", num_processed, len(channels))
 
-            ex = fut.exception()
-            if ex is not None:
-                logger.error(
+            try:
+                res = fut.result()
+            except Exception:
+                logger.exception(
                     "Failed to extract %d channel sample rates: %s",
                     len(channel_batch),
                     [ch.name for ch in channel_batch],
-                    exc_info=ex,
                 )
                 continue
-
-            res = fut.result()
-            for channel, rate in res.items():
-                results[channel] = rate
+            results.update(res)
 
         return results
 
 
 def _build_channel_groups(
-    points_per_second: Mapping[str, float],
-    channels_by_name: Mapping[str, Channel],
+    points_per_second: Mapping[tuple[str, str], float],
+    channels_by_key: Mapping[tuple[str, str], Channel],
     points_per_request: int,
-    channels_per_request: int,
+    max_channels_per_group: int,
     batch_duration: datetime.timedelta,
 ) -> tuple[list[list[Channel]], list[Channel]]:
-    """Build a tuple of groups of channels to read together, and a list of channels that must be read on their own."""
-    # Channels that can be read entirely in a single export request for a batch
-    channel_groups = []
+    """Bin-pack channels into groups that fit the per-request rate and channel-count budgets.
 
-    # Channels that wouldn't fit in a single export request for a batch
-    large_channels = []
+    Channels whose individual rate exceeds the per-group budget are returned separately as
+    `large_channels` — the caller handles subdividing their time ranges. Groups are built
+    highest-rate-first so any NaN padding from uneven channel lengths sits at the tail of
+    each export.
+    """
+    batch_seconds = batch_duration.total_seconds()
+    if batch_seconds <= 0:
+        raise ValueError(f"batch_duration must be positive, got {batch_duration}")
+    allowed_rate_per_group = points_per_request / batch_seconds
 
-    # Compute channel groups for numeric channels
-    allowed_rate_per_group = points_per_request / batch_duration.total_seconds()
+    # Defensive skip: names in points_per_second should also be in channels_by_key, but
+    # don't raise if the invariant breaks.
+    sorted_pairs = sorted(
+        ((channels_by_key[key], rate) for key, rate in points_per_second.items() if key in channels_by_key),
+        key=lambda pair: pair[1],
+        reverse=True,
+    )
+
+    groups: list[list[Channel]] = []
+    large: list[Channel] = []
     curr_group: list[Channel] = []
     curr_rate = 0.0
-    for channel_name, channel_rate in sorted(points_per_second.items(), key=lambda tup: tup[1], reverse=True):
-        # We build channel groups starting with the highest data rate channels to reduce the number of
-        # NaNs that are provided by the backend during data export
-        channel = channels_by_name[channel_name]
-        if channel_rate > allowed_rate_per_group:
-            large_channels.append(channel)
+    for channel, rate in sorted_pairs:
+        if rate > allowed_rate_per_group:
+            large.append(channel)
             continue
 
-        # If the current group is too big to be able to add the current channel, add to channel groups
-        if curr_rate + channel_rate > allowed_rate_per_group or len(curr_group) >= channels_per_request:
-            channel_groups.append(curr_group)
+        # If the current group is too big to fit the current channel, close it out.
+        if curr_rate + rate > allowed_rate_per_group or len(curr_group) >= max_channels_per_group:
+            groups.append(curr_group)
             curr_group = []
             curr_rate = 0.0
 
         curr_group.append(channel)
-        curr_rate += channel_rate
+        curr_rate += rate
 
     if curr_group:
-        channel_groups.append(curr_group)
+        groups.append(curr_group)
 
-    return channel_groups, large_channels
+    return groups, large
 
 
 @dataclasses.dataclass(frozen=True, unsafe_hash=True, order=True)
@@ -323,9 +382,34 @@ class _TimeRange:
         return self.subdivide_ns(int(duration.total_seconds() * 1e9))
 
 
+def _compute_batch_duration(
+    batch_duration: datetime.timedelta | None,
+    time_range: _TimeRange,
+    points_per_second: Mapping[tuple[str, str], float],
+    points_per_dataframe: int,
+) -> IntegralNanosecondsDuration:
+    """Compute the batch duration for export time slices.
+
+    If no explicit batch_duration is provided, computes one based on the total
+    point rate across all channels and the configured points_per_dataframe limit.
+    """
+    if batch_duration is None:
+        total_point_rate = sum(points_per_second.values())
+        if total_point_rate == 0.0:
+            logger.warning("No data detected in time range, attempting to export in one batch")
+            computed_duration = time_range.duration()
+        else:
+            computed_duration = datetime.timedelta(seconds=points_per_dataframe / total_point_rate)
+
+        # If the computed max batch duration is greater than the requested export duration, truncate
+        return min(int(computed_duration.total_seconds() * 1e9), time_range.duration_ns())
+    else:
+        return int(batch_duration.total_seconds() * 1e9)
+
+
 @dataclasses.dataclass(frozen=True, unsafe_hash=True)
 class _ExportJob:
-    """Represents an individual export task suitable for giving to subprocesses."""
+    """Represents a single CSV export request dispatched to a worker thread."""
 
     datasource_rid: str
     channel_names: list[str]
@@ -510,15 +594,19 @@ def _merge_dfs(dfs: Sequence[pl.DataFrame]) -> pl.DataFrame:
 
 
 class PolarsExportHandler:
-    """Manages streaming data out of Nominal using DataFrames.
+    """Streams data out of Nominal into Polars DataFrames.
 
-    Steps:
-    * If no bucket duration is provided, compute a max duration that fits the configured batch size.
-    * Compute read schedule, channel groupings, and time slices.
-    * For each time slice:
-        * in parallel, fetch each channel group
-        * stitch vertically within groups and then outer-join across groups on timestamp column
-    * Yield merged DataFrame batches
+    Pipeline:
+    * Filter to exportable channel types (DOUBLE/INT/STRING).
+    * Confirm each channel has data in the range (via `filter_channels_with_data`) and
+      estimate per-channel peak points-per-second.
+    * Compute a batch duration such that each DataFrame batch stays under `points_per_dataframe`,
+      unless the caller passes an explicit `batch_duration`.
+    * Bin-pack channels into per-request groups within the `points_per_request` rate budget;
+      channels whose rate exceeds the budget are split across sub-slices of the time range.
+    * For each time slice, fetch channel groups in parallel and stitch the results back into a
+      single DataFrame (via vertical concat within equal-column groups, outer-join across groups
+      on the timestamp column) before yielding.
     """
 
     def __init__(
@@ -537,47 +625,42 @@ class PolarsExportHandler:
 
         self._num_workers = num_workers
 
-    def _compute_channel_points_per_second(
-        self, numeric_channels: Sequence[Channel], time_range: _TimeRange, tags: Mapping[str, str] | None = None
-    ) -> dict[str, float]:
-        all_points_per_second = _channel_points_per_second(
+    def _compute_channel_rates(
+        self,
+        channels: Sequence[Channel],
+        time_range: _TimeRange,
+        tags: Mapping[str, str] | None,
+    ) -> tuple[list[Channel], dict[tuple[str, str], float]]:
+        """Filter by data presence, compute PPS, and fill in 0.0 for unknown/missing rates.
+
+        Returns the filtered channel list (confirmed to have data in the range) and a
+        mapping from (data_source, channel_name) to estimated peak PPS. Channels with
+        failed/degenerate PPS estimation default to 0.0 so they aren't silently dropped
+        downstream.
+        """
+        # Cost gate: PPS compute alone correctly handles empty-data channels, but this filter
+        # avoids running the expensive compute on channels with no data in the range.
+        supported_channels = list(
+            filter_channels_with_data(
+                channels,
+                tags=tags,
+                start_time=time_range.start_time,
+                end_time=time_range.end_time,
+            )
+        )
+        all_pps = _channel_points_per_second(
             client=self._client,
-            channels=numeric_channels,
+            channels=supported_channels,
             start=time_range.start_time,
             end=time_range.end_time,
             tags=tags,
         )
-        return {channel: rate for channel, rate in all_points_per_second.items() if rate}
-
-    def _compute_batch_duration(
-        self,
-        batch_duration: datetime.timedelta | None,
-        enum_channels: Sequence[Channel],
-        time_range: _TimeRange,
-        points_per_second: Mapping[str, float],
-    ) -> IntegralNanosecondsDuration:
-        # If the user has not given us a specific batch duration (expected), compute the duration
-        # that would support the provided batch size parameters (i.e. max points per request)
-        if batch_duration is None:
-            if enum_channels:
-                logger.warning(
-                    "No `batch_duration` provided, but exporting %d enum channels. "
-                    "These will not be accounted for in the computed `batch_duration`",
-                    len(enum_channels),
-                )
-
-            # Compute the theoretical max data rate in an second within the export time range
-            total_point_rate = sum(points_per_second.values())
-            if total_point_rate == 0.0:
-                logger.warning("No data detected in time range, attempting to export in one batch")
-                computed_duration = time_range.duration()
-            else:
-                computed_duration = datetime.timedelta(seconds=self._points_per_dataframe / total_point_rate)
-
-            # If the computed max batch duration is greater than the requested export duration, truncate
-            return min(int(computed_duration.total_seconds() * 1e9), time_range.duration_ns())
-        else:
-            return int(batch_duration.total_seconds() * 1e9)
+        # Drop channels whose rate estimator returned 0.0 or None — either the channel has no
+        # data in range (0.0) or the compute failed (None); either way there's nothing to
+        # export, and keeping them would just waste an export request per channel.
+        points_per_second = {key: rate for key, rate in all_pps.items() if rate}
+        exportable_channels = [ch for ch in supported_channels if (ch.data_source, ch.name) in points_per_second]
+        return exportable_channels, points_per_second
 
     def _compute_export_jobs(
         self,
@@ -589,80 +672,90 @@ class PolarsExportHandler:
         resolution: IntegralNanosecondsDuration | None = None,
         batch_duration: datetime.timedelta | None = None,
     ) -> Mapping[_TimeRange, Sequence[_ExportJob]]:
-        """Compute the mapping of export time slices to the sequence of export jobs to produce data for that range."""
+        """Compute the mapping of export time slices to the sequence of export jobs to produce data for that range.
+
+        `channels` is expected to be already filtered to exportable data types by the caller.
+        """
         if buckets is not None and resolution is not None:
             raise ValueError("Cannot provide `buckets` and `resolution`")
 
-        partitioned_channels = _group_channels_by_datatype(channels)
-        enum_channels = partitioned_channels.get(ChannelDataType.STRING, [])
-
-        numeric_channels = [
-            *partitioned_channels.get(ChannelDataType.DOUBLE, []),
-            *partitioned_channels.get(ChannelDataType.INT, []),
-        ]
-        if batch_duration is None and not numeric_channels:
-            raise ValueError("If no numeric channels are provided, a `batch_duration` must be provided!")
-
-        unknown_channels = partitioned_channels.get(ChannelDataType.UNKNOWN, [])
-        if unknown_channels:
-            logger.warning("Could not determine datatypes of %d channels-- ignoring for export", len(unknown_channels))
-
-        channels_by_name = {channel.name: channel for channel in channels}
-        points_per_second = self._compute_channel_points_per_second(numeric_channels, time_range, tags)
-        batch_duration_ns = self._compute_batch_duration(batch_duration, enum_channels, time_range, points_per_second)
-
-        # group channels by datasource
-        channel_names_by_datasource = collections.defaultdict(set)
-        for channel_group in (numeric_channels, enum_channels):
-            for channel in channel_group:
-                channel_names_by_datasource[channel.data_source].add(channel.name)
-
-        jobs = collections.defaultdict(list)
+        supported_channels, points_per_second = self._compute_channel_rates(channels, time_range, tags)
+        batch_duration_ns = _compute_batch_duration(
+            batch_duration, time_range, points_per_second, self._points_per_dataframe
+        )
         time_slices = time_range.subdivide_ns(batch_duration_ns)
-        for datasource_rid, channel_names in channel_names_by_datasource.items():
-            channel_groups, large_channels = _build_channel_groups(
-                {k: v for k, v in points_per_second.items() if k in channel_names},
-                {k: v for k, v in channels_by_name.items() if k in channel_names},
-                self._points_per_request,
-                self._channels_per_request,
-                datetime.timedelta(seconds=batch_duration_ns / 1e9),
+        batch_timedelta = datetime.timedelta(seconds=batch_duration_ns / 1e9)
+
+        channels_by_datasource: dict[str, list[Channel]] = collections.defaultdict(list)
+        for channel in supported_channels:
+            channels_by_datasource[channel.data_source].append(channel)
+
+        jobs: dict[_TimeRange, list[_ExportJob]] = collections.defaultdict(list)
+        for datasource_rid, ds_channels in channels_by_datasource.items():
+            ds_jobs = self._build_jobs_for_datasource(
+                datasource_rid=datasource_rid,
+                channels=ds_channels,
+                points_per_second=points_per_second,
+                time_slices=time_slices,
+                batch_duration=batch_timedelta,
+                timestamp_type=timestamp_type,
+                tags=tags,
+                buckets=buckets,
+                resolution=resolution,
             )
-            channel_groups.extend([[channel] for channel in enum_channels if channel.name in channel_names])
+            for time_slice, slice_jobs in ds_jobs.items():
+                jobs[time_slice].extend(slice_jobs)
 
-            for slice in time_slices:
-                for channel_group in channel_groups:
-                    jobs[slice].append(
-                        _ExportJob(
-                            datasource_rid=datasource_rid,
-                            channel_names=[ch.name for ch in channel_group],
-                            channel_types={ch.name: ch.data_type for ch in channel_group},
-                            time_slice=slice,
-                            tags=dict(tags or {}),
-                            buckets=buckets,
-                            resolution=resolution,
-                            timestamp_type=timestamp_type,
-                        )
-                    )
+        return jobs
 
-                # Add subdivided slices for large channels that cannot be read in a single export request
-                # For large channels, we need to subdivide the time range based on their data rates
-                for channel in large_channels:
-                    channel_rate = points_per_second[channel.name]
-                    sub_offset = datetime.timedelta(seconds=self._points_per_request / channel_rate)
-                    for sub_slice in slice.subdivide(sub_offset):
-                        jobs[slice].append(
-                            _ExportJob(
-                                datasource_rid=datasource_rid,
-                                channel_names=[channel.name],
-                                channel_types={ch.name: ch.data_type for ch in channel_group},
-                                time_slice=sub_slice,
-                                tags=dict(tags or {}),
-                                buckets=buckets,
-                                resolution=resolution,
-                                timestamp_type=timestamp_type,
-                            )
-                        )
+    def _build_jobs_for_datasource(
+        self,
+        *,
+        datasource_rid: str,
+        channels: Sequence[Channel],
+        points_per_second: Mapping[tuple[str, str], float],
+        time_slices: Sequence[_TimeRange],
+        batch_duration: datetime.timedelta,
+        timestamp_type: _AnyExportableTimestampType,
+        tags: Mapping[str, str] | None,
+        buckets: int | None,
+        resolution: IntegralNanosecondsDuration | None,
+    ) -> Mapping[_TimeRange, list[_ExportJob]]:
+        """Build export jobs for a single datasource's channels, keyed by parent time slice.
 
+        Channels are bin-packed by rate; any channel whose rate exceeds the per-request budget
+        is subdivided across sub-slices of each parent time slice, producing one single-channel
+        job per sub-slice.
+        """
+        channels_by_key = {(ch.data_source, ch.name): ch for ch in channels}
+        ds_pps = {key: points_per_second[key] for key in channels_by_key}
+        channel_groups, large_channels = _build_channel_groups(
+            ds_pps, channels_by_key, self._points_per_request, self._channels_per_request, batch_duration
+        )
+
+        def make_job(group: Sequence[Channel], slice_: _TimeRange) -> _ExportJob:
+            return _ExportJob(
+                datasource_rid=datasource_rid,
+                channel_names=[ch.name for ch in group],
+                channel_types={ch.name: ch.data_type for ch in group},
+                time_slice=slice_,
+                tags=dict(tags or {}),
+                buckets=buckets,
+                resolution=resolution,
+                timestamp_type=timestamp_type,
+            )
+
+        jobs: dict[_TimeRange, list[_ExportJob]] = collections.defaultdict(list)
+        for time_slice in time_slices:
+            for group in channel_groups:
+                jobs[time_slice].append(make_job(group, time_slice))
+            # Large channels exceed the per-request rate budget, so subdivide the slice per
+            # channel so each sub-slice fits. All sub-slice jobs roll up under the parent slice.
+            for channel in large_channels:
+                rate = ds_pps[(channel.data_source, channel.name)]
+                sub_offset = datetime.timedelta(seconds=self._points_per_request / rate)
+                for sub_slice in time_slice.subdivide(sub_offset):
+                    jobs[time_slice].append(make_job([channel], sub_slice))
         return jobs
 
     def export(
@@ -677,7 +770,30 @@ class PolarsExportHandler:
         resolution: IntegralNanosecondsDuration | None = None,
         join_batches: bool = True,
     ) -> Iterator[pl.DataFrame]:
-        """Yield DataFrame slices"""
+        """Yield exported data one DataFrame at a time.
+
+        LOG / UNKNOWN channels are filtered out with a warning; only DOUBLE, INT, and STRING
+        channels flow through the export pipeline.
+
+        Args:
+            channels: Channels to export.
+            start: Start of the export time range (nanoseconds UTC).
+            end: End of the export time range (nanoseconds UTC).
+            tags: Key-value pairs used to filter channel data server-side.
+            batch_duration: Explicit per-batch time window. If omitted, one is computed
+                from total channel rate and `points_per_dataframe`.
+            timestamp_type: Output timestamp representation (`epoch_seconds`, `iso8601`, etc.).
+            buckets: Decimate each channel to at most this many buckets per request. Mutually
+                exclusive with `resolution`.
+            resolution: Decimate each channel to samples at this interval (nanoseconds).
+                Mutually exclusive with `buckets`.
+            join_batches: If True (default), each yielded DataFrame is the outer-joined merge of
+                all channel groups for a single time slice. If False, yields one DataFrame per
+                channel group without merging.
+
+        Yields:
+            Polars DataFrames covering successive time slices of the export range.
+        """
         # Ensure user has selected channels to export
         if not channels:
             logger.warning("No channels requested for export-- returning")
@@ -686,6 +802,12 @@ class PolarsExportHandler:
         # Ensure user has not selected incompatible decimation options
         if None not in (buckets, resolution):
             raise ValueError("Cannot export data decimated with both buckets and resolution")
+
+        # Exclude channels with unsupported data types
+        supported_channels = [ch for ch in channels if ch.data_type in _EXPORTABLE_DATA_TYPES]
+        unsupported = len(channels) - len(supported_channels)
+        if unsupported:
+            logger.warning("Could not determine datatypes of %d channels -- ignoring for export", unsupported)
 
         if resolution is not None:
             # If the batch duration is higher than this number, and data is actually downsampled with the
@@ -710,9 +832,9 @@ class PolarsExportHandler:
 
         # Determine download schedule
         export_jobs = self._compute_export_jobs(
-            channels, _TimeRange(start, end), timestamp_type, tags or {}, buckets, resolution, batch_duration
+            supported_channels, _TimeRange(start, end), timestamp_type, tags or {}, buckets, resolution, batch_duration
         )
-        time_column = _get_exported_timestamp_channel([ch.name for ch in channels])
+        time_column = _get_exported_timestamp_channel([ch.name for ch in supported_channels])
         yield from self._export_dataframes(export_jobs, time_column, join_batches)
 
     def _export_dataframes(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nominal.core.channel import Channel, ChannelDataType
+
+
+@pytest.fixture
+def mock_clients():
+    """A mock _ClientsBunch with a preset auth header."""
+    clients = MagicMock()
+    clients.auth_header = "Bearer test-token"
+    return clients
+
+
+@pytest.fixture
+def make_channel(mock_clients):
+    """Factory fixture that creates Channel instances sharing the same mock clients."""
+
+    def _make(
+        name: str,
+        data_type: ChannelDataType | None = ChannelDataType.DOUBLE,
+        data_source: str = "ds-1",
+    ) -> Channel:
+        return Channel(
+            name=name,
+            data_source=data_source,
+            data_type=data_type,
+            unit=None,
+            description=None,
+            _clients=mock_clients,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_series_count_response():
+    """Factory fixture that builds a mock BatchGetSeriesCountResponse from a list of counts.
+
+    Pass `None` in a slot to simulate a channel on an external datasource (series_count absent).
+    """
+
+    def _make(counts: list[int | None]):
+        response = MagicMock()
+        response.responses = [MagicMock(series_count=count) for count in counts]
+        return response
+
+    return _make

--- a/tests/core/test_channel_filter.py
+++ b/tests/core/test_channel_filter.py
@@ -76,34 +76,40 @@ def test_external_datasources_excluded(mock_clients, make_channel, make_series_c
 
 def test_batching_respects_batch_size(mock_clients, make_channel, make_series_count_response):
     """Channels are split into batches of the configured size."""
-    mock_clients.datasource.batch_get_series_count.side_effect = [
-        make_series_count_response([1, 1]),
-        make_series_count_response([1, 1]),
-        make_series_count_response([1]),
-    ]
+    # A callable side_effect keeps the test deterministic regardless of which order the
+    # ThreadPoolExecutor happens to complete batches in — each request gets a response
+    # whose shape matches its contents.
+    def side_effect(_auth_header, request):
+        return make_series_count_response([1] * len(request.requests))
+
+    mock_clients.datasource.batch_get_series_count.side_effect = side_effect
     channels = [make_channel(f"ch{i}") for i in range(5)]
 
     result = list(filter_channels_with_data(channels, start_time=START_TIME, end_time=END_TIME, batch_size=2))
 
     assert len(result) == 5
+    # 5 channels at batch_size=2 → batches of 2, 2, 1 = 3 API calls.
     assert mock_clients.datasource.batch_get_series_count.call_count == 3
 
 
 def test_all_results_collected_across_concurrent_batches(mock_clients, make_channel, make_series_count_response):
     """With multiple batches and workers, all results are collected without drops."""
-    mock_clients.datasource.batch_get_series_count.side_effect = [
-        make_series_count_response([1, 0, 1]),
-        make_series_count_response([1, 1, 0]),
-        make_series_count_response([0, 1, 1]),
-        make_series_count_response([1]),
-    ]
+    # 7 of 10 channels have data; the rest don't. Encoding the outcome per channel (not
+    # per batch) makes the test agnostic to batch-completion order.
+    has_data = {f"ch{i}" for i in (0, 2, 3, 4, 7, 8, 9)}
+
+    def side_effect(_auth_header, request):
+        counts = [1 if req.channel in has_data else 0 for req in request.requests]
+        return make_series_count_response(counts)
+
+    mock_clients.datasource.batch_get_series_count.side_effect = side_effect
     channels = [make_channel(f"ch{i}") for i in range(10)]
 
     result = list(
         filter_channels_with_data(channels, start_time=START_TIME, end_time=END_TIME, batch_size=3, num_workers=4)
     )
 
-    assert len(result) == 7
+    assert {ch.name for ch in result} == has_data
 
 
 def test_api_error_triggers_individual_retry_then_excludes_still_failing(

--- a/tests/core/test_channel_filter.py
+++ b/tests/core/test_channel_filter.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from nominal.core.channel import filter_channels_with_data
+
+# Common time bounds used across the test suite; concrete values don't matter, they just
+# need to be valid and shared so tests don't re-state them.
+START_TIME = datetime(2024, 1, 1, tzinfo=timezone.utc)
+END_TIME = datetime(2024, 12, 31, tzinfo=timezone.utc)
+
+
+def test_returns_channels_with_data(mock_clients, make_channel, make_series_count_response):
+    """Only channels with data (series_count > 0) are yielded."""
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([1, 0, 1])
+    channels = [make_channel("has_data_1"), make_channel("no_data"), make_channel("has_data_2")]
+
+    result = list(filter_channels_with_data(channels, start_time=START_TIME, end_time=END_TIME))
+
+    assert {ch.name for ch in result} == {"has_data_1", "has_data_2"}
+
+
+def test_empty_input_yields_nothing():
+    """An empty channel list produces an empty iterator with no API calls."""
+    result = list(filter_channels_with_data([], start_time=START_TIME, end_time=END_TIME))
+
+    assert result == []
+
+
+def test_tags_are_forwarded_to_api(mock_clients, make_channel, make_series_count_response):
+    """Tags are included in the API request so the server filters by them."""
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([0, 1])
+    channels = [make_channel("no_match"), make_channel("match")]
+
+    result = list(filter_channels_with_data(channels, tags={"env": "prod"}, start_time=START_TIME, end_time=END_TIME))
+
+    assert [ch.name for ch in result] == ["match"]
+    request = mock_clients.datasource.batch_get_series_count.call_args[0][1]
+    assert request.requests[0].tag_filters is not None
+
+
+def test_accepts_nanosecond_timestamps(mock_clients, make_channel, make_series_count_response):
+    """Integer nanosecond timestamps are accepted alongside datetime objects."""
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([1])
+    start_ns = int(START_TIME.timestamp() * 1_000_000_000)
+    end_ns = int(END_TIME.timestamp() * 1_000_000_000)
+
+    result = list(filter_channels_with_data([make_channel("ch1")], start_time=start_ns, end_time=end_ns))
+
+    assert [ch.name for ch in result] == ["ch1"]
+
+
+def test_underconstrained_channels_still_yielded(mock_clients, make_channel, make_series_count_response):
+    """Channels whose tag set matches multiple series (series_count > 1) are still yielded.
+
+    Underconstrained tags signal an incomplete caller filter, but the data is present — the
+    channels should still flow through the pipeline so the caller can see them.
+    """
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([3, 5])
+    channels = [make_channel("ch1"), make_channel("ch2")]
+
+    result = list(filter_channels_with_data(channels, tags={"env": "prod"}, start_time=START_TIME, end_time=END_TIME))
+
+    assert [ch.name for ch in result] == ["ch1", "ch2"]
+
+
+def test_external_datasources_excluded(mock_clients, make_channel, make_series_count_response):
+    """Channels returning series_count=None (external datasources) are excluded."""
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([None, 1])
+    channels = [make_channel("external"), make_channel("nominal")]
+
+    result = list(filter_channels_with_data(channels, start_time=START_TIME, end_time=END_TIME))
+
+    assert [ch.name for ch in result] == ["nominal"]
+
+
+def test_batching_respects_batch_size(mock_clients, make_channel, make_series_count_response):
+    """Channels are split into batches of the configured size."""
+    mock_clients.datasource.batch_get_series_count.side_effect = [
+        make_series_count_response([1, 1]),
+        make_series_count_response([1, 1]),
+        make_series_count_response([1]),
+    ]
+    channels = [make_channel(f"ch{i}") for i in range(5)]
+
+    result = list(filter_channels_with_data(channels, start_time=START_TIME, end_time=END_TIME, batch_size=2))
+
+    assert len(result) == 5
+    assert mock_clients.datasource.batch_get_series_count.call_count == 3
+
+
+def test_all_results_collected_across_concurrent_batches(mock_clients, make_channel, make_series_count_response):
+    """With multiple batches and workers, all results are collected without drops."""
+    mock_clients.datasource.batch_get_series_count.side_effect = [
+        make_series_count_response([1, 0, 1]),
+        make_series_count_response([1, 1, 0]),
+        make_series_count_response([0, 1, 1]),
+        make_series_count_response([1]),
+    ]
+    channels = [make_channel(f"ch{i}") for i in range(10)]
+
+    result = list(
+        filter_channels_with_data(channels, start_time=START_TIME, end_time=END_TIME, batch_size=3, num_workers=4)
+    )
+
+    assert len(result) == 7
+
+
+def test_api_error_triggers_individual_retry_then_excludes_still_failing(
+    mock_clients, make_channel, make_series_count_response
+):
+    """Failed batch triggers per-channel retry; channels that still fail are excluded, not admitted.
+
+    Behavior verified:
+    * The batch call is retried — once per channel — after the initial batch failure.
+    * A channel whose individual retry succeeds is yielded.
+    * A channel whose individual retry also fails is excluded from the result.
+    """
+
+    # Multi-channel requests are the initial batch — fail. Single-channel requests are retries —
+    # pass or fail based on the channel name. Checking request size keeps the test deterministic
+    # regardless of ThreadPoolExecutor scheduling.
+    def side_effect(_auth_header, request):
+        if len(request.requests) > 1:
+            raise RuntimeError("batch failed")
+        if request.requests[0].channel == "ch0":
+            return make_series_count_response([1])
+        raise RuntimeError("still failing")
+
+    mock_clients.datasource.batch_get_series_count.side_effect = side_effect
+    channels = [make_channel("ch0"), make_channel("ch1")]
+
+    result = list(filter_channels_with_data(channels, start_time=START_TIME, end_time=END_TIME, batch_size=2))
+
+    # ch0 confirmed by individual retry; ch1 excluded because both attempts failed.
+    assert [ch.name for ch in result] == ["ch0"]
+    # 1 batch call + 2 individual retries = 3 API calls total. Confirms the retry actually
+    # happened rather than both channels being silently excluded or admitted.
+    assert mock_clients.datasource.batch_get_series_count.call_count == 3
+
+
+def test_preserves_input_order(mock_clients, make_channel, make_series_count_response):
+    """Channels are yielded in input order, not batch-completion order."""
+    channels = [make_channel("c"), make_channel("a"), make_channel("b")]
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([1, 1, 1])
+
+    result = list(filter_channels_with_data(channels, start_time=START_TIME, end_time=END_TIME))
+
+    assert [ch.name for ch in result] == ["c", "a", "b"]

--- a/tests/core/test_channel_filter.py
+++ b/tests/core/test_channel_filter.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from nominal.core.channel import filter_channels_with_data
+
+# Common time bounds used across the test suite; concrete values don't matter, they just
+# need to be valid and shared so tests don't re-state them.
+START_TIME = datetime(2024, 1, 1, tzinfo=timezone.utc)
+END_TIME = datetime(2024, 12, 31, tzinfo=timezone.utc)
+
+
+def test_returns_channels_with_data(mock_clients, make_channel, make_series_count_response):
+    """Only channels with data (series_count > 0) are yielded."""
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([1, 0, 1])
+    channels = [make_channel("has_data_1"), make_channel("no_data"), make_channel("has_data_2")]
+
+    result = list(filter_channels_with_data(channels, start_time=START_TIME, end_time=END_TIME))
+
+    assert {ch.name for ch in result} == {"has_data_1", "has_data_2"}
+
+
+def test_empty_input_yields_nothing():
+    """An empty channel list produces an empty iterator with no API calls."""
+    result = list(filter_channels_with_data([], start_time=START_TIME, end_time=END_TIME))
+
+    assert result == []
+
+
+def test_tags_are_forwarded_to_api(mock_clients, make_channel, make_series_count_response):
+    """Tags are included in the API request so the server filters by them."""
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([0, 1])
+    channels = [make_channel("no_match"), make_channel("match")]
+
+    result = list(filter_channels_with_data(channels, tags={"env": "prod"}, start_time=START_TIME, end_time=END_TIME))
+
+    assert [ch.name for ch in result] == ["match"]
+    request = mock_clients.datasource.batch_get_series_count.call_args[0][1]
+    assert request.requests[0].tag_filters is not None
+
+
+def test_accepts_nanosecond_timestamps(mock_clients, make_channel, make_series_count_response):
+    """Integer nanosecond timestamps are accepted alongside datetime objects."""
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([1])
+    start_ns = int(START_TIME.timestamp() * 1_000_000_000)
+    end_ns = int(END_TIME.timestamp() * 1_000_000_000)
+
+    result = list(filter_channels_with_data([make_channel("ch1")], start_time=start_ns, end_time=end_ns))
+
+    assert [ch.name for ch in result] == ["ch1"]
+
+
+def test_underconstrained_channels_still_yielded(mock_clients, make_channel, make_series_count_response):
+    """Channels whose tag set matches multiple series (series_count > 1) are still yielded.
+
+    Underconstrained tags signal an incomplete caller filter, but the data is present — the
+    channels should still flow through the pipeline so the caller can see them.
+    """
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([3, 5])
+    channels = [make_channel("ch1"), make_channel("ch2")]
+
+    result = list(filter_channels_with_data(channels, tags={"env": "prod"}, start_time=START_TIME, end_time=END_TIME))
+
+    assert [ch.name for ch in result] == ["ch1", "ch2"]
+
+
+def test_external_datasources_excluded(mock_clients, make_channel, make_series_count_response):
+    """Channels returning series_count=None (external datasources) are excluded."""
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([None, 1])
+    channels = [make_channel("external"), make_channel("nominal")]
+
+    result = list(filter_channels_with_data(channels, start_time=START_TIME, end_time=END_TIME))
+
+    assert [ch.name for ch in result] == ["nominal"]
+
+
+def test_batching_respects_batch_size(mock_clients, make_channel, make_series_count_response):
+    """Channels are split into batches of the configured size."""
+
+    # A callable side_effect keeps the test deterministic regardless of which order the
+    # ThreadPoolExecutor happens to complete batches in — each request gets a response
+    # whose shape matches its contents.
+    def side_effect(_auth_header, request):
+        return make_series_count_response([1] * len(request.requests))
+
+    mock_clients.datasource.batch_get_series_count.side_effect = side_effect
+    channels = [make_channel(f"ch{i}") for i in range(5)]
+
+    result = list(filter_channels_with_data(channels, start_time=START_TIME, end_time=END_TIME, batch_size=2))
+
+    assert len(result) == 5
+    # 5 channels at batch_size=2 → batches of 2, 2, 1 = 3 API calls.
+    assert mock_clients.datasource.batch_get_series_count.call_count == 3
+
+
+def test_all_results_collected_across_concurrent_batches(mock_clients, make_channel, make_series_count_response):
+    """With multiple batches and workers, all results are collected without drops."""
+    # 7 of 10 channels have data; the rest don't. Encoding the outcome per channel (not
+    # per batch) makes the test agnostic to batch-completion order.
+    has_data = {f"ch{i}" for i in (0, 2, 3, 4, 7, 8, 9)}
+
+    def side_effect(_auth_header, request):
+        counts = [1 if req.channel in has_data else 0 for req in request.requests]
+        return make_series_count_response(counts)
+
+    mock_clients.datasource.batch_get_series_count.side_effect = side_effect
+    channels = [make_channel(f"ch{i}") for i in range(10)]
+
+    result = list(
+        filter_channels_with_data(channels, start_time=START_TIME, end_time=END_TIME, batch_size=3, num_workers=4)
+    )
+
+    assert {ch.name for ch in result} == has_data
+
+
+def test_api_error_triggers_individual_retry_then_excludes_still_failing(
+    mock_clients, make_channel, make_series_count_response
+):
+    """Failed batch triggers per-channel retry; channels that still fail are excluded, not admitted.
+
+    Behavior verified:
+    * The batch call is retried — once per channel — after the initial batch failure.
+    * A channel whose individual retry succeeds is yielded.
+    * A channel whose individual retry also fails is excluded from the result.
+    """
+
+    # Multi-channel requests are the initial batch — fail. Single-channel requests are retries —
+    # pass or fail based on the channel name. Checking request size keeps the test deterministic
+    # regardless of ThreadPoolExecutor scheduling.
+    def side_effect(_auth_header, request):
+        if len(request.requests) > 1:
+            raise RuntimeError("batch failed")
+        if request.requests[0].channel == "ch0":
+            return make_series_count_response([1])
+        raise RuntimeError("still failing")
+
+    mock_clients.datasource.batch_get_series_count.side_effect = side_effect
+    channels = [make_channel("ch0"), make_channel("ch1")]
+
+    result = list(filter_channels_with_data(channels, start_time=START_TIME, end_time=END_TIME, batch_size=2))
+
+    # ch0 confirmed by individual retry; ch1 excluded because both attempts failed.
+    assert [ch.name for ch in result] == ["ch0"]
+    # 1 batch call + 2 individual retries = 3 API calls total. Confirms the retry actually
+    # happened rather than both channels being silently excluded or admitted.
+    assert mock_clients.datasource.batch_get_series_count.call_count == 3
+
+
+def test_preserves_input_order(mock_clients, make_channel, make_series_count_response):
+    """Channels are yielded in input order, not batch-completion order."""
+    channels = [make_channel("c"), make_channel("a"), make_channel("b")]
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([1, 1, 1])
+
+    result = list(filter_channels_with_data(channels, start_time=START_TIME, end_time=END_TIME))
+
+    assert [ch.name for ch in result] == ["c", "a", "b"]

--- a/tests/core/test_channel_filter.py
+++ b/tests/core/test_channel_filter.py
@@ -76,6 +76,7 @@ def test_external_datasources_excluded(mock_clients, make_channel, make_series_c
 
 def test_batching_respects_batch_size(mock_clients, make_channel, make_series_count_response):
     """Channels are split into batches of the configured size."""
+
     # A callable side_effect keeps the test deterministic regardless of which order the
     # ThreadPoolExecutor happens to complete batches in — each request gets a response
     # whose shape matches its contents.

--- a/tests/thirdparty/polars/conftest.py
+++ b/tests/thirdparty/polars/conftest.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from nominal_api import api, scout_compute_api
+
+
+@pytest.fixture
+def mock_client():
+    """A mock NominalClient for compute API calls."""
+    return MagicMock()
+
+
+@pytest.fixture
+def make_numeric_response():
+    """Factory that builds a bucketed numeric ComputeNodeResponse."""
+
+    def _make(bucket_counts: list[int], bucket_interval_seconds: int = 10):
+        response = MagicMock(spec=scout_compute_api.ComputeNodeResponse)
+        response.bucketed_numeric = MagicMock()
+        response.bucketed_numeric.timestamps = [
+            api.Timestamp(seconds=i * bucket_interval_seconds, nanos=0) for i in range(len(bucket_counts))
+        ]
+        response.bucketed_numeric.buckets = [
+            scout_compute_api.NumericBucket(
+                count=c,
+                min=0.0,
+                max=1.0,
+                mean=0.5,
+                variance=0.1,
+                first_point=MagicMock(),
+                last_point=MagicMock(),
+            )
+            for c in bucket_counts
+        ]
+        response.numeric = None
+        response.numeric_point = None
+        response.bucketed_enum = None
+        response.enum = None
+        return response
+
+    return _make
+
+
+@pytest.fixture
+def make_enum_response():
+    """Factory that builds a bucketed enum ComputeNodeResponse."""
+
+    def _make(histograms: list[dict[int, int]], bucket_interval_seconds: int = 10):
+        response = MagicMock(spec=scout_compute_api.ComputeNodeResponse)
+        response.bucketed_numeric = None
+        response.numeric = None
+        response.numeric_point = None
+        response.bucketed_enum = MagicMock()
+        response.bucketed_enum.timestamps = [
+            api.Timestamp(seconds=i * bucket_interval_seconds, nanos=0) for i in range(len(histograms))
+        ]
+        response.bucketed_enum.buckets = [
+            scout_compute_api.EnumBucket(histogram=h, first_point=MagicMock(), last_point=None) for h in histograms
+        ]
+        response.enum = None
+        return response
+
+    return _make
+
+
+@pytest.fixture
+def make_compute_result():
+    """Factory that builds a single compute result entry for batch responses."""
+
+    def _make(success=None, error=None):
+        result = MagicMock()
+        result.compute_result = MagicMock()
+        result.compute_result.error = error
+        result.compute_result.success = success
+        return result
+
+    return _make

--- a/tests/thirdparty/polars/test_polars_export_handler.py
+++ b/tests/thirdparty/polars/test_polars_export_handler.py
@@ -1,0 +1,525 @@
+from __future__ import annotations
+
+import contextlib
+import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from nominal_api import api, scout_compute_api
+
+from nominal.core.channel import ChannelDataType
+from nominal.thirdparty.polars.polars_export_handler import (
+    PolarsExportHandler,
+    _batch_channel_points_per_second,
+    _build_channel_groups,
+    _extract_bucket_counts,
+    _peak_points_per_second,
+    _TimeRange,
+)
+
+# Note: for new test coverage, prefer testing through `PolarsExportHandler._compute_export_jobs`
+# (with MagicMock on the client fixtures) rather than direct unit tests of private helpers like
+# `_batch_channel_points_per_second`. Integration-style tests are less brittle to internal refactors.
+
+TEN_SECONDS_NS = 10_000_000_000
+TWENTY_SECONDS_NS = 20_000_000_000
+
+
+def _empty_response() -> MagicMock:
+    """Create a ComputeNodeResponse with all union variants unset (the caller fills one in)."""
+    response = MagicMock(spec=scout_compute_api.ComputeNodeResponse)
+    response.bucketed_numeric = None
+    response.numeric = None
+    response.numeric_point = None
+    response.bucketed_enum = None
+    response.enum = None
+    return response
+
+
+# -- _extract_bucket_counts --
+
+
+def test_extract_numeric_bucketed(make_numeric_response):
+    """Bucketed numeric response yields (timestamp_ns, count) pairs preserving bucket order."""
+    result = _extract_bucket_counts(make_numeric_response([50, 75]))
+
+    assert result == [(0, 50), (TEN_SECONDS_NS, 75)]
+
+
+def test_extract_numeric_undecimated():
+    """Undecimated numeric series yields count=1 per timestamp."""
+    response = _empty_response()
+    response.numeric = MagicMock()
+    response.numeric.timestamps = [api.Timestamp(seconds=s, nanos=0) for s in (100, 200, 300)]
+
+    result = _extract_bucket_counts(response)
+
+    assert len(result) == 3
+    assert all(count == 1 for _, count in result)
+
+
+def test_extract_numeric_single_point():
+    """A single numeric point yields one entry with count=1."""
+    response = _empty_response()
+    response.numeric_point = MagicMock()
+    response.numeric_point.timestamp = api.Timestamp(seconds=100, nanos=0)
+
+    assert _extract_bucket_counts(response) == [(100_000_000_000, 1)]
+
+
+def test_extract_enum_bucketed(make_enum_response):
+    """Bucketed enum response sums histogram frequencies per bucket."""
+    result = _extract_bucket_counts(make_enum_response([{0: 30, 1: 20}, {0: 10}]))
+
+    assert result == [(0, 50), (TEN_SECONDS_NS, 10)]
+
+
+def test_extract_enum_undecimated():
+    """Undecimated enum series yields count=1 per timestamp."""
+    response = _empty_response()
+    response.enum = MagicMock()
+    response.enum.timestamps = [api.Timestamp(seconds=s, nanos=0) for s in (100, 200)]
+
+    result = _extract_bucket_counts(response)
+
+    assert len(result) == 2
+    assert all(count == 1 for _, count in result)
+
+
+def test_extract_unrecognized_response_returns_empty():
+    """An unrecognized response shape returns an empty list rather than raising."""
+    response = _empty_response()
+    response.type = "something_unknown"
+
+    assert _extract_bucket_counts(response) == []
+
+
+# -- _peak_points_per_second --
+
+
+def test_peak_pps_empty_buckets():
+    """No buckets yields zero PPS."""
+    assert _peak_points_per_second([], 0, TEN_SECONDS_NS) == 0.0
+
+
+def test_peak_pps_single_bucket():
+    """A single bucket divides its count by the full time range."""
+    result = _peak_points_per_second([(5_000_000_000, 100)], start_ns=0, end_ns=TEN_SECONDS_NS)
+
+    assert result == pytest.approx(10.0)
+
+
+def test_peak_pps_returns_peak_across_buckets():
+    """Multiple buckets return the highest PPS between any consecutive pair."""
+    buckets = [
+        (1_000_000_000, 10),
+        (2_000_000_000, 100),
+        (3_000_000_000, 20),
+    ]
+    assert _peak_points_per_second(buckets, start_ns=0, end_ns=3_000_000_000) == pytest.approx(100.0)
+
+
+def test_peak_pps_zero_duration_returns_zero():
+    """A zero-length time range returns 0 instead of dividing by zero."""
+    assert _peak_points_per_second([(5_000_000_000, 100)], start_ns=0, end_ns=0) == 0.0
+
+
+def test_peak_pps_skips_duplicate_timestamps():
+    """Consecutive buckets with identical timestamps are skipped, not divided by zero."""
+    buckets = [
+        (1_000_000_000, 10),
+        (1_000_000_000, 50),
+        (2_000_000_000, 20),
+    ]
+    # Only the 1s→2s interval contributes: 20 pts / 1s = 20 PPS
+    assert _peak_points_per_second(buckets, start_ns=0, end_ns=2_000_000_000) == pytest.approx(20.0)
+
+
+# -- _batch_channel_points_per_second --
+
+
+@pytest.mark.parametrize(
+    "data_type,response_kind",
+    [
+        (ChannelDataType.DOUBLE, "numeric"),
+        (ChannelDataType.INT, "numeric"),
+        (ChannelDataType.STRING, "enum"),
+    ],
+)
+def test_pps_supported_types_produce_positive_rates(
+    mock_client,
+    make_channel,
+    make_numeric_response,
+    make_enum_response,
+    make_compute_result,
+    data_type,
+    response_kind,
+):
+    """All supported channel types produce positive PPS from a bucketed compute response."""
+    response = (
+        make_numeric_response([50, 100])
+        if response_kind == "numeric"
+        else make_enum_response([{0: 30, 1: 20}, {0: 10}])
+    )
+    mock_client._clients.compute.batch_compute_with_units.return_value = MagicMock(
+        results=[make_compute_result(success=response)]
+    )
+
+    result = _batch_channel_points_per_second(
+        mock_client, [make_channel("ch", data_type)], 0, TWENTY_SECONDS_NS, {}, 100
+    )
+
+    rate = result[("ds-1", "ch")]
+    assert rate is not None and rate > 0
+
+
+def test_pps_unsupported_type_raises(mock_client, make_channel):
+    """Unsupported channel types surface as a ValueError to the caller.
+
+    Callers are expected to pre-filter to DOUBLE/INT/STRING so that this function has a
+    single source of truth for type support rather than silently coercing to None.
+    """
+    with pytest.raises(ValueError):
+        _batch_channel_points_per_second(
+            mock_client, [make_channel("mystery", ChannelDataType.UNKNOWN)], 0, TEN_SECONDS_NS, {}, 100
+        )
+
+
+def test_pps_empty_success_returns_none(mock_client, make_channel, make_compute_result):
+    """A compute result with neither success nor error payload produces None.
+
+    Covers a malformed conjure response where both union variants are unset; the caller
+    should see None rather than an AssertionError bubbling up.
+    """
+    mock_client._clients.compute.batch_compute_with_units.return_value = MagicMock(
+        results=[make_compute_result(success=None, error=None)]
+    )
+
+    result = _batch_channel_points_per_second(mock_client, [make_channel("empty")], 0, TEN_SECONDS_NS, {}, 100)
+
+    assert result == {("ds-1", "empty"): None}
+
+
+def test_pps_empty_channels_skips_api(mock_client):
+    """An empty channel list returns empty results without calling the compute API."""
+    result = _batch_channel_points_per_second(mock_client, [], 0, TEN_SECONDS_NS, {}, 100)
+
+    assert result == {}
+    mock_client._clients.compute.batch_compute_with_units.assert_not_called()
+
+
+def test_pps_api_failure_returns_none_for_all(mock_client, make_channel):
+    """If the compute API raises, all channels get None PPS so callers can distinguish failure from zero-data."""
+    mock_client._clients.compute.batch_compute_with_units.side_effect = RuntimeError("API down")
+
+    result = _batch_channel_points_per_second(
+        mock_client, [make_channel("a"), make_channel("b")], 0, TEN_SECONDS_NS, {}, 100
+    )
+
+    assert result == {("ds-1", "a"): None, ("ds-1", "b"): None}
+
+
+def test_pps_per_channel_error_returns_none_for_failed(
+    mock_client, make_channel, make_numeric_response, make_compute_result
+):
+    """Individual channel errors produce None for that channel while peers still succeed."""
+    mock_client._clients.compute.batch_compute_with_units.return_value = MagicMock(
+        results=[
+            make_compute_result(success=make_numeric_response([50, 100])),
+            make_compute_result(error="channel not found"),
+        ]
+    )
+
+    result = _batch_channel_points_per_second(
+        mock_client, [make_channel("good"), make_channel("bad")], 0, TWENTY_SECONDS_NS, {}, 100
+    )
+
+    good_rate = result[("ds-1", "good")]
+    assert good_rate is not None and good_rate > 0
+    assert result[("ds-1", "bad")] is None
+
+
+# -- _build_channel_groups --
+
+
+def _group_args(pairs):
+    """Build (pps_by_key, channels_by_key) dicts from a list of (Channel, rate) pairs."""
+    pps_by_key = {(ch.data_source, ch.name): rate for ch, rate in pairs}
+    channels_by_key = {(ch.data_source, ch.name): ch for ch, _ in pairs}
+    return pps_by_key, channels_by_key
+
+
+def test_groups_mixed_types_share_a_group_when_budget_allows(make_channel):
+    """Numeric (DOUBLE/INT) and string channels are packed into the same group under the rate budget.
+
+    Now that PPS estimation works for all types, grouping is budget-driven and no longer
+    partitions by data type. With a roomy budget, all channels fit in a single group.
+    """
+    pps, channels = _group_args(
+        [
+            (make_channel("temp", ChannelDataType.DOUBLE), 100.0),
+            (make_channel("pressure", ChannelDataType.INT), 100.0),
+            (make_channel("status", ChannelDataType.STRING), 50.0),
+        ]
+    )
+
+    groups, large = _build_channel_groups(
+        pps,
+        channels,
+        points_per_request=1_000_000,
+        max_channels_per_group=100,
+        batch_duration=datetime.timedelta(seconds=10),
+    )
+
+    assert large == []
+    assert len(groups) == 1
+    assert {ch.name for ch in groups[0]} == {"temp", "pressure", "status"}
+
+
+def test_groups_split_when_rate_budget_exceeded(make_channel):
+    """Channels are split into new groups when cumulative PPS exceeds the per-request budget."""
+    # 5 channels at 200 PPS each, budget 500 PPS → expect groups of 2, 2, 1.
+    pps, channels = _group_args([(make_channel(f"ch{i}"), 200.0) for i in range(5)])
+
+    groups, large = _build_channel_groups(
+        pps,
+        channels,
+        points_per_request=500,
+        max_channels_per_group=100,
+        batch_duration=datetime.timedelta(seconds=1),
+    )
+
+    assert len(groups) == 3
+    assert large == []
+
+
+def test_groups_isolate_high_rate_channels(make_channel):
+    """A channel whose individual rate exceeds the per-group budget is returned as large."""
+    pps, channels = _group_args(
+        [
+            (make_channel("fast"), 10_000.0),
+            (make_channel("slow"), 100.0),
+        ]
+    )
+
+    groups, large = _build_channel_groups(
+        pps,
+        channels,
+        points_per_request=500,
+        max_channels_per_group=100,
+        batch_duration=datetime.timedelta(seconds=1),
+    )
+
+    assert [ch.name for ch in large] == ["fast"]
+    assert len(groups) == 1
+    assert [ch.name for ch in groups[0]] == ["slow"]
+
+
+def test_groups_respect_max_channels_per_group(make_channel):
+    """Groups are capped at the configured max channels per group."""
+    pps, channels = _group_args([(make_channel(f"ch{i}"), 1.0) for i in range(10)])
+
+    groups, large = _build_channel_groups(
+        pps,
+        channels,
+        points_per_request=1_000_000,
+        max_channels_per_group=3,
+        batch_duration=datetime.timedelta(seconds=1),
+    )
+
+    assert large == []
+    assert sum(len(g) for g in groups) == 10
+    assert all(len(g) <= 3 for g in groups)
+
+
+def test_groups_empty_input():
+    """Empty inputs produce no groups and no large channels."""
+    groups, large = _build_channel_groups(
+        {},
+        {},
+        points_per_request=1_000_000,
+        max_channels_per_group=100,
+        batch_duration=datetime.timedelta(seconds=1),
+    )
+
+    assert groups == []
+    assert large == []
+
+
+def test_groups_include_zero_rate_channels(make_channel):
+    """Channels with 0.0 PPS (unknown rate) are still grouped, not silently dropped."""
+    pps, channels = _group_args(
+        [
+            (make_channel("known"), 100.0),
+            (make_channel("unknown"), 0.0),
+        ]
+    )
+
+    groups, large = _build_channel_groups(
+        pps,
+        channels,
+        points_per_request=1_000_000,
+        max_channels_per_group=100,
+        batch_duration=datetime.timedelta(seconds=10),
+    )
+
+    assert large == []
+    assert {ch.name for group in groups for ch in group} == {"known", "unknown"}
+
+
+# -- _compute_export_jobs --
+
+
+def test_compute_export_jobs_excludes_zero_and_none_pps_channels(
+    mock_client, mock_clients, make_channel, make_compute_result, make_numeric_response, make_series_count_response
+):
+    """Channels whose rate estimate is 0.0 or None are excluded from export jobs.
+
+    These channels have nothing to export — either no data in range (0.0) or the rate
+    estimator errored (None). Including them would waste an export request per channel.
+    """
+    channels = [
+        make_channel("known", ChannelDataType.DOUBLE),
+        make_channel("none_rate", ChannelDataType.DOUBLE),
+        make_channel("zero_rate", ChannelDataType.DOUBLE),
+    ]
+    # Data-presence filter: all three channels pass — the cheap pre-filter doesn't catch
+    # every "no data" case, so the exclusion must be enforced after PPS compute too.
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([1, 1, 1])
+    # PPS estimation: "known" gets a positive rate, "none_rate" errors (None), "zero_rate"
+    # succeeds with no buckets (0.0).
+    mock_client._clients.compute.batch_compute_with_units.return_value = MagicMock(
+        results=[
+            make_compute_result(success=make_numeric_response([50, 100])),
+            make_compute_result(error="compute failed"),
+            make_compute_result(success=make_numeric_response([])),
+        ]
+    )
+
+    handler = PolarsExportHandler(client=mock_client)
+    jobs = handler._compute_export_jobs(channels, _TimeRange(0, TEN_SECONDS_NS), timestamp_type="epoch_seconds")
+
+    exported_names = {name for job_list in jobs.values() for job in job_list for name in job.channel_names}
+    assert exported_names == {"known"}
+
+
+def test_compute_export_jobs_handles_cross_datasource_name_collision(
+    mock_client, mock_clients, make_channel, make_compute_result, make_numeric_response, make_series_count_response
+):
+    """Two channels sharing a name but different datasources both appear with correct attributes.
+
+    Regression guard for name-keyed internal maps: when `channels_by_key` was keyed by name
+    alone, a same-named channel from a second datasource would silently overwrite the first.
+    The maps are now keyed by `(data_source, name)` tuples.
+    """
+    channels = [
+        make_channel("temp", ChannelDataType.DOUBLE, data_source="ds-a"),
+        make_channel("temp", ChannelDataType.INT, data_source="ds-b"),
+    ]
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([1, 1])
+    mock_client._clients.compute.batch_compute_with_units.return_value = MagicMock(
+        results=[
+            make_compute_result(success=make_numeric_response([50, 100])),
+            make_compute_result(success=make_numeric_response([50, 100])),
+        ]
+    )
+
+    handler = PolarsExportHandler(client=mock_client)
+    jobs = handler._compute_export_jobs(channels, _TimeRange(0, TEN_SECONDS_NS), timestamp_type="epoch_seconds")
+
+    jobs_by_ds: dict[str, list] = {}
+    for job_list in jobs.values():
+        for job in job_list:
+            jobs_by_ds.setdefault(job.datasource_rid, []).append(job)
+
+    assert set(jobs_by_ds.keys()) == {"ds-a", "ds-b"}
+    assert any(job.channel_types == {"temp": ChannelDataType.DOUBLE} for job in jobs_by_ds["ds-a"])
+    assert any(job.channel_types == {"temp": ChannelDataType.INT} for job in jobs_by_ds["ds-b"])
+
+
+def test_export_excludes_unsupported_channel_types(
+    mock_client, mock_clients, make_channel, make_compute_result, make_numeric_response, make_series_count_response
+):
+    """export() filters out LOG/UNKNOWN channels so only DOUBLE/INT/STRING reach the API pipeline."""
+    channels = [
+        make_channel("temp", ChannelDataType.DOUBLE),
+        make_channel("logs", ChannelDataType.LOG),
+        make_channel("mystery", ChannelDataType.UNKNOWN),
+    ]
+    # Wire up just enough of the pipeline that it can reach (but not necessarily complete)
+    # the data-presence check — which is what we care about observing.
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([1])
+    mock_client._clients.compute.batch_compute_with_units.return_value = MagicMock(
+        results=[make_compute_result(success=make_numeric_response([50, 100]))]
+    )
+    mock_client._clients.dataexport.export_channel_data.return_value = MagicMock()
+    mock_client.get_datasource.return_value = MagicMock()
+
+    handler = PolarsExportHandler(client=mock_client)
+    # The export() pipeline may error downstream on MagicMock CSV responses; we only need the
+    # type filter (which runs before any yield) to have executed.
+    with contextlib.suppress(Exception):
+        list(handler.export(channels, start=0, end=TEN_SECONDS_NS))
+
+    # Only the DOUBLE channel reached the data-presence API — LOG/UNKNOWN were filtered upstream.
+    request = mock_clients.datasource.batch_get_series_count.call_args[0][1]
+    assert [req.channel for req in request.requests] == ["temp"]
+
+
+# -- large_channels sub-slice path --
+
+
+def test_compute_export_jobs_subdivides_large_channel_into_sub_slices(
+    mock_client, mock_clients, make_channel, make_compute_result, make_numeric_response, make_series_count_response
+):
+    """Channels exceeding the per-group rate budget are split into one job per sub-slice.
+
+    Behavior verified:
+    * The high-PPS channel is routed to ``large_channels`` and subdivided into sub-slices of
+      width ``points_per_request / channel_rate`` seconds.
+    * Each sub-slice becomes its own ``_ExportJob`` with ``channel_names`` equal to the single
+      large channel's name and ``time_slice`` equal to the sub-slice range.
+    * All sub-slice jobs for one parent batch are keyed under that parent ``time_slice``.
+    * ``channel_types`` on each sub-slice job contains exactly one entry — this was a silent
+      bug fix: the pre-PR code reused the group-wide dict for single-channel sub-slices.
+    * Sub-slices tile the parent range with no gaps, no overlaps, and full coverage.
+    """
+    # Tune numbers so the math is clean:
+    #   * channel rate = 1000 pts across 10s = 100 PPS
+    #   * per-group budget = points_per_request / batch_duration_s = 500 / 10 = 50 PPS
+    #     -> 100 > 50, so firehose lands in large_channels
+    #   * sub-slice width = points_per_request / channel_rate = 500 / 100 = 5s
+    #   * 10s parent slice / 5s sub-slice = 2 sub-slices
+    points_per_request = 500
+    parent_range = _TimeRange(0, TEN_SECONDS_NS)
+    batch_duration = datetime.timedelta(seconds=10)
+    channel = make_channel("firehose", ChannelDataType.DOUBLE)
+
+    mock_clients.datasource.batch_get_series_count.return_value = make_series_count_response([1])
+    mock_client._clients.compute.batch_compute_with_units.return_value = MagicMock(
+        results=[make_compute_result(success=make_numeric_response([1000, 1000]))]
+    )
+
+    handler = PolarsExportHandler(client=mock_client, points_per_request=points_per_request)
+    jobs = handler._compute_export_jobs(
+        [channel], parent_range, timestamp_type="epoch_seconds", batch_duration=batch_duration
+    )
+
+    # All sub-slices roll up under a single parent time_slice.
+    assert len(jobs) == 1
+    parent_slice, job_list = next(iter(jobs.items()))
+    assert parent_slice == parent_range
+    assert len(job_list) > 1
+
+    # Every sub-slice job is single-channel with the per-channel channel_types dict.
+    for job in job_list:
+        assert job.channel_names == ["firehose"]
+        assert job.channel_types == {"firehose": ChannelDataType.DOUBLE}
+
+    # Sub-slices tile the parent: no gaps, no overlaps, full coverage, each narrower than parent.
+    sub_ranges = sorted(job.time_slice for job in job_list)
+    assert sub_ranges[0].start_time == parent_slice.start_time
+    assert sub_ranges[-1].end_time == parent_slice.end_time
+    for a, b in zip(sub_ranges, sub_ranges[1:]):
+        assert a.end_time == b.start_time
+    assert all(r.duration_ns() < parent_slice.duration_ns() for r in sub_ranges)

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.131.0"
+version = "1.132.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
                                                   
  This PR rewrites how the Polars exporter plans its work so it handles every channel type correctly, not just floats.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
   
  Previously, only `DOUBLE` channels got a data-rate estimate — INT and string/enum channels either bypassed rate budgeting or got dropped from scheduling, so the planner was under-informed for most real-world exports. Now every supported type goes through the same peak-PPS estimator, and channel grouping is a single budget-driven bin-pack rather than a per-type partition.                                                                                                                                                                                                                  
                                                                      
  Preflight is dramatically faster too. The old data-presence probe made one API call per channel; the new `filter_channels_with_data` batches up to 200 at a time and retries per-channel on batch failure. A 1000-channel export drops from roughly 1000 API round-trips to 5. The filter is exposed on `nominal.core` so callers can use it without running a full export.                                                                                                                                                                                                                            
                                                                      
  `export()` keeps the same signature and yields the same DataFrame shape — this is a scheduler rewrite, not an interface change.                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                      
  ## Bugs fixed along the way                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
  
  - **Sub-slice jobs carried the wrong `channel_types`.** When a large channel was split across sub-slices, each sub-slice job was built with `channel_types={ch.name for ch in channel_group}` — a set comprehension that produced a `set`, not a `dict`, and reused the group-wide collection. Each sub-slice now carries `{channel.name: channel.data_type}` for its single channel.                                                                                                                                                                                                                  
  - **Bogus `assert compute_result.success is not None`.** The preceding guard only checked `error is not None`, so a conjure response with both union variants `None` crashed the export with `AssertionError`. Replaced with a log-and-skip branch.
  - **Same-named channels across datasources shared rate estimates.** Internal maps were keyed by channel name only; two channels with the same name on different datasources would silently overwrite each other in the rate dict. All internal maps are now keyed by `(data_source, name)` tuples, end to end.                                                                                                                                                                                                                                                                                         
  - **Unsupported channel types at `_batch_channel_points_per_second` now raise** instead of being silently coerced to `None`. The defensive handling was unreachable dead code — the upstream type filter guarantees only `DOUBLE`/`INT`/`STRING` reach it.                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
  ## Verification                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
  - `uv run pytest tests/` — 209 passed, 8 skipped                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
  - `uv run mypy nominal/` — clean across 137 files
  - `uv run ruff check nominal/ tests/` — clean