### PR TITLE
feat(asset): disambiguate get_or_create_asset_by_properties by exact name

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -122,6 +122,11 @@ class WorkspaceSearchType(enum.Enum):
 WorkspaceSearchT = WorkspaceSearchType | Workspace | str
 
 
+def filter_assets_by_exact_name(assets: Iterable[Asset], exact_match: str) -> list[Asset]:
+    """Return only the assets whose name is exactly ``exact_match``."""
+    return [a for a in assets if a.name == exact_match]
+
+
 @dataclass(frozen=True)
 class NominalClient:
     _clients: ClientsBunch = field(repr=False)
@@ -1252,7 +1257,7 @@ class NominalClient:
         )
         results = list(self._iter_search_assets(query, archive_status))
         if exact_match is not None:
-            results = [a for a in results if a.name == exact_match]
+            results = filter_assets_by_exact_name(results, exact_match)
         return results
 
     def list_streaming_checklists(self, asset: Asset | str | None = None) -> Sequence[str]:

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -1186,8 +1186,9 @@ class NominalClient:
             return assets[0]
 
         if len(assets) > 1:
-            # Multiple assets match the given properties; disambiguate by exact name.
-            by_name = self.search_assets(properties=properties, exact_match=name, workspace=WorkspaceSearchType.DEFAULT)
+            # Multiple assets match the given properties; disambiguate by exact
+            # name using the already-fetched results (no extra server call).
+            by_name = [a for a in assets if a.name == name]
             if len(by_name) == 1:
                 return by_name[0]
             asset_names_str = "\n".join(a.name for a in assets[:MAX_ASSETS_SHOWN]) + (

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -1164,12 +1164,14 @@ class NominalClient:
     def get_or_create_asset_by_properties(
         self, properties: Mapping[str, str], *, name: str, description: str | None = None, labels: Sequence[str] = ()
     ) -> Asset:
-        """Searches for an asset using using properties. If no assets returned, create one.
-           If multiple assets returned, throw error.
+        """Searches for an asset using properties. If no assets returned, create one.
+        If multiple assets share those properties, disambiguate by exact name match;
+        raise only when the name still does not uniquely identify one asset.
 
         Args:
             properties: key-value properties to use when searching for and creating assets.
-            name: Name of asset to be used if creation is necessary.
+            name: Name of asset. Used to disambiguate when multiple assets share the given
+                properties, and used when creation is necessary.
             description: Description of asset to be used if creation is necessary.
             labels: a sequence of labels to use when if creation is necessary.
 
@@ -1180,14 +1182,22 @@ class NominalClient:
 
         logger.info("Found %d assets searching by properties.", len(assets))
 
+        if len(assets) == 1:
+            return assets[0]
+
         if len(assets) > 1:
+            # Multiple assets match the given properties; disambiguate by exact name.
+            by_name = self.search_assets(properties=properties, exact_match=name, workspace=WorkspaceSearchType.DEFAULT)
+            if len(by_name) == 1:
+                return by_name[0]
             asset_names_str = "\n".join(a.name for a in assets[:MAX_ASSETS_SHOWN]) + (
                 "\n..." if len(assets) > MAX_ASSETS_SHOWN else ""
             )
-            raise ValueError(f"Multiple assets returned per search parameters:\n{asset_names_str}")
-
-        if len(assets) == 1:
-            return assets[0]
+            raise ValueError(
+                f"Multiple assets match properties {dict(properties)!r} and "
+                f"{len(by_name)} match name {name!r}; cannot uniquely identify one asset:\n"
+                f"{asset_names_str}"
+            )
 
         return self.create_asset(name=name, description=description, properties=properties, labels=labels)
 
@@ -1203,6 +1213,7 @@ class NominalClient:
         self,
         search_text: str | None = None,
         *,
+        exact_match: str | None = None,
         labels: Sequence[str] | None = None,
         properties: Mapping[str, str] | None = None,
         exact_substring: str | None = None,
@@ -1214,6 +1225,8 @@ class NominalClient:
 
         Args:
             search_text: case-insensitive search for any of the keywords in all string fields
+            exact_match: Filter results to only assets whose name exactly matches this string.
+                Applied client-side after the server-side filters.
             labels: A sequence of labels that must ALL be present on a asset to be included.
             properties: A mapping of key-value pairs that must ALL be present on a asset to be included.
             exact_substring: case-insensitive search for exact string match in all string fields
@@ -1236,7 +1249,10 @@ class NominalClient:
             exact_substring=exact_substring,
             workspace_rid=self._workspace_rid_for_search(workspace or WorkspaceSearchType.ALL),
         )
