### PR TITLE
feat: multi-asset run migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ uv.toml
 *.csv
 *.parquet
 *migration_utils_output_*.txt
+
+# AI
+.claude

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -87,6 +87,7 @@ class Run(HasRid, RefreshableMixin[scout_run_api.Run], _DatasetWrapper):
         properties: Mapping[str, str] | None = None,
         labels: Sequence[str] | None = None,
         links: Sequence[str | Link | LinkDict] | None = None,
+        assets: Sequence[Asset | str] | None = None,
     ) -> Self:
         """Replace run metadata.
         Updates the current instance, and returns it.
@@ -101,6 +102,11 @@ class Run(HasRid, RefreshableMixin[scout_run_api.Run], _DatasetWrapper):
             for old_label in run.labels:
                 new_labels.append(old_label)
             run = run.update(labels=new_labels)
+
+        Note: When `assets` is provided it fully replaces the run's asset list. To append an asset, merge with
+        the existing list first:
+
+            run = run.update(assets=[*run.assets, new_asset])
         """
         request = scout_run_api.UpdateRunRequest(
             description=description,
@@ -109,7 +115,7 @@ class Run(HasRid, RefreshableMixin[scout_run_api.Run], _DatasetWrapper):
             start_time=None if start is None else _SecondsNanos.from_flexible(start).to_scout_run_api(),
             end_time=None if end is None else _SecondsNanos.from_flexible(end).to_scout_run_api(),
             title=name,
-            assets=[],
+            assets=[] if assets is None else [rid_from_instance_or_string(a) for a in assets],
             links=None if links is None else create_links(links),
         )
         updated_run = self._clients.run.update_run(self._clients.auth_header, request, self.rid)

--- a/nominal/experimental/migration/migrator/run_migrator.py
+++ b/nominal/experimental/migration/migrator/run_migrator.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Iterable, Mapping, Sequence
 
 from nominal.core import NominalClient
-from nominal.core._utils.api_tools import Link, LinkDict
+from nominal.core._utils.api_tools import Link, LinkDict, rid_from_instance_or_string
 from nominal.core.asset import Asset
 from nominal.core.attachment import Attachment
 from nominal.core.run import Run
@@ -44,6 +44,8 @@ class RunMigrator(Migrator[Run, RunCopyOptions]):
     def _copy_from_impl(self, source: Run, options: RunCopyOptions) -> Run:
         existing_run = self.get_existing_destination_resource(source)
         if existing_run is not None:
+            if options.new_assets is not None:
+                return self._ensure_assets_added(existing_run, options.new_assets)
             return existing_run
 
         destination_client = self.destination_client_for(source)
@@ -60,6 +62,23 @@ class RunMigrator(Migrator[Run, RunCopyOptions]):
         )
         self.ctx.migration_state.record_mapping(self.resource_type, source.rid, new_run.rid)
         return new_run
+
+    def _ensure_assets_added(self, run: Run, new_assets: Sequence[Asset | str]) -> Run:
+        """Add any assets from new_assets that are not already on run. Returns the (possibly updated) run.
+
+        Raises:
+            ValueError: if new_assets is empty, since runs must always have at least one asset.
+        """
+        if not new_assets:
+            raise ValueError("new_assets must be non-empty; runs must have at least one asset.")
+        existing_rids = set(run.assets)
+        missing_rids = [
+            rid_from_instance_or_string(a) for a in new_assets if rid_from_instance_or_string(a) not in existing_rids
+        ]
+        if not missing_rids:
+            return run
+        logger.debug("Adding %d missing asset(s) to existing run %s", len(missing_rids), run.rid)
+        return run.update(assets=[*existing_rids, *missing_rids])
 
     def _get_resource_name(self, resource: Run) -> str:
         return resource.name

--- a/tests/core/test_run_migrator.py
+++ b/tests/core/test_run_migrator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -144,7 +144,7 @@ class TestRunMigratorExistingRun:
         assert result is existing_dest_run
 
     def test_no_update_when_no_new_assets_in_options(self) -> None:
