### PR TITLE
feat: add destination client resolver to migration runner

### DIFF
--- a/nominal/experimental/migration/migration_runner.py
+++ b/nominal/experimental/migration/migration_runner.py
@@ -10,7 +10,7 @@ from nominal.experimental.migration.config.migration_data_config import Migratio
 from nominal.experimental.migration.config.migration_resources import MigrationResources
 from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.migrator.asset_migrator import AssetCopyOptions, AssetMigrator
-from nominal.experimental.migration.migrator.context import MigrationContext
+from nominal.experimental.migration.migrator.context import DestinationClientResolver, MigrationContext
 from nominal.experimental.migration.migrator.workbook_template_migrator import WorkbookTemplateMigrator
 
 logger = logging.getLogger(__name__)
@@ -31,12 +31,14 @@ class MigrationRunner:
     migration_resources: MigrationResources
     dataset_config: MigrationDatasetConfig
     destination_client: NominalClient
+    destination_client_resolver: DestinationClientResolver | None
 
     def __init__(
         self,
         migration_resources: MigrationResources,
         dataset_config: MigrationDatasetConfig,
         destination_client: NominalClient,
+        destination_client_resolver: DestinationClientResolver | None = None,
         migration_state_path: Path | str | None = None,
     ) -> None:
         """Create a migration runner state.
@@ -45,11 +47,14 @@ class MigrationRunner:
             migration_resources (MigrationResources): _description_
             dataset_config (MigrationDatasetConfig): _description_
             destination_client (NominalClient): _description_
+            destination_client_resolver (DestinationClientResolver | None): Optional callback that resolves the
+                destination client for each source resource. Defaults to None.
             migration_state_path (Path | str | None, optional): _description_. Defaults to None.
         """
         self.migration_resources = migration_resources
         self.dataset_config = dataset_config
         self.destination_client = destination_client
+        self.destination_client_resolver = destination_client_resolver
         resolved_path = Path(migration_state_path) if migration_state_path is not None else Path("migration_state.json")
 
         if migration_state_path is not None and resolved_path.exists():