-        return list(self._iter_search_assets(query, archive_status))
+        results = list(self._iter_search_assets(query, archive_status))
+        if exact_match is not None:
+            results = [a for a in results if a.name == exact_match]
+        return results
 
     def list_streaming_checklists(self, asset: Asset | str | None = None) -> Sequence[str]:
         """List all Streaming Checklists.

--- a/tests/core/test_get_or_create_asset.py
+++ b/tests/core/test_get_or_create_asset.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nominal.core.client import NominalClient, WorkspaceSearchType
+
+
+def _make_client() -> NominalClient:
+    clients = MagicMock()
+    clients.auth_header = "Bearer token"
+    return NominalClient(_clients=clients)
+
+
+def _asset(name: str) -> MagicMock:
+    asset = MagicMock()
+    asset.name = name
+    return asset
+
+
+def test_returns_single_property_match_without_disambiguation() -> None:
+    """When exactly one asset matches the properties, it is returned directly."""
+    client = _make_client()
+    properties = {"serial_num": "SN-001"}
+    match = _asset("streaming_demo_asset")
+
+    with patch.object(NominalClient, "search_assets", return_value=[match]) as search_assets:
+        assert client.get_or_create_asset_by_properties(properties, name="streaming_demo_asset") is match
+
+    search_assets.assert_called_once_with(properties=properties, workspace=WorkspaceSearchType.DEFAULT)
+
+
+def test_creates_when_no_property_match() -> None:
+    """When no asset matches the properties, a new one is created."""
+    client = _make_client()
+    properties = {"serial_num": "SN-001"}
+    created = MagicMock()
+
+    with (
+        patch.object(NominalClient, "search_assets", return_value=[]),
+        patch.object(NominalClient, "create_asset", return_value=created) as create_asset,
+    ):
+        assert (
+            client.get_or_create_asset_by_properties(
+                properties, name="streaming_demo_asset", description="desc", labels=["l"]
+            )
+            is created
+        )
+
+    create_asset.assert_called_once_with(
+        name="streaming_demo_asset", description="desc", properties=properties, labels=["l"]
+    )
+
+
+def test_disambiguates_multiple_property_matches_by_exact_name() -> None:
+    """When multiple assets share the properties, the one whose name matches exactly is returned."""
+    client = _make_client()
+    properties = {"team": "Michigan", "car_number": "8"}
+    match = _asset("FSAE CT8 Vehicle")
+    dupe = _asset("FSAE CT8 Vehicle2")
+
+    # First call returns both property matches; second call (with exact_match) returns only `match`.
+    with patch.object(NominalClient, "search_assets", side_effect=[[match, dupe], [match]]) as search_assets:
+        assert client.get_or_create_asset_by_properties(properties, name="FSAE CT8 Vehicle") is match
+
+    assert search_assets.call_count == 2
+    search_assets.assert_any_call(properties=properties, workspace=WorkspaceSearchType.DEFAULT)
+    search_assets.assert_any_call(
+        properties=properties, exact_match="FSAE CT8 Vehicle", workspace=WorkspaceSearchType.DEFAULT
+    )
+
+
+def test_raises_when_disambiguation_still_ambiguous() -> None:
+    """Multiple property matches AND multiple name matches is genuinely ambiguous."""
+    client = _make_client()
+    properties = {"team": "Michigan", "car_number": "8"}
+    match_a = _asset("FSAE CT8 Vehicle")
+    match_b = _asset("FSAE CT8 Vehicle")
+
+    with patch.object(NominalClient, "search_assets", side_effect=[[match_a, match_b], [match_a, match_b]]):
+        with pytest.raises(ValueError, match="cannot uniquely identify one asset"):
+            client.get_or_create_asset_by_properties(properties, name="FSAE CT8 Vehicle")
+
+
+def test_raises_when_multiple_property_matches_and_no_name_match() -> None:
+    """Multiple property matches but none match the caller's name is still ambiguous."""
+    client = _make_client()
+    properties = {"team": "Michigan", "car_number": "8"}
+    match_a = _asset("FSAE CT8 Vehicle2")
+    match_b = _asset("FSAE CT8 Vehicle3")
+
+    with patch.object(NominalClient, "search_assets", side_effect=[[match_a, match_b], []]):
+        with pytest.raises(ValueError, match="cannot uniquely identify one asset"):
+            client.get_or_create_asset_by_properties(properties, name="FSAE CT8 Vehicle")
+
+
+def test_search_assets_exact_match_filters_client_side() -> None:
+    """search_assets(exact_match=...) filters results to assets whose name matches exactly."""
+    client = _make_client()
+    match = _asset("FSAE CT8 Vehicle")
+    other = _asset("FSAE CT8 Vehicle2")
+
+    with patch.object(NominalClient, "_iter_search_assets", return_value=iter([match, other])):
+        results = client.search_assets(exact_match="FSAE CT8 Vehicle")
+
+    assert results == [match]