-        """When new_assets is None (default options), _ensure_assets_added is skipped and the existing run is returned as-is."""
+        """When new_assets is None (default options), _ensure_assets_added is skipped, the existing run is returned."""
         ctx = _make_context()
         migrator = RunMigrator(ctx)
 

--- a/tests/core/test_run_migrator.py
+++ b/tests/core/test_run_migrator.py
@@ -1,0 +1,241 @@
+"""Tests for RunMigrator, focusing on multi-asset run migration behavior."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, call
+
+import pytest
+
+if sys.version_info < (3, 13):
+    pytest.skip("Migration module requires Python 3.13+ (TypeVar default parameter)", allow_module_level=True)
+
+from nominal.experimental.migration.migration_state import MigrationState
+from nominal.experimental.migration.migrator.context import MigrationContext
+from nominal.experimental.migration.migrator.run_migrator import RunCopyOptions, RunMigrator
+from nominal.experimental.migration.resource_type import ResourceType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_STACK = "cerulean-staging"
+
+
+def _run_rid(n: int) -> str:
+    hex8 = f"{n:08x}"
+    return f"ri.scout.{_STACK}.run.{hex8}-0000-0000-0000-000000000000"
+
+
+def _asset_rid(n: int) -> str:
+    hex8 = f"{n:08x}"
+    return f"ri.scout.{_STACK}.asset.{hex8}-0000-0000-0000-000000000000"
+
+
+def _make_run(rid: str, name: str = "Run", asset_rids: list[str] | None = None) -> MagicMock:
+    run = MagicMock()
+    run.rid = rid
+    run.name = name
+    run.assets = asset_rids or []
+    run.start = 0
+    run.end = None
+    run.description = ""
+    run.properties = {}
+    run.labels = []
+    run.links = []
+    run.list_attachments.return_value = []
+    # update() returns a new mock with updated assets by default - tests can override
+    run.update.return_value = run
+    return run
+
+
+def _make_context() -> MigrationContext:
+    mock_client = MagicMock()
+    mock_client._clients.workspace_rid = "ws-rid"
+    mock_workspace = MagicMock()
+    mock_workspace.rid = "ws-rid"
+    mock_client.get_workspace.return_value = mock_workspace
+    return MigrationContext(destination_client=mock_client, migration_state=MigrationState())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunMigratorNewRun:
+    def test_creates_run_with_new_asset(self) -> None:
+        """When the run hasn't been migrated yet, create_run is called with the given asset."""
+        ctx = _make_context()
+        migrator = RunMigrator(ctx)
+
+        source_run = _make_run(_run_rid(1))
+        dest_asset_rid = _asset_rid(10)
+
+        dest_run = _make_run(_run_rid(100), asset_rids=[dest_asset_rid])
+        ctx.destination_client.create_run.return_value = dest_run
+
+        result = migrator.copy_from(source_run, RunCopyOptions(new_assets=[dest_asset_rid]))
+
+        ctx.destination_client.create_run.assert_called_once()
+        assert result.rid == _run_rid(100)
+        assert ctx.migration_state.get_mapped_rid(ResourceType.RUN, _run_rid(1)) == _run_rid(100)
+
+    def test_mapping_recorded_after_creation(self) -> None:
+        """The old→new RID mapping is recorded in migration state after creation."""
+        ctx = _make_context()
+        migrator = RunMigrator(ctx)
+
+        source_run = _make_run(_run_rid(1))
+        dest_run = _make_run(_run_rid(100))
+        ctx.destination_client.create_run.return_value = dest_run
+
+        migrator.copy_from(source_run, RunCopyOptions())
+
+        assert ctx.migration_state.get_mapped_rid(ResourceType.RUN, _run_rid(1)) == _run_rid(100)
+
+
+class TestRunMigratorExistingRun:
+    def test_adds_missing_asset_to_existing_run(self) -> None:
+        """When a run was already migrated, a new asset that isn't on it yet is added via update()."""
+        ctx = _make_context()
+        migrator = RunMigrator(ctx)
+
+        source_rid = _run_rid(1)
+        dest_rid = _run_rid(100)
+        asset_a_rid = _asset_rid(10)  # already on the run
+        asset_b_rid = _asset_rid(20)  # new asset being migrated now
+
+        # Run already migrated
+        ctx.migration_state.record_mapping(ResourceType.RUN, source_rid, dest_rid)
+
+        existing_dest_run = _make_run(dest_rid, asset_rids=[asset_a_rid])
+        ctx.destination_client.get_run.return_value = existing_dest_run
+
+        updated_run = _make_run(dest_rid, asset_rids=[asset_a_rid, asset_b_rid])
+        existing_dest_run.update.return_value = updated_run
+
+        source_run = _make_run(source_rid)
+        result = migrator.copy_from(source_run, RunCopyOptions(new_assets=[asset_b_rid]))
+
+        existing_dest_run.update.assert_called_once()
+        call_kwargs = existing_dest_run.update.call_args
+        assert set(call_kwargs.kwargs["assets"]) == {asset_a_rid, asset_b_rid}
+        assert result is updated_run
+
+    def test_no_update_when_asset_already_present(self) -> None:
+        """When the new asset is already on the existing run, update() is not called."""
+        ctx = _make_context()
+        migrator = RunMigrator(ctx)
+
+        source_rid = _run_rid(1)
+        dest_rid = _run_rid(100)
+        asset_rid = _asset_rid(10)
+
+        ctx.migration_state.record_mapping(ResourceType.RUN, source_rid, dest_rid)
+
+        existing_dest_run = _make_run(dest_rid, asset_rids=[asset_rid])
+        ctx.destination_client.get_run.return_value = existing_dest_run
+
+        source_run = _make_run(source_rid)
+        result = migrator.copy_from(source_run, RunCopyOptions(new_assets=[asset_rid]))
+
+        existing_dest_run.update.assert_not_called()
+        assert result is existing_dest_run
+
+    def test_no_update_when_no_new_assets_in_options(self) -> None:
+        """When new_assets is None (default options), _ensure_assets_added is skipped and the existing run is returned as-is."""
+        ctx = _make_context()
+        migrator = RunMigrator(ctx)
+
+        source_rid = _run_rid(1)
+        dest_rid = _run_rid(100)
+
+        ctx.migration_state.record_mapping(ResourceType.RUN, source_rid, dest_rid)
+
+        existing_dest_run = _make_run(dest_rid, asset_rids=[_asset_rid(10)])
+        ctx.destination_client.get_run.return_value = existing_dest_run
+
+        source_run = _make_run(source_rid)
+        result = migrator.copy_from(source_run, RunCopyOptions())
+
+        existing_dest_run.update.assert_not_called()
+        assert result is existing_dest_run
+
+    def test_create_run_not_called_for_existing_run(self) -> None:
+        """When the run is already in migration state, create_run is never called."""
+        ctx = _make_context()
+        migrator = RunMigrator(ctx)
+
+        source_rid = _run_rid(1)
+        dest_rid = _run_rid(100)
+
+        ctx.migration_state.record_mapping(ResourceType.RUN, source_rid, dest_rid)
+        ctx.destination_client.get_run.return_value = _make_run(dest_rid)
+
+        source_run = _make_run(source_rid)
+        migrator.copy_from(source_run, RunCopyOptions())
+
+        ctx.destination_client.create_run.assert_not_called()
+
+    def test_adds_multiple_missing_assets(self) -> None:
+        """Multiple missing assets are all added in a single update() call."""
+        ctx = _make_context()
+        migrator = RunMigrator(ctx)
+
+        source_rid = _run_rid(1)
+        dest_rid = _run_rid(100)
+        existing_asset = _asset_rid(10)
+        new_asset_b = _asset_rid(20)
+        new_asset_c = _asset_rid(30)
+
+        ctx.migration_state.record_mapping(ResourceType.RUN, source_rid, dest_rid)
+
+        existing_dest_run = _make_run(dest_rid, asset_rids=[existing_asset])
+        ctx.destination_client.get_run.return_value = existing_dest_run
+
+        source_run = _make_run(source_rid)
+        migrator.copy_from(source_run, RunCopyOptions(new_assets=[new_asset_b, new_asset_c]))
+
+        existing_dest_run.update.assert_called_once()
+        call_kwargs = existing_dest_run.update.call_args
+        assert set(call_kwargs.kwargs["assets"]) == {existing_asset, new_asset_b, new_asset_c}
+
+
+class TestRunMigratorEnsureAssetsAdded:
+    """Unit tests for _ensure_assets_added in isolation."""
+
+    def _make_migrator(self) -> RunMigrator:
+        return RunMigrator(_make_context())
+
+    def test_accepts_asset_object(self) -> None:
+        """Asset objects (with .rid) are resolved to RIDs correctly."""
+        migrator = self._make_migrator()
+
+        asset_rid = _asset_rid(99)
+        asset_obj = MagicMock()
+        asset_obj.rid = asset_rid
+
+        run = _make_run(_run_rid(1), asset_rids=[])
+        migrator._ensure_assets_added(run, [asset_obj])
+
+        run.update.assert_called_once()
+        assert asset_rid in run.update.call_args.kwargs["assets"]
+
+    def test_accepts_string_rid(self) -> None:
+        """Plain string RIDs are accepted as new_assets."""
+        migrator = self._make_migrator()
+
+        asset_rid = _asset_rid(99)
+        run = _make_run(_run_rid(1), asset_rids=[])
+        migrator._ensure_assets_added(run, [asset_rid])
+
+        run.update.assert_called_once()
+        assert asset_rid in run.update.call_args.kwargs["assets"]
+
+    def test_empty_new_assets_list_raises(self) -> None:
+        """An empty new_assets list raises ValueError since runs must have at least one asset."""
+        migrator = self._make_migrator()
+        run = _make_run(_run_rid(1), asset_rids=[_asset_rid(10)])
+        with pytest.raises(ValueError, match="non-empty"):
+            migrator._ensure_assets_added(run, [])

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.128.0"
+version = "1.131.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

