### PR TITLE
fix: export LogStream type from nominal.core

### DIFF
--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -1,5 +1,5 @@
 from nominal.core._event_types import EventType, SearchEventOriginType
-from nominal.core._stream.write_stream import DataStream, WriteStream
+from nominal.core._stream.write_stream import DataStream, LogStream, WriteStream
 from nominal.core._utils.api_tools import LinkDict
 from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.core.asset import Asset
@@ -61,6 +61,7 @@ __all__ = [
     "IngestWaitType",
     "LinkDict",
     "LogPoint",
+    "LogStream",
     "NominalClient",
     "poll_until_ingestion_completed",
     "Run",


### PR DESCRIPTION
## Summary

`LogStream` (the return type of `Dataset.get_log_stream()`) was only defined in the protected `nominal.core._stream` module, so users couldn't type-annotate variables without importing from a private path. This re-exports it from `nominal.core`.