@@ -73,12 +78,13 @@ class MigrationRunner:
         dataset_config (MigrationDataConfig | None): Configuration for dataset migration.
         """
         try:
-            asset_migrator = AssetMigrator(
-                MigrationContext(destination_client=self.destination_client, migration_state=self.migration_state)
+            migration_context = MigrationContext(
+                destination_client=self.destination_client,
+                migration_state=self.migration_state,
+                destination_client_resolver=self.destination_client_resolver,
             )
-            template_migrator = WorkbookTemplateMigrator(
-                MigrationContext(destination_client=self.destination_client, migration_state=self.migration_state)
-            )
+            asset_migrator = AssetMigrator(migration_context)
+            template_migrator = WorkbookTemplateMigrator(migration_context)
             for asset_resources in self.migration_resources.source_assets.values():
                 source_asset = asset_resources.asset
                 asset_migrator.copy_from(

--- a/nominal/experimental/migration/migrator/__init__.py
+++ b/nominal/experimental/migration/migrator/__init__.py
@@ -2,7 +2,7 @@ from nominal.experimental.migration.migrator.asset_migrator import AssetCopyOpti
 from nominal.experimental.migration.migrator.attachment_migrator import AttachmentMigrator
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.migrator.checklist_migrator import ChecklistCopyOptions, ChecklistMigrator
-from nominal.experimental.migration.migrator.context import MigrationContext
+from nominal.experimental.migration.migrator.context import DestinationClientResolver, MigrationContext
 from nominal.experimental.migration.migrator.dataset_migrator import DatasetCopyOptions, DatasetMigrator
 from nominal.experimental.migration.migrator.event_migrator import EventCopyOptions, EventMigrator
 from nominal.experimental.migration.migrator.run_migrator import RunCopyOptions, RunMigrator
@@ -21,6 +21,7 @@ __all__ = [
     "ChecklistMigrator",
     "DatasetCopyOptions",
     "DatasetMigrator",
+    "DestinationClientResolver",
     "EventCopyOptions",
     "EventMigrator",
     "MigrationContext",

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -9,7 +9,6 @@ from nominal.core.asset import Asset
 from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.migrator.checklist_migrator import ChecklistCopyOptions, ChecklistMigrator
-from nominal.experimental.migration.migrator.context import MigrationContext
 from nominal.experimental.migration.migrator.dataset_migrator import DatasetCopyOptions, DatasetMigrator
 from nominal.experimental.migration.migrator.event_migrator import EventCopyOptions, EventMigrator
 from nominal.experimental.migration.migrator.run_migrator import RunCopyOptions, RunMigrator
@@ -81,11 +80,12 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
         return resource.name
 
     def _resolve_destination_asset(self, source_asset: Asset, options: AssetCopyOptions) -> Asset:
+        destination_client = self.ctx.destination_client_for(source_asset)
         mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source_asset.rid)
         if mapped_rid is not None:
             logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source_asset.rid)
-            return self.ctx.destination_client.get_asset(mapped_rid)
-        return self.ctx.destination_client.create_asset(
+            return destination_client.get_asset(mapped_rid)
+        return destination_client.create_asset(
             name=options.new_asset_name if options.new_asset_name is not None else source_asset.name,
             description=options.new_asset_description
             if options.new_asset_description is not None
@@ -100,12 +100,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
         if options.dataset_config is None:
             return
 
-        dataset_migrator = DatasetMigrator(
-            MigrationContext(
-                destination_client=self.ctx.destination_client,
-                migration_state=self.ctx.migration_state,
-            )
-        )
+        dataset_migrator = DatasetMigrator(self.ctx)
 
         source_data_scopes = source_asset._list_dataset_scopes()
         source_datasets = {ds.rid: ds for _, ds in source_asset.list_datasets()}
@@ -143,33 +138,18 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                 )
 
     def _copy_asset_events(self, source_asset: Asset, destination_asset: Asset) -> None:
-        event_migrator = EventMigrator(
-            MigrationContext(
-                destination_client=self.ctx.destination_client,
-                migration_state=self.ctx.migration_state,
-            )
-        )
+        event_migrator = EventMigrator(self.ctx)
         source_events = source_asset.search_events(origin_types=SearchEventOriginType.get_manual_origin_types())
         for source_event in source_events:
             event_migrator.copy_from(source_event, EventCopyOptions(new_assets=[destination_asset]))
 
     def _copy_asset_runs(self, source_asset: Asset, destination_asset: Asset) -> None:
-        run_migrator = RunMigrator(
-            MigrationContext(
-                destination_client=self.ctx.destination_client,
-                migration_state=self.ctx.migration_state,
-            )
-        )
+        run_migrator = RunMigrator(self.ctx)
         for source_run in source_asset.list_runs():
             run_migrator.copy_from(source_run, RunCopyOptions(new_assets=[destination_asset]))
 
     def _copy_asset_checklists(self, source_asset: Asset) -> None:
-        checklist_migrator = ChecklistMigrator(
-            MigrationContext(
-                destination_client=self.ctx.destination_client,
-                migration_state=self.ctx.migration_state,
-            )
-        )
+        checklist_migrator = ChecklistMigrator(self.ctx)
         for source_data_review in source_asset.search_data_reviews():
             source_checklist = source_data_review.get_checklist()
             logger.debug("Found Data Review %s", source_checklist.rid)
@@ -193,12 +173,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                 )
 
     def _copy_asset_videos(self, source_asset: Asset, new_asset: Asset) -> None:
-        video_migrator = VideoMigrator(
-            MigrationContext(
-                destination_client=self.ctx.destination_client,
-                migration_state=self.ctx.migration_state,
-            )
-        )
+        video_migrator = VideoMigrator(self.ctx)
         for data_scope, video_dataset in source_asset.list_videos():
             new_video_dataset = video_migrator.copy_from(
                 video_dataset,
@@ -218,12 +193,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                 )
 
     def _copy_asset_and_run_workbooks(self, source_asset: Asset, new_asset: Asset, include_runs: bool) -> None:
-        workbook_migrator = WorkbookMigrator(
-            MigrationContext(
-                destination_client=self.ctx.destination_client,
-                migration_state=self.ctx.migration_state,
-            )
-        )
+        workbook_migrator = WorkbookMigrator(self.ctx)
         asset_workbooks = source_asset.search_workbooks(include_drafts=True)
         for workbook in asset_workbooks:
             if workbook.asset_rids and len(workbook.asset_rids) == 1:
@@ -235,7 +205,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                 if destination_run_rid is None:
                     logger.warning("Run %s not found in migration state", source_run.rid)
                     continue
-                destination_run = self.ctx.destination_client.get_run(destination_run_rid)
+                destination_run = self.ctx.destination_client_for(source_run).get_run(destination_run_rid)
                 for workbook in source_run.search_workbooks(include_drafts=True):
                     if workbook.run_rids and len(workbook.run_rids) == 1:
                         workbook_migrator.copy_from(workbook, WorkbookCopyOptions(destination_run=destination_run))

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Sequence
 
+from nominal.core import NominalClient
 from nominal.core._event_types import SearchEventOriginType
 from nominal.core.asset import Asset
 from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
@@ -79,13 +80,15 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
     def _get_resource_name(self, resource: Asset) -> str:
         return resource.name
 
+    def _get_existing_destination_resource(self, destination_client: NominalClient, mapped_rid: str) -> Asset:
+        return destination_client.get_asset(mapped_rid)
+
     def _resolve_destination_asset(self, source_asset: Asset, options: AssetCopyOptions) -> Asset:
-        destination_client = self.ctx.destination_client_for(source_asset)
-        mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source_asset.rid)
-        if mapped_rid is not None:
-            logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source_asset.rid)
-            return destination_client.get_asset(mapped_rid)
-        return destination_client.create_asset(
+        existing_asset = self.get_existing_destination_resource(source_asset)
+        if existing_asset is not None:
+            return existing_asset
+
+        return self.destination_client_for(source_asset).create_asset(
             name=options.new_asset_name if options.new_asset_name is not None else source_asset.name,
             description=options.new_asset_description
             if options.new_asset_description is not None

--- a/nominal/experimental/migration/migrator/attachment_migrator.py
+++ b/nominal/experimental/migration/migrator/attachment_migrator.py
@@ -36,16 +36,17 @@ class AttachmentMigrator(Migrator[Attachment, ResourceCopyOptions]):
         return self.copy_from(source_attachment)
 
     def _copy_from_impl(self, source: Attachment, options: ResourceCopyOptions) -> Attachment:
+        destination_client = self.ctx.destination_client_for(source)
         mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
         if mapped_rid is not None:
             logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return self.ctx.destination_client.get_attachment(mapped_rid)
+            return destination_client.get_attachment(mapped_rid)
 
         source_clients = cast(ClientsBunch, source._clients)
         raw = source_clients.attachment.get(source_clients.auth_header, source.rid)
         content = source_clients.attachment.get_content(source_clients.auth_header, source.rid)
         file_type = FileType("", raw.file_type) if raw.file_type else FileTypes.BINARY
-        new_attachment = self.ctx.destination_client.create_attachment_from_io(
+        new_attachment = destination_client.create_attachment_from_io(
             content,
             raw.title,
             file_type,

--- a/nominal/experimental/migration/migrator/attachment_migrator.py
+++ b/nominal/experimental/migration/migrator/attachment_migrator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import cast
 
+from nominal.core import NominalClient
 from nominal.core._clientsbunch import ClientsBunch
 from nominal.core.attachment import Attachment
 from nominal.core.filetype import FileType, FileTypes
@@ -23,25 +24,27 @@ class AttachmentMigrator(Migrator[Attachment, ResourceCopyOptions]):
     def migrate_by_rid(self, source_clients: ClientsBunch, attachment_rid: str) -> Attachment:
         """Migrate an attachment identified by its RID.
 
