### PR TITLE
feat: add container image tarball upload to self-hosted registry

### DIFF
--- a/nominal/cli/__init__.py
+++ b/nominal/cli/__init__.py
@@ -2,7 +2,7 @@ import importlib.metadata
 
 import click
 
-from nominal.cli import attachment, config, dataset, download, mis, run
+from nominal.cli import attachment, config, container_registry, dataset, download, mis, run
 
 
 @click.group(context_settings={"show_default": True, "help_option_names": ("-h", "--help")})
@@ -13,6 +13,7 @@ def nom() -> None:
 
 nom.add_command(attachment.attachment_cmd)
 nom.add_command(config.config_cmd)
+nom.add_command(container_registry.container_registry_cmd)
 nom.add_command(dataset.dataset_cmd)
 nom.add_command(download.download_cmd)
 nom.add_command(mis.mis_cmd)

--- a/nominal/cli/container_registry.py
+++ b/nominal/cli/container_registry.py
@@ -26,7 +26,10 @@ def container_registry_cmd() -> None:
 @client_options
 @global_options
 def upload(name: str, tag: str, file: Path, client: NominalClient) -> None:
-    """Upload a container image tarball to Nominal's registry."""
+    """Upload a container image tarball to Nominal's registry.
+
+    Prints the resulting container image RID on stdout for shell-script capture.
+    """
     with open(file, "rb") as f:
         image = client.upload_container_image_from_io(f, name, tag)
-    click.echo(image)
+    click.echo(image.rid)

--- a/nominal/cli/container_registry.py
+++ b/nominal/cli/container_registry.py
@@ -19,7 +19,6 @@ def container_registry_cmd() -> None:
 @click.option(
     "-f",
     "--file",
-    "file",
     required=True,
     type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=Path),
     help="path to the container image tarball to upload",

--- a/nominal/cli/container_registry.py
+++ b/nominal/cli/container_registry.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from nominal.cli.util.global_decorators import client_options, global_options
+from nominal.core.client import NominalClient
+from nominal.core.filetype import FileType
+
+
+@click.group(name="container-registry")
+def container_registry_cmd() -> None:
+    pass
+
+
+@container_registry_cmd.command("upload")
+@click.option("-n", "--name", required=True, help="image name (e.g. 'my-extractor')")
+@click.option("-t", "--tag", required=True, help="image tag (e.g. 'v1.2.3')")
+@click.option("-f", "--file", required=True, help="path to the container image tarball to upload")
+@client_options
+@global_options
+def upload(name: str, tag: str, file: str, client: NominalClient) -> None:
+    """Upload a container image tarball to Nominal's registry."""
+    path = Path(file)
+    file_type = FileType.from_path(path)
+    with open(path, "rb") as f:
+        image = client.upload_container_image_from_io(f, name, tag, file_type=file_type)
+    click.echo(image)

--- a/nominal/cli/container_registry.py
+++ b/nominal/cli/container_registry.py
@@ -6,7 +6,6 @@ import click
 
 from nominal.cli.util.global_decorators import client_options, global_options
 from nominal.core.client import NominalClient
-from nominal.core.filetype import FileType
 
 
 @click.group(name="container-registry")
@@ -17,13 +16,18 @@ def container_registry_cmd() -> None:
 @container_registry_cmd.command("upload")
 @click.option("-n", "--name", required=True, help="image name (e.g. 'my-extractor')")
 @click.option("-t", "--tag", required=True, help="image tag (e.g. 'v1.2.3')")
-@click.option("-f", "--file", required=True, help="path to the container image tarball to upload")
+@click.option(
+    "-f",
+    "--file",
+    "file",
+    required=True,
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=Path),
+    help="path to the container image tarball to upload",
+)
 @client_options
 @global_options
-def upload(name: str, tag: str, file: str, client: NominalClient) -> None:
+def upload(name: str, tag: str, file: Path, client: NominalClient) -> None:
     """Upload a container image tarball to Nominal's registry."""
-    path = Path(file)
-    file_type = FileType.from_path(path)
-    with open(path, "rb") as f:
-        image = client.upload_container_image_from_io(f, name, tag, file_type=file_type)
+    with open(file, "rb") as f:
+        image = client.upload_container_image_from_io(f, name, tag)
     click.echo(image)

