### PR TITLE
feat: add overwrite_overlapping param to Video.add_file / add_from_io

### DIFF
--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -126,6 +126,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         *,
         start: datetime | IntegralNanosecondsUTC,
         description: str | None = None,
+        overwrite_overlapping: bool = False,
     ) -> VideoFile: ...
 
     @overload
@@ -135,6 +136,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         *,
         frame_timestamps: Sequence[IntegralNanosecondsUTC],
         description: str | None = None,
+        overwrite_overlapping: bool = False,
     ) -> VideoFile: ...
 
     def add_file(
@@ -144,6 +146,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         start: datetime | IntegralNanosecondsUTC | None = None,
         frame_timestamps: Sequence[IntegralNanosecondsUTC] | None = None,
         description: str | None = None,
+        overwrite_overlapping: bool = False,
     ) -> VideoFile:
         """Append to a video from a file-path to H264-encoded video data. Only one of start or frame_timestamps
         is allowed.
@@ -155,6 +158,8 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
                 parameter, unless precise per-frame metadata is available and desired.
             description: Description of the video file.
                 NOTE: this is currently not displayed to users and may be removed in the future.
+            overwrite_overlapping: If True, after ingestion completes, any existing video files whose time ranges
+                overlap with the newly added file will be archived. This requires polling until ingestion is done.
 
         Returns:
             Reference to the created video file.
@@ -170,6 +175,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
                     start=start,
                     description=description,
                     file_type=file_type,
+                    overwrite_overlapping=overwrite_overlapping,
                 )
             elif frame_timestamps is not None:
                 return self.add_from_io(
@@ -178,6 +184,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
                     frame_timestamps=frame_timestamps,
                     description=description,
                     file_type=file_type,
+                    overwrite_overlapping=overwrite_overlapping,
                 )
             else:  # This should never be reached due to the validation above
                 raise ValueError("Either 'start' or 'frame_timestamps' must be provided")
@@ -191,6 +198,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         start: datetime | IntegralNanosecondsUTC,
         description: str | None = None,
         file_type: tuple[str, str] | FileType = FileTypes.MP4,
+        overwrite_overlapping: bool = False,
     ) -> VideoFile: ...
 
     @overload
@@ -202,6 +210,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         frame_timestamps: Sequence[IntegralNanosecondsUTC],
         description: str | None = None,
         file_type: tuple[str, str] | FileType = FileTypes.MP4,
+        overwrite_overlapping: bool = False,
     ) -> VideoFile: ...
 
     def add_from_io(
@@ -212,6 +221,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         frame_timestamps: Sequence[IntegralNanosecondsUTC] | None = None,
         description: str | None = None,
         file_type: tuple[str, str] | FileType = FileTypes.MP4,
+        overwrite_overlapping: bool = False,
     ) -> VideoFile:
         """Append to a video from a file-like object containing video data encoded in H264 or H265.
 
@@ -224,6 +234,8 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
             description: Description of the video file.
                 NOTE: this is currently not displayed to users and may be removed in the future.
             file_type: Metadata about the type of video file, e.g., MP4 vs. MKV.
+            overwrite_overlapping: If True, after ingestion completes, any existing video files whose time ranges
+                overlap with the newly added file will be archived. This requires polling until ingestion is done.
 
         Returns:
             Reference to the created video file.
@@ -263,10 +275,13 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         if response.details.video is None:
             raise NominalIngestError("error ingesting video: no video created")
 
-        return VideoFile._from_conjure(
+        new_file = VideoFile._from_conjure(
             self._clients,
             self._clients.video_file.get(self._clients.auth_header, response.details.video.video_file_rid),
         )
+        if overwrite_overlapping:
+            self._archive_overlapping_files(new_file)
+        return new_file
 
     add_to_video_from_io = add_from_io
 
@@ -367,6 +382,32 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         )
 
     add_mcap_to_video_from_io = add_mcap_from_io