-        Checks migration state first to avoid re-fetching already-migrated attachments.
-        This is a convenience for callers (e.g. workbook migrator) that discover attachment
-        RIDs as strings rather than having pre-constructed Attachment objects.
+        This is a convenience for callers (e.g. workbook migrator) that discover
+        attachment RIDs as strings rather than having pre-constructed Attachment
+        objects. We still materialize the source attachment so resolver-based
+        destination routing stays consistent for already-mapped attachments.
         """
-        mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, attachment_rid)
-        if mapped_rid is not None:
-            logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, attachment_rid)
-            return self.ctx.destination_client.get_attachment(mapped_rid)
         raw = source_clients.attachment.get(source_clients.auth_header, attachment_rid)
         source_attachment = Attachment._from_conjure(source_clients, raw)
+        existing_attachment = self.get_existing_destination_resource(source_attachment)
+        if existing_attachment is not None:
+            return existing_attachment
         return self.copy_from(source_attachment)
 
-    def _copy_from_impl(self, source: Attachment, options: ResourceCopyOptions) -> Attachment:
-        destination_client = self.ctx.destination_client_for(source)
-        mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
-        if mapped_rid is not None:
-            logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return destination_client.get_attachment(mapped_rid)
+    def _get_existing_destination_resource(self, destination_client: NominalClient, mapped_rid: str) -> Attachment:
+        return destination_client.get_attachment(mapped_rid)
 
+    def _copy_from_impl(self, source: Attachment, options: ResourceCopyOptions) -> Attachment:
+        existing_attachment = self.get_existing_destination_resource(source)
+        if existing_attachment is not None:
+            return existing_attachment
+
+        destination_client = self.destination_client_for(source)
         source_clients = cast(ClientsBunch, source._clients)
         raw = source_clients.attachment.get(source_clients.auth_header, source.rid)
         content = source_clients.attachment.get_content(source_clients.auth_header, source.rid)

--- a/nominal/experimental/migration/migrator/base.py
+++ b/nominal/experimental/migration/migrator/base.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
+from nominal.core import NominalClient
 from nominal.core._utils.api_tools import HasRid
 from nominal.experimental.migration.migrator.context import MigrationContext
 from nominal.experimental.migration.resource_type import ResourceType
@@ -41,12 +42,24 @@ class Migrator(ABC, Generic[Resource, CopyOptions]):
     def clone(self, source: Resource) -> Resource:
         return self.copy_from(source)
 
+    def destination_client_for(self, source: Resource) -> NominalClient:
+        return self.ctx.destination_client_for(source)
+
+    def get_existing_destination_resource(self, source: Resource) -> Resource | None:
+        mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
+        if mapped_rid is None:
+            return None
+
+        logger = logging.getLogger(type(self).__module__)
+        logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
+        return self._get_existing_destination_resource(self.destination_client_for(source), mapped_rid)
+
     def copy_from(self, source: Resource, options: CopyOptions | None = None) -> Resource:
         resolved_options = self.default_copy_options() if options is None else options
         if resolved_options is None:
             raise NotImplementedError(f"{type(self).__name__} requires explicit copy options.")
         source_rid = source.rid
-        destination_client = self.ctx.destination_client_for(source)
+        destination_client = self.destination_client_for(source)
 
         logger = logging.getLogger(type(self).__module__)
         log_extras = {
@@ -103,6 +116,10 @@ class Migrator(ABC, Generic[Resource, CopyOptions]):
         Returns:
             Resource: The new resource.
         """
+
+    @abstractmethod
+    def _get_existing_destination_resource(self, destination_client: NominalClient, mapped_rid: str) -> Resource:
+        """Fetches an already-migrated resource from the destination client."""
 
     @abstractmethod
     def _get_resource_name(self, resource: Resource) -> str:

--- a/nominal/experimental/migration/migrator/base.py
+++ b/nominal/experimental/migration/migrator/base.py
@@ -46,11 +46,12 @@ class Migrator(ABC, Generic[Resource, CopyOptions]):
         if resolved_options is None:
             raise NotImplementedError(f"{type(self).__name__} requires explicit copy options.")
         source_rid = source.rid