--- a/tests/core/test_get_or_create_asset.py
+++ b/tests/core/test_get_or_create_asset.py
@@ -60,15 +60,11 @@ def test_disambiguates_multiple_property_matches_by_exact_name() -> None:
     match = _asset("FSAE CT8 Vehicle")
     dupe = _asset("FSAE CT8 Vehicle2")
 
-    # First call returns both property matches; second call (with exact_match) returns only `match`.
-    with patch.object(NominalClient, "search_assets", side_effect=[[match, dupe], [match]]) as search_assets:
+    with patch.object(NominalClient, "search_assets", return_value=[match, dupe]) as search_assets:
         assert client.get_or_create_asset_by_properties(properties, name="FSAE CT8 Vehicle") is match
 
-    assert search_assets.call_count == 2
-    search_assets.assert_any_call(properties=properties, workspace=WorkspaceSearchType.DEFAULT)
-    search_assets.assert_any_call(
-        properties=properties, exact_match="FSAE CT8 Vehicle", workspace=WorkspaceSearchType.DEFAULT
-    )
+    # Disambiguation filters the already-fetched list locally; no extra server call.
+    search_assets.assert_called_once_with(properties=properties, workspace=WorkspaceSearchType.DEFAULT)
 
 
 def test_raises_when_disambiguation_still_ambiguous() -> None:
@@ -78,7 +74,7 @@ def test_raises_when_disambiguation_still_ambiguous() -> None:
     match_a = _asset("FSAE CT8 Vehicle")
     match_b = _asset("FSAE CT8 Vehicle")
 
-    with patch.object(NominalClient, "search_assets", side_effect=[[match_a, match_b], [match_a, match_b]]):
+    with patch.object(NominalClient, "search_assets", return_value=[match_a, match_b]):
         with pytest.raises(ValueError, match="cannot uniquely identify one asset"):
             client.get_or_create_asset_by_properties(properties, name="FSAE CT8 Vehicle")
 
@@ -90,7 +86,7 @@ def test_raises_when_multiple_property_matches_and_no_name_match() -> None:
     match_a = _asset("FSAE CT8 Vehicle2")
     match_b = _asset("FSAE CT8 Vehicle3")
 
-    with patch.object(NominalClient, "search_assets", side_effect=[[match_a, match_b], []]):
+    with patch.object(NominalClient, "search_assets", return_value=[match_a, match_b]):
         with pytest.raises(ValueError, match="cannot uniquely identify one asset"):
             client.get_or_create_asset_by_properties(properties, name="FSAE CT8 Vehicle")
 
@@ -105,3 +101,20 @@ def test_search_assets_exact_match_filters_client_side() -> None:
         results = client.search_assets(exact_match="FSAE CT8 Vehicle")
 
     assert results == [match]
+
+
+def test_search_assets_exact_match_ignores_iteration_order() -> None:
+    """exact_match must match the exact name, not just the first result.
+
+    The non-target asset is alphanumerically less than the target, so a naive
+    implementation that returned the first result (or the alphabetically first)
+    would incorrectly pick the non-target.
+    """
+    client = _make_client()
+    non_target = _asset("a_non_target_asset")
+    target = _asset("target_asset")
+
+    with patch.object(NominalClient, "_iter_search_assets", return_value=iter([non_target, target])):
+        results = client.search_assets(exact_match="target_asset")
+
+    assert results == [target]

