### PR TITLE
feat: add attachment_migrator to asset and run migrators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ uv.toml
 *.csv
 *.parquet
 *migration_utils_output_*.txt
+
+# AI
+.claude

--- a/nominal/experimental/migration/migration_runner.py
+++ b/nominal/experimental/migration/migration_runner.py
@@ -91,6 +91,7 @@ class MigrationRunner:
                     source_asset,
                     AssetCopyOptions(
                         dataset_config=self.dataset_config,
+                        include_attachments=True,
                         include_events=True,
                         include_runs=True,
                         include_video=True,

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -183,12 +183,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                     "Skipping data review execution for %s: already in migration state", source_data_review.rid
                 )
 
-    def _copy_asset_attachments(self, source_asset: Asset, destination_asset: Asset) -> None:
-        attachment_migrator = AttachmentMigrator(
-            MigrationContext(
-                destination_client=self.ctx.destination_client,
-                migration_state=self.ctx.migration_state,
-            )
+        attachment_migrator = AttachmentMigrator(self.ctx)
         )
         new_attachments = [attachment_migrator.copy_from(a) for a in source_asset.list_attachments()]
         if new_attachments:

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -11,6 +11,7 @@ from nominal.experimental.migration.config.migration_data_config import Migratio
 from nominal.experimental.migration.migrator.attachment_migrator import AttachmentMigrator
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.migrator.checklist_migrator import ChecklistCopyOptions, ChecklistMigrator
+from nominal.experimental.migration.migrator.context import MigrationContext
 from nominal.experimental.migration.migrator.dataset_migrator import DatasetCopyOptions, DatasetMigrator
 from nominal.experimental.migration.migrator.event_migrator import EventCopyOptions, EventMigrator
 from nominal.experimental.migration.migrator.run_migrator import RunCopyOptions, RunMigrator

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -11,7 +11,6 @@ from nominal.experimental.migration.config.migration_data_config import Migratio
 from nominal.experimental.migration.migrator.attachment_migrator import AttachmentMigrator
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.migrator.checklist_migrator import ChecklistCopyOptions, ChecklistMigrator
-from nominal.experimental.migration.migrator.context import MigrationContext
 from nominal.experimental.migration.migrator.dataset_migrator import DatasetCopyOptions, DatasetMigrator
 from nominal.experimental.migration.migrator.event_migrator import EventCopyOptions, EventMigrator
 from nominal.experimental.migration.migrator.run_migrator import RunCopyOptions, RunMigrator
@@ -183,8 +182,8 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                     "Skipping data review execution for %s: already in migration state", source_data_review.rid
                 )
 
+    def _copy_asset_attachments(self, source_asset: Asset, destination_asset: Asset) -> None:
         attachment_migrator = AttachmentMigrator(self.ctx)
-        )
         new_attachments = [attachment_migrator.copy_from(a) for a in source_asset.list_attachments()]
         if new_attachments:
             destination_asset.add_attachments(new_attachments)

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -8,6 +8,7 @@ from nominal.core import NominalClient
 from nominal.core._event_types import SearchEventOriginType
 from nominal.core.asset import Asset
 from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
+from nominal.experimental.migration.migrator.attachment_migrator import AttachmentMigrator
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.migrator.checklist_migrator import ChecklistCopyOptions, ChecklistMigrator
 from nominal.experimental.migration.migrator.dataset_migrator import DatasetCopyOptions, DatasetMigrator
@@ -27,6 +28,7 @@ class AssetCopyOptions(ResourceCopyOptions):
     new_asset_properties: dict[str, Any] | None = None
     new_asset_labels: Sequence[str] | None = None
     dataset_config: MigrationDatasetConfig | None = None
+    include_attachments: bool = False
     include_events: bool = False
     include_runs: bool = False
     include_video: bool = False
