### PR TITLE
feat: multi-asset/run workbook migration

### DIFF
--- a/nominal/experimental/migration/migration_runner.py
+++ b/nominal/experimental/migration/migration_runner.py
@@ -4,13 +4,16 @@ import json
 import logging
 import re
 from pathlib import Path
+from typing import cast
 
 from nominal.core import NominalClient
+from nominal.core._clientsbunch import ClientsBunch
 from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
 from nominal.experimental.migration.config.migration_resources import MigrationResources
 from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.migrator.asset_migrator import AssetCopyOptions, AssetMigrator
 from nominal.experimental.migration.migrator.context import DestinationClientResolver, MigrationContext
+from nominal.experimental.migration.migrator.workbook_migrator import WorkbookMigrator
 from nominal.experimental.migration.migrator.workbook_template_migrator import WorkbookTemplateMigrator
 
 logger = logging.getLogger(__name__)
@@ -82,6 +85,7 @@ class MigrationRunner:
                 destination_client=self.destination_client,
                 migration_state=self.migration_state,
                 destination_client_resolver=self.destination_client_resolver,
+                source_asset_rids=frozenset(self.migration_resources.source_assets.keys()),
             )
             asset_migrator = AssetMigrator(migration_context)
             template_migrator = WorkbookTemplateMigrator(migration_context)
@@ -101,6 +105,12 @@ class MigrationRunner:
 
             for source_template in self.migration_resources.source_standalone_templates:
                 template_migrator.clone(source_template)
+
+            source_clients_by_asset_rid: dict[str, ClientsBunch] = {
+                asset_rid: cast(ClientsBunch, asset_resources.asset._clients)
+                for asset_rid, asset_resources in self.migration_resources.source_assets.items()
+            }
+            WorkbookMigrator(migration_context).migrate_deferred_workbooks(source_clients_by_asset_rid)
         finally:
             self.save_state()
         logger.info("Completed migration")

--- a/nominal/experimental/migration/migration_state.py
+++ b/nominal/experimental/migration/migration_state.py
@@ -8,12 +8,42 @@ from nominal.experimental.migration.resource_type import ResourceType
 
 
 @dataclass
+class SkippedResource:
+    resource_type: str
+    source_rid: str
+    reason: str
+
+
+@dataclass
 class MigrationState(JSONWizard):
     # resource_type -> old_rid -> new_rid
     rid_mapping: dict[str, dict[str, str]] = field(default_factory=dict)
+    # source workbook_rid -> list of source asset_rids (for deferred multi-asset migration)
+    pending_multi_asset_workbooks: dict[str, list[str]] = field(default_factory=dict)
+    # source workbook_rid -> list of source run_rids (for deferred multi-run migration)
+    pending_multi_run_workbooks: dict[str, list[str]] = field(default_factory=dict)
+    # log of resources skipped due to missing dependencies or out-of-scope references
+    skipped_resources: list[SkippedResource] = field(default_factory=list)
 
     def record_mapping(self, resource_type: ResourceType, old_rid: str, new_rid: str) -> None:
         self.rid_mapping.setdefault(resource_type.value, {})[old_rid] = new_rid
 
     def get_mapped_rid(self, resource_type: ResourceType, old_rid: str) -> str | None:
         return self.rid_mapping.get(resource_type.value, {}).get(old_rid)
+
+    def record_pending_multi_asset_workbook(self, workbook_rid: str, asset_rids: list[str]) -> None:
+        """Record a multi-asset workbook for deferred migration. Overwrites any prior entry for idempotency."""
+        self.pending_multi_asset_workbooks[workbook_rid] = asset_rids
+
+    def record_pending_multi_run_workbook(self, workbook_rid: str, run_rids: list[str]) -> None:
+        """Record a multi-run workbook for deferred migration. Overwrites any prior entry for idempotency."""
+        self.pending_multi_run_workbooks[workbook_rid] = run_rids
+
+    def clear_pending_multi_asset_workbook(self, workbook_rid: str) -> None:
+        self.pending_multi_asset_workbooks.pop(workbook_rid, None)
+
+    def clear_pending_multi_run_workbook(self, workbook_rid: str) -> None:
+        self.pending_multi_run_workbooks.pop(workbook_rid, None)
+
+    def record_skip(self, resource_type: ResourceType, source_rid: str, reason: str) -> None:
+        self.skipped_resources.append(SkippedResource(resource_type.value, source_rid, reason))

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -7,6 +7,7 @@ from typing import Any, Sequence
 from nominal.core import NominalClient
 from nominal.core._event_types import SearchEventOriginType
 from nominal.core.asset import Asset
+from nominal.core.workbook import Workbook
 from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
 from nominal.experimental.migration.migrator.attachment_migrator import AttachmentMigrator
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
@@ -212,8 +213,12 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
         workbook_migrator = WorkbookMigrator(self.ctx)
         asset_workbooks = source_asset.search_workbooks(include_drafts=True)
         for workbook in asset_workbooks:
-            if workbook.asset_rids and len(workbook.asset_rids) == 1:
+            if not workbook.asset_rids:
+                continue
+            if len(workbook.asset_rids) == 1:
                 workbook_migrator.copy_from(workbook, WorkbookCopyOptions(destination_asset=new_asset))
+            else:
+                self._enqueue_multi_asset_workbook(workbook, list(workbook.asset_rids))
 
         if include_runs:
             for source_run in source_asset.list_runs():
@@ -223,5 +228,28 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                     continue
                 destination_run = self.ctx.destination_client_for(source_run).get_run(destination_run_rid)
                 for workbook in source_run.search_workbooks(include_drafts=True):
-                    if workbook.run_rids and len(workbook.run_rids) == 1:
+                    if not workbook.run_rids:
+                        continue
+                    if len(workbook.run_rids) == 1:
                         workbook_migrator.copy_from(workbook, WorkbookCopyOptions(destination_run=destination_run))
+                    else:
+                        self._enqueue_multi_run_workbook(workbook, list(workbook.run_rids))
+
+    def _enqueue_multi_asset_workbook(self, workbook: Workbook, source_asset_rids: list[str]) -> None:
+        missing = [
+            rid
+            for rid in source_asset_rids
+            if rid not in self.ctx.source_asset_rids
+            and self.ctx.migration_state.get_mapped_rid(ResourceType.ASSET, rid) is None
+        ]
+        if missing:
+            reason = f"assets not in migration scope: {missing}"
+            logger.warning("Skipping multi-asset workbook %s: %s", workbook.rid, reason)
+            self.ctx.migration_state.record_skip(ResourceType.WORKBOOK, workbook.rid, reason)
+        else:
+            logger.debug("Queuing multi-asset workbook %s for deferred migration", workbook.rid)
+            self.ctx.migration_state.record_pending_multi_asset_workbook(workbook.rid, source_asset_rids)
+
+    def _enqueue_multi_run_workbook(self, workbook: Workbook, source_run_rids: list[str]) -> None:
+        logger.debug("Queuing multi-run workbook %s for deferred migration", workbook.rid)
+        self.ctx.migration_state.record_pending_multi_run_workbook(workbook.rid, source_run_rids)

--- a/nominal/experimental/migration/migrator/context.py
+++ b/nominal/experimental/migration/migrator/context.py
@@ -20,6 +20,7 @@ class MigrationContext:
     destination_client: NominalClient
     migration_state: MigrationState
     destination_client_resolver: DestinationClientResolver | None = None
+    source_asset_rids: frozenset[str] = field(default_factory=frozenset)
     _singleflight_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
     _singleflight_futures: dict[tuple[str, str], concurrent.futures.Future[Any]] = field(
         default_factory=dict,

--- a/nominal/experimental/migration/migrator/workbook_migrator.py
+++ b/nominal/experimental/migration/migrator/workbook_migrator.py
@@ -180,6 +180,7 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
                 reason = f"asset {old_rid} not found in migration state"
                 logger.warning("Skipping multi-asset workbook %s: %s", source.rid, reason)
                 self.ctx.migration_state.record_skip(ResourceType.WORKBOOK, source.rid, reason)
+                self.ctx.migration_state.clear_pending_multi_asset_workbook(source.rid)
                 return None
             rid_map[old_rid] = new_rid
 
@@ -243,6 +244,7 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
                 reason = f"run {old_rid} not found in migration state"
                 logger.warning("Skipping multi-run workbook %s: %s", source.rid, reason)
                 self.ctx.migration_state.record_skip(ResourceType.WORKBOOK, source.rid, reason)
+                self.ctx.migration_state.clear_pending_multi_run_workbook(source.rid)
                 return None
             rid_map[old_rid] = new_rid
 

--- a/nominal/experimental/migration/migrator/workbook_migrator.py
+++ b/nominal/experimental/migration/migrator/workbook_migrator.py
@@ -246,6 +246,11 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
                 return None
             rid_map[old_rid] = new_rid
 
+        # Also remap any asset RIDs embedded in the content (channels resolve against both
+        # run RIDs and asset RIDs, so both must be substituted).
+        asset_rid_map = dict(self.ctx.migration_state.rid_mapping.get(ResourceType.ASSET.value, {}))
+        rid_overrides = {**asset_rid_map, **rid_map}
+
         source_clients = cast(ClientsBunch, source._clients)
         raw_notebook = source_clients.notebook.get(source_clients.auth_header, source.rid)
 
@@ -257,7 +262,7 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
             raise ValueError(f"Missing content for workbook {source.rid}")
 
         new_layout, new_content = clone_conjure_objects_with_rid_overrides(
-            (raw_notebook.layout, content), rid_overrides=rid_map
+            (raw_notebook.layout, content), rid_overrides=rid_overrides
         )
 
         destination_client = self.destination_client_for(source)

--- a/nominal/experimental/migration/migrator/workbook_migrator.py
+++ b/nominal/experimental/migration/migrator/workbook_migrator.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Mapping, Sequence, cast
 
 from nominal_api import api as nominal_api
-from nominal_api import scout_notebook_api
+from nominal_api import scout_notebook_api, scout_workbookcommon_api
 
 from nominal.core import NominalClient
 from nominal.core._clientsbunch import ClientsBunch
@@ -22,6 +22,7 @@ from nominal.experimental.migration.migrator.workbook_template_migrator import (
     WorkbookTemplateMigrator,
 )
 from nominal.experimental.migration.resource_type import ResourceType
+from nominal.experimental.migration.utils.conjure_clone_utils import clone_conjure_objects_with_rid_overrides
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +162,181 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
         )
 
         logger.info("Migrated preview image for workbook %s", dest.title)
