### PR TITLE
feat: use presigned link endpoint in polars export handler

### DIFF
--- a/nominal/thirdparty/polars/polars_export_handler.py
+++ b/nominal/thirdparty/polars/polars_export_handler.py
@@ -2,8 +2,11 @@ import collections
 import concurrent.futures
 import dataclasses
 import datetime
+import io
 import logging
 from typing import Iterator, Mapping, Sequence
+
+import requests
 
 import polars as pl
 from nominal_api import api, scout_compute_api, scout_dataexport_api
@@ -419,7 +422,9 @@ def _export_job(job: _ExportJob, client: NominalClient) -> pl.DataFrame:
 
     datasource = client.get_datasource(job.datasource_rid)
     req = job.export_request(datasource)
-    resp = client._clients.dataexport.export_channel_data(client._clients.auth_header, req)
+    link = client._clients.dataexport.generate_export_channel_data_presigned_link(client._clients.auth_header, req)
+    http_resp = requests.get(link.presigned_url.url)
+    http_resp.raise_for_status()
 
     # force schema for export based on known channel types (helps if columns are all nan for a given part to prevent
     # that channel from loading as strings)
@@ -436,8 +441,8 @@ def _export_job(job: _ExportJob, client: NominalClient) -> pl.DataFrame:
                 logger.warning("Can't add missing channel %s to dataframe-- no known datatype!", channel_name)
                 continue
 
-    # Read CSV via Polars
-    df = pl.read_csv(resp, schema_overrides=schema)
+    # Read CSV via Polars; gzip magic bytes are detected automatically from the BytesIO
+    df = pl.read_csv(io.BytesIO(http_resp.content), schema_overrides=schema)
     if df.is_empty():
         logger.warning("No data found for export for channels %s", job.channel_names)
         return pl.DataFrame({col: [] for col in [*job.channel_names, time_col]})

--- a/nominal/thirdparty/polars/polars_export_handler.py
+++ b/nominal/thirdparty/polars/polars_export_handler.py
@@ -6,9 +6,8 @@ import io
 import logging
 from typing import Iterator, Mapping, Sequence
 
-import requests
-
 import polars as pl
+import requests
 from nominal_api import api, scout_compute_api, scout_dataexport_api
 from typing_extensions import Self
 

--- a/nominal/thirdparty/polars/polars_export_handler.py
+++ b/nominal/thirdparty/polars/polars_export_handler.py
@@ -412,7 +412,7 @@ def _get_exported_timestamp_channel(channel_names: list[str]) -> str:
     return renamed_timestamp_col
 
 
-def _export_job(job: _ExportJob, client: NominalClient) -> pl.DataFrame:
+def _export_job(job: _ExportJob, client: NominalClient) -> pl.DataFrame:  # noqa: PLR0912
     if not job.channel_names:
         raise ValueError("No channels to extract")
 
@@ -422,11 +422,12 @@ def _export_job(job: _ExportJob, client: NominalClient) -> pl.DataFrame:
     datasource = client.get_datasource(job.datasource_rid)
     req = job.export_request(datasource)
     link = client._clients.dataexport.generate_export_channel_data_presigned_link(client._clients.auth_header, req)
-    http_resp = requests.get(link.presigned_url.url)
-    try:
-        http_resp.raise_for_status()
-    except requests.HTTPError as e:
-        raise RuntimeError(f"Failed to fetch export data from presigned URL for channels {job.channel_names}: {e}") from e
+    http_resp = requests.get(link.presigned_url.url, timeout=60)
+    if not http_resp.ok:
+        raise RuntimeError(
+            f"Failed to fetch export data from presigned URL for channels {job.channel_names}: "
+            f"{http_resp.status_code} {http_resp.reason}"
+        )
 
     # force schema for export based on known channel types (helps if columns are all nan for a given part to prevent
     # that channel from loading as strings)

--- a/nominal/thirdparty/polars/polars_export_handler.py
+++ b/nominal/thirdparty/polars/polars_export_handler.py
@@ -423,7 +423,10 @@ def _export_job(job: _ExportJob, client: NominalClient) -> pl.DataFrame:
     req = job.export_request(datasource)
     link = client._clients.dataexport.generate_export_channel_data_presigned_link(client._clients.auth_header, req)
     http_resp = requests.get(link.presigned_url.url)
-    http_resp.raise_for_status()
+    try:
+        http_resp.raise_for_status()
+    except requests.HTTPError as e:
+        raise RuntimeError(f"Failed to fetch export data from presigned URL for channels {job.channel_names}: {e}") from e
 
     # force schema for export based on known channel types (helps if columns are all nan for a given part to prevent
     # that channel from loading as strings)


### PR DESCRIPTION
## Summary

- Replaces `export_channel_data` (streaming) with `generate_export_channel_data_presigned_link` in `_export_job`
- Fetches the presigned URL via `requests.get`, then wraps the content in `io.BytesIO` for `pl.read_csv`
- Polars detects gzip compression automatically from magic bytes — no change needed to the `ExportDataRequest`

## Notes

This is a draft to explore what the migration looks like for the polars path specifically. The same pattern could be applied to the pandas and MATLAB export handlers.

One open question: the presigned link response also includes `file_size_bytes`, which could be used for progress reporting in the future.

## Test plan

- [ ] Verify `pl.read_csv` correctly decompresses gzip from `BytesIO` with the presigned URL response
- [ ] Run an end-to-end export via `PolarsExportHandler.export()` against a real environment