+        destination_client = self.ctx.destination_client_for(source)
 
         logger = logging.getLogger(type(self).__module__)
         log_extras = {
-            "destination_client_workspace": self.ctx.destination_client.get_workspace(
-                self.ctx.destination_client._clients.workspace_rid
+            "destination_client_workspace": destination_client.get_workspace(
+                destination_client._clients.workspace_rid
             ).rid
         }
         logger.debug(

--- a/nominal/experimental/migration/migrator/checklist_migrator.py
+++ b/nominal/experimental/migration/migrator/checklist_migrator.py
@@ -42,10 +42,11 @@ class ChecklistMigrator(Migrator[Checklist, ChecklistCopyOptions]):
         return ChecklistCopyOptions()
 
     def _copy_from_impl(self, source: Checklist, options: ChecklistCopyOptions) -> Checklist:
+        destination_client = self.ctx.destination_client_for(source)
         mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
         if mapped_rid is not None:
             logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return self.ctx.destination_client.get_checklist(mapped_rid)
+            return destination_client.get_checklist(mapped_rid)
 
         api_source_checklist = source._get_latest_api()
         commit_message = (
@@ -74,12 +75,10 @@ class ChecklistMigrator(Migrator[Checklist, ChecklistCopyOptions]):
             if options.new_is_published is not None
             else api_source_checklist.metadata.is_published
         )
-        workspace_rid = self.ctx.destination_client.get_workspace(
-            self.ctx.destination_client._clients.workspace_rid
-        ).rid
+        workspace_rid = destination_client.get_workspace(destination_client._clients.workspace_rid).rid
 
         new_checklist = _create_checklist_with_content(
-            client=self.ctx.destination_client,
+            client=destination_client,
             commit_message=commit_message,
             title=title,
             description=description,

--- a/nominal/experimental/migration/migrator/checklist_migrator.py
+++ b/nominal/experimental/migration/migrator/checklist_migrator.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 from nominal_api import scout_checks_api
 
+from nominal.core import NominalClient
 from nominal.core.checklist import Checklist
 from nominal.experimental.checklist_utils.checklist_utils import (
     _create_checklist_with_content,
@@ -41,13 +42,15 @@ class ChecklistMigrator(Migrator[Checklist, ChecklistCopyOptions]):
     def default_copy_options(self) -> ChecklistCopyOptions:
         return ChecklistCopyOptions()
 
-    def _copy_from_impl(self, source: Checklist, options: ChecklistCopyOptions) -> Checklist:
-        destination_client = self.ctx.destination_client_for(source)
-        mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
-        if mapped_rid is not None:
-            logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return destination_client.get_checklist(mapped_rid)
+    def _get_existing_destination_resource(self, destination_client: NominalClient, mapped_rid: str) -> Checklist:
+        return destination_client.get_checklist(mapped_rid)
 
+    def _copy_from_impl(self, source: Checklist, options: ChecklistCopyOptions) -> Checklist:
+        existing_checklist = self.get_existing_destination_resource(source)
+        if existing_checklist is not None:
+            return existing_checklist
+
+        destination_client = self.destination_client_for(source)
         api_source_checklist = source._get_latest_api()
         commit_message = (
             options.new_commit_message

--- a/nominal/experimental/migration/migrator/context.py
+++ b/nominal/experimental/migration/migrator/context.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any, Callable
 
 from nominal.core import NominalClient
 from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.resource_type import ResourceType
+
+DestinationClientResolver = Callable[[Any], NominalClient]
 
 
 @dataclass
@@ -13,6 +16,12 @@ class MigrationContext:
 
     destination_client: NominalClient
     migration_state: MigrationState
+    destination_client_resolver: DestinationClientResolver | None = None
+
+    def destination_client_for(self, source_resource: Any) -> NominalClient:
+        if self.destination_client_resolver is None:
+            return self.destination_client
+        return self.destination_client_resolver(source_resource)
 
     def record_mapping(self, resource_type: ResourceType, old_rid: str, new_rid: str) -> None:
         self.migration_state.record_mapping(resource_type=resource_type, old_rid=old_rid, new_rid=new_rid)

--- a/nominal/experimental/migration/migrator/dataset_migrator.py
+++ b/nominal/experimental/migration/migrator/dataset_migrator.py
@@ -45,14 +45,15 @@ class DatasetMigrator(Migrator[Dataset, DatasetCopyOptions]):
         return new_dataset
 
     def _resolve_destination_dataset(self, source: Dataset, options: DatasetCopyOptions) -> Dataset:
+        destination_client = self.ctx.destination_client_for(source)
         mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
         if mapped_rid is not None:
             logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return self.ctx.destination_client.get_dataset(mapped_rid)
+            return destination_client.get_dataset(mapped_rid)
 
         log_extras = {
-            "destination_client_workspace": self.ctx.destination_client.get_workspace(
-                self.ctx.destination_client._clients.workspace_rid
+            "destination_client_workspace": destination_client.get_workspace(
+                destination_client._clients.workspace_rid
             ).rid
         }
         dataset_name = options.new_dataset_name if options.new_dataset_name is not None else source.name
@@ -136,7 +137,7 @@ class DatasetMigrator(Migrator[Dataset, DatasetCopyOptions]):
                 raise ValueError(f"Could not extract UUID from dataset rid: {source.rid}")
             source_uuid = match.group(2)
             return create_dataset_with_uuid(
-                client=self.ctx.destination_client,
+                client=self.ctx.destination_client_for(source),
                 dataset_uuid=source_uuid,
                 name=dataset_name,
                 description=dataset_description,
@@ -144,7 +145,7 @@ class DatasetMigrator(Migrator[Dataset, DatasetCopyOptions]):
                 properties=dataset_properties,
             )
 
-        return self.ctx.destination_client.create_dataset(
+        return self.ctx.destination_client_for(source).create_dataset(
             name=dataset_name,
             description=dataset_description,
             properties=dataset_properties,

--- a/nominal/experimental/migration/migrator/dataset_migrator.py
+++ b/nominal/experimental/migration/migrator/dataset_migrator.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+from nominal.core import NominalClient
 from nominal.core.dataset import Dataset
 from nominal.core.datasource import CreateChannelRequest
 from nominal.experimental.dataset_utils import create_dataset_with_uuid
@@ -44,13 +45,15 @@ class DatasetMigrator(Migrator[Dataset, DatasetCopyOptions]):
 
         return new_dataset
 
-    def _resolve_destination_dataset(self, source: Dataset, options: DatasetCopyOptions) -> Dataset:
-        destination_client = self.ctx.destination_client_for(source)
-        mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
-        if mapped_rid is not None:
-            logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return destination_client.get_dataset(mapped_rid)
+    def _get_existing_destination_resource(self, destination_client: NominalClient, mapped_rid: str) -> Dataset:
+        return destination_client.get_dataset(mapped_rid)
 
+    def _resolve_destination_dataset(self, source: Dataset, options: DatasetCopyOptions) -> Dataset:
+        existing_dataset = self.get_existing_destination_resource(source)
+        if existing_dataset is not None:
+            return existing_dataset
+
+        destination_client = self.destination_client_for(source)
         log_extras = {
             "destination_client_workspace": destination_client.get_workspace(
                 destination_client._clients.workspace_rid
@@ -137,7 +140,7 @@ class DatasetMigrator(Migrator[Dataset, DatasetCopyOptions]):
                 raise ValueError(f"Could not extract UUID from dataset rid: {source.rid}")
             source_uuid = match.group(2)
             return create_dataset_with_uuid(
-                client=self.ctx.destination_client_for(source),
+                client=self.destination_client_for(source),
                 dataset_uuid=source_uuid,
                 name=dataset_name,
                 description=dataset_description,
@@ -145,7 +148,7 @@ class DatasetMigrator(Migrator[Dataset, DatasetCopyOptions]):
                 properties=dataset_properties,
             )
 
-        return self.ctx.destination_client_for(source).create_dataset(
+        return self.destination_client_for(source).create_dataset(
             name=dataset_name,
             description=dataset_description,
             properties=dataset_properties,

--- a/nominal/experimental/migration/migrator/event_migrator.py
+++ b/nominal/experimental/migration/migrator/event_migrator.py
@@ -36,12 +36,13 @@ class EventMigrator(Migrator[Event, EventCopyOptions]):
         return EventCopyOptions()
 
     def _copy_from_impl(self, source: Event, options: EventCopyOptions) -> Event:
+        destination_client = self.ctx.destination_client_for(source)
         mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
         if mapped_rid is not None:
             logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return self.ctx.destination_client.get_event(mapped_rid)
+            return destination_client.get_event(mapped_rid)
 
-        new_event = self.ctx.destination_client.create_event(
+        new_event = destination_client.create_event(
             name=options.new_name if options.new_name is not None else source.name,
             type=options.new_type if options.new_type is not None else source.type,
             start=options.new_start if options.new_start is not None else source.start,

--- a/nominal/experimental/migration/migrator/event_migrator.py
+++ b/nominal/experimental/migration/migrator/event_migrator.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Iterable, Mapping
 
+from nominal.core import NominalClient
 from nominal.core._event_types import EventType
 from nominal.core.asset import Asset
 from nominal.core.event import Event
@@ -35,13 +36,15 @@ class EventMigrator(Migrator[Event, EventCopyOptions]):
     def default_copy_options(self) -> EventCopyOptions:
         return EventCopyOptions()
 
-    def _copy_from_impl(self, source: Event, options: EventCopyOptions) -> Event:
-        destination_client = self.ctx.destination_client_for(source)
-        mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
-        if mapped_rid is not None:
-            logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return destination_client.get_event(mapped_rid)
+    def _get_existing_destination_resource(self, destination_client: NominalClient, mapped_rid: str) -> Event:
+        return destination_client.get_event(mapped_rid)
 
+    def _copy_from_impl(self, source: Event, options: EventCopyOptions) -> Event:
+        existing_event = self.get_existing_destination_resource(source)
+        if existing_event is not None:
+            return existing_event
+
+        destination_client = self.destination_client_for(source)
         new_event = destination_client.create_event(
             name=options.new_name if options.new_name is not None else source.name,
             type=options.new_type if options.new_type is not None else source.type,

--- a/nominal/experimental/migration/migrator/run_migrator.py
+++ b/nominal/experimental/migration/migrator/run_migrator.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Iterable, Mapping, Sequence
 
+from nominal.core import NominalClient
 from nominal.core._utils.api_tools import Link, LinkDict
 from nominal.core.asset import Asset
 from nominal.core.attachment import Attachment
@@ -37,13 +38,15 @@ class RunMigrator(Migrator[Run, RunCopyOptions]):
     def default_copy_options(self) -> RunCopyOptions:
         return RunCopyOptions()
 
-    def _copy_from_impl(self, source: Run, options: RunCopyOptions) -> Run:
-        destination_client = self.ctx.destination_client_for(source)
-        mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
-        if mapped_rid is not None:
-            logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return destination_client.get_run(mapped_rid)
+    def _get_existing_destination_resource(self, destination_client: NominalClient, mapped_rid: str) -> Run:
+        return destination_client.get_run(mapped_rid)
 
+    def _copy_from_impl(self, source: Run, options: RunCopyOptions) -> Run:
+        existing_run = self.get_existing_destination_resource(source)
+        if existing_run is not None:
+            return existing_run
+
+        destination_client = self.destination_client_for(source)
         new_run = destination_client.create_run(
             name=options.new_name if options.new_name is not None else source.name,
             start=options.new_start if options.new_start is not None else source.start,

--- a/nominal/experimental/migration/migrator/run_migrator.py
+++ b/nominal/experimental/migration/migrator/run_migrator.py
@@ -38,12 +38,13 @@ class RunMigrator(Migrator[Run, RunCopyOptions]):
         return RunCopyOptions()
 
     def _copy_from_impl(self, source: Run, options: RunCopyOptions) -> Run:
+        destination_client = self.ctx.destination_client_for(source)
         mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
         if mapped_rid is not None:
             logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return self.ctx.destination_client.get_run(mapped_rid)
+            return destination_client.get_run(mapped_rid)
 
-        new_run = self.ctx.destination_client.create_run(
+        new_run = destination_client.create_run(
             name=options.new_name if options.new_name is not None else source.name,
             start=options.new_start if options.new_start is not None else source.start,
             end=options.new_end if options.new_end is not None else source.end,

--- a/nominal/experimental/migration/migrator/video_migrator.py
+++ b/nominal/experimental/migration/migrator/video_migrator.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Sequence
 
+from nominal.core import NominalClient
 from nominal.core.video import Video
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.migrator.video_file_migrator import VideoFileMigrator
@@ -39,13 +40,15 @@ class VideoMigrator(Migrator[Video, VideoCopyOptions]):
 
         return result
 
+    def _get_existing_destination_resource(self, destination_client: NominalClient, mapped_rid: str) -> Video:
+        return destination_client.get_video(mapped_rid)
+
     def _resolve_destination_video(self, source: Video, options: VideoCopyOptions) -> Video:
-        destination_client = self.ctx.destination_client_for(source)
-        mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
-        if mapped_rid is not None:
-            logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return destination_client.get_video(mapped_rid)
-        new_video = destination_client.create_video(
+        existing_video = self.get_existing_destination_resource(source)
+        if existing_video is not None:
+            return existing_video
+
+        new_video = self.destination_client_for(source).create_video(
             name=options.new_video_name if options.new_video_name is not None else source.name,
             description=options.new_video_description
             if options.new_video_description is not None

--- a/nominal/experimental/migration/migrator/video_migrator.py
+++ b/nominal/experimental/migration/migrator/video_migrator.py
@@ -40,11 +40,12 @@ class VideoMigrator(Migrator[Video, VideoCopyOptions]):
         return result
 
     def _resolve_destination_video(self, source: Video, options: VideoCopyOptions) -> Video:
+        destination_client = self.ctx.destination_client_for(source)
         mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
         if mapped_rid is not None:
             logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return self.ctx.destination_client.get_video(mapped_rid)
-        new_video = self.ctx.destination_client.create_video(
+            return destination_client.get_video(mapped_rid)
+        new_video = destination_client.create_video(
             name=options.new_video_name if options.new_video_name is not None else source.name,
             description=options.new_video_description
             if options.new_video_description is not None

--- a/nominal/experimental/migration/migrator/workbook_migrator.py
+++ b/nominal/experimental/migration/migrator/workbook_migrator.py
@@ -55,7 +55,7 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
         mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
         if mapped_rid is not None:
             logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return self.ctx.destination_client.get_workbook(mapped_rid)
+            return self.ctx.destination_client_for(source).get_workbook(mapped_rid)
 
         if (options.destination_asset is None) == (options.destination_run is None):
             raise ValueError("Exactly one of destination_asset or destination_run must be provided.")
@@ -139,7 +139,7 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
             rid_map[old_rid] = new_attachment.rid
             logger.debug("Migrated preview image attachment %s -> %s", old_rid, new_attachment.rid)
 
-        dest_clients = self.ctx.destination_client._clients
+        dest_clients = self.ctx.destination_client_for(source)._clients
         dest_clients.notebook.update_metadata(
             dest_clients.auth_header,
             scout_notebook_api.UpdateNotebookMetadataRequest(

--- a/nominal/experimental/migration/migrator/workbook_migrator.py
+++ b/nominal/experimental/migration/migrator/workbook_migrator.py
@@ -8,6 +8,7 @@ from typing import Mapping, Sequence, cast
 from nominal_api import api as nominal_api
 from nominal_api import scout_notebook_api
 
+from nominal.core import NominalClient
 from nominal.core._clientsbunch import ClientsBunch
 from nominal.core.asset import Asset
 from nominal.core.run import Run
@@ -46,16 +47,18 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
     def default_copy_options(self) -> WorkbookCopyOptions | None:
         return None
 
+    def _get_existing_destination_resource(self, destination_client: NominalClient, mapped_rid: str) -> Workbook:
+        return destination_client.get_workbook(mapped_rid)
+
     def _copy_from_impl(self, source: Workbook, options: WorkbookCopyOptions) -> Workbook:
         """This method copies content from an old workbook to a new workbook by use of templates, in order to
         modify hardcoded variables in workbook content. We do this by creating a template in the source
         client, copying the template to the destination client, creating a new workbook from the template in the
         destination client, and then archiving the template in both clients.
         """
-        mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
-        if mapped_rid is not None:
-            logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return self.ctx.destination_client_for(source).get_workbook(mapped_rid)
+        existing_workbook = self.get_existing_destination_resource(source)
+        if existing_workbook is not None:
+            return existing_workbook
 
         if (options.destination_asset is None) == (options.destination_run is None):
             raise ValueError("Exactly one of destination_asset or destination_run must be provided.")
@@ -139,7 +142,7 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
             rid_map[old_rid] = new_attachment.rid
             logger.debug("Migrated preview image attachment %s -> %s", old_rid, new_attachment.rid)
 
-        dest_clients = self.ctx.destination_client_for(source)._clients
+        dest_clients = self.destination_client_for(source)._clients
         dest_clients.notebook.update_metadata(
             dest_clients.auth_header,
             scout_notebook_api.UpdateNotebookMetadataRequest(

--- a/nominal/experimental/migration/migrator/workbook_template_migrator.py
+++ b/nominal/experimental/migration/migrator/workbook_template_migrator.py
@@ -11,6 +11,7 @@ from conjure_python_client._serde.decoder import ConjureDecoder
 from conjure_python_client._serde.encoder import ConjureEncoder
 from nominal_api import scout_layout_api, scout_template_api, scout_workbookcommon_api
 
+from nominal.core import NominalClient
 from nominal.core._clientsbunch import ClientsBunch
 from nominal.core.workbook_template import WorkbookTemplate, _create_workbook_template_with_content_and_layout
 from nominal.experimental.id_utils.id_utils import UUID_RE
@@ -41,13 +42,17 @@ class WorkbookTemplateMigrator(Migrator[WorkbookTemplate, WorkbookTemplateCopyOp
     def default_copy_options(self) -> WorkbookTemplateCopyOptions:
         return WorkbookTemplateCopyOptions(include_content_and_layout=True)
 
-    def _copy_from_impl(self, source: WorkbookTemplate, options: WorkbookTemplateCopyOptions) -> WorkbookTemplate:
-        destination_client = self.ctx.destination_client_for(source)
-        mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
-        if mapped_rid is not None:
-            logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return destination_client.get_workbook_template(mapped_rid)
+    def _get_existing_destination_resource(
+        self, destination_client: NominalClient, mapped_rid: str
+    ) -> WorkbookTemplate:
+        return destination_client.get_workbook_template(mapped_rid)
 
+    def _copy_from_impl(self, source: WorkbookTemplate, options: WorkbookTemplateCopyOptions) -> WorkbookTemplate:
+        existing_template = self.get_existing_destination_resource(source)
+        if existing_template is not None:
+            return existing_template
+
+        destination_client = self.destination_client_for(source)
         raw_source_template = source._clients.template.get(source._clients.auth_header, source.rid)
         new_template_layout, new_workbook_content = self._resolve_template_content_and_layout(
             raw_source_template,

--- a/nominal/experimental/migration/migrator/workbook_template_migrator.py
+++ b/nominal/experimental/migration/migrator/workbook_template_migrator.py
@@ -42,10 +42,11 @@ class WorkbookTemplateMigrator(Migrator[WorkbookTemplate, WorkbookTemplateCopyOp
         return WorkbookTemplateCopyOptions(include_content_and_layout=True)
 
     def _copy_from_impl(self, source: WorkbookTemplate, options: WorkbookTemplateCopyOptions) -> WorkbookTemplate:
+        destination_client = self.ctx.destination_client_for(source)
         mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
         if mapped_rid is not None:
             logger.debug("Skipping %s (rid: %s): already in migration state", self.resource_label, source.rid)
-            return self.ctx.destination_client.get_workbook_template(mapped_rid)
+            return destination_client.get_workbook_template(mapped_rid)
 
         raw_source_template = source._clients.template.get(source._clients.auth_header, source.rid)
         new_template_layout, new_workbook_content = self._resolve_template_content_and_layout(
@@ -58,7 +59,7 @@ class WorkbookTemplateMigrator(Migrator[WorkbookTemplate, WorkbookTemplateCopyOp
         )
 
         new_workbook_template = _create_workbook_template_with_content_and_layout(
-            clients=self.ctx.destination_client._clients,
+            clients=destination_client._clients,
             title=options.new_template_title
             if options.new_template_title is not None
             else raw_source_template.metadata.title,
@@ -74,9 +75,7 @@ class WorkbookTemplateMigrator(Migrator[WorkbookTemplate, WorkbookTemplateCopyOp
             layout=new_template_layout,
             content=new_workbook_content,
             commit_message="Cloned from template",
-            workspace_rid=self.ctx.destination_client.get_workspace(
-                self.ctx.destination_client._clients.workspace_rid
-            ).rid,
+            workspace_rid=destination_client.get_workspace(destination_client._clients.workspace_rid).rid,
             is_published=raw_source_template.metadata.is_published,
         )
         self.ctx.migration_state.record_mapping(self.resource_type, source.rid, new_workbook_template.rid)

--- a/tests/core/test_attachment_migrator.py
+++ b/tests/core/test_attachment_migrator.py
@@ -130,6 +130,7 @@ class TestAttachmentMigrator:
 
         old_rid = _rid(1)
         new_rid = _rid(100)
+        raw = _make_raw_attachment(old_rid)
 
         # Pre-populate migration state
         ctx.migration_state.record_mapping(ResourceType.ATTACHMENT, old_rid, new_rid)
@@ -139,15 +140,51 @@ class TestAttachmentMigrator:
         existing_att.rid = new_rid
         ctx.destination_client.get_attachment.return_value = existing_att
 
-        source_clients = MagicMock()
+        source_clients = _make_source_clients(raw)
         result = migrator.migrate_by_rid(source_clients, old_rid)
 
-        # No source fetch occurred
-        source_clients.attachment.get.assert_not_called()
+        source_clients.attachment.get.assert_called_once_with("Bearer source", old_rid)
 
         # Returned the existing destination attachment
         assert result.rid == new_rid
         ctx.destination_client.get_attachment.assert_called_once_with(new_rid)
+
+    @patch("nominal.experimental.migration.migrator.attachment_migrator.Attachment")
+    def test_migrate_by_rid_already_mapped_uses_resolved_destination_client(
+        self, mock_attachment_cls: MagicMock
+    ) -> None:
+        """migrate_by_rid honors the resolver when an attachment was already migrated."""
+        migrator, ctx = self._make_migrator()
+
+        old_rid = _rid(1)
+        new_rid = _rid(100)
+        raw = _make_raw_attachment(old_rid)
+        source_clients = _make_source_clients(raw)
+
+        source_attachment = MagicMock()
+        source_attachment.rid = old_rid
+        source_attachment.name = "image.png"
+        mock_attachment_cls._from_conjure.return_value = source_attachment
+
+        resolved_client = MagicMock()
+        resolved_client._clients.workspace_rid = "resolved-ws-rid"
+        resolved_workspace = MagicMock()
+        resolved_workspace.rid = "resolved-ws-rid"
+        resolved_client.get_workspace.return_value = resolved_workspace
+        resolved_attachment = MagicMock()
+        resolved_attachment.rid = new_rid
+        resolved_client.get_attachment.return_value = resolved_attachment
+
+        ctx.destination_client_resolver = lambda resource: resolved_client if resource is source_attachment else None
+        ctx.migration_state.record_mapping(ResourceType.ATTACHMENT, old_rid, new_rid)
+
+        result = migrator.migrate_by_rid(source_clients, old_rid)
+
+        source_clients.attachment.get.assert_called_once_with("Bearer source", old_rid)
+        mock_attachment_cls._from_conjure.assert_called_once_with(source_clients, raw)
+        resolved_client.get_attachment.assert_called_once_with(new_rid)
+        ctx.destination_client.get_attachment.assert_not_called()
+        assert result is resolved_attachment
 
     @patch("nominal.experimental.migration.migrator.attachment_migrator.Attachment")
     def test_copy_from_records_mapping(self, mock_attachment_cls: MagicMock) -> None:

--- a/tests/core/test_migration_destination_client_resolution.py
+++ b/tests/core/test_migration_destination_client_resolution.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+if sys.version_info < (3, 13):
+    pytest.skip("Migration module requires Python 3.13+ (TypeVar default parameter)", allow_module_level=True)
+
+from nominal.experimental.migration.migration_state import MigrationState
+from nominal.experimental.migration.migrator.asset_migrator import AssetCopyOptions, AssetMigrator
+from nominal.experimental.migration.migrator.context import MigrationContext
+from nominal.experimental.migration.migrator.run_migrator import RunMigrator
+from nominal.experimental.migration.resource_type import ResourceType
+
+
+def _make_client(name: str) -> MagicMock:
+    client = MagicMock(name=name)
+    client._clients.workspace_rid = f"{name}-workspace"
+    workspace = MagicMock()
+    workspace.rid = f"{name}-workspace"
+    client.get_workspace.return_value = workspace
+    return client
+
+
+def _make_run(*, rid: str, name: str | None = None) -> MagicMock:
+    run = MagicMock()
+    run.rid = rid
+    run.name = name or rid
+    run.start = "2026-04-10T00:00:00Z"
+    run.end = "2026-04-10T01:00:00Z"
+    run.description = f"description-{rid}"
+    run.properties = {"rid": rid}
+    run.labels = [rid]
+    run.assets = []
+    run.links = []
+    run.list_attachments.return_value = []
+    run.search_workbooks.return_value = []
+    return run
+
+
+def _make_asset(rid: str) -> MagicMock:
+    asset = MagicMock()
+    asset.rid = rid
+    asset.name = f"asset-{rid}"
+    asset.description = f"description-{rid}"
+    asset.properties = {"rid": rid}
+    asset.labels = [rid]
+    asset.list_runs.return_value = []
+    asset.search_workbooks.return_value = []
+    asset._list_dataset_scopes.return_value = []
+    asset.list_datasets.return_value = []
+    asset.list_videos.return_value = []
+    asset.search_events.return_value = []
+    asset.search_data_reviews.return_value = []
+    return asset
+
+
+def test_default_destination_client_behavior_is_unchanged() -> None:
+    destination_client = _make_client("destination")
+    source_run = _make_run(rid="run-default")
+    destination_run = MagicMock(rid="dest-run-default")
+    destination_client.create_run.return_value = destination_run
+
+    ctx = MigrationContext(destination_client=destination_client, migration_state=MigrationState())
+    result = RunMigrator(ctx).copy_from(source_run)
+
+    assert ctx.destination_client_for(source_run) is destination_client
+    assert result is destination_run
+    destination_client.create_run.assert_called_once()
+    assert ctx.migration_state.get_mapped_rid(ResourceType.RUN, source_run.rid) == destination_run.rid
+
+
+def test_custom_destination_client_resolver_can_vary_per_source_resource() -> None:
+    default_client = _make_client("default")
+    run_client_a = _make_client("run-a")
+    run_client_b = _make_client("run-b")
+
+    source_run_a = _make_run(rid="run-a")
+    source_run_b = _make_run(rid="run-b")
+
+    destination_run_a = MagicMock(rid="dest-run-a")
+    destination_run_b = MagicMock(rid="dest-run-b")
+    run_client_a.create_run.return_value = destination_run_a
+    run_client_b.create_run.return_value = destination_run_b
+
+    ctx = MigrationContext(
+        destination_client=default_client,
+        migration_state=MigrationState(),
+        destination_client_resolver=lambda source_resource: run_client_a
+        if source_resource.rid == source_run_a.rid
+        else run_client_b,
+    )
+    migrator = RunMigrator(ctx)
+
+    assert migrator.copy_from(source_run_a) is destination_run_a
+    assert migrator.copy_from(source_run_b) is destination_run_b
+
+    run_client_a.create_run.assert_called_once()
+    run_client_b.create_run.assert_called_once()
+    default_client.create_run.assert_not_called()
+    assert ctx.migration_state.get_mapped_rid(ResourceType.RUN, source_run_a.rid) == destination_run_a.rid
+    assert ctx.migration_state.get_mapped_rid(ResourceType.RUN, source_run_b.rid) == destination_run_b.rid
+
+
+def test_nested_migrations_resolve_destination_client_per_child_resource() -> None:
+    default_client = _make_client("default")
+    asset_client = _make_client("asset")
+    run_client = _make_client("run")
+
+    source_asset = _make_asset("asset-source")
+    source_run = _make_run(rid="run-source")
+    source_asset.list_runs.return_value = [source_run]
+
+    destination_asset = MagicMock(rid="asset-destination")
+    destination_run = MagicMock(rid="run-destination")
+    asset_client.create_asset.return_value = destination_asset
+    run_client.create_run.return_value = destination_run
+    run_client.get_run.return_value = destination_run
+
+    ctx = MigrationContext(
+        destination_client=default_client,
+        migration_state=MigrationState(),
+        destination_client_resolver=lambda source_resource: asset_client
+        if source_resource.rid == source_asset.rid
+        else run_client,
+    )
+
+    AssetMigrator(ctx).copy_from(
+        source_asset,
+        AssetCopyOptions(
+            dataset_config=None,
+            include_events=False,
+            include_runs=True,
+            include_video=False,
+            include_checklists=False,
+        ),
+    )
+
+    asset_client.create_asset.assert_called_once()
+    run_client.create_run.assert_called_once()
+    asset_client.create_run.assert_not_called()
+    default_client.create_asset.assert_not_called()
+    default_client.create_run.assert_not_called()
+    run_client.get_run.assert_called_once_with(destination_run.rid)
+    assert ctx.migration_state.get_mapped_rid(ResourceType.ASSET, source_asset.rid) == destination_asset.rid
+    assert ctx.migration_state.get_mapped_rid(ResourceType.RUN, source_run.rid) == destination_run.rid

--- a/tests/core/test_migrator_base.py
+++ b/tests/core/test_migrator_base.py
@@ -43,10 +43,13 @@ class _FakeMigrator(Migrator["_FakeResource", "_FakeCopyOptions"]):
     def default_copy_options(self) -> _FakeCopyOptions:
         return _FakeCopyOptions()
 
+    def _get_existing_destination_resource(self, destination_client: MagicMock, mapped_rid: str) -> _FakeResource:
+        return _FakeResource(rid=mapped_rid, name="MyAsset")
+
     def _copy_from_impl(self, source: _FakeResource, options: _FakeCopyOptions) -> _FakeResource:
-        mapped_rid = self.ctx.migration_state.get_mapped_rid(self.resource_type, source.rid)
-        if mapped_rid is not None:
-            return _FakeResource(rid=mapped_rid, name=source.name)
+        existing = self.get_existing_destination_resource(source)
+        if existing is not None:
+            return _FakeResource(rid=existing.rid, name=source.name)
         new = _FakeResource(rid=f"new-{source.rid}", name=source.name)
         self.ctx.migration_state.record_mapping(self.resource_type, source.rid, new.rid)
         return new


### PR DESCRIPTION
## Summary
- add a generic destination-client resolver seam to `MigrationContext` and thread it through `MigrationRunner`
- resolve the destination `NominalClient` at resource migration time across assets, datasets, runs, events, checklists, videos, workbook templates, workbooks, and attachments
- preserve existing single-client behavior by default and add regression tests for custom per-resource and nested-resource resolution

## Testing
- uv run --python 3.13 pytest --no-cov tests/core/test_migrator_base.py tests/core/test_attachment_migrator.py tests/core/test_workbook_migrator.py tests/core/test_workbook_template_migrator.py tests/core/test_migration_destination_client_resolution.py
- uv run python -m compileall nominal/experimental/migration tests/core/test_migration_destination_client_resolution.py
- uv run ruff check nominal/experimental/migration/migration_runner.py nominal/experimental/migration/migrator/__init__.py nominal/experimental/migration/migrator/context.py nominal/experimental/migration/migrator/base.py nominal/experimental/migration/migrator/asset_migrator.py nominal/experimental/migration/migrator/dataset_migrator.py nominal/experimental/migration/migrator/run_migrator.py nominal/experimental/migration/migrator/event_migrator.py nominal/experimental/migration/migrator/checklist_migrator.py nominal/experimental/migration/migrator/video_migrator.py nominal/experimental/migration/migrator/attachment_migrator.py nominal/experimental/migration/migrator/workbook_template_migrator.py nominal/experimental/migration/migrator/workbook_migrator.py tests/core/test_migration_destination_client_resolution.py
- uv run ruff format --check nominal/experimental/migration/migration_runner.py nominal/experimental/migration/migrator/__init__.py nominal/experimental/migration/migrator/context.py nominal/experimental/migration/migrator/base.py nominal/experimental/migration/migrator/asset_migrator.py nominal/experimental/migration/migrator/dataset_migrator.py nominal/experimental/migration/migrator/run_migrator.py nominal/experimental/migration/migrator/event_migrator.py nominal/experimental/migration/migrator/checklist_migrator.py nominal/experimental/migration/migrator/video_migrator.py nominal/experimental/migration/migrator/attachment_migrator.py nominal/experimental/migration/migrator/workbook_template_migrator.py nominal/experimental/migration/migrator/workbook_migrator.py tests/core/test_migration_destination_client_resolution.py