### PR TITLE
fix: resolve threadpool connection size warnings

### DIFF
--- a/nominal/core/_utils/networking.py
+++ b/nominal/core/_utils/networking.py
@@ -237,6 +237,12 @@ def create_multipart_request_session(
         status_forcelist=(429, 500, 502, 503, 504),
     )
     session = requests.Session()
-    adapter = SslBypassRequestsAdapter(max_retries=retries, pool_maxsize=pool_size)
+    adapter = SslBypassRequestsAdapter(
+        max_retries=retries,
+        # Match the number of cached host pools to the thread count to avoid LRU eviction.
+        pool_connections=pool_size,
+        # Double the per-host connection limit so retries/redirects don't discard connections.
+        pool_maxsize=pool_size * 2,
+    )
     session.mount("https://", adapter)
     return session

--- a/nominal/core/_utils/networking.py
+++ b/nominal/core/_utils/networking.py
@@ -228,9 +228,13 @@ def create_multipart_request_session(
     and connection pool, safe for concurrent use across threads.
 
     Args:
-        pool_size: Maximum number of connections to keep in the pool.
+        pool_size: Number of concurrent workers. Controls the number of cached host pools
+            and the per-host connection limit (2 * pool_size).
         num_retries: Number of times to retry failed requests.
     """
+    if pool_size <= 0:
+        raise ValueError(f"pool_size must be positive, got {pool_size}")
+
     retries = Retry(
         total=num_retries,
         backoff_factor=0.5,


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->
## Summary                                                                                                                                                                       
  - Fix urllib3 "Connection pool is full, discarding connection" warnings when using multipart uploads/downloads with thread pools larger than 10
  - Set `pool_connections` to match the thread count so the PoolManager LRU doesn't evict host pools under concurrent use                                                          
  - Set `pool_maxsize` to `2 * pool_size` to absorb extra connections created by retries/redirects without discarding them                                                         
                                                                                                                                                                                   
  ## Context                                                                                                                                                                       
  The `requests` library defaults both `pool_connections` and `pool_maxsize` to 10. We were only overriding `pool_maxsize`, leaving `pool_connections` at the default. When        
  downloading with e.g. 16 threads, urllib3 would log warnings about discarding connections that couldn't fit back into the pool.                                                  
  
  The warnings were harmless (work still completed), but the discarded connections meant unnecessary TCP+TLS re-handshakes on subsequent requests. Doubling `pool_maxsize` relative
   to the thread count gives headroom for the transient extra connections that retries and redirects create, while setting `pool_connections` prevents host-pool eviction.