+
+    def _archive_overlapping_files(self, new_file: VideoFile) -> None:
+        """Poll until new_file is ingested, then archive any existing files whose time ranges overlap with it."""
+        new_file.poll_until_ingestion_completed()
+        raw_new_file = new_file._get_latest_api()
+        if raw_new_file.segment_metadata is None:
+            logger.warning(
+                "Cannot determine time range for new video file %r; skipping overlap archival", new_file.rid
+            )
+            return
+        new_start = _SecondsNanos.from_api(raw_new_file.segment_metadata.min_absolute_timestamp).to_nanoseconds()
+        new_end = _SecondsNanos.from_api(raw_new_file.segment_metadata.max_absolute_timestamp).to_nanoseconds()
+        for existing_file in self.list_files():
+            if existing_file.rid == new_file.rid:
+                continue
+            raw_existing = existing_file._get_latest_api()
+            if raw_existing.segment_metadata is None:
+                continue
+            existing_start = _SecondsNanos.from_api(
+                raw_existing.segment_metadata.min_absolute_timestamp
+            ).to_nanoseconds()
+            existing_end = _SecondsNanos.from_api(
+                raw_existing.segment_metadata.max_absolute_timestamp
+            ).to_nanoseconds()
+            if new_start <= existing_end and new_end >= existing_start:
+                existing_file.archive()
 
     def list_files(self) -> Sequence[VideoFile]:
         """List all video files associated with the video."""

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -385,8 +385,21 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
     add_mcap_to_video_from_io = add_mcap_from_io
 
     def _archive_overlapping_files(self, new_file: VideoFile) -> None:
-        """Poll until new_file is ingested, then archive any existing files whose time ranges overlap with it."""
-        new_file.poll_until_ingestion_completed()
+        """Poll until new_file is ingested, then archive any existing files whose time ranges overlap with it.
+
+        The video file has already been uploaded successfully before this is called. If polling or archival
+        fails, a warning is logged and the new file is left intact.
+        """
+        try:
+            new_file.poll_until_ingestion_completed()
+        except Exception as e:
+            logger.warning(
+                "Video file %r was uploaded successfully but overlap archival was skipped: "
+                "failed to poll ingestion status: %s",
+                new_file.rid,
+                e,
+            )
+            return
         raw_new_file = new_file._get_latest_api()
         if raw_new_file.segment_metadata is None:
             logger.warning(

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -280,7 +280,29 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
             self._clients.video_file.get(self._clients.auth_header, response.details.video.video_file_rid),
         )
         if overwrite_overlapping:
-            self._archive_overlapping_files(new_file)
+            new_file.poll_until_ingestion_completed()
+            raw_new_file = new_file._get_latest_api()
+            if raw_new_file.segment_metadata is None:
+                logger.warning(
+                    "Cannot determine time range for new video file %r; skipping overlap archival", new_file.rid
+                )
+            else:
+                new_start = _SecondsNanos.from_api(raw_new_file.segment_metadata.min_absolute_timestamp).to_nanoseconds()
+                new_end = _SecondsNanos.from_api(raw_new_file.segment_metadata.max_absolute_timestamp).to_nanoseconds()
+                for existing_file in self.list_files():
+                    if existing_file.rid == new_file.rid:
+                        continue
+                    raw_existing = existing_file._get_latest_api()
+                    if raw_existing.segment_metadata is None:
+                        continue
+                    existing_start = _SecondsNanos.from_api(
+                        raw_existing.segment_metadata.min_absolute_timestamp
+                    ).to_nanoseconds()
+                    existing_end = _SecondsNanos.from_api(
+                        raw_existing.segment_metadata.max_absolute_timestamp
+                    ).to_nanoseconds()
+                    if new_start <= existing_end and new_end >= existing_start:
+                        existing_file.archive()
         return new_file
 
     add_to_video_from_io = add_from_io
@@ -382,32 +404,6 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         )
 
     add_mcap_to_video_from_io = add_mcap_from_io