+
+    def copy_multi_asset_workbook(self, source: Workbook, source_asset_rids: list[str]) -> Workbook | None:
+        """Copy a multi-asset workbook by find/replacing asset RIDs in the serialized content.
+
+        All source_asset_rids must already be present in the migration state before calling this.
+        Returns None if any asset RID is missing from the migration state (already logged as a skip).
+        """
+        existing = self.get_existing_destination_resource(source)
+        if existing is not None:
+            return existing
+
+        rid_map: dict[str, str] = {}
+        for old_rid in source_asset_rids:
+            new_rid = self.ctx.migration_state.get_mapped_rid(ResourceType.ASSET, old_rid)
+            if new_rid is None:
+                reason = f"asset {old_rid} not found in migration state"
+                logger.warning("Skipping multi-asset workbook %s: %s", source.rid, reason)
+                self.ctx.migration_state.record_skip(ResourceType.WORKBOOK, source.rid, reason)
+                return None
+            rid_map[old_rid] = new_rid
+
+        source_clients = cast(ClientsBunch, source._clients)
+        raw_notebook = source_clients.notebook.get(source_clients.auth_header, source.rid)
+
+        content_v2 = raw_notebook.content_v2
+        if content_v2 is not None and not isinstance(content_v2, scout_workbookcommon_api.UnifiedWorkbookContent):
+            raise ValueError(f"Unexpected content_v2 type for workbook {source.rid}")
+        content = (content_v2.workbook if content_v2 is not None else None) or raw_notebook.content
+        if content is None:
+            raise ValueError(f"Missing content for workbook {source.rid}")
+
+        new_layout, new_content = clone_conjure_objects_with_rid_overrides(
+            (raw_notebook.layout, content), rid_overrides=rid_map
+        )
+
+        destination_client = self.destination_client_for(source)
+        dest_clients = cast(ClientsBunch, destination_client._clients)
+        request = scout_notebook_api.CreateNotebookRequest(
+            title=raw_notebook.metadata.title,
+            description=raw_notebook.metadata.description,
+            is_draft=source.is_draft(),
+            state_as_json="{}",
+            data_scope=scout_notebook_api.NotebookDataScope(
+                asset_rids=[rid_map[r] for r in source_asset_rids],
+                run_rids=None,
+            ),
+            layout=new_layout,
+            content_v2=scout_workbookcommon_api.UnifiedWorkbookContent(workbook=new_content),
+            event_refs=[],
+            workspace=dest_clients.resolve_default_workspace_rid(),
+        )
+        raw_new_notebook = dest_clients.notebook.create(dest_clients.auth_header, request)
+        new_workbook = Workbook._from_conjure(dest_clients, raw_new_notebook)
+
+        self.ctx.migration_state.record_mapping(ResourceType.WORKBOOK, source.rid, new_workbook.rid)
+        self.ctx.migration_state.clear_pending_multi_asset_workbook(source.rid)
+
+        source_metadata = raw_notebook.metadata
+        new_workbook.update(labels=source_metadata.labels, properties=source_metadata.properties)
+        self._migrate_preview_image(source, new_workbook)
+
+        logger.info("Migrated multi-asset workbook %s -> %s", source.rid, new_workbook.rid)
+        return new_workbook
+
+    def copy_multi_run_workbook(self, source: Workbook, source_run_rids: list[str]) -> Workbook | None:
+        """Copy a multi-run workbook by find/replacing run RIDs in the serialized content.
+
+        All source_run_rids must already be present in the migration state before calling this.
+        Returns None if any run RID is missing from the migration state (already logged as a skip).
+        """
+        existing = self.get_existing_destination_resource(source)
+        if existing is not None:
+            return existing
+
+        rid_map: dict[str, str] = {}
+        for old_rid in source_run_rids:
+            new_rid = self.ctx.migration_state.get_mapped_rid(ResourceType.RUN, old_rid)
+            if new_rid is None:
+                reason = f"run {old_rid} not found in migration state"
+                logger.warning("Skipping multi-run workbook %s: %s", source.rid, reason)
+                self.ctx.migration_state.record_skip(ResourceType.WORKBOOK, source.rid, reason)
+                return None
+            rid_map[old_rid] = new_rid
+
+        source_clients = cast(ClientsBunch, source._clients)
+        raw_notebook = source_clients.notebook.get(source_clients.auth_header, source.rid)
+
+        content_v2 = raw_notebook.content_v2
+        if content_v2 is not None and not isinstance(content_v2, scout_workbookcommon_api.UnifiedWorkbookContent):
+            raise ValueError(f"Unexpected content_v2 type for workbook {source.rid}")
+        content = (content_v2.workbook if content_v2 is not None else None) or raw_notebook.content
+        if content is None:
+            raise ValueError(f"Missing content for workbook {source.rid}")
+
+        new_layout, new_content = clone_conjure_objects_with_rid_overrides(
+            (raw_notebook.layout, content), rid_overrides=rid_map
+        )
+
+        destination_client = self.destination_client_for(source)
+        dest_clients = cast(ClientsBunch, destination_client._clients)
+        request = scout_notebook_api.CreateNotebookRequest(
+            title=raw_notebook.metadata.title,
+            description=raw_notebook.metadata.description,
+            is_draft=source.is_draft(),
+            state_as_json="{}",
+            data_scope=scout_notebook_api.NotebookDataScope(
+                asset_rids=None,
+                run_rids=[rid_map[r] for r in source_run_rids],
+            ),
+            layout=new_layout,
+            content_v2=scout_workbookcommon_api.UnifiedWorkbookContent(workbook=new_content),
+            event_refs=[],
+            workspace=dest_clients.resolve_default_workspace_rid(),
+        )
+        raw_new_notebook = dest_clients.notebook.create(dest_clients.auth_header, request)
+        new_workbook = Workbook._from_conjure(dest_clients, raw_new_notebook)
+
+        self.ctx.migration_state.record_mapping(ResourceType.WORKBOOK, source.rid, new_workbook.rid)
+        self.ctx.migration_state.clear_pending_multi_run_workbook(source.rid)
+
+        source_metadata = raw_notebook.metadata
+        new_workbook.update(labels=source_metadata.labels, properties=source_metadata.properties)
+        self._migrate_preview_image(source, new_workbook)
+
+        logger.info("Migrated multi-run workbook %s -> %s", source.rid, new_workbook.rid)
+        return new_workbook
+
+    def migrate_deferred_workbooks(self, source_clients_by_asset_rid: dict[str, ClientsBunch]) -> None:
+        """Migrate all pending multi-asset and multi-run workbooks recorded in the migration state.
+
+        Should be called after all assets (and their runs) have been migrated so that the full
+        RID mapping is available for find/replace.
+        """
+        pending_multi_asset = dict(self.ctx.migration_state.pending_multi_asset_workbooks)
+        pending_multi_run = dict(self.ctx.migration_state.pending_multi_run_workbooks)
+
+        if pending_multi_asset:
+            logger.info("Migrating %d deferred multi-asset workbook(s)", len(pending_multi_asset))
+            for workbook_rid, source_asset_rids in pending_multi_asset.items():
+                source_clients = self._resolve_source_clients(
+                    workbook_rid, source_asset_rids, source_clients_by_asset_rid
+                )
+                if source_clients is None:
+                    continue
+                raw_notebook = source_clients.notebook.get(source_clients.auth_header, workbook_rid)
+                source_workbook = Workbook._from_conjure(source_clients, raw_notebook)
+                self.copy_multi_asset_workbook(source_workbook, source_asset_rids)
+
+        if pending_multi_run:
+            logger.info("Migrating %d deferred multi-run workbook(s)", len(pending_multi_run))
+            for workbook_rid, source_run_rids in pending_multi_run.items():
+                source_clients = next(iter(source_clients_by_asset_rid.values()), None)
+                if source_clients is None:
+                    logger.warning("No source assets available to fetch multi-run workbook %s — skipping", workbook_rid)
+                    continue
+                raw_notebook = source_clients.notebook.get(source_clients.auth_header, workbook_rid)
+                source_workbook = Workbook._from_conjure(source_clients, raw_notebook)
+                self.copy_multi_run_workbook(source_workbook, source_run_rids)
+
+    def _resolve_source_clients(
+        self,
+        workbook_rid: str,
+        source_asset_rids: list[str],
+        source_clients_by_asset_rid: dict[str, ClientsBunch],
+    ) -> ClientsBunch | None:
+        for asset_rid in source_asset_rids:
+            clients = source_clients_by_asset_rid.get(asset_rid)
+            if clients is not None:
+                return clients
+        logger.warning(
+            "Could not resolve source client for multi-asset workbook %s "
+            "(none of its assets are in migration resources) — skipping",
+            workbook_rid,
+        )
+        return None
 
     def _get_resource_name(self, resource: Workbook) -> str:
         return resource.title