--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -9,6 +9,7 @@ from nominal.core.channel import Channel, ChannelDataType
 from nominal.core.checklist import Checklist
 from nominal.core.client import NominalClient, WorkspaceSearchType
 from nominal.core.connection import Connection
+from nominal.core.container_image import ContainerImage, ContainerImageStatus
 from nominal.core.containerized_extractors import (
     ContainerizedExtractor,
     DockerImageSource,
@@ -45,6 +46,8 @@ __all__ = [
     "Checklist",
     "CheckViolation",
     "Connection",
+    "ContainerImage",
+    "ContainerImageStatus",
     "ContainerizedExtractor",
     "DataReview",
     "DataReviewBuilder",

--- a/nominal/core/_api_types.py
+++ b/nominal/core/_api_types.py
@@ -1,0 +1,34 @@
+"""Typed Python mirrors of JSON payloads returned by gRPC-gateway-transcoded services.
+
+Parsed at the HTTP boundary so downstream code works with typed fields instead of raw
+dicts. Add new wire types here as more gRPC-transcoded services get Python clients.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class _ApiContainerImage:
+    """Typed wire representation of a `nominal.registry.v1.ContainerImage` JSON payload."""
+
+    rid: str
+    name: str
+    tag: str
+    status: str
+    created_at: str
+    size_bytes: int | None
+
+    @classmethod
+    def _parse(cls, raw: Mapping[str, Any]) -> _ApiContainerImage:
+        raw_size = raw.get("sizeBytes")
+        return cls(
+            rid=str(raw["rid"]),
+            name=str(raw.get("name", "")),
+            tag=str(raw.get("tag", "")),
+            status=str(raw.get("status", "")),
+            created_at=str(raw["createdAt"]),
+            size_bytes=int(raw_size) if raw_size is not None else None,
+        )

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -115,7 +115,11 @@ class ProtoWriteService(Service):
 
 
 class RegistryService(Service):
-    """HTTP client for nominal.registry.v1.RegistryService via the gRPC-gateway JSON transcoder."""
+    """HTTP client for nominal.registry.v1.RegistryService via the gRPC-gateway JSON transcoder.
+
+    Inherits conjure_python_client.Service to pick up the shared truststore configuration used
+    against on-prem / self-hosted backends, even though this is not a conjure-modeled service.
+    """
 
     def create_image(self, auth_header: str, request: Mapping[str, Any]) -> _ApiContainerImage:
         _headers = {

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import time
 from dataclasses import dataclass, field
-from typing import Mapping, Protocol, TypeVar
+from typing import Any, Mapping, Protocol, TypeVar
 
 from conjure_python_client import Service, ServiceConfiguration
 from nominal_api import (
@@ -113,6 +113,26 @@ class ProtoWriteService(Service):
         self._request("POST", self._uri + _path, params={}, headers=_headers, data=request)
 
 
+class RegistryService(Service):
+    """HTTP client for nominal.registry.v1.RegistryService via the gRPC-gateway JSON transcoder."""
+
+    def create_image(self, auth_header: str, request: Mapping[str, Any]) -> dict[str, Any]:
+        _headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": auth_header,
+        }
+        response = self._request(
+            "POST",
+            self._uri + "/registry/v1/images",
+            params={},
+            headers=_headers,
+            json=request,
+        )
+        parsed: dict[str, Any] = response.json()
+        return parsed
+
+
 @dataclass(frozen=True)
 class ClientsBunch:
     auth_header: str
@@ -158,6 +178,7 @@ class ClientsBunch:
     workspace: security_api_workspace.WorkspaceService
     containerized_extractors: ingest_api.ContainerizedExtractorService
     secrets: secrets_api.SecretService
+    registry: RegistryService
 
     def with_default_request_headers(self, headers: Mapping[str, str]) -> Self:
         return type(self).from_config(
@@ -299,6 +320,7 @@ class ClientsBunch:
             workspace=client_factory(security_api_workspace.WorkspaceService),
             containerized_extractors=client_factory(ingest_api.ContainerizedExtractorService),
             secrets=client_factory(secrets_api.SecretService),
+            registry=client_factory(RegistryService),
         )
 
 

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -116,7 +116,7 @@ class ProtoWriteService(Service):
 class RegistryService(Service):
     """HTTP client for nominal.registry.v1.RegistryService via the gRPC-gateway JSON transcoder."""
 
-    def create_image(self, auth_header: str, request: Mapping[str, Any]) -> dict[str, Any]:
+    def create_image(self, auth_header: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
         _headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -33,6 +33,7 @@ from nominal_api import (
 from typing_extensions import Self
 
 from nominal._utils.dataclass_tools import LazyField
+from nominal.core._api_types import _ApiContainerImage
 from nominal.core._utils.networking import create_conjure_client_factory
 from nominal.core.exceptions import NominalConfigError
 from nominal.ts import IntegralNanosecondsUTC
@@ -116,7 +117,7 @@ class ProtoWriteService(Service):
 class RegistryService(Service):
     """HTTP client for nominal.registry.v1.RegistryService via the gRPC-gateway JSON transcoder."""
 
-    def create_image(self, auth_header: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+    def create_image(self, auth_header: str, request: Mapping[str, Any]) -> _ApiContainerImage:
         _headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",
@@ -129,8 +130,11 @@ class RegistryService(Service):
             headers=_headers,
             json=request,
         )
-        parsed: dict[str, Any] = response.json()
-        return parsed
+        body: dict[str, Any] = response.json()
+        image = body.get("image")
+        if not isinstance(image, Mapping):
+            raise ValueError(f"unexpected CreateImageResponse from registry: {body!r}")
+        return _ApiContainerImage._parse(image)
 
 
 @dataclass(frozen=True)

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -74,6 +74,7 @@ from nominal.core.asset import Asset
 from nominal.core.attachment import Attachment, _iter_get_attachments
 from nominal.core.checklist import Checklist
 from nominal.core.connection import Connection, StreamingConnection
+from nominal.core.container_image import ContainerImage
 from nominal.core.containerized_extractors import (
     ContainerizedExtractor,
     DockerImageSource,
@@ -984,6 +985,42 @@ class NominalClient:
         """Retrieve an attachment by its RID."""
         response = self._clients.attachment.get(self._clients.auth_header, rid)
         return Attachment._from_conjure(self._clients, response)
+
+    def upload_container_image_from_io(
+        self,
+        tarball: BinaryIO,
+        name: str,
+        tag: str,
+        *,
+        file_type: tuple[str, str] | FileType = FileTypes.TAR,
+    ) -> ContainerImage:
+        """Upload a container image tarball to Nominal's self-hosted registry.
+
+        The tarball must be a file-like object in binary mode, e.g. open(path, "rb") or io.BytesIO.
+        """
+        if isinstance(tarball, TextIOBase):
+            raise TypeError(f"tarball {tarball!r} must be open in binary mode, rather than text mode")
+
+        file_type = FileType(*file_type)
+        s3_path = upload_multipart_io(
+            self._clients.auth_header,
+            self._clients.workspace_rid,
+            tarball,
+            f"{name}-{tag}",
+            file_type,
+            self._clients.upload,
+        )
+        request = {
+            "workspaceRid": self._clients.workspace_rid,
+            "name": name,
+            "tag": tag,
+            "objectPath": s3_path,
+        }
+        response = self._clients.registry.create_image(self._clients.auth_header, request)
+        image = response.get("image")
+        if not isinstance(image, dict):
+            raise NominalError(f"unexpected CreateImageResponse from registry: {response!r}")
+        return ContainerImage._from_response(self._clients, image)
 
     def get_attachments(self, rids: Iterable[str]) -> Sequence[Attachment]:
         """Retrive attachments by their RIDs."""

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -988,26 +988,23 @@ class NominalClient:
 
     def upload_container_image_from_io(
         self,
-        tarball: BinaryIO,
+        path: BinaryIO,
         name: str,
         tag: str,
-        *,
-        file_type: tuple[str, str] | FileType = FileTypes.TAR,
     ) -> ContainerImage:
         """Upload a container image tarball to Nominal's self-hosted registry.
 
         The tarball must be a file-like object in binary mode, e.g. open(path, "rb") or io.BytesIO.
         """
-        if isinstance(tarball, TextIOBase):
-            raise TypeError(f"tarball {tarball!r} must be open in binary mode, rather than text mode")
+        if isinstance(path, TextIOBase):
+            raise TypeError(f"tarball {path!r} must be open in binary mode, rather than text mode")
 
-        file_type = FileType(*file_type)
         s3_path = upload_multipart_io(
             self._clients.auth_header,
             self._clients.workspace_rid,
-            tarball,
+            path,
             f"{name}-{tag}",
-            file_type,
+            FileTypes.TAR,
             self._clients.upload,
         )
         request = {
@@ -1020,7 +1017,7 @@ class NominalClient:
         image = response.get("image")
         if not isinstance(image, dict):
             raise NominalError(f"unexpected CreateImageResponse from registry: {response!r}")
-        return ContainerImage._from_response(self._clients, image)
+        return ContainerImage._from_grpc(self._clients, image)
 
     def get_attachments(self, rids: Iterable[str]) -> Sequence[Attachment]:
         """Retrive attachments by their RIDs."""

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -1013,11 +1013,8 @@ class NominalClient:
             "tag": tag,
             "objectPath": s3_path,
         }
-        response = self._clients.registry.create_image(self._clients.auth_header, request)
-        image = response.get("image")
-        if not isinstance(image, dict):
-            raise NominalError(f"unexpected CreateImageResponse from registry: {response!r}")
-        return ContainerImage._from_grpc(self._clients, image)
+        api_image = self._clients.registry.create_image(self._clients.auth_header, request)
+        return ContainerImage._from_grpc(self._clients, api_image)
 
     def get_attachments(self, rids: Iterable[str]) -> Sequence[Attachment]:
         """Retrive attachments by their RIDs."""

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from io import TextIOBase
 from pathlib import Path
-from typing import BinaryIO, Iterable, Mapping, Sequence, overload
+from typing import BinaryIO, Iterable, List, Mapping, Sequence, cast, overload
 
 import certifi
 import conjure_python_client
@@ -79,6 +79,7 @@ from nominal.core.containerized_extractors import (
     ContainerizedExtractor,
     DockerImageSource,
     FileExtractionInput,
+    FileExtractionParameter,
     FileOutputFormat,
 )
 from nominal.core.data_review import DataReview, DataReviewBuilder, _iter_search_data_reviews
@@ -995,20 +996,25 @@ class NominalClient:
         """Upload a container image tarball to Nominal's self-hosted registry.
 
         The tarball must be a file-like object in binary mode, e.g. open(path, "rb") or io.BytesIO.
+        The client's configured `workspace_rid` is used.
         """
         if isinstance(path, TextIOBase):
             raise TypeError(f"tarball {path!r} must be open in binary mode, rather than text mode")
 
+        workspace_rid = self._clients.workspace_rid
+        if workspace_rid is None:
+            raise ValueError("client profile must specify workspace_rid to upload a container image")
+
         s3_path = upload_multipart_io(
             self._clients.auth_header,
-            self._clients.workspace_rid,
+            workspace_rid,
             path,
             f"{name}-{tag}",
             FileTypes.TAR,
             self._clients.upload,
         )
         request = {
-            "workspaceRid": self._clients.workspace_rid,
+            "workspaceRid": workspace_rid,
             "name": name,
             "tag": tag,
             "objectPath": s3_path,
@@ -1418,6 +1424,7 @@ class NominalClient:
             self._clients.containerized_extractors.get_containerized_extractor(self._clients.auth_header, rid),
         )
 
+    @overload
     def create_containerized_extractor(
         self,
         name: str,
@@ -1426,30 +1433,91 @@ class NominalClient:
         timestamp_column: str,
         timestamp_type: ts._AnyTimestampType,
         inputs: Sequence[FileExtractionInput] = (),
+        parameters: Sequence[FileExtractionParameter] = (),
         file_output_format: FileOutputFormat | None = None,
         labels: Sequence[str] = (),
         properties: Mapping[str, str] | None = None,
         description: str | None = None,
+    ) -> ContainerizedExtractor: ...
+    @overload
+    def create_containerized_extractor(
+        self,
+        name: str,
+        *,
+        container_image_rid: str,
+        timestamp_column: str,
+        timestamp_type: ts._AnyTimestampType,
+        inputs: Sequence[FileExtractionInput] = (),
+        parameters: Sequence[FileExtractionParameter] = (),
+        file_output_format: FileOutputFormat | None = None,
+        labels: Sequence[str] = (),
+        properties: Mapping[str, str] | None = None,
+        description: str | None = None,
+    ) -> ContainerizedExtractor: ...
+    def create_containerized_extractor(
+        self,
+        name: str,
+        **kwargs: object,
     ) -> ContainerizedExtractor:
-        workspace_rid = self._clients.resolve_default_workspace_rid()
+        description = cast(str | None, kwargs.pop("description", None))
+
+        docker_image = cast(DockerImageSource | None, kwargs.pop("docker_image", None))
+        container_image_rid = cast(str | None, kwargs.pop("container_image_rid", None))
+        if docker_image is None and container_image_rid is None:
+            raise TypeError("missing required keyword-only argument: 'docker_image' or 'container_image_rid'")
+        if docker_image is not None and container_image_rid is not None:
+            raise TypeError("got mutually exclusive keyword arguments: 'docker_image' and 'container_image_rid'")
+        image = docker_image._to_conjure() if docker_image is not None else None
+
+        file_extraction_inputs = cast(Sequence[FileExtractionInput], kwargs.pop("inputs", ()))
+        inputs=[file_extraction_input._to_conjure() for file_extraction_input in file_extraction_inputs]
+
+        file_extraction_parameters = cast(Sequence[FileExtractionParameter], kwargs.pop("parameters", ()))
+        parameters=[file_extraction_parameter._to_conjure() for file_extraction_parameter in file_extraction_parameters]
+
+        properties = dict(cast(Mapping[str, str] | None, kwargs.pop("properties", None)) or {})
+
+        labels: List[str] = list(cast(Sequence[str] | None, kwargs.pop("labels", None)) or [])
+
+        workspace_rid = self._clients.workspace_rid
+        if workspace_rid is None:
+            raise ValueError("client profile must specify workspace_rid to create a containerized extractor")
+
+        timestamp_column = cast(str, self._pop_required_kwarg(kwargs, "timestamp_column"))
+        timestamp_type = cast(ts._AnyTimestampType, self._pop_required_kwarg(kwargs, "timestamp_type"))
+
+        file_output_format = cast(FileOutputFormat | None, kwargs.pop("file_output_format", None))
+        output_file_format = file_output_format._to_conjure() if file_output_format is not None else None
+
+        if kwargs:
+            unexpected_arg = next(iter(kwargs))
+            raise TypeError(f"got an unexpected keyword argument {unexpected_arg!r}")
 
         req = ingest_api.RegisterContainerizedExtractorRequest(
-            image=docker_image._to_conjure(),
-            inputs=[file_input._to_conjure() for file_input in inputs],
-            labels=list(labels),
             name=name,
-            parameters=[],
-            properties={} if properties is None else {**properties},
+            description=description,
+            image=image,
+            container_image_rid=container_image_rid,
+            inputs=inputs,
+            parameters=parameters,
+            properties=properties,
+            labels=labels,
+            workspace=workspace_rid,
             timestamp_metadata=ingest_api.TimestampMetadata(
                 series_name=timestamp_column,
                 timestamp_type=_to_typed_timestamp_type(timestamp_type)._to_conjure_ingest_api(),
             ),
-            workspace=workspace_rid,
-            description=description,
-            output_file_format=file_output_format._to_conjure() if file_output_format is not None else None,
+            output_file_format=output_file_format,
         )
         resp = self._clients.containerized_extractors.register_containerized_extractor(self._clients.auth_header, req)
         return self.get_containerized_extractor(resp.extractor_rid)
+
+    @staticmethod
+    def _pop_required_kwarg(kwargs: dict[str, object], name: str) -> object:
+        try:
+            return kwargs.pop(name)
+        except KeyError:
+            raise TypeError(f"missing required keyword-only argument: {name!r}") from None
 
     def search_containerized_extractors(
         self,

--- a/nominal/core/container_image.py
+++ b/nominal/core/container_image.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Protocol
+from typing import Protocol
 
 from typing_extensions import Self
 
+from nominal.core._api_types import _ApiContainerImage
 from nominal.core._clientsbunch import HasScoutParams, RegistryService
 from nominal.core._utils.api_tools import HasRid
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
@@ -27,7 +28,7 @@ class ContainerImageStatus(Enum):
     """Registry push failed. The image will not become available."""
 
     @classmethod
-    def _from_conjure(cls, api_status: str) -> ContainerImageStatus:
+    def _from_grpc(cls, api_status: str) -> ContainerImageStatus:
         try:
             return cls(api_status)
         except ValueError:
@@ -69,21 +70,13 @@ class ContainerImage(HasRid):
         def registry(self) -> RegistryService: ...
 
     @classmethod
-    def _from_grpc(cls, clients: _Clients, image: dict[str, Any]) -> Self:
-        raw_size = image.get("sizeBytes")
-        size_bytes = int(raw_size) if raw_size is not None else None
-        raw_status = image.get("status")
-        status = (
-            ContainerImageStatus._from_conjure(raw_status)
-            if isinstance(raw_status, str)
-            else ContainerImageStatus.UNSPECIFIED
-        )
+    def _from_grpc(cls, clients: _Clients, image: _ApiContainerImage) -> Self:
         return cls(
-            rid=str(image["rid"]),
-            name=str(image.get("name", "")),
-            tag=str(image.get("tag", "")),
-            status=status,
-            created_at=_SecondsNanos.from_flexible(image["createdAt"]).to_nanoseconds(),
-            size_bytes=size_bytes,
+            rid=image.rid,
+            name=image.name,
+            tag=image.tag,
+            status=ContainerImageStatus._from_grpc(image.status),
+            created_at=_SecondsNanos.from_flexible(image.created_at).to_nanoseconds(),
+            size_bytes=image.size_bytes,
             _clients=clients,
         )

--- a/nominal/core/container_image.py
+++ b/nominal/core/container_image.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Protocol
+
+from typing_extensions import Self
+
+from nominal.core._clientsbunch import HasScoutParams, RegistryService
+from nominal.core._utils.api_tools import HasRid
+from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
+
+
+class ContainerImageStatus(str, Enum):
+    UNSPECIFIED = "CONTAINER_IMAGE_STATUS_UNSPECIFIED"
+    PENDING = "CONTAINER_IMAGE_STATUS_PENDING"
+    READY = "CONTAINER_IMAGE_STATUS_READY"
+    FAILED = "CONTAINER_IMAGE_STATUS_FAILED"
+
+    @classmethod
+    def _parse(cls, raw: object) -> ContainerImageStatus:
+        if isinstance(raw, str):
+            try:
+                return cls(raw)
+            except ValueError:
+                pass
+        return cls.UNSPECIFIED
+
+
+@dataclass(frozen=True)
+class ContainerImage(HasRid):
+    rid: str
+    name: str
+    tag: str
+    status: ContainerImageStatus
+    created_at: IntegralNanosecondsUTC
+    size_bytes: int | None
+
+    _clients: _Clients = field(repr=False)
+
+    class _Clients(HasScoutParams, Protocol):
+        @property
+        def registry(self) -> RegistryService: ...
+
+    @classmethod
+    def _from_response(cls, clients: _Clients, image: dict[str, Any]) -> Self:
+        raw_size = image.get("sizeBytes")
+        size_bytes = int(raw_size) if raw_size is not None else None
+        return cls(
+            rid=str(image["rid"]),
+            name=str(image.get("name", "")),
+            tag=str(image.get("tag", "")),
+            status=ContainerImageStatus._parse(image.get("status")),
+            created_at=_SecondsNanos.from_flexible(image["createdAt"]).to_nanoseconds(),
+            size_bytes=size_bytes,
+            _clients=clients,
+        )

--- a/nominal/core/container_image.py
+++ b/nominal/core/container_image.py
@@ -11,30 +11,56 @@ from nominal.core._utils.api_tools import HasRid
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
 
 
-class ContainerImageStatus(str, Enum):
+class ContainerImageStatus(Enum):
+    """Lifecycle state of a container image in Nominal's registry."""
+
     UNSPECIFIED = "CONTAINER_IMAGE_STATUS_UNSPECIFIED"
+    """Status is unset or unrecognized. Treat as an unknown state."""
+
     PENDING = "CONTAINER_IMAGE_STATUS_PENDING"
+    """Tarball uploaded but is not ready for use yet."""
+
     READY = "CONTAINER_IMAGE_STATUS_READY"
+    """Image is available in the registry and can be pulled."""
+
     FAILED = "CONTAINER_IMAGE_STATUS_FAILED"
+    """Registry push failed. The image will not become available."""
 
     @classmethod
-    def _parse(cls, raw: object) -> ContainerImageStatus:
-        if isinstance(raw, str):
-            try:
-                return cls(raw)
-            except ValueError:
-                pass
-        return cls.UNSPECIFIED
+    def _from_conjure(cls, api_status: str) -> ContainerImageStatus:
+        try:
+            return cls(api_status)
+        except ValueError:
+            return cls.UNSPECIFIED
 
 
 @dataclass(frozen=True)
 class ContainerImage(HasRid):
+    """A container image tarball stored in Nominal's registry.
+
+    Create one via `NominalClient.upload_container_image_from_io`. The registry push is
+    asynchronous: a freshly uploaded image may be returned in `PENDING` state and transition
+    to `READY` (or `FAILED`) once the server finishes pushing the tarball to the internal
+    OCI registry.
+    """
+
     rid: str
+    """Nominal resource identifier for this image."""
+
     name: str
+    """Image name within the workspace (e.g. `my-extractor`)."""
+
     tag: str
+    """Image tag (e.g. `v1.2.3`). Unique per `(workspace, name)`."""
+
     status: ContainerImageStatus
+    """Current lifecycle state of the image."""
+
     created_at: IntegralNanosecondsUTC
+    """Creation timestamp, in nanoseconds since the Unix epoch."""
+
     size_bytes: int | None
+    """Size of the uploaded tarball in bytes, or `None` until the server populates it."""
 
     _clients: _Clients = field(repr=False)
 
@@ -43,14 +69,20 @@ class ContainerImage(HasRid):
         def registry(self) -> RegistryService: ...
 
     @classmethod
-    def _from_response(cls, clients: _Clients, image: dict[str, Any]) -> Self:
+    def _from_grpc(cls, clients: _Clients, image: dict[str, Any]) -> Self:
         raw_size = image.get("sizeBytes")
         size_bytes = int(raw_size) if raw_size is not None else None
+        raw_status = image.get("status")
+        status = (
+            ContainerImageStatus._from_conjure(raw_status)
+            if isinstance(raw_status, str)
+            else ContainerImageStatus.UNSPECIFIED
+        )
         return cls(
             rid=str(image["rid"]),
             name=str(image.get("name", "")),
             tag=str(image.get("tag", "")),
-            status=ContainerImageStatus._parse(image.get("status")),
+            status=status,
             created_at=_SecondsNanos.from_flexible(image["createdAt"]).to_nanoseconds(),
             size_bytes=size_bytes,
             _clients=clients,

--- a/nominal/core/containerized_extractors.py
+++ b/nominal/core/containerized_extractors.py
@@ -89,6 +89,41 @@ class FileExtractionInput:
             required=self.required,
         )
 
+@dataclass(frozen=True)
+class FileExtractionParameter:
+    """Configuration for a file extraction parameter in a containerized extractor.
+
+    Args:
+        name: Human-readable name for this parameter configuration.
+        description: Optional detailed description of what this parameter represents.
+        environment_variable: Environment variable name that will be set in the container
+            to specify the input file path.
+        file_suffixes: List of file extensions that this input accepts (e.g., ['.csv', '.txt']).
+        required: Whether this input is mandatory for the extractor to run. Defaults to False.
+    """
+
+    name: str
+    description: str | None
+    environment_variable: str
+    required: bool
+
+    @classmethod
+    def _from_conjure(cls, file_extraction_parameter: ingest_api.FileExtractionParameter) -> Self:
+        return cls(
+            name=file_extraction_parameter.name,
+            description=file_extraction_parameter.description,
+            environment_variable=file_extraction_parameter.environment_variable,
+            required=file_extraction_parameter.required if file_extraction_parameter.required is not None else False,
+        )
+
+    def _to_conjure(self) -> ingest_api.FileExtractionParameter:
+        return ingest_api.FileExtractionParameter(
+            environment_variable=self.environment_variable,
+            name=self.name,
+            description=self.description,
+            required=self.required,
+        )
+
 
 @dataclass(frozen=True)
 class TagDetails:

--- a/nominal/core/filetype.py
+++ b/nominal/core/filetype.py
@@ -132,6 +132,7 @@ class FileTypes:
     TS: FileType = FileType(".ts", "video/mp2t")
     JOURNAL_JSONL: FileType = FileType(".jsonl", "application/jsonl")
     JOURNAL_JSONL_GZ: FileType = FileType(".jsonl.gz", "application/jsonl")
+    TAR: FileType = FileType(".tar", "application/x-tar")
 
     _CSV_TYPES = (CSV, CSV_GZ)
     _PARQUET_FILE_TYPES = (PARQUET_GZ, PARQUET)

--- a/tests/cli/test_container_registry.py
+++ b/tests/cli/test_container_registry.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from nominal.cli.container_registry import container_registry_cmd
+
+
+def test_upload_help_omits_workspace_rid_option() -> None:
+    result = CliRunner().invoke(container_registry_cmd, ["upload", "--help"])
+
+    assert result.exit_code == 0
+    assert "--workspace-rid" not in result.output
+
+
+def test_upload_uses_profile_client_workspace(tmp_path) -> None:
+    tarball = tmp_path / "image.tar"
+    tarball.write_bytes(b"image")
+    client = MagicMock()
+    client.upload_container_image_from_io.return_value = SimpleNamespace(rid="ri.container-image.main.image.1")
+
+    with patch("nominal.cli.util.global_decorators.NominalClient.from_profile", return_value=client):
+        result = CliRunner().invoke(
+            container_registry_cmd,
+            [
+                "upload",
+                "-n",
+                "extractor",
+                "-t",
+                "v1",
+                "-f",
+                str(tarball),
+                "--profile",
+                "default",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "ri.container-image.main.image.1\n"
+    client.upload_container_image_from_io.assert_called_once()
+    call_args = client.upload_container_image_from_io.call_args
+    assert call_args.kwargs == {}
+    assert call_args.args[1:] == ("extractor", "v1")

--- a/tests/core/test_container_registry.py
+++ b/tests/core/test_container_registry.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from io import BytesIO
+from unittest.mock import MagicMock
+
+import pytest
+
+from nominal.core.client import NominalClient
+
+
+def test_upload_container_image_requires_profile_workspace() -> None:
+    clients = MagicMock()
+    clients.workspace_rid = None
+    clients.resolve_default_workspace_rid = MagicMock()
+    client = NominalClient(_clients=clients)
+
+    with pytest.raises(ValueError, match="client profile must specify workspace_rid"):
+        client.upload_container_image_from_io(BytesIO(b"image"), "extractor", "v1")
+
+    clients.resolve_default_workspace_rid.assert_not_called()
+    clients.upload.initiate_multipart_upload.assert_not_called()
+
+
+def test_create_containerized_extractor_requires_profile_workspace() -> None:
+    clients = MagicMock()
+    clients.workspace_rid = None
+    clients.resolve_default_workspace_rid = MagicMock()
+    client = NominalClient(_clients=clients)
+
+    with pytest.raises(ValueError, match="client profile must specify workspace_rid"):
+        client.create_containerized_extractor(
+            "extractor",
+            container_image_rid="ri.container-image.main.image.1",
+            timestamp_column="timestamp",
+            timestamp_type="absolute",
+        )
+
+    clients.resolve_default_workspace_rid.assert_not_called()
+    clients.containerized_extractors.register_containerized_extractor.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `nom container-image upload -n <name> -t <tag> -f <tarball>` CLI command and a corresponding `NominalClient.upload_container_image_from_io` method.