-
-    def _archive_overlapping_files(self, new_file: VideoFile) -> None:
-        """Poll until new_file is ingested, then archive any existing files whose time ranges overlap with it."""
-        new_file.poll_until_ingestion_completed()
-        raw_new_file = new_file._get_latest_api()
-        if raw_new_file.segment_metadata is None:
-            logger.warning(
-                "Cannot determine time range for new video file %r; skipping overlap archival", new_file.rid
-            )
-            return
-        new_start = _SecondsNanos.from_api(raw_new_file.segment_metadata.min_absolute_timestamp).to_nanoseconds()
-        new_end = _SecondsNanos.from_api(raw_new_file.segment_metadata.max_absolute_timestamp).to_nanoseconds()
-        for existing_file in self.list_files():
-            if existing_file.rid == new_file.rid:
-                continue
-            raw_existing = existing_file._get_latest_api()
-            if raw_existing.segment_metadata is None:
-                continue
-            existing_start = _SecondsNanos.from_api(
-                raw_existing.segment_metadata.min_absolute_timestamp
-            ).to_nanoseconds()
-            existing_end = _SecondsNanos.from_api(
-                raw_existing.segment_metadata.max_absolute_timestamp
-            ).to_nanoseconds()
-            if new_start <= existing_end and new_end >= existing_start:
-                existing_file.archive()
 
     def list_files(self) -> Sequence[VideoFile]:
         """List all video files associated with the video."""

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -281,29 +281,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
             self._clients.video_file.get(self._clients.auth_header, response.details.video.video_file_rid),
         )
         if overwrite_overlapping:
-            new_file.poll_until_ingestion_completed()
-            raw_new_file = new_file._get_latest_api()
-            if raw_new_file.segment_metadata is None:
-                logger.warning(
-                    "Cannot determine time range for new video file %r; skipping overlap archival", new_file.rid
-                )
-            else:
-                new_start = _SecondsNanos.from_api(raw_new_file.segment_metadata.min_absolute_timestamp).to_nanoseconds()
-                new_end = _SecondsNanos.from_api(raw_new_file.segment_metadata.max_absolute_timestamp).to_nanoseconds()
-                for existing_file in self.list_files():
-                    if existing_file.rid == new_file.rid:
-                        continue
-                    raw_existing = existing_file._get_latest_api()
-                    if raw_existing.segment_metadata is None:
-                        continue
-                    existing_start = _SecondsNanos.from_api(
-                        raw_existing.segment_metadata.min_absolute_timestamp
-                    ).to_nanoseconds()
-                    existing_end = _SecondsNanos.from_api(
-                        raw_existing.segment_metadata.max_absolute_timestamp
-                    ).to_nanoseconds()
-                    if new_start <= existing_end and new_end >= existing_start:
-                        existing_file.archive()
+            self._archive_overlapping_files(new_file)
         return new_file
 
     add_to_video_from_io = add_from_io
@@ -405,6 +383,32 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         )
 
     add_mcap_to_video_from_io = add_mcap_from_io
+
+    def _archive_overlapping_files(self, new_file: VideoFile) -> None:
+        """Poll until new_file is ingested, then archive any existing files whose time ranges overlap with it."""
+        new_file.poll_until_ingestion_completed()
+        raw_new_file = new_file._get_latest_api()
+        if raw_new_file.segment_metadata is None:
+            logger.warning(
+                "Cannot determine time range for new video file %r; skipping overlap archival", new_file.rid
+            )
+            return
+        new_start = _SecondsNanos.from_api(raw_new_file.segment_metadata.min_absolute_timestamp).to_nanoseconds()
+        new_end = _SecondsNanos.from_api(raw_new_file.segment_metadata.max_absolute_timestamp).to_nanoseconds()
+        for existing_file in self.list_files():
+            if existing_file.rid == new_file.rid:
+                continue
+            raw_existing = existing_file._get_latest_api()
+            if raw_existing.segment_metadata is None:
+                continue
+            existing_start = _SecondsNanos.from_api(
+                raw_existing.segment_metadata.min_absolute_timestamp
+            ).to_nanoseconds()
+            existing_end = _SecondsNanos.from_api(
+                raw_existing.segment_metadata.max_absolute_timestamp
+            ).to_nanoseconds()
+            if new_start <= existing_end and new_end >= existing_start:
+                existing_file.archive()
 
     def list_files(self) -> Sequence[VideoFile]:
         """List all video files associated with the video."""

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -236,7 +236,9 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
                 NOTE: this is currently not displayed to users and may be removed in the future.
             file_type: Metadata about the type of video file, e.g., MP4 vs. MKV.
             overwrite_overlapping: If True, after ingestion completes, any existing video files whose time ranges