--- a/tests/core/test_get_or_create_asset.py
+++ b/tests/core/test_get_or_create_asset.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nominal.core.client import NominalClient, WorkspaceSearchType
+from nominal.core.client import NominalClient, WorkspaceSearchType, filter_assets_by_exact_name
 
 
 def _make_client() -> NominalClient:
@@ -91,30 +91,22 @@ def test_raises_when_multiple_property_matches_and_no_name_match() -> None:
             client.get_or_create_asset_by_properties(properties, name="FSAE CT8 Vehicle")
 
 
-def test_search_assets_exact_match_filters_client_side() -> None:
-    """search_assets(exact_match=...) filters results to assets whose name matches exactly."""
-    client = _make_client()
+def test_filter_assets_by_exact_name_returns_only_matches() -> None:
+    """The filter keeps only assets whose name equals the requested string."""
     match = _asset("FSAE CT8 Vehicle")
     other = _asset("FSAE CT8 Vehicle2")
 
-    with patch.object(NominalClient, "_iter_search_assets", return_value=iter([match, other])):
-        results = client.search_assets(exact_match="FSAE CT8 Vehicle")
-
-    assert results == [match]
+    assert filter_assets_by_exact_name([match, other], "FSAE CT8 Vehicle") == [match]
 
 
-def test_search_assets_exact_match_ignores_iteration_order() -> None:
-    """exact_match must match the exact name, not just the first result.
+def test_filter_assets_by_exact_name_ignores_iteration_order() -> None:
+    """Filtering must match on exact name, not position in the input.
 
     The non-target asset is alphanumerically less than the target, so a naive
     implementation that returned the first result (or the alphabetically first)
     would incorrectly pick the non-target.
     """
-    client = _make_client()
     non_target = _asset("a_non_target_asset")
     target = _asset("target_asset")
 
-    with patch.object(NominalClient, "_iter_search_assets", return_value=iter([non_target, target])):
-        results = client.search_assets(exact_match="target_asset")
-
-    assert results == [target]
+    assert filter_assets_by_exact_name([non_target, target], "target_asset") == [target]


### PR DESCRIPTION
## Summary

`NominalClient.get_or_create_asset_by_properties` currently raises `ValueError` as soon as two or more assets share the provided `properties` dict. In practice this breaks any re-run in a workspace that already has duplicate assets from prior `create_asset` calls — the docs quickstart scripts hit this as soon as a user ran them twice before switching to the idempotent API.

This PR:

- Adds `exact_match: str | None` to `NominalClient.search_assets` (matches the shape of `search_datasets.exact_match`). Implemented as a client-side post-filter on `asset.name == exact_match` because `scout_asset_api.SearchAssetsQuery` does not expose a title-exact-match field.
- Uses the new kwarg inside `get_or_create_asset_by_properties` as a disambiguator: when more than one asset matches the property set, re-search with `exact_match=name` and return the single match if found.
- Only raises when the `(properties, name)` combination still identifies multiple (or zero) assets — the error message now names both the properties and the caller's expected name.

No change to the single-match or zero-match paths; existing `test_get_or_create_asset_by_properties_uses_default_workspace_resolution_for_search` continues to pass unmodified.

## Downstream follow-up

Once this lands and a new client version is released, the fern-docs quickstart scripts can be simplified:

- `fern/code-snippets/core/tutorial/single_asset_fsae_tutorial.py`
- `fern/code-snippets/core/sdk/python/getting_started/stream_data_to_dataset.py`

Both currently wrap `get_or_create_asset_by_properties` in a `try/except ValueError` that falls back to `search_assets(exact_substring=...)` to disambiguate. After this PR ships, the except block can be dropped and the call reverts to a single clean invocation.

## Test plan

- [x] `just verify` (pytest + ruff format + mypy + ruff check) passes locally — 176 passed, 8 skipped
- New `tests/core/test_get_or_create_asset.py` covers:
  - single property match returned directly (no second search)
  - no matches → `create_asset` called
  - multiple property matches, one name match → returned
  - multiple property matches, multiple name matches → raises
  - multiple property matches, zero name matches → raises
  - `search_assets(exact_match=...)` filters client-side by exact name equality