@@ -41,6 +43,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
     def default_copy_options(self) -> AssetCopyOptions:
         return AssetCopyOptions(
             dataset_config=MigrationDatasetConfig(preserve_dataset_uuid=True, include_dataset_files=True),
+            include_attachments=True,
             include_events=True,
             include_runs=True,
             include_video=True,
@@ -73,6 +76,10 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
         if options.include_video:
             logger.info("Copying videos for asset %s (rid: %s)", source_asset.name, source_asset.rid)
             self._copy_asset_videos(source_asset, new_asset)
+
+        if options.include_attachments:
+            logger.info("Copying attachments for asset %s (rid: %s)", source_asset.name, source_asset.rid)
+            self._copy_asset_attachments(source_asset, new_asset)
 
         self._copy_asset_and_run_workbooks(source_asset, new_asset, options.include_runs)
         return new_asset
@@ -174,6 +181,17 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                 logger.debug(
                     "Skipping data review execution for %s: already in migration state", source_data_review.rid
                 )
+
+    def _copy_asset_attachments(self, source_asset: Asset, destination_asset: Asset) -> None:
+        attachment_migrator = AttachmentMigrator(
+            MigrationContext(
+                destination_client=self.ctx.destination_client,
+                migration_state=self.ctx.migration_state,
+            )
+        )
+        new_attachments = [attachment_migrator.copy_from(a) for a in source_asset.list_attachments()]
+        if new_attachments:
+            destination_asset.add_attachments(new_attachments)
 
     def _copy_asset_videos(self, source_asset: Asset, new_asset: Asset) -> None:
         video_migrator = VideoMigrator(self.ctx)

--- a/nominal/experimental/migration/migrator/run_migrator.py
+++ b/nominal/experimental/migration/migrator/run_migrator.py
@@ -10,6 +10,7 @@ from nominal.core._utils.api_tools import Link, LinkDict
 from nominal.core.asset import Asset
 from nominal.core.attachment import Attachment
 from nominal.core.run import Run
+from nominal.experimental.migration.migrator.attachment_migrator import AttachmentMigrator
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.resource_type import ResourceType
 from nominal.ts import IntegralNanosecondsUTC
@@ -47,6 +48,12 @@ class RunMigrator(Migrator[Run, RunCopyOptions]):
             return existing_run
 
         destination_client = self.destination_client_for(source)
+
+        attachments = options.new_attachments
+        if attachments is None:
+            attachment_migrator = AttachmentMigrator(self.ctx)
+            attachments = [attachment_migrator.copy_from(a) for a in source.list_attachments()]
+
         new_run = destination_client.create_run(
             name=options.new_name if options.new_name is not None else source.name,
             start=options.new_start if options.new_start is not None else source.start,
@@ -56,7 +63,7 @@ class RunMigrator(Migrator[Run, RunCopyOptions]):
             labels=options.new_labels if options.new_labels is not None else source.labels,
             assets=options.new_assets if options.new_assets is not None else source.assets,
             links=options.new_links if options.new_links is not None else source.links,
-            attachments=options.new_attachments if options.new_attachments is not None else source.list_attachments(),
+            attachments=attachments,
         )
         self.ctx.migration_state.record_mapping(self.resource_type, source.rid, new_run.rid)
         return new_run

--- a/tests/core/test_asset_migrator.py
+++ b/tests/core/test_asset_migrator.py
@@ -1,0 +1,159 @@
+"""Tests for AssetMigrator attachment migration."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+if sys.version_info < (3, 13):
+    pytest.skip("Migration module requires Python 3.13+ (TypeVar default parameter)", allow_module_level=True)
+
+from nominal.experimental.migration.migration_state import MigrationState
+from nominal.experimental.migration.migrator.asset_migrator import AssetCopyOptions, AssetMigrator
+from nominal.experimental.migration.migrator.context import MigrationContext
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_STACK = "cerulean-staging"
+
+
+def _att_rid(n: int) -> str:
+    hex8 = f"{n:08x}"
+    return f"ri.attachments.{_STACK}.attachment.{hex8}-0000-0000-0000-000000000000"
+
+
+def _make_context() -> MigrationContext:
+    mock_client = MagicMock()
+    mock_client._clients.workspace_rid = "ws-rid"
+    mock_workspace = MagicMock()
+    mock_workspace.rid = "ws-rid"
+    mock_client.get_workspace.return_value = mock_workspace
+    return MigrationContext(destination_client=mock_client, migration_state=MigrationState())
+
+
+def _make_source_asset(
+    rid: str = "source-asset-rid",
+    name: str = "Source Asset",
+    attachments: list[MagicMock] | None = None,
+) -> MagicMock:
+    asset = MagicMock()
+    asset.rid = rid
+    asset.name = name
+    asset.description = "A description"
+    asset.properties = {}
+    asset.labels = []
+    asset.list_attachments.return_value = attachments or []
+    asset.search_workbooks.return_value = []
+    return asset
+
+
+def _make_dest_asset(rid: str = "dest-asset-rid") -> MagicMock:
+    asset = MagicMock()
+    asset.rid = rid
+    return asset
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAssetMigratorAttachments:
+    def _make_migrator(self) -> tuple[AssetMigrator, MigrationContext]:
+        ctx = _make_context()
+        return AssetMigrator(ctx), ctx
+
+    def test_default_copy_options_includes_attachments(self) -> None:
+        """default_copy_options enables attachment migration."""
+        migrator, _ = self._make_migrator()
+        assert migrator.default_copy_options().include_attachments is True
+
+    @patch("nominal.experimental.migration.migrator.asset_migrator.AttachmentMigrator")
+    def test_include_attachments_false_skips_migration(self, mock_att_cls: MagicMock) -> None:
+        """When include_attachments=False, AttachmentMigrator is never instantiated."""
+        migrator, ctx = self._make_migrator()
+
+        source_att = MagicMock()
+        source_att.rid = _att_rid(1)
+        source_asset = _make_source_asset(attachments=[source_att])
+
+        dest_asset = _make_dest_asset()
+        ctx.destination_client.create_asset.return_value = dest_asset
+
+        migrator.copy_from(source_asset, AssetCopyOptions(include_attachments=False))
+
+        mock_att_cls.assert_not_called()
+        dest_asset.add_attachments.assert_not_called()
+
+    @patch("nominal.experimental.migration.migrator.asset_migrator.AttachmentMigrator")
+    def test_include_attachments_true_migrates_each_attachment(self, mock_att_cls: MagicMock) -> None:
+        """When include_attachments=True, each source attachment is migrated via AttachmentMigrator."""
+        migrator, ctx = self._make_migrator()
+
+        old_rid_1 = _att_rid(1)
+        old_rid_2 = _att_rid(2)
+        new_rid_1 = _att_rid(101)
+        new_rid_2 = _att_rid(102)
+
+        source_att_1 = MagicMock()
+        source_att_1.rid = old_rid_1
+        source_att_2 = MagicMock()
+        source_att_2.rid = old_rid_2
+
+        source_asset = _make_source_asset(attachments=[source_att_1, source_att_2])
+
+        dest_asset = _make_dest_asset()
+        ctx.destination_client.create_asset.return_value = dest_asset
+
+        new_att_1 = MagicMock()
+        new_att_1.rid = new_rid_1
+        new_att_2 = MagicMock()
+        new_att_2.rid = new_rid_2
+
+        mock_att_migrator = mock_att_cls.return_value
+        mock_att_migrator.copy_from.side_effect = [new_att_1, new_att_2]
+
+        migrator.copy_from(source_asset, AssetCopyOptions(include_attachments=True))
+
+        mock_att_migrator.copy_from.assert_has_calls([call(source_att_1), call(source_att_2)])
+        dest_asset.add_attachments.assert_called_once_with([new_att_1, new_att_2])
+
+    @patch("nominal.experimental.migration.migrator.asset_migrator.AttachmentMigrator")
+    def test_include_attachments_true_no_source_attachments_skips_add(self, mock_att_cls: MagicMock) -> None:
+        """When include_attachments=True but source has no attachments, add_attachments is not called."""
+        migrator, ctx = self._make_migrator()
+
+        source_asset = _make_source_asset(attachments=[])
+        dest_asset = _make_dest_asset()
+        ctx.destination_client.create_asset.return_value = dest_asset
+
+        migrator.copy_from(source_asset, AssetCopyOptions(include_attachments=True))
+
+        mock_att_cls.return_value.copy_from.assert_not_called()
+        dest_asset.add_attachments.assert_not_called()
+
+    @patch("nominal.experimental.migration.migrator.asset_migrator.AttachmentMigrator")
+    def test_include_attachments_records_mapping_in_shared_state(self, mock_att_cls: MagicMock) -> None:
+        """AttachmentMigrator is constructed with the same migration state so mappings are shared."""
+        migrator, ctx = self._make_migrator()
+
+        source_att = MagicMock()
+        source_att.rid = _att_rid(1)
+        source_asset = _make_source_asset(attachments=[source_att])
+
+        dest_asset = _make_dest_asset()
+        ctx.destination_client.create_asset.return_value = dest_asset
+
+        new_att = MagicMock()
+        new_att.rid = _att_rid(101)
+        mock_att_cls.return_value.copy_from.return_value = new_att
+
+        migrator.copy_from(source_asset, AssetCopyOptions(include_attachments=True))
+
+        # AttachmentMigrator was constructed with a context that shares the same migration_state
+        init_ctx = mock_att_cls.call_args[0][0]
+        assert init_ctx.migration_state is ctx.migration_state

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.128.0"
+version = "1.131.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Description

Building on top of the attachment_migrator previously built, this PR adds the option to migrate attachments as part of asset and run migration.

## Testing

Tested with a test asset in the demo tenant and migrate to staging.

Configuration:
* 1 Asset w/ one attachment
* 1 run attached to asset w/ one attachment

```
from nominal.core import NominalClient
import logging
from nominal.core.event import SearchEventOriginType
from nominal.experimental.migration.migrator import AssetMigrator
from nominal.experimental.migration.migration_state import MigrationState
from nominal.experimental.migration.migrator.context import MigrationContext
logging.basicConfig(level=logging.DEBUG)

source_client = NominalClient.from_profile(profile="prod-tutorial")

print(source_client.get_workspace().id)


target_client = NominalClient.from_profile("staging")
template = source_client.get_workbook_template("RID")
#asset = source_client.get_asset("RID")

asset = source_client.get_asset("RID")

asset_migrator = AssetMigrator(MigrationContext(destination_client=target_client, migration_state=MigrationState(rid_mapping={})))

destination_asset = asset_migrator.copy_from(asset)
```