--- a/nominal/experimental/migration/migrator/workbook_migrator.py
+++ b/nominal/experimental/migration/migrator/workbook_migrator.py
@@ -198,7 +198,7 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
         )
 
         destination_client = self.destination_client_for(source)
-        dest_clients = cast(ClientsBunch, destination_client._clients)
+        dest_clients = destination_client._clients
         request = scout_notebook_api.CreateNotebookRequest(
             title=raw_notebook.metadata.title,
             description=raw_notebook.metadata.description,
@@ -266,7 +266,7 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
         )
 
         destination_client = self.destination_client_for(source)
-        dest_clients = cast(ClientsBunch, destination_client._clients)
+        dest_clients = destination_client._clients
         request = scout_notebook_api.CreateNotebookRequest(
             title=raw_notebook.metadata.title,
             description=raw_notebook.metadata.description,

--- a/nominal/experimental/migration/utils/conjure_clone_utils.py
+++ b/nominal/experimental/migration/utils/conjure_clone_utils.py
@@ -105,3 +105,45 @@ def clone_conjure_objects_with_new_uuids(
         decoder.do_decode(new_json_obj, obj_type) for new_json_obj, obj_type in zip(new_json_objs, original_types)
     ]
     return tuple(result) if isinstance(objs, tuple) else result
+
+
+@overload
+def clone_conjure_objects_with_rid_overrides(
+    objs: tuple[T1, T2],
+    rid_overrides: dict[str, str],
+) -> tuple[T1, T2]: ...
+
+
+@overload
+def clone_conjure_objects_with_rid_overrides(
+    objs: list[ConjureType],
+    rid_overrides: dict[str, str],
+) -> list[ConjureType]: ...
+
+
+def clone_conjure_objects_with_rid_overrides(
+    objs: tuple[ConjureType, ...] | list[ConjureType],
+    rid_overrides: dict[str, str],
+) -> tuple[ConjureType, ...] | list[ConjureType]:
+    """Clone conjure objects with fresh internal UUIDs, applying explicit RID substitutions.
+
+    Behaves like clone_conjure_objects_with_new_uuids but merges rid_overrides into the UUID
+    mapping before replacement. This replaces specific RIDs (e.g. source asset/run RIDs) with
+    their known destination counterparts, while all other internal UUIDs are regenerated as usual.
+
+    rid_overrides entries take precedence: any auto-generated mapping for an override key is
+    removed before the overrides are merged in, ensuring the explicit value is always used.
+    """
+    original_types = [type(obj) for obj in objs]
+    json_objs = [ConjureEncoder.do_encode(obj) for obj in objs]
+    mapping = _generate_uuid_mapping(json_objs)
+    for rid in rid_overrides:
+        mapping.pop(rid, None)
+    mapping.update(rid_overrides)
+    new_json_objs = [_replace_uuids_in_obj(json_obj, mapping) for json_obj in json_objs]
+
+    decoder = ConjureDecoder()
+    result = [
+        decoder.do_decode(new_json_obj, obj_type) for new_json_obj, obj_type in zip(new_json_objs, original_types)
+    ]
+    return tuple(result) if isinstance(objs, tuple) else result

--- a/tests/core/test_asset_migrator.py
+++ b/tests/core/test_asset_migrator.py
@@ -99,7 +99,7 @@ class TestAssetMigratorAttachments:
         source_asset = _make_source_asset(attachments=[source_att])
 
         dest_asset = _make_dest_asset()
-        ctx.destination_client.create_asset.return_value = dest_asset
+        ctx.destination_client.create_asset.return_value = dest_asset  # type: ignore[attr-defined]
 
         migrator.copy_from(source_asset, AssetCopyOptions(include_attachments=False))
 
@@ -124,7 +124,7 @@ class TestAssetMigratorAttachments:
         source_asset = _make_source_asset(attachments=[source_att_1, source_att_2])
 
         dest_asset = _make_dest_asset()
-        ctx.destination_client.create_asset.return_value = dest_asset
+        ctx.destination_client.create_asset.return_value = dest_asset  # type: ignore[attr-defined]
 
         new_att_1 = MagicMock()
         new_att_1.rid = new_rid_1
@@ -146,7 +146,7 @@ class TestAssetMigratorAttachments:
 
         source_asset = _make_source_asset(attachments=[])
         dest_asset = _make_dest_asset()
-        ctx.destination_client.create_asset.return_value = dest_asset
+        ctx.destination_client.create_asset.return_value = dest_asset  # type: ignore[attr-defined]
 
         migrator.copy_from(source_asset, AssetCopyOptions(include_attachments=True))
 
@@ -163,7 +163,7 @@ class TestAssetMigratorAttachments:
         source_asset = _make_source_asset(attachments=[source_att])
 
         dest_asset = _make_dest_asset()
-        ctx.destination_client.create_asset.return_value = dest_asset
+        ctx.destination_client.create_asset.return_value = dest_asset  # type: ignore[attr-defined]
 
         new_att = MagicMock()
         new_att.rid = _att_rid(101)
@@ -276,7 +276,7 @@ class TestAssetMigratorWorkbookRouting:
         source_asset.list_runs.return_value = [run1, run2]
 
         dest_run1 = MagicMock()
-        ctx.destination_client.get_run.return_value = dest_run1
+        ctx.destination_client.get_run.return_value = dest_run1  # type: ignore[attr-defined]
 
         migrator = AssetMigrator(ctx)
         migrator._copy_asset_and_run_workbooks(source_asset, new_asset, include_runs=True)

--- a/tests/core/test_asset_migrator.py
+++ b/tests/core/test_asset_migrator.py
@@ -13,6 +13,7 @@ if sys.version_info < (3, 13):
 from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.migrator.asset_migrator import AssetCopyOptions, AssetMigrator
 from nominal.experimental.migration.migrator.context import MigrationContext
+from nominal.experimental.migration.resource_type import ResourceType
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -26,13 +27,29 @@ def _att_rid(n: int) -> str:
     return f"ri.attachments.{_STACK}.attachment.{hex8}-0000-0000-0000-000000000000"
 
 
-def _make_context() -> MigrationContext:
+def _asset_rid(n: int) -> str:
+    return f"ri.scout.{_STACK}.asset.{n:08x}-0000-0000-0000-000000000000"
+
+
+def _run_rid(n: int) -> str:
+    return f"ri.scout.{_STACK}.run.{n:08x}-0000-0000-0000-000000000000"
+
+
+def _wb_rid(n: int) -> str:
+    return f"ri.scout.{_STACK}.notebook.{n:08x}-0000-0000-0000-000000000000"
+
+
+def _make_context(source_asset_rids: frozenset[str] = frozenset()) -> MigrationContext:
     mock_client = MagicMock()
     mock_client._clients.workspace_rid = "ws-rid"
     mock_workspace = MagicMock()
     mock_workspace.rid = "ws-rid"
     mock_client.get_workspace.return_value = mock_workspace
-    return MigrationContext(destination_client=mock_client, migration_state=MigrationState())
+    return MigrationContext(
+        destination_client=mock_client,
+        migration_state=MigrationState(),
+        source_asset_rids=source_asset_rids,
+    )
 
 
 def _make_source_asset(
@@ -157,3 +174,117 @@ class TestAssetMigratorAttachments:
         # AttachmentMigrator was constructed with a context that shares the same migration_state
         init_ctx = mock_att_cls.call_args[0][0]
         assert init_ctx.migration_state is ctx.migration_state
+
+
+# ---------------------------------------------------------------------------
+# Workbook routing: _copy_asset_and_run_workbooks
+# ---------------------------------------------------------------------------
+
+
+def _stub_workbook(rid: str, asset_rids: list[str] | None = None, run_rids: list[str] | None = None) -> MagicMock:
+    wb = MagicMock()
+    wb.rid = rid
+    wb.asset_rids = asset_rids
+    wb.run_rids = run_rids
+    return wb
+
+
+class TestAssetMigratorWorkbookRouting:
+    """Tests for _copy_asset_and_run_workbooks: single vs. multi routing and scope checks."""
+
+    @patch("nominal.experimental.migration.migrator.asset_migrator.WorkbookMigrator")
+    def test_routing_single_asset_multi_asset_and_out_of_scope(self, mock_wm_cls: MagicMock) -> None:
+        """Verifies all routing branches in one pass:
+        - single-asset workbook → copy_from called
+        - multi-asset workbook with all assets in source_asset_rids → pending
+        - multi-asset workbook with all assets already in migration state (prior run) → pending
+        - multi-asset workbook with one asset completely out of scope → skip recorded
+        - workbook with no asset_rids → ignored
+        """
+        a1, a2, a3, a_out = _asset_rid(1), _asset_rid(2), _asset_rid(3), _asset_rid(99)
+        new_a3 = _asset_rid(103)
+        wb_single = _wb_rid(1)
+        wb_multi_in_scope = _wb_rid(2)
+        wb_multi_prior_run = _wb_rid(3)
+        wb_multi_missing = _wb_rid(4)
+        wb_no_rids = _wb_rid(5)
+
+        # a1, a2 are in the current migration config; a3 was migrated in a prior run
+        ctx = _make_context(source_asset_rids=frozenset([a1, a2]))
+        ctx.migration_state.record_mapping(ResourceType.ASSET, a3, new_a3)
+
+        source_asset = _make_source_asset()
+        new_asset = _make_dest_asset()
+        source_asset.search_workbooks.return_value = [
+            _stub_workbook(wb_single, asset_rids=[a1]),  # single → copy_from
+            _stub_workbook(wb_multi_in_scope, asset_rids=[a1, a2]),  # all in config → pending
+            _stub_workbook(wb_multi_prior_run, asset_rids=[a1, a3]),  # a3 in state → pending
+            _stub_workbook(wb_multi_missing, asset_rids=[a1, a_out]),  # a_out missing → skip
+            _stub_workbook(wb_no_rids, asset_rids=None),  # no rids → ignored
+        ]
+        source_asset.list_runs.return_value = []
+
+        migrator = AssetMigrator(ctx)
+        migrator._copy_asset_and_run_workbooks(source_asset, new_asset, include_runs=False)
+
+        mock_wm = mock_wm_cls.return_value
+        mock_wm.copy_from.assert_called_once()
+
+        state = ctx.migration_state
+        assert wb_multi_in_scope in state.pending_multi_asset_workbooks
+        assert state.pending_multi_asset_workbooks[wb_multi_in_scope] == [a1, a2]
+
+        assert wb_multi_prior_run in state.pending_multi_asset_workbooks
+        assert state.pending_multi_asset_workbooks[wb_multi_prior_run] == [a1, a3]
+
+        assert wb_multi_missing not in state.pending_multi_asset_workbooks
+        assert len(state.skipped_resources) == 1
+        assert a_out in state.skipped_resources[0].reason
+
+    @patch("nominal.experimental.migration.migrator.asset_migrator.WorkbookMigrator")
+    def test_multi_run_workbook_always_enqueued_single_run_uses_copy_from(self, mock_wm_cls: MagicMock) -> None:
+        """Single-run workbooks go to copy_from; multi-run workbooks are always enqueued
+        for deferred migration without an upfront scope check. Also verifies that finding
+        the same multi-run workbook via two different runs overwrites the pending entry
+        idempotently.
+        """
+        r1, r2 = _run_rid(1), _run_rid(2)
+        new_r1, new_r2 = _run_rid(101), _run_rid(102)
+        wb_single_run = _wb_rid(1)
+        wb_multi_run = _wb_rid(2)
+
+        ctx = _make_context()
+        ctx.migration_state.record_mapping(ResourceType.RUN, r1, new_r1)
+        ctx.migration_state.record_mapping(ResourceType.RUN, r2, new_r2)
+
+        source_asset = _make_source_asset()
+        new_asset = _make_dest_asset()
+        source_asset.search_workbooks.return_value = []
+
+        run1 = MagicMock()
+        run1.rid = r1
+        run1.search_workbooks.return_value = [
+            _stub_workbook(wb_single_run, run_rids=[r1]),
+            _stub_workbook(wb_multi_run, run_rids=[r1, r2]),
+        ]
+        run2 = MagicMock()
+        run2.rid = r2
+        # wb_multi_run found again via run2 — should overwrite pending, not duplicate
+        run2.search_workbooks.return_value = [
+            _stub_workbook(wb_multi_run, run_rids=[r1, r2]),
+        ]
+        source_asset.list_runs.return_value = [run1, run2]
+
+        dest_run1 = MagicMock()
+        ctx.destination_client.get_run.return_value = dest_run1
+
+        migrator = AssetMigrator(ctx)
+        migrator._copy_asset_and_run_workbooks(source_asset, new_asset, include_runs=True)
+
+        mock_wm = mock_wm_cls.return_value
+        assert mock_wm.copy_from.call_count == 1  # only wb_single_run
+
+        state = ctx.migration_state
+        assert wb_multi_run in state.pending_multi_run_workbooks
+        assert state.pending_multi_run_workbooks[wb_multi_run] == [r1, r2]
+        assert len(state.pending_multi_run_workbooks) == 1  # not duplicated

--- a/tests/core/test_conjure_clone_utils.py
+++ b/tests/core/test_conjure_clone_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -129,7 +130,7 @@ class TestUuidMappingAndReplacement:
 class TestCloneWithRidOverrides:
     """End-to-end tests via the public function, with Conjure encode/decode patched to be identity ops."""
 
-    def _make_source_obj(self, d: dict) -> MagicMock:
+    def _make_source_obj(self, d: dict[str, Any]) -> MagicMock:
         obj = MagicMock()
         obj.__class__ = MagicMock  # satisfies type() call in the function
         return obj

--- a/tests/core/test_conjure_clone_utils.py
+++ b/tests/core/test_conjure_clone_utils.py
@@ -1,0 +1,187 @@
+"""Tests for conjure_clone_utils: UUID extraction/replacement and RID override logic."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if sys.version_info < (3, 13):
+    pytest.skip("Migration module requires Python 3.13+ (TypeVar default parameter)", allow_module_level=True)
+
+from nominal.experimental.id_utils.id_utils import UUID_PATTERN
+from nominal.experimental.migration.utils.conjure_clone_utils import (
+    _generate_uuid_mapping,
+    _replace_uuids_in_obj,
+    clone_conjure_objects_with_rid_overrides,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_A = "aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa"
+_B = "bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb"
+_C = "cccccccc-3333-3333-3333-cccccccccccc"
+
+_ASSET_RID = "ri.scout.cerulean-staging.asset.dddddddd-4444-4444-4444-dddddddddddd"
+_NEW_ASSET_RID = "ri.scout.prod.asset.eeeeeeee-5555-5555-5555-eeeeeeeeeeee"
+_RUN_RID = "ri.scout.cerulean-staging.run.ffffffff-6666-6666-6666-ffffffffffff"
+_NEW_RUN_RID = "ri.scout.prod.run.11111111-7777-7777-7777-111111111111"
+
+
+# ---------------------------------------------------------------------------
+# _generate_uuid_mapping and _replace_uuids_in_obj
+# ---------------------------------------------------------------------------
+
+
+class TestUuidMappingAndReplacement:
+    """Tests the dict-level helpers with plain JSON-like dicts."""
+
+    def test_uuid_key_values_extracted_replaced_and_non_uuid_strings_untouched(self) -> None:
+        """UUID_KEY values are extracted into the mapping and substituted; other strings are left alone.
+        Also verifies that prefixed UUIDs (like RIDs) preserve their prefix when regenerated.
+        """
+        prefixed_rid = f"ri.scout.cerulean-staging.notebook.{_A}"
+        obj = {"id": _A, "functionUuid": _B, "label": "my-chart", "rid": prefixed_rid}
+
+        mapping = _generate_uuid_mapping([obj])
+
+        # Both UUID_KEY values were extracted
+        assert _A in mapping
+        assert _B in mapping
+        assert prefixed_rid in mapping
+        # They were given distinct fresh values
+        assert mapping[_A] != _A
+        assert mapping[_B] != _B
+        assert mapping[prefixed_rid] != prefixed_rid
+        # The notebook RID preserves its prefix
+        assert mapping[prefixed_rid].startswith("ri.scout.cerulean-staging.notebook.")
+
+        result = _replace_uuids_in_obj(obj, mapping)
+        assert result["id"] == mapping[_A]
+        assert result["functionUuid"] == mapping[_B]
+        assert result["rid"] == mapping[prefixed_rid]
+        assert result["label"] == "my-chart"  # plain string untouched
+
+    def test_asset_rid_not_auto_extracted_but_replaced_via_override(self) -> None:
+        """Asset/run RIDs under non-UUID_KEY keys are not extracted automatically,
+        but are replaced when explicitly added to the mapping as overrides.
+        Also confirms override takes precedence if the same string somehow appeared in auto-mapping.
+        """
+        obj = {
+            "id": _A,
+            "variable": _ASSET_RID,  # non-UUID_KEY key → not auto-extracted
+            "assetRidVariableName": _RUN_RID,  # non-UUID_KEY key → not auto-extracted
+        }
+
+        mapping = _generate_uuid_mapping([obj])
+        assert _ASSET_RID not in mapping
+        assert _RUN_RID not in mapping
+
+        # Add overrides (simulating what clone_conjure_objects_with_rid_overrides does)
+        mapping.pop(_ASSET_RID, None)
+        mapping.pop(_RUN_RID, None)
+        mapping[_ASSET_RID] = _NEW_ASSET_RID
+        mapping[_RUN_RID] = _NEW_RUN_RID
+
+        result = _replace_uuids_in_obj(obj, mapping)
+        assert result["variable"] == _NEW_ASSET_RID
+        assert result["assetRidVariableName"] == _NEW_RUN_RID
+        assert result["id"] == mapping[_A]  # internal UUID still regenerated
+        assert result["id"] != _A
+
+    def test_cross_object_uuid_coherence(self) -> None:
+        """The same UUID appearing across multiple objects gets the same replacement in both.
+        This covers the layout↔content panel-ID coherence requirement.
+        """
+        obj1 = {"id": _A}
+        obj2 = {"id": _A, "functionUuid": _B}
+
+        mapping = _generate_uuid_mapping([obj1, obj2])
+        # _A is only added to the mapping once — same new value used for both objects
+        result1 = _replace_uuids_in_obj(obj1, mapping)
+        result2 = _replace_uuids_in_obj(obj2, mapping)
+
+        assert result1["id"] == result2["id"]
+        assert result1["id"] != _A
+
+    def test_nested_json_encoded_string_values_are_also_replaced(self) -> None:
+        """Values that are JSON-encoded strings are unpacked and have their contents replaced too."""
+        import json
+
+        inner = {"variable": _ASSET_RID}
+        obj = {"state": json.dumps(inner)}  # JSON-encoded string field
+
+        mapping = {_ASSET_RID: _NEW_ASSET_RID}
+        result = _replace_uuids_in_obj(obj, mapping)
+
+        reparsed = json.loads(result["state"])
+        assert reparsed["variable"] == _NEW_ASSET_RID
+
+
+# ---------------------------------------------------------------------------
+# clone_conjure_objects_with_rid_overrides (integration via patched Conjure serde)
+# ---------------------------------------------------------------------------
+
+
+class TestCloneWithRidOverrides:
+    """End-to-end tests via the public function, with Conjure encode/decode patched to be identity ops."""
+
+    def _make_source_obj(self, d: dict) -> MagicMock:
+        obj = MagicMock()
+        obj.__class__ = MagicMock  # satisfies type() call in the function
+        return obj
+
+    @patch("nominal.experimental.migration.utils.conjure_clone_utils.ConjureDecoder")
+    @patch("nominal.experimental.migration.utils.conjure_clone_utils.ConjureEncoder")
+    def test_overrides_applied_and_internal_uuids_regenerated(
+        self, mock_encoder: MagicMock, mock_decoder: MagicMock
+    ) -> None:
+        """RID overrides are substituted; UUID_KEY values are regenerated; empty overrides also work."""
+        input_dict = {"id": _A, "variable": _ASSET_RID}
+        mock_encoder.do_encode.return_value = input_dict
+        mock_decoder.return_value.do_decode.side_effect = lambda obj, t: obj
+
+        src = MagicMock()
+        clone_conjure_objects_with_rid_overrides([src], rid_overrides={_ASSET_RID: _NEW_ASSET_RID})
+
+        result_dict = mock_decoder.return_value.do_decode.call_args[0][0]
+        assert result_dict["variable"] == _NEW_ASSET_RID  # override applied
+        assert result_dict["id"] != _A  # internal UUID regenerated
+        assert UUID_PATTERN.match(result_dict["id"])  # still a valid UUID
+
+        # Empty overrides: only UUID regeneration, no RID substitution
+        mock_decoder.reset_mock()
+        clone_conjure_objects_with_rid_overrides([src], rid_overrides={})
+        result_dict_no_overrides = mock_decoder.return_value.do_decode.call_args[0][0]
+        assert result_dict_no_overrides["variable"] == _ASSET_RID  # unchanged (not in mapping)
+        assert result_dict_no_overrides["id"] != _A  # still regenerated
+
+    @patch("nominal.experimental.migration.utils.conjure_clone_utils.ConjureDecoder")
+    @patch("nominal.experimental.migration.utils.conjure_clone_utils.ConjureEncoder")
+    def test_tuple_overload_preserves_types_and_shares_uuid_mapping(
+        self, mock_encoder: MagicMock, mock_decoder: MagicMock
+    ) -> None:
+        """When called with a tuple of two objects, cross-object UUID coherence is maintained
+        and the return type mirrors the input (tuple).
+        """
+        layout_dict = {"id": _A}  # panel UUID in layout
+        content_dict = {"id": _A, "variable": _ASSET_RID}  # same panel UUID in content
+
+        mock_encoder.do_encode.side_effect = [layout_dict, content_dict]
+        mock_decoder.return_value.do_decode.side_effect = lambda obj, t: obj
+
+        src1, src2 = MagicMock(), MagicMock()
+        result = clone_conjure_objects_with_rid_overrides((src1, src2), rid_overrides={_ASSET_RID: _NEW_ASSET_RID})
+
+        assert isinstance(result, tuple)
+        calls = mock_decoder.return_value.do_decode.call_args_list
+        result_layout = calls[0][0][0]
+        result_content = calls[1][0][0]
+
+        # Same shared UUID gets the same replacement in both objects
+        assert result_layout["id"] == result_content["id"]
+        assert result_layout["id"] != _A
+        assert result_content["variable"] == _NEW_ASSET_RID

--- a/tests/core/test_multi_workbook_migration.py
+++ b/tests/core/test_multi_workbook_migration.py
@@ -57,7 +57,9 @@ def _stub_source_workbook(
     return wb
 
 
-def _stub_raw_notebook(title: str = "WB", labels: list[str] | None = None, properties: dict[str, str] | None = None) -> MagicMock:
+def _stub_raw_notebook(
+    title: str = "WB", labels: list[str] | None = None, properties: dict[str, str] | None = None
+) -> MagicMock:
     nb = MagicMock()
     nb.content_v2 = None  # forces use of nb.content, avoiding isinstance check on MagicMock
     nb.metadata.title = title

--- a/tests/core/test_multi_workbook_migration.py
+++ b/tests/core/test_multi_workbook_migration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -56,7 +57,7 @@ def _stub_source_workbook(
     return wb
 
 
-def _stub_raw_notebook(title: str = "WB", labels: list | None = None, properties: dict | None = None) -> MagicMock:
+def _stub_raw_notebook(title: str = "WB", labels: list[str] | None = None, properties: dict[str, str] | None = None) -> MagicMock:
     nb = MagicMock()
     nb.content_v2 = None  # forces use of nb.content, avoiding isinstance check on MagicMock
     nb.metadata.title = title
@@ -114,7 +115,7 @@ class TestMigrationStatePendingAndSkips:
 
 
 class TestCopyMultiAssetWorkbook:
-    def _make_migrator(self, **ctx_kwargs: object) -> tuple[WorkbookMigrator, MigrationContext]:
+    def _make_migrator(self, **ctx_kwargs: Any) -> tuple[WorkbookMigrator, MigrationContext]:
         ctx = _make_context(**ctx_kwargs)
         return WorkbookMigrator(ctx), ctx
 
@@ -155,7 +156,7 @@ class TestCopyMultiAssetWorkbook:
         assert kwargs["rid_overrides"] == {old_a1: new_a1, old_a2: new_a2}
 
         # notebook created with new asset RIDs in data_scope
-        create_req = ctx.destination_client._clients.notebook.create.call_args[0][1]
+        create_req = ctx.destination_client._clients.notebook.create.call_args[0][1]  # type: ignore[attr-defined]
         assert set(create_req.data_scope.asset_rids) == {new_a1, new_a2}
         assert create_req.data_scope.run_rids is None
 
@@ -186,7 +187,7 @@ class TestCopyMultiAssetWorkbook:
         assert result is None
         assert len(ctx.migration_state.skipped_resources) == 1
         assert old_a2 in ctx.migration_state.skipped_resources[0].reason
-        ctx.destination_client._clients.notebook.create.assert_not_called()
+        ctx.destination_client._clients.notebook.create.assert_not_called()  # type: ignore[attr-defined]
 
     @patch("nominal.experimental.migration.migrator.workbook_migrator.clone_conjure_objects_with_rid_overrides")
     @patch("nominal.experimental.migration.migrator.workbook_migrator.Workbook._from_conjure")
@@ -203,14 +204,14 @@ class TestCopyMultiAssetWorkbook:
 
         existing_wb = MagicMock()
         existing_wb.rid = wb_dst
-        ctx.destination_client.get_workbook.return_value = existing_wb
+        ctx.destination_client.get_workbook.return_value = existing_wb  # type: ignore[attr-defined]
 
         source = _stub_source_workbook(wb_src, asset_rids=[_asset_rid(1)])
         result = migrator.copy_multi_asset_workbook(source, [_asset_rid(1)])
 
         assert result is existing_wb
         mock_clone.assert_not_called()
-        ctx.destination_client._clients.notebook.create.assert_not_called()
+        ctx.destination_client._clients.notebook.create.assert_not_called()  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------
@@ -253,7 +254,7 @@ class TestCopyMultiRunWorkbook:
         _, kwargs = mock_clone.call_args
         assert kwargs["rid_overrides"] == {old_r1: new_r1, old_r2: new_r2, old_a1: new_a1}
 
-        create_req = ctx.destination_client._clients.notebook.create.call_args[0][1]
+        create_req = ctx.destination_client._clients.notebook.create.call_args[0][1]  # type: ignore[attr-defined]
         assert set(create_req.data_scope.run_rids) == {new_r1, new_r2}
         assert create_req.data_scope.asset_rids is None
 
@@ -276,7 +277,7 @@ class TestCopyMultiRunWorkbook:
         assert result is None
         assert len(ctx.migration_state.skipped_resources) == 1
         assert old_r2 in ctx.migration_state.skipped_resources[0].reason
-        ctx.destination_client._clients.notebook.create.assert_not_called()
+        ctx.destination_client._clients.notebook.create.assert_not_called()  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------
@@ -289,7 +290,7 @@ class TestMigrateDeferredWorkbooks:
         """When no workbooks are pending, no source clients are fetched and no copy methods are called."""
         ctx = _make_context()
         migrator = WorkbookMigrator(ctx)
-        source_clients: dict = {}
+        source_clients: dict[str, Any] = {}
 
         migrator.migrate_deferred_workbooks(source_clients)
         # Nothing to assert beyond no exceptions raised

--- a/tests/core/test_multi_workbook_migration.py
+++ b/tests/core/test_multi_workbook_migration.py
@@ -243,10 +243,15 @@ class TestCopyMultiRunWorkbook:
         new_wb.rid = wb_dst
         mock_from_conjure.return_value = new_wb
 
+        # Also record a migrated asset to verify it's included in rid_overrides
+        old_a1 = _asset_rid(1)
+        new_a1 = _asset_rid(101)
+        ctx.migration_state.record_mapping(ResourceType.ASSET, old_a1, new_a1)
+
         result = migrator.copy_multi_run_workbook(source, [old_r1, old_r2])
 
         _, kwargs = mock_clone.call_args
-        assert kwargs["rid_overrides"] == {old_r1: new_r1, old_r2: new_r2}
+        assert kwargs["rid_overrides"] == {old_r1: new_r1, old_r2: new_r2, old_a1: new_a1}
 
         create_req = ctx.destination_client._clients.notebook.create.call_args[0][1]
         assert set(create_req.data_scope.run_rids) == {new_r1, new_r2}

--- a/tests/core/test_multi_workbook_migration.py
+++ b/tests/core/test_multi_workbook_migration.py
@@ -1,0 +1,349 @@
+"""Tests for multi-asset/run workbook migration: copy methods, deferred routing, and migration state."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if sys.version_info < (3, 13):
+    pytest.skip("Migration module requires Python 3.13+ (TypeVar default parameter)", allow_module_level=True)
+
+from nominal.experimental.migration.migration_state import MigrationState
+from nominal.experimental.migration.migrator.context import MigrationContext
+from nominal.experimental.migration.migrator.workbook_migrator import WorkbookMigrator
+from nominal.experimental.migration.resource_type import ResourceType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_STACK = "cerulean-staging"
+
+
+def _asset_rid(n: int) -> str:
+    return f"ri.scout.{_STACK}.asset.{n:08x}-0000-0000-0000-000000000000"
+
+
+def _run_rid(n: int) -> str:
+    return f"ri.scout.{_STACK}.run.{n:08x}-0000-0000-0000-000000000000"
+
+
+def _wb_rid(n: int) -> str:
+    return f"ri.scout.{_STACK}.notebook.{n:08x}-0000-0000-0000-000000000000"
+
+
+def _make_context(source_asset_rids: frozenset[str] = frozenset()) -> MigrationContext:
+    mock_client = MagicMock()
+    return MigrationContext(
+        destination_client=mock_client,
+        migration_state=MigrationState(),
+        source_asset_rids=source_asset_rids,
+    )
+
+
+def _stub_source_workbook(
+    rid: str, asset_rids: list[str] | None = None, run_rids: list[str] | None = None
+) -> MagicMock:
+    wb = MagicMock()
+    wb.rid = rid
+    wb.title = "Test Workbook"
+    wb.asset_rids = asset_rids
+    wb.run_rids = run_rids
+    wb.is_draft.return_value = False
+    wb._clients.auth_header = "Bearer src"
+    return wb
+
+
+def _stub_raw_notebook(title: str = "WB", labels: list | None = None, properties: dict | None = None) -> MagicMock:
+    nb = MagicMock()
+    nb.content_v2 = None  # forces use of nb.content, avoiding isinstance check on MagicMock
+    nb.metadata.title = title
+    nb.metadata.description = ""
+    nb.metadata.labels = labels or ["tag"]
+    nb.metadata.properties = properties or {"env": "staging"}
+    nb.metadata.preview_image = None
+    return nb
+
+
+# ---------------------------------------------------------------------------
+# MigrationState: pending workbooks and skip log
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationStatePendingAndSkips:
+    def test_pending_workbooks_are_idempotent_and_clearable(self) -> None:
+        """record_pending overwrites on repeat calls; clear removes the entry without error;
+        clearing a missing key is a no-op.
+        """
+        state = MigrationState()
+        wb = _wb_rid(1)
+        assets = [_asset_rid(1), _asset_rid(2)]
+
+        state.record_pending_multi_asset_workbook(wb, assets)
+        assert state.pending_multi_asset_workbooks[wb] == assets
+
+        # Second call with different list overwrites (idempotent re-run behaviour)
+        updated = [_asset_rid(1)]
+        state.record_pending_multi_asset_workbook(wb, updated)
+        assert state.pending_multi_asset_workbooks[wb] == updated
+
+        state.clear_pending_multi_asset_workbook(wb)
+        assert wb not in state.pending_multi_asset_workbooks
+
+        # Clearing again is a no-op
+        state.clear_pending_multi_asset_workbook(wb)
+
+    def test_record_skip_accumulates_entries(self) -> None:
+        """record_skip appends without overwriting; multiple skips for different resources are all kept."""
+        state = MigrationState()
+
+        state.record_skip(ResourceType.WORKBOOK, _wb_rid(1), "asset out of scope")
+        state.record_skip(ResourceType.WORKBOOK, _wb_rid(2), "run not in state")
+
+        assert len(state.skipped_resources) == 2
+        reasons = {s.source_rid: s.reason for s in state.skipped_resources}
+        assert reasons[_wb_rid(1)] == "asset out of scope"
+        assert reasons[_wb_rid(2)] == "run not in state"
+
+
+# ---------------------------------------------------------------------------
+# WorkbookMigrator.copy_multi_asset_workbook
+# ---------------------------------------------------------------------------
+
+
+class TestCopyMultiAssetWorkbook:
+    def _make_migrator(self, **ctx_kwargs: object) -> tuple[WorkbookMigrator, MigrationContext]:
+        ctx = _make_context(**ctx_kwargs)
+        return WorkbookMigrator(ctx), ctx
+
+    @patch("nominal.experimental.migration.migrator.workbook_migrator.clone_conjure_objects_with_rid_overrides")
+    @patch("nominal.experimental.migration.migrator.workbook_migrator.Workbook._from_conjure")
+    def test_happy_path_remaps_rids_records_state_and_copies_metadata(
+        self, mock_from_conjure: MagicMock, mock_clone: MagicMock
+    ) -> None:
+        """All assets present: RID map is built correctly, clone called with overrides,
+        notebook created with remapped data_scope, mapping recorded, pending cleared,
+        labels/properties copied from source.
+        """
+        old_a1, old_a2 = _asset_rid(1), _asset_rid(2)
+        new_a1, new_a2 = _asset_rid(101), _asset_rid(102)
+        wb_src = _wb_rid(1)
+        wb_dst = _wb_rid(100)
+
+        migrator, ctx = self._make_migrator()
+        ctx.migration_state.record_mapping(ResourceType.ASSET, old_a1, new_a1)
+        ctx.migration_state.record_mapping(ResourceType.ASSET, old_a2, new_a2)
+        ctx.migration_state.record_pending_multi_asset_workbook(wb_src, [old_a1, old_a2])
+
+        source = _stub_source_workbook(wb_src, asset_rids=[old_a1, old_a2])
+        raw_nb = _stub_raw_notebook(labels=["lbl"], properties={"k": "v"})
+        source._clients.notebook.get.return_value = raw_nb
+
+        new_layout, new_content = MagicMock(), MagicMock()
+        mock_clone.return_value = (new_layout, new_content)
+        new_wb = MagicMock()
+        new_wb.rid = wb_dst
+        mock_from_conjure.return_value = new_wb
+
+        result = migrator.copy_multi_asset_workbook(source, [old_a1, old_a2])
+
+        # clone called with the correct RID overrides
+        mock_clone.assert_called_once()
+        _, kwargs = mock_clone.call_args
+        assert kwargs["rid_overrides"] == {old_a1: new_a1, old_a2: new_a2}
+
+        # notebook created with new asset RIDs in data_scope
+        create_req = ctx.destination_client._clients.notebook.create.call_args[0][1]
+        assert set(create_req.data_scope.asset_rids) == {new_a1, new_a2}
+        assert create_req.data_scope.run_rids is None
+
+        # state: mapping recorded, pending cleared
+        assert ctx.migration_state.get_mapped_rid(ResourceType.WORKBOOK, wb_src) == wb_dst
+        assert wb_src not in ctx.migration_state.pending_multi_asset_workbooks
+
+        # metadata copied
+        new_wb.update.assert_called_once_with(labels=["lbl"], properties={"k": "v"})
+        assert result is new_wb
+
+    def test_missing_assets_returns_none_and_records_skip(self) -> None:
+        """When one or more asset RIDs are absent from the migration state, returns None
+        and records a skip entry; no notebook is created.
+        """
+        old_a1, old_a2 = _asset_rid(1), _asset_rid(2)
+        new_a1 = _asset_rid(101)
+        # old_a2 intentionally not mapped
+
+        migrator, ctx = self._make_migrator()
+        ctx.migration_state.record_mapping(ResourceType.ASSET, old_a1, new_a1)
+
+        source = _stub_source_workbook(_wb_rid(1), asset_rids=[old_a1, old_a2])
+        source._clients.notebook.get.return_value = _stub_raw_notebook()
+
+        result = migrator.copy_multi_asset_workbook(source, [old_a1, old_a2])
+
+        assert result is None
+        assert len(ctx.migration_state.skipped_resources) == 1
+        assert old_a2 in ctx.migration_state.skipped_resources[0].reason
+        ctx.destination_client._clients.notebook.create.assert_not_called()
+
+    @patch("nominal.experimental.migration.migrator.workbook_migrator.clone_conjure_objects_with_rid_overrides")
+    @patch("nominal.experimental.migration.migrator.workbook_migrator.Workbook._from_conjure")
+    def test_idempotent_returns_existing_workbook_without_creating(
+        self, mock_from_conjure: MagicMock, mock_clone: MagicMock
+    ) -> None:
+        """If the workbook is already in the migration state, the existing destination workbook
+        is returned and no new notebook is created.
+        """
+        wb_src, wb_dst = _wb_rid(1), _wb_rid(100)
+
+        migrator, ctx = self._make_migrator()
+        ctx.migration_state.record_mapping(ResourceType.WORKBOOK, wb_src, wb_dst)
+
+        existing_wb = MagicMock()
+        existing_wb.rid = wb_dst
+        ctx.destination_client.get_workbook.return_value = existing_wb
+
+        source = _stub_source_workbook(wb_src, asset_rids=[_asset_rid(1)])
+        result = migrator.copy_multi_asset_workbook(source, [_asset_rid(1)])
+
+        assert result is existing_wb
+        mock_clone.assert_not_called()
+        ctx.destination_client._clients.notebook.create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# WorkbookMigrator.copy_multi_run_workbook
+# ---------------------------------------------------------------------------
+
+
+class TestCopyMultiRunWorkbook:
+    def _make_migrator(self) -> tuple[WorkbookMigrator, MigrationContext]:
+        ctx = _make_context()
+        return WorkbookMigrator(ctx), ctx
+
+    @patch("nominal.experimental.migration.migrator.workbook_migrator.clone_conjure_objects_with_rid_overrides")
+    @patch("nominal.experimental.migration.migrator.workbook_migrator.Workbook._from_conjure")
+    def test_happy_path_remaps_run_rids(self, mock_from_conjure: MagicMock, mock_clone: MagicMock) -> None:
+        """All runs present: RID map built, data_scope has new run RIDs, mapping recorded, pending cleared."""
+        old_r1, old_r2 = _run_rid(1), _run_rid(2)
+        new_r1, new_r2 = _run_rid(101), _run_rid(102)
+        wb_src, wb_dst = _wb_rid(1), _wb_rid(100)
+
+        migrator, ctx = self._make_migrator()
+        ctx.migration_state.record_mapping(ResourceType.RUN, old_r1, new_r1)
+        ctx.migration_state.record_mapping(ResourceType.RUN, old_r2, new_r2)
+        ctx.migration_state.record_pending_multi_run_workbook(wb_src, [old_r1, old_r2])
+
+        source = _stub_source_workbook(wb_src, run_rids=[old_r1, old_r2])
+        source._clients.notebook.get.return_value = _stub_raw_notebook()
+        mock_clone.return_value = (MagicMock(), MagicMock())
+        new_wb = MagicMock()
+        new_wb.rid = wb_dst
+        mock_from_conjure.return_value = new_wb
+
+        result = migrator.copy_multi_run_workbook(source, [old_r1, old_r2])
+
+        _, kwargs = mock_clone.call_args
+        assert kwargs["rid_overrides"] == {old_r1: new_r1, old_r2: new_r2}
+
+        create_req = ctx.destination_client._clients.notebook.create.call_args[0][1]
+        assert set(create_req.data_scope.run_rids) == {new_r1, new_r2}
+        assert create_req.data_scope.asset_rids is None
+
+        assert ctx.migration_state.get_mapped_rid(ResourceType.WORKBOOK, wb_src) == wb_dst
+        assert wb_src not in ctx.migration_state.pending_multi_run_workbooks
+        assert result is new_wb
+
+    def test_missing_run_returns_none_and_records_skip(self) -> None:
+        """A run RID absent from the migration state causes the workbook to be skipped."""
+        old_r1, old_r2 = _run_rid(1), _run_rid(2)
+        migrator, ctx = self._make_migrator()
+        ctx.migration_state.record_mapping(ResourceType.RUN, old_r1, _run_rid(101))
+        # old_r2 not mapped
+
+        source = _stub_source_workbook(_wb_rid(1), run_rids=[old_r1, old_r2])
+        source._clients.notebook.get.return_value = _stub_raw_notebook()
+
+        result = migrator.copy_multi_run_workbook(source, [old_r1, old_r2])
+
+        assert result is None
+        assert len(ctx.migration_state.skipped_resources) == 1
+        assert old_r2 in ctx.migration_state.skipped_resources[0].reason
+        ctx.destination_client._clients.notebook.create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# WorkbookMigrator.migrate_deferred_workbooks
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateDeferredWorkbooks:
+    def test_empty_pending_is_noop(self) -> None:
+        """When no workbooks are pending, no source clients are fetched and no copy methods are called."""
+        ctx = _make_context()
+        migrator = WorkbookMigrator(ctx)
+        source_clients: dict = {}
+
+        migrator.migrate_deferred_workbooks(source_clients)
+        # Nothing to assert beyond no exceptions raised
+
+    @patch.object(WorkbookMigrator, "copy_multi_run_workbook")
+    @patch.object(WorkbookMigrator, "copy_multi_asset_workbook")
+    @patch("nominal.experimental.migration.migrator.workbook_migrator.Workbook._from_conjure")
+    def test_routes_pending_asset_and_run_workbooks(
+        self,
+        mock_from_conjure: MagicMock,
+        mock_copy_asset: MagicMock,
+        mock_copy_run: MagicMock,
+    ) -> None:
+        """Pending asset and run workbooks are fetched from source clients and routed to the
+        correct copy method. The correct source_asset_rids / source_run_rids are forwarded.
+        Multi-run workbook falls back to first available client when no asset RID matches.
+        """
+        asset_rid_1 = _asset_rid(1)
+        wb_asset = _wb_rid(1)
+        wb_run = _wb_rid(2)
+        run_rids = [_run_rid(1), _run_rid(2)]
+
+        ctx = _make_context()
+        ctx.migration_state.record_pending_multi_asset_workbook(wb_asset, [asset_rid_1])
+        ctx.migration_state.record_pending_multi_run_workbook(wb_run, run_rids)
+
+        source_clients = MagicMock()
+        source_clients.auth_header = "Bearer src"
+        raw_nb_asset = _stub_raw_notebook()
+        raw_nb_run = _stub_raw_notebook()
+        source_clients.notebook.get.side_effect = [raw_nb_asset, raw_nb_run]
+
+        source_wb_asset = MagicMock()
+        source_wb_run = MagicMock()
+        mock_from_conjure.side_effect = [source_wb_asset, source_wb_run]
+
+        migrator = WorkbookMigrator(ctx)
+        migrator.migrate_deferred_workbooks({asset_rid_1: source_clients})
+
+        # Both workbooks were fetched
+        assert source_clients.notebook.get.call_count == 2
+        source_clients.notebook.get.assert_any_call(source_clients.auth_header, wb_asset)
+        source_clients.notebook.get.assert_any_call(source_clients.auth_header, wb_run)
+
+        # Each routed to the correct copy method with the right RID lists
+        mock_copy_asset.assert_called_once_with(source_wb_asset, [asset_rid_1])
+        mock_copy_run.assert_called_once_with(source_wb_run, run_rids)
+
+    @patch("nominal.experimental.migration.migrator.workbook_migrator.Workbook._from_conjure")
+    def test_missing_source_client_for_asset_workbook_skips_gracefully(self, mock_from_conjure: MagicMock) -> None:
+        """If none of a multi-asset workbook's asset RIDs are in source_clients_by_asset_rid,
+        the workbook is skipped with a warning and no exception is raised.
+        """
+        wb_asset = _wb_rid(1)
+        ctx = _make_context()
+        ctx.migration_state.record_pending_multi_asset_workbook(wb_asset, [_asset_rid(99)])
+
+        migrator = WorkbookMigrator(ctx)
+        # Empty client map — asset_rid(99) not present
+        migrator.migrate_deferred_workbooks({})
+
+        mock_from_conjure.assert_not_called()

--- a/tests/core/test_multi_workbook_migration.py
+++ b/tests/core/test_multi_workbook_migration.py
@@ -171,17 +171,19 @@ class TestCopyMultiAssetWorkbook:
         assert result is new_wb
 
     def test_missing_assets_returns_none_and_records_skip(self) -> None:
-        """When one or more asset RIDs are absent from the migration state, returns None
-        and records a skip entry; no notebook is created.
+        """When one or more asset RIDs are absent from the migration state, returns None,
+        records a skip entry, clears the pending entry, and creates no notebook.
         """
         old_a1, old_a2 = _asset_rid(1), _asset_rid(2)
         new_a1 = _asset_rid(101)
+        wb_src = _wb_rid(1)
         # old_a2 intentionally not mapped
 
         migrator, ctx = self._make_migrator()
         ctx.migration_state.record_mapping(ResourceType.ASSET, old_a1, new_a1)
+        ctx.migration_state.record_pending_multi_asset_workbook(wb_src, [old_a1, old_a2])
 
-        source = _stub_source_workbook(_wb_rid(1), asset_rids=[old_a1, old_a2])
+        source = _stub_source_workbook(wb_src, asset_rids=[old_a1, old_a2])
         source._clients.notebook.get.return_value = _stub_raw_notebook()
 
         result = migrator.copy_multi_asset_workbook(source, [old_a1, old_a2])
@@ -189,6 +191,7 @@ class TestCopyMultiAssetWorkbook:
         assert result is None
         assert len(ctx.migration_state.skipped_resources) == 1
         assert old_a2 in ctx.migration_state.skipped_resources[0].reason
+        assert wb_src not in ctx.migration_state.pending_multi_asset_workbooks
         ctx.destination_client._clients.notebook.create.assert_not_called()  # type: ignore[attr-defined]
 
     @patch("nominal.experimental.migration.migrator.workbook_migrator.clone_conjure_objects_with_rid_overrides")
@@ -265,13 +268,17 @@ class TestCopyMultiRunWorkbook:
         assert result is new_wb
 
     def test_missing_run_returns_none_and_records_skip(self) -> None:
-        """A run RID absent from the migration state causes the workbook to be skipped."""
+        """A run RID absent from the migration state causes the workbook to be skipped,
+        clears the pending entry, and creates no notebook.
+        """
         old_r1, old_r2 = _run_rid(1), _run_rid(2)
+        wb_src = _wb_rid(1)
         migrator, ctx = self._make_migrator()
         ctx.migration_state.record_mapping(ResourceType.RUN, old_r1, _run_rid(101))
+        ctx.migration_state.record_pending_multi_run_workbook(wb_src, [old_r1, old_r2])
         # old_r2 not mapped
 
-        source = _stub_source_workbook(_wb_rid(1), run_rids=[old_r1, old_r2])
+        source = _stub_source_workbook(wb_src, run_rids=[old_r1, old_r2])
         source._clients.notebook.get.return_value = _stub_raw_notebook()
 
         result = migrator.copy_multi_run_workbook(source, [old_r1, old_r2])
@@ -279,6 +286,7 @@ class TestCopyMultiRunWorkbook:
         assert result is None
         assert len(ctx.migration_state.skipped_resources) == 1
         assert old_r2 in ctx.migration_state.skipped_resources[0].reason
+        assert wb_src not in ctx.migration_state.pending_multi_run_workbooks
         ctx.destination_client._clients.notebook.create.assert_not_called()  # type: ignore[attr-defined]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.131.0"
+version = "1.132.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.132.0"
+version = "1.132.1"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
### Problem                                                                                                                                                                                                                                    
   
  The existing workbook migration path works by creating a template from the source workbook, copying the template to the destination, and instantiating a new workbook from it. This round-trip through the template API works well for         
  single-asset and single-run workbooks, but cannot handle workbooks whose `dataScope` references more than one asset or run. Those workbooks were silently skipped — they would never appear on the destination tenant.
                                                                                                                                                                                                                                                 
  ### Strategy                                                                                                                                                                                                                                   
  
  #### Phase 1 — Enqueue during per-asset migration                                                                                                                                                                                              
                                                            
  When `AssetMigrator` processes a workbook associated with an asset, it now branches on the workbook's scope:

  - **Single-asset / single-run workbooks** continue to use the existing template-based copy path.                                                                                                                                               
  - **Multi-asset workbooks** are enqueued as *pending* in `MigrationState`. Before enqueuing, a scope check determines whether all referenced assets are either (a) present in the current migration config or (b) already mapped in the
  migration state from a previous run. If any asset is entirely outside both, the workbook is recorded as a skip with a structured reason rather than silently dropped.                                                                          
  - **Multi-run workbooks** are always enqueued as pending (no upfront scope check; validation deferred to migration time when the full RID mapping is available).
                                                                                                                                                                                                                                                 
  #### Phase 2 — Deferred resolution                        
                                                                                                                                                                                                                                                 
  After all assets and runs have been migrated, `WorkbookMigrator.migrate_deferred_workbooks()` iterates the pending lists and attempts each workbook:

  1. Looks up every source asset/run RID in the migration state to build a find-and-replace map.                                                                                                                                                 
  2. If any required RID is missing (e.g. one asset was out of scope), records a structured skip and moves on — no partial workbooks are created.
  3. Serialises the source workbook's layout and content objects via `ConjureEncoder`, applies the RID map using `clone_conjure_objects_with_rid_overrides`, and deserialises back. This function extends the existing UUID-regeneration logic:  
  internal panel/chart UUIDs are regenerated (with cross-object coherence preserved so layout↔content panel IDs stay in sync), while explicit asset/run RID overrides are substituted in-place without being regenerated.                        
  4. Creates the new workbook on the destination via `CreateNotebookRequest` with the updated `dataScope` and remapped content, then copies labels, properties, and preview image.
                                                                                                                                                                                                                                                 
  **Key insight for multi-run workbooks:** channel compute specs reference *both* run RIDs (`runRidVariableName`) and asset RIDs (`assetRidVariableName` / `computeSpecV2.run.assetRid`). The RID override map therefore merges both the run     
  mapping *and* all migrated asset mappings from the migration state; substituting only run RIDs leaves dangling source-tenant asset references and causes channels to show no data.                                                             
                                                                                                                                                                                                                                                 
  #### Structured skip / error log                          

  `MigrationState` gains a `skipped_resources` list of `SkippedResource(resource_type, source_rid, reason)` entries. This replaces the previous silent-drop behaviour and gives operators a clear post-run audit of what was not migrated and    
  why.
                                                                                                                                                                                                                                                 
  ### Long-term strategy                                    

  The RID find-and-replace approach is strictly more general than the template-based path. Once the multi-asset/run path has accumulated enough production confidence, the intent is to route single-asset and single-run workbooks through it as
   well, retiring the template round-trip entirely. The template path is retained unchanged in this PR.
                                                                                                                                                                                                                                                 
  ### Testing                                               

  #### Automated unit tests

  - **`test_conjure_clone_utils.py`** — tests `_generate_uuid_mapping` and `_replace_uuids_in_obj` directly:                                                                                                                                     
    - UUID-keyed values are extracted into the mapping and regenerated; plain strings are untouched; RID-prefixed UUIDs preserve their prefix.
    - Asset/run RIDs under non-UUID keys are not auto-extracted but are correctly substituted when added as explicit overrides.                                                                                                                  
    - The same UUID appearing across multiple objects receives the same replacement in both (layout↔content coherence).                                                                                                                          
    - JSON-encoded string field values are unpacked and have their contents replaced.
    - Integration tests via `clone_conjure_objects_with_rid_overrides` with patched Conjure serde: overrides applied, internal UUIDs regenerated, tuple overload preserves types and cross-object coherence.                                     
                                                                                                                                                                                                                                                 
  - **`test_multi_workbook_migration.py`** — tests `MigrationState`, `WorkbookMigrator.copy_multi_asset_workbook`, `copy_multi_run_workbook`, and `migrate_deferred_workbooks`:                                                                  
    - Pending workbook entries are idempotent on re-registration and clearable.                                                                                                                                                                  
    - Skip entries accumulate without overwriting.                                                                                                                                                                                               
    - Happy path: correct RID map passed to clone, `dataScope` populated with new RIDs, mapping recorded, pending cleared, labels/properties copied.
    - Missing asset or run: returns `None`, records a skip with the missing RID in the reason, no notebook created.                                                                                                                              
    - Idempotency: already-mapped workbook returns the existing destination workbook without creating a new one.                                                                                                                                 
    - Multi-run asset RID inclusion: migrated asset RIDs are merged into the override map alongside run RIDs.
    - Deferred routing: pending asset and run workbooks are each fetched from the correct source client and dispatched to the right copy method.                                                                                                 
    - Missing source client: workbook is skipped gracefully without raising.
                                                                                                                                                                                                                                                 
  - **`test_asset_migrator.py`** (extended) — tests `_copy_asset_and_run_workbooks` routing:                                                                                                                                                     
    - Single-asset workbook → `copy_from` (template path).
    - Multi-asset workbook with all assets in current config → pending.                                                                                                                                                                          
    - Multi-asset workbook with one asset already migrated in a prior run → pending (state check, not just config check).
    - Multi-asset workbook with an asset outside both config and state → skip recorded.                                                                                                                                                          
    - Single-run workbook → `copy_from`.
    - Multi-run workbook → always enqueued; same workbook encountered via two different runs is deduplicated idempotently.                                                                                                                       
                                                                                                                                                                                                                                                 
  #### Manual validation
                                                                                                                                                                                                                                                 
  - Migrated two assets that share a multi-asset workbook from a source tenant to a destination tenant. Verified the migrated workbook loaded with data wired up correctly for both assets.                                                      
  - Migrated the same two assets where one of them also had an associated multi-run workbook. Confirmed that after the initial fix (run RIDs only), channels referencing assets showed no data — then verified the fix (merging asset RIDs into
  the override map) resolved the issue and data appeared correctly.                                                                                                                                                                              
  - Verified the partial-migration case: migrating only one of the two assets causes the shared workbook to be skipped, with a skip entry recorded in the migration state naming the missing asset.