-                overlap with the newly added file will be archived. This requires polling until ingestion is done.
+                overlap with the newly added file will be archived (files are considered overlapping if their time
+                ranges have any intersection). This requires polling until ingestion is done. For videos with many
+                existing files this may be slow, as metadata is fetched per file.
 
         Returns:
             Reference to the created video file.
@@ -389,6 +391,9 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
 
         The video file has already been uploaded successfully before this is called. If polling or archival
         fails, a warning is logged and the new file is left intact.
+
+        Note: this fetches all files in the video and then makes an individual API call per file to retrieve
+        segment metadata. For videos with many files this may be slow.
         """
         try:
             new_file.poll_until_ingestion_completed()
@@ -401,27 +406,32 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
             )
             return
         raw_new_file = new_file._get_latest_api()
-        if raw_new_file.segment_metadata is None:
+        seg = raw_new_file.segment_metadata
+        if seg is None or seg.min_absolute_timestamp is None or seg.max_absolute_timestamp is None:
             logger.warning(
                 "Cannot determine time range for new video file %r; skipping overlap archival", new_file.rid
             )
             return
-        new_start = _SecondsNanos.from_api(raw_new_file.segment_metadata.min_absolute_timestamp).to_nanoseconds()
-        new_end = _SecondsNanos.from_api(raw_new_file.segment_metadata.max_absolute_timestamp).to_nanoseconds()
-        for existing_file in self.list_files():
-            if existing_file.rid == new_file.rid:
-                continue
+        new_start = _SecondsNanos.from_api(seg.min_absolute_timestamp).to_nanoseconds()
+        new_end = _SecondsNanos.from_api(seg.max_absolute_timestamp).to_nanoseconds()
+        existing_files = [f for f in self.list_files() if f.rid != new_file.rid]
+        logger.debug("Checking %d existing video files for overlap with %r", len(existing_files), new_file.rid)
+        for existing_file in existing_files:
             raw_existing = existing_file._get_latest_api()
-            if raw_existing.segment_metadata is None:
+            existing_seg = raw_existing.segment_metadata
+            if (
+                existing_seg is None
+                or existing_seg.min_absolute_timestamp is None
+                or existing_seg.max_absolute_timestamp is None
+            ):
                 continue
-            existing_start = _SecondsNanos.from_api(
-                raw_existing.segment_metadata.min_absolute_timestamp
-            ).to_nanoseconds()
-            existing_end = _SecondsNanos.from_api(
-                raw_existing.segment_metadata.max_absolute_timestamp
-            ).to_nanoseconds()
+            existing_start = _SecondsNanos.from_api(existing_seg.min_absolute_timestamp).to_nanoseconds()
+            existing_end = _SecondsNanos.from_api(existing_seg.max_absolute_timestamp).to_nanoseconds()
             if new_start <= existing_end and new_end >= existing_start:
-                existing_file.archive()
+                try:
+                    existing_file.archive()
+                except Exception as e:
+                    logger.warning("Failed to archive overlapping video file %r: %s", existing_file.rid, e)
 
     def list_files(self) -> Sequence[VideoFile]:
         """List all video files associated with the video."""

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -289,6 +289,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         path: PathLike,
         topic: str,
         description: str | None = None,
+        overwrite_overlapping: bool = False,
     ) -> VideoFile:
         """Append to a video from a file-path to an MCAP file containing video data.
 
@@ -297,6 +298,8 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
             topic: Topic pointing to video data within the MCAP file.
             description: Description of the video file.
                 NOTE: this is currently not displayed to users and may be removed in the future.
+            overwrite_overlapping: If True, any segments from other video files within this video that overlap
+                with the newly added file will be deleted before inserting the new segments.
 
         Returns:
             Reference to the created video file.
@@ -313,6 +316,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
                 topic=topic,
                 description=description,
                 file_type=file_type,
+                overwrite_overlapping=overwrite_overlapping,
             )
 
     add_mcap_to_video = add_mcap