## Description

Add handling for multiple assets in a run during migration.  This requires adding functionality on `run.py`'s `update()` method, which didn't allow to modify assets due to it being implemented before multi-asset runs existed.

## Testing

Created a test run with two assets in a source tenant.  Used the `migration_runner`to migrate the two assets. Verified we created 1x run with mapping to the new assets preserved.

Test code:

```
from nominal.core import NominalClient
import logging
from nominal.core.event import SearchEventOriginType
from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
from nominal.experimental.migration.migrator import AssetMigrator
from nominal.experimental.migration.migration_state import MigrationState
from nominal.experimental.migration.migration_runner import MigrationRunner
from nominal.experimental.migration.config.migration_resources import MigrationResources, AssetResources
logging.basicConfig(level=logging.DEBUG)

source_client = NominalClient.from_profile(profile="prod-tutorial")
target_client = NominalClient.from_profile("staging"

asset1 = source_client.get_asset("<asset_1_rid>")
asset2 = source_client.get_asset("<asset_2_rid>")

migration_runner = MigrationRunner(migration_resources=MigrationResources(source_assets={"rid1": AssetResources(asset1,[]), "rid2": AssetResources(asset2,[])}, source_standalone_templates=[]), dataset_config=MigrationDatasetConfig(preserve_dataset_uuid=False, include_dataset_files=False), destination_client=target_client, migration_state_path="/Users/sean/Downloads/test_multi_asset_run.json")

migration_runner.run_migration()
```