@@ -324,6 +328,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         topic: str,
         description: str | None = None,
         file_type: tuple[str, str] | FileType = FileTypes.MCAP,
+        overwrite_overlapping: bool = False,
     ) -> VideoFile:
         """Append to a video from a file-like binary stream with MCAP data containing video data.
 
@@ -334,6 +339,8 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
             description: Description of the video file.
                 NOTE: this is currently not displayed to users and may be removed in the future.
             file_type: Metadata about the type of video (e.g. MCAP).
+            overwrite_overlapping: If True, any segments from other video files within this video that overlap
+                with the newly added file will be deleted before inserting the new segments.
 
         Returns:
             Reference to the created video file.
@@ -368,6 +375,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
                     timestamp_manifest=scout_video_api.VideoFileTimestampManifest(
                         mcap=scout_video_api.McapTimestampManifest(api.McapChannelLocator(topic=topic))
                     ),
+                    over_write_segments=overwrite_overlapping or None,
                 )
             )
         )

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -158,9 +158,8 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
                 parameter, unless precise per-frame metadata is available and desired.
             description: Description of the video file.
                 NOTE: this is currently not displayed to users and may be removed in the future.
-            overwrite_overlapping: If True, after ingestion completes, any existing video files whose time ranges
-                overlap with the newly added file will be archived (files are considered overlapping if their time
-                ranges have any intersection). This requires polling until ingestion is done.
+            overwrite_overlapping: If True, any segments from other video files within this video that overlap
+                with the newly added file will be deleted before inserting the new segments.
 
         Returns:
             Reference to the created video file.
@@ -235,9 +234,8 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
             description: Description of the video file.
                 NOTE: this is currently not displayed to users and may be removed in the future.
             file_type: Metadata about the type of video file, e.g., MP4 vs. MKV.
-            overwrite_overlapping: If True, after ingestion completes, any existing video files whose time ranges
-                overlap with the newly added file will be archived (files are considered overlapping if their time
-                ranges have any intersection). This requires polling until ingestion is done. For videos with many
+            overwrite_overlapping: If True, any segments from other video files within this video that overlap
+                with the newly added file will be deleted before inserting the new segments. For videos with many
                 existing files this may be slow, as metadata is fetched per file.
 
         Returns:
@@ -271,6 +269,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
                         )
                     ),
                     timestamp_manifest=timestamp_manifest,
+                    over_write_segments=overwrite_overlapping or None,
                 )
             )
         )
@@ -278,13 +277,10 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         if response.details.video is None:
             raise NominalIngestError("error ingesting video: no video created")
 
-        new_file = VideoFile._from_conjure(
+        return VideoFile._from_conjure(
             self._clients,
             self._clients.video_file.get(self._clients.auth_header, response.details.video.video_file_rid),
         )
-        if overwrite_overlapping:
-            self._archive_overlapping_files(new_file)
-        return new_file
 
     add_to_video_from_io = add_from_io
 
@@ -385,51 +381,6 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         )
 
     add_mcap_to_video_from_io = add_mcap_from_io
-
-    def _archive_overlapping_files(self, new_file: VideoFile) -> None:
-        """Poll until new_file is ingested, then archive any existing files whose time ranges overlap with it.
-
-        The video file has already been uploaded successfully before this is called. If polling or archival
-        fails, a warning is logged and the new file is left intact.
-
-        Note: this fetches all files in the video and then makes an individual API call per file to retrieve
-        segment metadata. For videos with many files this may be slow.
-        """
-        try:
-            new_file.poll_until_ingestion_completed()
-        except Exception as e:
-            logger.warning(
-                "Video file %r was uploaded successfully but overlap archival was skipped: "
-                "failed to poll ingestion status: %s",
-                new_file.rid,
-                e,
-            )
-            return
-        raw_new_file = new_file._get_latest_api()
-        seg = raw_new_file.segment_metadata
-        if seg is None or seg.min_absolute_timestamp is None or seg.max_absolute_timestamp is None:
-            logger.warning("Cannot determine time range for new video file %r; skipping overlap archival", new_file.rid)
-            return
-        new_start = _SecondsNanos.from_api(seg.min_absolute_timestamp).to_nanoseconds()
-        new_end = _SecondsNanos.from_api(seg.max_absolute_timestamp).to_nanoseconds()
-        existing_files = [f for f in self.list_files() if f.rid != new_file.rid]
-        logger.debug("Checking %d existing video files for overlap with %r", len(existing_files), new_file.rid)
-        for existing_file in existing_files:
-            raw_existing = existing_file._get_latest_api()
-            existing_seg = raw_existing.segment_metadata
-            if (
-                existing_seg is None
-                or existing_seg.min_absolute_timestamp is None
-                or existing_seg.max_absolute_timestamp is None
-            ):
-                continue
-            existing_start = _SecondsNanos.from_api(existing_seg.min_absolute_timestamp).to_nanoseconds()
-            existing_end = _SecondsNanos.from_api(existing_seg.max_absolute_timestamp).to_nanoseconds()
-            if new_start <= existing_end and new_end >= existing_start:
-                try:
-                    existing_file.archive()
-                except Exception as e:
-                    logger.warning("Failed to archive overlapping video file %r: %s", existing_file.rid, e)
 
     def list_files(self) -> Sequence[VideoFile]:
         """List all video files associated with the video."""

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -159,7 +159,8 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
             description: Description of the video file.
                 NOTE: this is currently not displayed to users and may be removed in the future.
             overwrite_overlapping: If True, after ingestion completes, any existing video files whose time ranges
-                overlap with the newly added file will be archived. This requires polling until ingestion is done.
+                overlap with the newly added file will be archived (files are considered overlapping if their time
+                ranges have any intersection). This requires polling until ingestion is done.
 
         Returns:
             Reference to the created video file.

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -235,8 +235,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
                 NOTE: this is currently not displayed to users and may be removed in the future.
             file_type: Metadata about the type of video file, e.g., MP4 vs. MKV.
             overwrite_overlapping: If True, any segments from other video files within this video that overlap
-                with the newly added file will be deleted before inserting the new segments. For videos with many
-                existing files this may be slow, as metadata is fetched per file.
+                with the newly added file will be deleted before inserting the new segments.
 
         Returns:
             Reference to the created video file.

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -408,9 +408,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
         raw_new_file = new_file._get_latest_api()
         seg = raw_new_file.segment_metadata
         if seg is None or seg.min_absolute_timestamp is None or seg.max_absolute_timestamp is None:
-            logger.warning(
-                "Cannot determine time range for new video file %r; skipping overlap archival", new_file.rid
-            )
+            logger.warning("Cannot determine time range for new video file %r; skipping overlap archival", new_file.rid)
             return
         new_start = _SecondsNanos.from_api(seg.min_absolute_timestamp).to_nanoseconds()
         new_end = _SecondsNanos.from_api(seg.max_absolute_timestamp).to_nanoseconds()

--- a/nominal/core/video_file.py
+++ b/nominal/core/video_file.py
@@ -126,6 +126,10 @@ class VideoFile(HasRid, RefreshableMixin[scout_video_api.VideoFile]):
                     raise NominalIngestFailed(
                         f"ingest failed for video {self.rid!r}: {error.message} ({error.error_type})"
                     )
+                else:
+                    raise NominalIngestError(
+                        f"ingest status type marked as 'error' but with no error details for video file {self.rid!r}"
+                    )
             else:
                 raise NominalIngestError(f"Unhandled ingest status {status.type!r} for video {self.rid!r}")
 


### PR DESCRIPTION
## Summary

- Adds `overwrite_overlapping: bool = False` to `Video.add_file` and `Video.add_from_io` (including their `@overload` signatures)
- When `True`, after the new file is ingested, polls until ingestion completes then archives any existing video files in the video whose time ranges overlap with the newly added file
- MCAP methods (`add_mcap`, `add_mcap_from_io`) are excluded since segment metadata may not be available for MCAP-sourced files in the same way

## Test plan

- [ ] Upload a video file to a video with an existing overlapping file and verify the overlapping file is archived
- [ ] Verify non-overlapping files are unaffected
- [ ] Verify default behavior (`overwrite_overlapping=False`) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)