### PR TITLE
feat: move migration runner to nominal-client

### DIFF
--- a/nominal/experimental/migration/migration_cli.py
+++ b/nominal/experimental/migration/migration_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, Sequence
@@ -245,6 +246,7 @@ class ImpersonatingDestinationClientResolver:
         self._destination_client = destination_client
         self._impersonation_config = impersonation_config
         self._impersonated_clients_by_user_rid: dict[str, NominalClient] = {}
+        self._lock = threading.Lock()
 
     def __call__(self, source_resource: Any) -> NominalClient:
         source_user_rid = get_source_user_rid(source_resource)
@@ -269,15 +271,16 @@ class ImpersonatingDestinationClientResolver:
             )
             return self._destination_client
 
-        if destination_user_rid not in self._impersonated_clients_by_user_rid:
-            logger.debug(
-                "Creating impersonated destination client for source user %s -> destination user %s.",
-                source_user_rid,
-                destination_user_rid,
-            )
-            self._impersonated_clients_by_user_rid[destination_user_rid] = as_user(
-                self._destination_client, destination_user_rid
-            )
+        with self._lock:
+            if destination_user_rid not in self._impersonated_clients_by_user_rid:
+                logger.debug(
+                    "Creating impersonated destination client for source user %s -> destination user %s.",
+                    source_user_rid,
+                    destination_user_rid,
+                )
+                self._impersonated_clients_by_user_rid[destination_user_rid] = as_user(
+                    self._destination_client, destination_user_rid
+                )
 
         logger.debug(
             "Using impersonated destination client for %s (rid: %s): source user %s -> destination user %s.",
@@ -530,7 +533,7 @@ def copy(
     type=click.Path(dir_okay=False, path_type=Path),
     help="Path where the generated migration config YAML will be written.",
 )
-def prep(client: NominalClient, migration_name: str, output_path: Path) -> dict[str, set[str]]:
+def prep(client: NominalClient, migration_name: str, output_path: Path) -> None:
     """Count resources on a tenant to determine migration scope and generate a starter config."""
     logger.info("In-scope migration numbers:")
 
@@ -611,18 +614,3 @@ def prep(client: NominalClient, migration_name: str, output_path: Path) -> dict[
     with output_path.open("w", encoding="utf-8") as f:
         yaml.dump(config, f, default_flow_style=False, sort_keys=False)
     logger.info("Wrote migration config to %s", output_path)
-
-    return {
-        "runs": {r.rid for r in runs},
-        "workbooks_single_asset_run": workbooks_with_single_asset_run,
-        "manually_created_assets": manually_created_asset_rids,
-        "auto_created_assets": auto_created_assets,
-        "all_assets": all_assets,
-        "total_datasets": {d.rid for d in datasets},
-        "datasets_with_assets": datasets_with_assets,
-        "workbooks_multi_asset_run": workbooks_with_multi_asset_run,
-        "orphaned_datasets": orphaned_datasets,
-        "streaming_checklists": set(streaming_checklists),
-        "containerized_extractors": {e.rid for e in containerized_extractors},
-        "videos": {v.rid for v in videos},
-    }

--- a/nominal/experimental/migration/migration_cli.py
+++ b/nominal/experimental/migration/migration_cli.py
@@ -1,0 +1,628 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Sequence
+
+import click
+import yaml
+from nominal_api.scout_sandbox_api import SandboxWorkspaceService, SetDemoWorkbooksRequest
+
+from nominal.cli.util.global_decorators import client_options, global_options
+from nominal.core import Asset, NominalClient
+from nominal.experimental import as_user
+from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
+from nominal.experimental.migration.config.migration_resources import AssetResources, MigrationResources
+from nominal.experimental.migration.migration_decorators import migration_client_options
+from nominal.experimental.migration.migration_runner import MigrationRunner
+from nominal.experimental.migration.migrator.context import DestinationClientResolver
+from nominal.experimental.migration.parallel_migration_runner import run_parallel_migration
+from nominal.experimental.migration.resource_type import ResourceType
+
+logger = logging.getLogger(__name__)
+
+UnmappedSourceUserBehavior = Literal["service_user"]
+
+
+@dataclass(frozen=True)
+class ImpersonationConfig:
+    enabled: bool
+    source_to_destination_user_rids: dict[str, str]
+    unmapped_source_user_behavior: UnmappedSourceUserBehavior = "service_user"
+
+
+def _parse_asset_entry(
+    source_client: NominalClient,
+    entry: Any,
+    index: int,
+    *,
+    asset_rid: str | None = None,
+    path_label: str,
+) -> AssetResources:
+    if not isinstance(entry, dict):
+        raise click.UsageError(f"'{path_label}' must be a mapping.")
+
+    if asset_rid is None:
+        rid = entry.get("asset_rid")
+        if not isinstance(rid, str) or not rid.strip():
+            raise click.UsageError(f"'{path_label}.asset_rid' must be a non-empty string.")
+    else:
+        rid = asset_rid
+        if "asset_rid" in entry and entry.get("asset_rid") != rid:
+            raise click.UsageError(f"'migration.source_assets' entry {index} asset_rid does not match map key '{rid}'.")
+
+    asset_resource = source_client.get_asset(rid)
+    if not asset_resource:
+        raise click.UsageError(f"Asset with RID '{rid}' not found in source client.")
+
+    template_rids = entry.get("workbook_template_rids")
+    if template_rids is None:
+        template_rids = []
+    elif not isinstance(template_rids, list) or not all(isinstance(t, str) and t.strip() for t in template_rids):
+        raise click.UsageError(f"'{path_label}.workbook_template_rids' must be a list of strings.")
+
+    templates = []
+    for t in template_rids:
+        template_resource = source_client.get_workbook_template(t)
+        if not template_resource:
+            raise click.UsageError(f"Workbook Template with RID '{t}' not found in source client.")
+        templates.append(template_resource)
+
+    return AssetResources(asset=asset_resource, source_workbook_templates=templates)
+
+
+def _load_migration_block(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict) or "migration" not in raw:
+        raise click.UsageError("Config must be a mapping with a top-level 'migration' key.")
+
+    m = raw["migration"]
+    if not isinstance(m, dict):
+        raise click.UsageError("'migration' must be a mapping.")
+
+    return m
+
+
+def _require_non_empty_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise click.UsageError(f"'{label}' must be a non-empty string.")
+    return value
+
+
+def _require_bool(value: Any, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise click.UsageError(f"'{label}' must be a boolean.")
+    return value
+
+
+def _load_asset_resources(
+    source_client: NominalClient,
+    asset_rids: Any,
+    source_assets: Any,
+) -> dict[str, AssetResources]:
+    if asset_rids is not None and source_assets is not None:
+        raise click.UsageError("Provide only one of 'migration.source_asset_rids' or 'migration.source_assets'.")
+
+    if source_assets is None:
+        if not isinstance(asset_rids, list) or not asset_rids:
+            raise click.UsageError("'migration.source_asset_rids' must be a non-empty list.")
+        return _load_asset_resources_from_list(source_client, asset_rids)
+
+    if not isinstance(source_assets, dict) or not source_assets:
+        raise click.UsageError("'migration.source_assets' must be a non-empty mapping.")
+    return _load_asset_resources_from_map(source_client, source_assets)
+
+
+def _load_asset_resources_from_list(source_client: NominalClient, asset_rids: list[Any]) -> dict[str, AssetResources]:
+    asset_resources_by_rid: dict[str, AssetResources] = {}
+    for i, entry in enumerate(asset_rids):
+        asset_resource = _parse_asset_entry(source_client, entry, i, path_label=f"migration.source_asset_rids[{i}]")
+        rid = asset_resource.asset.rid
+        if rid in asset_resources_by_rid:
+            raise click.UsageError(f"Duplicate asset RID '{rid}' in migration.source_asset_rids.")
+        asset_resources_by_rid[rid] = asset_resource
+    return asset_resources_by_rid
+
+
+def _load_asset_resources_from_map(
+    source_client: NominalClient, source_assets: dict[Any, Any]
+) -> dict[str, AssetResources]:
+    asset_resources_by_rid: dict[str, AssetResources] = {}
+    for rid, entry in source_assets.items():
+        if not isinstance(rid, str) or not rid.strip():
+            raise click.UsageError("'migration.source_assets' keys must be non-empty strings.")
+        if not isinstance(entry, dict):
+            raise click.UsageError(f"'migration.source_assets.{rid}' must be a mapping.")
+        asset_resource = _parse_asset_entry(
+            source_client,
+            entry,
+            0,
+            asset_rid=rid,
+            path_label=f"migration.source_assets.{rid}",
+        )
+        if rid in asset_resources_by_rid:
+            raise click.UsageError(f"Duplicate asset RID '{rid}' in migration.source_assets.")
+        asset_resources_by_rid[rid] = asset_resource
+    return asset_resources_by_rid
+
+
+def _load_standalone_templates(source_client: NominalClient, template_rids: Any) -> list[Any]:
+    if template_rids is None:
+        return []
+
+    if not isinstance(template_rids, list) or not all(isinstance(t, str) and t.strip() for t in template_rids):
+        raise click.UsageError("'migration.standalone_workbook_template_rids' must be a list of strings.")
+
+    templates = []
+    for t in template_rids:
+        template_resource = source_client.get_workbook_template(t)
+        if not template_resource:
+            raise click.UsageError(f"Workbook Template with RID '{t}' not found in source client.")
+        templates.append(template_resource)
+    return templates
+
+
+def load_impersonation_config(raw: Any) -> ImpersonationConfig | None:
+    if raw is None:
+        return None
+
+    if not isinstance(raw, dict):
+        raise click.UsageError("'migration.impersonation' must be a mapping.")
+
+    enabled = raw.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise click.UsageError("'migration.impersonation.enabled' must be a boolean.")
+    if not enabled:
+        return None
+
+    unmapped_source_user_behavior = raw.get("unmapped_source_user_behavior", "service_user")
+    if unmapped_source_user_behavior != "service_user":
+        raise click.UsageError("'migration.impersonation.unmapped_source_user_behavior' must be 'service_user'.")
+
+    raw_mapping = raw.get("source_to_destination_user_rids")
+    if not isinstance(raw_mapping, dict) or not raw_mapping:
+        raise click.UsageError("'migration.impersonation.source_to_destination_user_rids' must be a non-empty mapping.")
+
+    source_to_destination_user_rids: dict[str, str] = {}
+    for source_user_rid, destination_user_rid in raw_mapping.items():
+        if not isinstance(source_user_rid, str) or not source_user_rid.strip():
+            raise click.UsageError(
+                "'migration.impersonation.source_to_destination_user_rids' keys must be non-empty strings."
+            )
+        if not isinstance(destination_user_rid, str) or not destination_user_rid.strip():
+            raise click.UsageError(
+                "'migration.impersonation.source_to_destination_user_rids' values must be non-empty strings."
+            )
+        source_to_destination_user_rids[source_user_rid] = destination_user_rid
+
+    return ImpersonationConfig(
+        enabled=True,
+        source_to_destination_user_rids=source_to_destination_user_rids,
+        unmapped_source_user_behavior=unmapped_source_user_behavior,
+    )
+
+
+def get_source_user_rid(source_resource: Any) -> str | None:
+    """Resolve the source user RID for impersonation.
+
+    This is intentionally narrow and ordered rather than a broad alias sweep:
+    prefer stable top-level creator fields on the resource wrapper, then fall back
+    to the latest API object and its metadata if needed.
+    """
+    user_rid = _extract_user_rid_from_object(source_resource)
+    if user_rid is not None:
+        return user_rid
+
+    latest_api_getter = getattr(source_resource, "_get_latest_api", None)
+    if not callable(latest_api_getter):
+        return None
+
+    try:
+        latest_api = latest_api_getter()
+    except Exception:
+        logger.debug("Unable to fetch latest API object while resolving source user RID.", exc_info=True)
+        return None
+
+    user_rid = _extract_user_rid_from_object(latest_api)
+    if user_rid is not None:
+        return user_rid
+
+    return _extract_user_rid_from_object(getattr(latest_api, "metadata", None))
+
+
+def build_destination_client_resolver(
+    destination_client: NominalClient,
+    impersonation_config: ImpersonationConfig | None,
+) -> DestinationClientResolver | None:
+    if impersonation_config is None or not impersonation_config.enabled:
+        return None
+    return ImpersonatingDestinationClientResolver(destination_client, impersonation_config)
+
+
+class ImpersonatingDestinationClientResolver:
+    def __init__(self, destination_client: NominalClient, impersonation_config: ImpersonationConfig) -> None:
+        """Create a destination client resolver backed by impersonated client caching."""
+        self._destination_client = destination_client
+        self._impersonation_config = impersonation_config
+        self._impersonated_clients_by_user_rid: dict[str, NominalClient] = {}
+
+    def __call__(self, source_resource: Any) -> NominalClient:
+        source_user_rid = get_source_user_rid(source_resource)
+        source_rid = getattr(source_resource, "rid", None)
+        source_type = type(source_resource).__name__
+
+        if source_user_rid is None:
+            logger.debug(
+                "Using destination service user for %s (rid: %s): source user RID could not be determined.",
+                source_type,
+                source_rid,
+            )
+            return self._destination_client
+
+        destination_user_rid = self._impersonation_config.source_to_destination_user_rids.get(source_user_rid)
+        if destination_user_rid is None:
+            logger.debug(
+                "Using destination service user for %s (rid: %s): no destination mapping for source user %s.",
+                source_type,
+                source_rid,
+                source_user_rid,
+            )
+            return self._destination_client
+
+        if destination_user_rid not in self._impersonated_clients_by_user_rid:
+            logger.debug(
+                "Creating impersonated destination client for source user %s -> destination user %s.",
+                source_user_rid,
+                destination_user_rid,
+            )
+            self._impersonated_clients_by_user_rid[destination_user_rid] = as_user(
+                self._destination_client, destination_user_rid
+            )
+
+        logger.debug(
+            "Using impersonated destination client for %s (rid: %s): source user %s -> destination user %s.",
+            source_type,
+            source_rid,
+            source_user_rid,
+            destination_user_rid,
+        )
+        return self._impersonated_clients_by_user_rid[destination_user_rid]
+
+
+def _extract_user_rid_from_object(value: Any) -> str | None:
+    if value is None:
+        return None
+
+    for attribute_name in ("created_by_rid", "author_rid"):
+        nested_value = getattr(value, attribute_name, None)
+        if isinstance(nested_value, str) and nested_value.strip():
+            return nested_value
+
+    for attribute_name in ("created_by", "author"):
+        nested_value = getattr(value, attribute_name, None)
+        nested_user_rid = _extract_user_rid_from_identity(nested_value)
+        if nested_user_rid is not None:
+            return nested_user_rid
+
+    return None
+
+
+def _extract_user_rid_from_identity(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value
+
+    if value is None:
+        return None
+
+    for attribute_name in ("user_rid", "rid"):
+        nested_value = getattr(value, attribute_name, None)
+        if isinstance(nested_value, str) and nested_value.strip():
+            return nested_value
+
+    return None
+
+
+def _load_migration_config(
+    source_client: NominalClient, config_path: Path
+) -> tuple[str, MigrationResources, MigrationDatasetConfig, bool, ImpersonationConfig | None]:
+    with config_path.open("r", encoding="utf-8") as f:
+        raw: Any = yaml.safe_load(f)
+
+    m = _load_migration_block(raw)
+
+    name = _require_non_empty_string(m.get("name"), "migration.name")
+    include_dataset_files = _require_bool(m.get("include_dataset_files"), "migration.include_dataset_files")
+    preserve_dataset_uuid = _require_bool(m.get("preserve_dataset_uuid"), "migration.preserve_dataset_uuid")
+
+    set_to_demo_workbook_raw = m.get("set_to_demo_workbook", False)
+    if not isinstance(set_to_demo_workbook_raw, bool):
+        raise click.UsageError("'migration.set_to_demo_workbook' must be a boolean.")
+    set_to_demo_workbook: bool = set_to_demo_workbook_raw
+
+    asset_resources_by_rid = _load_asset_resources(
+        source_client,
+        m.get("source_asset_rids"),
+        m.get("source_assets"),
+    )
+
+    standalone_workbook_templates = _load_standalone_templates(
+        source_client,
+        m.get("standalone_workbook_template_rids"),
+    )
+    impersonation_config = load_impersonation_config(m.get("impersonation"))
+
+    dataset_config = MigrationDatasetConfig(
+        preserve_dataset_uuid=preserve_dataset_uuid,
+        include_dataset_files=include_dataset_files,
+    )
+
+    return (
+        name,
+        MigrationResources(
+            source_assets=asset_resources_by_rid,
+            source_standalone_templates=standalone_workbook_templates,
+        ),
+        dataset_config,
+        set_to_demo_workbook,
+        impersonation_config,
+    )
+
+
+def _validate_demo_workbook_metadata(source_client: NominalClient, migration_resources: MigrationResources) -> bool:
+    """Validate that all source workbooks have non-empty title, description, and labels.
+
+    Returns True if all workbooks pass validation, False otherwise.
+    """
+    violations: list[str] = []
+    for asset_resources in migration_resources.source_assets.values():
+        source_asset = asset_resources.asset
+        workbooks = source_asset.search_workbooks(include_drafts=True)
+        for workbook in workbooks:
+            raw_notebook = workbook._get_latest_api()
+            metadata = raw_notebook.metadata
+            problems = []
+            if not workbook.title or not workbook.title.strip():
+                problems.append("empty title")
+            if not workbook.description or not workbook.description.strip():
+                problems.append("empty description")
+            if not metadata.labels:
+                problems.append("no labels")
+            if problems:
+                violations.append(
+                    f"Workbook '{workbook.title}' (rid: {workbook.rid}) on asset '{source_asset.name}' "
+                    f"(rid: {source_asset.rid}): {', '.join(problems)}"
+                )
+
+    if violations:
+        for v in violations:
+            logger.error("Demo workbook validation failed: %s", v)
+        return False
+    return True
+
+
+def _create_sandbox_workspace_service(target_client: NominalClient) -> SandboxWorkspaceService:
+    """Create a SandboxWorkspaceService by reusing the connection details from the target client."""
+    existing_service = target_client._clients.workspace
+    return SandboxWorkspaceService(
+        requests_session=existing_service._requests_session,
+        uris=existing_service._uris,
+        _connect_timeout=existing_service._connect_timeout,
+        _read_timeout=existing_service._read_timeout,
+        _verify=existing_service._verify,
+    )
+
+
+def _update_demo_workbooks(target_client: NominalClient, runner: MigrationRunner) -> None:
+    """After migration, append newly created workbook RIDs to the sandbox demo workbooks list."""
+    new_workbook_rids = list(runner.migration_state.rid_mapping.get(ResourceType.WORKBOOK.value, {}).values())
+    if not new_workbook_rids:
+        logger.info("No new workbooks were created; skipping demo workbook update.")
+        return
+
+    workspace_rid = target_client.get_workspace().rid
+    auth_header = target_client._clients.auth_header
+    sandbox_service = _create_sandbox_workspace_service(target_client)
+
+    existing_response = sandbox_service.get_demo_workbooks(auth_header, workspace_rid)
+    existing_rids = existing_response.notebook_rids
+
+    combined_rids = list(dict.fromkeys(existing_rids + new_workbook_rids))
+    sandbox_service.set_demo_workbooks(auth_header, SetDemoWorkbooksRequest(notebook_rids=combined_rids), workspace_rid)
+    logger.info(
+        "Updated demo workbooks: %d existing + %d new = %d total",
+        len(existing_rids),
+        len(new_workbook_rids),
+        len(combined_rids),
+    )
+
+
+@click.group(name="migrate", help="Commands to migrate resources between Nominal tenants.")
+def migrate_cmd() -> None:
+    pass
+
+
+@migrate_cmd.command(name="copy", help="Copy resources from a source tenant to a destination tenant.")
+@migration_client_options
+@global_options
+@click.option(
+    "--config",
+    "config_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Path to the migration config YAML file.",
+)
+@click.option(
+    "--migration-state-path",
+    "migration_state_path",
+    required=False,
+    default=None,
+    type=click.Path(path_type=Path),
+    help="Path to load/save migration state JSON for resumable migrations. Defaults to 'migration_state.json'.",
+)
+@click.option(
+    "--max-workers",
+    default=1,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Maximum number of top-level asset/template migrations to run concurrently.",
+)
+def copy(
+    clients: tuple[NominalClient, NominalClient],
+    config_path: Path,
+    migration_state_path: Path | None,
+    max_workers: int,
+) -> None:
+    source_client, target_client = clients
+    logger.info("Loading migration config from: %s", config_path)
+    name, migration_resources, dataset_config, set_to_demo_workbook, impersonation_config = _load_migration_config(
+        source_client, config_path
+    )
+
+    if set_to_demo_workbook:
+        workspace = target_client.get_workspace()
+        if workspace.id != "sandbox":
+            logger.error(
+                "set_to_demo_workbook is true but destination workspace displayable id is '%s', expected 'sandbox'. "
+                "Skipping migration.",
+                workspace.id,
+            )
+            return
+        if not _validate_demo_workbook_metadata(source_client, migration_resources):
+            logger.error("Demo workbook validation failed. Skipping migration.")
+            return
+
+    logger.info(
+        "Processing migration config: %s (source_assets=%d, source_standalone_templates=%d)",
+        name,
+        len(migration_resources.source_assets),
+        len(migration_resources.source_standalone_templates),
+    )
+    destination_client_resolver = build_destination_client_resolver(target_client, impersonation_config)
+    if destination_client_resolver is not None:
+        logger.info("Destination impersonation is enabled for this migration config.")
+
+    runner = MigrationRunner(
+        migration_resources=migration_resources,
+        dataset_config=dataset_config,
+        destination_client=target_client,
+        destination_client_resolver=destination_client_resolver,
+        migration_state_path=migration_state_path,
+    )
+    run_parallel_migration(runner, max_workers=max_workers)
+
+    if set_to_demo_workbook:
+        _update_demo_workbooks(target_client, runner)
+
+
+@migrate_cmd.command(name="prep", help="Count in-scope and out-of-scope resources and generate a migration config.")
+@client_options
+@global_options
+@click.option(
+    "--name",
+    "migration_name",
+    required=True,
+    help="Name for the migration (written into the generated config file).",
+)
+@click.option(
+    "--output",
+    "output_path",
+    required=True,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Path where the generated migration config YAML will be written.",
+)
+def prep(client: NominalClient, migration_name: str, output_path: Path) -> dict[str, set[str]]:
+    """Count resources on a tenant to determine migration scope and generate a starter config."""
+    logger.info("In-scope migration numbers:")
+
+    runs = client.search_runs()
+    logger.info("  Total runs: %d", len(runs))
+
+    workbooks = client.search_workbooks(include_drafts=True)
+    workbooks_with_single_asset_run: set[str] = set()
+    workbooks_with_multi_asset_run: set[str] = set()
+
+    for workbook in workbooks:
+        if workbook.run_rids:
+            if len(workbook.run_rids) == 1:
+                workbooks_with_single_asset_run.add(workbook.rid)
+            else:
+                workbooks_with_multi_asset_run.add(workbook.rid)
+        elif workbook.asset_rids:
+            if len(workbook.asset_rids) == 1:
+                workbooks_with_single_asset_run.add(workbook.rid)
+            else:
+                workbooks_with_multi_asset_run.add(workbook.rid)
+
+    logger.info("  Workbooks with single asset/run: %d", len(workbooks_with_single_asset_run))
+
+    manually_created_assets: Sequence[Asset] = client.search_assets()
+    logger.info("  Manually-created assets: %d", len(manually_created_assets))
+
+    manually_created_asset_rids = {a.rid for a in manually_created_assets}
+    all_assets: set[str] = set(manually_created_asset_rids)
+    auto_created_assets: set[str] = set()
+
+    for run in runs:
+        asset_rid = run.assets[0]
+        if asset_rid not in manually_created_asset_rids:
+            auto_created_assets.add(asset_rid)
+            all_assets.add(asset_rid)
+
+    logger.info("  Auto-created assets: %d", len(auto_created_assets))
+    logger.info("  All assets: %d", len(all_assets))
+
+    datasets = client.search_datasets()
+    logger.info("  Total datasets: %d", len(datasets))
+
+    datasets_with_assets: set[str] = set()
+    videos = client.search_videos()
+
+    logger.info("  Total videos: %d", len(videos))
+
+    for asset_rid in all_assets:
+        asset = client.get_asset(asset_rid)
+        for _data_scope, dataset in asset.list_datasets():
+            datasets_with_assets.add(dataset.rid)
+
+    logger.info("  Datasets with assets: %d", len(datasets_with_assets))
+
+    orphaned_datasets: set[str] = {d.rid for d in datasets if d.rid not in datasets_with_assets}
+
+    logger.info("Out-of-scope migration numbers:")
+    logger.info("  Workbooks with multiple asset/runs: %d", len(workbooks_with_multi_asset_run))
+    logger.info("  Orphaned datasets: %d", len(orphaned_datasets))
+
+    streaming_checklists = client.list_streaming_checklists()
+    logger.info("  Streaming checklists: %d", len(streaming_checklists))
+
+    containerized_extractors = client.search_containerized_extractors()
+    logger.info("  Containerized extractors: %d", len(containerized_extractors))
+
+    config = {
+        "migration": {
+            "name": migration_name,
+            "include_dataset_files": False,
+            "preserve_dataset_uuid": True,
+            "set_to_demo_workbook": False,
+            "source_asset_rids": [{"asset_rid": rid} for rid in sorted(all_assets)],
+        }
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as f:
+        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+    logger.info("Wrote migration config to %s", output_path)
+
+    return {
+        "runs": {r.rid for r in runs},
+        "workbooks_single_asset_run": workbooks_with_single_asset_run,
+        "manually_created_assets": manually_created_asset_rids,
+        "auto_created_assets": auto_created_assets,
+        "all_assets": all_assets,
+        "total_datasets": {d.rid for d in datasets},
+        "datasets_with_assets": datasets_with_assets,
+        "workbooks_multi_asset_run": workbooks_with_multi_asset_run,
+        "orphaned_datasets": orphaned_datasets,
+        "streaming_checklists": set(streaming_checklists),
+        "containerized_extractors": {e.rid for e in containerized_extractors},
+        "videos": {v.rid for v in videos},
+    }

--- a/nominal/experimental/migration/migration_decorators.py
+++ b/nominal/experimental/migration/migration_decorators.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import functools
+import logging
+import pathlib
+import typing
+
+import click
+
+from nominal.core.client import NominalClient
+
+logger = logging.getLogger(__name__)
+
+Param = typing.ParamSpec("Param")
+T = typing.TypeVar("T")
+
+
+def migration_client_options(
+    func: typing.Callable[Param, T],
+) -> typing.Callable[Param, T]:
+    """Decorator to add click options to a click command for dynamically creating and injecting instances of the
+    NominalClient into commands based on user-provided flags to configure its creation.
+
+    This will add options --source-profile and --destination-profile which perform the aforementioned
+    configurations before spawning a NominalClient.
+    """
+    source_profile_option = click.option(
+        "--source-profile",
+        required=True,
+        help=(
+            "If provided, use the given named config profile for instantiating a Nominal Client "
+            "for the source tenant. This is the preferred mechanism for instantiating a client today-- "
+            "see `nom config profile add` to create a configuration profile. If provided, takes precedence "
+            "over --token, --token-path, and --base-url."
+        ),
+    )
+
+    destination_profile_option = click.option(
+        "--destination-profile",
+        required=True,
+        help=(
+            "If provided, use the given named config profile for instantiating a Nominal Client "
+            "for the destination tenant. This is the preferred mechanism for instantiating a client today-- "
+            "see `nom config profile add` to create a configuration profile. If provided, takes precedence "
+            "over --token, --token-path, and --base-url."
+        ),
+    )
+
+    trust_store_option = click.option(
+        "--trust-store-path",
+        type=click.Path(dir_okay=False, exists=True, resolve_path=True, path_type=pathlib.Path),
+        help=(
+            "Path to a trust store CA root file to initiate SSL connections. "
+            "If not provided, defaults to certifi's trust store."
+        ),
+    )
+
+    @functools.wraps(func)
+    def wrapped_function(
+        *args: Param.args,
+        **kwargs: Param.kwargs,
+    ) -> T:
+        source_profile: str = kwargs.pop("source_profile")  # type: ignore[assignment]
+        destination_profile: str = kwargs.pop("destination_profile")  # type: ignore[assignment]
+        trust_store_path: pathlib.Path | None = kwargs.pop("trust_store_path")  # type: ignore[assignment]
+
+        trust_store_str = str(trust_store_path) if trust_store_path else None
+
+        logger.info("Instantiating client from profile '%s'", source_profile)
+        source_client = NominalClient.from_profile(source_profile, trust_store_path=trust_store_str)
+        logger.info("Instantiating client from profile '%s'", destination_profile)
+        destination_client = NominalClient.from_profile(destination_profile, trust_store_path=trust_store_str)
+        kwargs["clients"] = (source_client, destination_client)
+        return func(*args, **kwargs)
+
+    return destination_profile_option(source_profile_option(trust_store_option(wrapped_function)))

--- a/nominal/experimental/migration/parallel_migration_executor.py
+++ b/nominal/experimental/migration/parallel_migration_executor.py
@@ -1,0 +1,47 @@
+"""Execution helpers for parallel resource migration."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+import os
+from dataclasses import dataclass
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MigrationTask:
+    rid: str
+    label: str
+    fn: Callable[[], None]
+
+
+def validate_max_workers(max_workers: int) -> int:
+    """Validate and clamp max_workers to [1, cpu_count]."""
+    cpu_count = os.cpu_count() or 4
+    return max(1, min(max_workers, cpu_count))
+
+
+def run_concurrent(
+    executor: concurrent.futures.ThreadPoolExecutor,
+    tasks: list[MigrationTask],
+) -> None:
+    """Submit tasks concurrently and raise a RuntimeError listing all failures."""
+    if not tasks:
+        return
+
+    errors: list[Exception] = []
+    futures = {executor.submit(task.fn): task for task in tasks}
+    for future in concurrent.futures.as_completed(futures):
+        task = futures[future]
+        try:
+            future.result()
+            logger.info("Completed migration for %s (rid: %s)", task.label, task.rid)
+        except Exception as exc:  # pragma: no cover - exercised by production callers
+            logger.error("Failed to migrate %s (rid: %s)", task.label, task.rid, exc_info=exc)
+            errors.append(exc)
+    if errors:
+        error_summary = "; ".join(str(e) for e in errors)
+        raise RuntimeError(f"Parallel migration had {len(errors)} failure(s): {error_summary}")

--- a/nominal/experimental/migration/parallel_migration_runner.py
+++ b/nominal/experimental/migration/parallel_migration_runner.py
@@ -42,7 +42,11 @@ def run_parallel_migration(runner: MigrationRunner, max_workers: int) -> None:
     max_workers = validate_max_workers(max_workers)
     runner.migration_state = ThreadSafeMigrationState(rid_mapping=runner.migration_state.rid_mapping)
 
-    ctx = MigrationContext(destination_client=runner.destination_client, migration_state=runner.migration_state)
+    ctx = MigrationContext(
+        destination_client=runner.destination_client,
+        migration_state=runner.migration_state,
+        source_asset_rids=frozenset(runner.migration_resources.source_assets.keys()),
+    )
     if getattr(runner, "destination_client_resolver", None) is not None:
         setattr(ctx, "destination_client_resolver", runner.destination_client_resolver)
     asset_migrator = AssetMigrator(ctx)

--- a/nominal/experimental/migration/parallel_migration_runner.py
+++ b/nominal/experimental/migration/parallel_migration_runner.py
@@ -1,0 +1,71 @@
+"""Parallel helpers for resource migration."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+
+from nominal.experimental.migration.migration_runner import MigrationRunner
+from nominal.experimental.migration.migrator.asset_migrator import AssetCopyOptions, AssetMigrator
+from nominal.experimental.migration.migrator.context import MigrationContext
+from nominal.experimental.migration.migrator.workbook_template_migrator import WorkbookTemplateMigrator
+from nominal.experimental.migration.parallel_migration_executor import (
+    MigrationTask,
+    run_concurrent,
+    validate_max_workers,
+)
+from nominal.experimental.migration.parallel_migration_state import ThreadSafeMigrationState
+
+logger = logging.getLogger(__name__)
+
+
+def run_parallel_migration(runner: MigrationRunner, max_workers: int) -> None:
+    """Run resource migration with a shared thread pool."""
+    max_workers = validate_max_workers(max_workers)
+    runner.migration_state = ThreadSafeMigrationState(rid_mapping=runner.migration_state.rid_mapping)
+
+    ctx = MigrationContext(destination_client=runner.destination_client, migration_state=runner.migration_state)
+    if getattr(runner, "destination_client_resolver", None) is not None:
+        setattr(ctx, "destination_client_resolver", runner.destination_client_resolver)
+    asset_migrator = AssetMigrator(ctx)
+    template_migrator = WorkbookTemplateMigrator(ctx)
+    asset_copy_options = AssetCopyOptions(
+        dataset_config=runner.dataset_config,
+        include_attachments=True,
+        include_events=True,
+        include_runs=True,
+        include_video=True,
+        include_checklists=True,
+    )
+
+    asset_tasks = [
+        MigrationTask(
+            rid=rid,
+            label="asset",
+            fn=lambda ar=asset_resources: asset_migrator.copy_from(ar.asset, asset_copy_options),
+        )
+        for rid, asset_resources in runner.migration_resources.source_assets.items()
+    ]
+    template_tasks = [
+        MigrationTask(
+            rid=template.rid,
+            label="template",
+            fn=lambda template=template: template_migrator.clone(template),
+        )
+        for template in runner.migration_resources.source_standalone_templates
+    ]
+    tasks = asset_tasks + template_tasks
+
+    logger.info(
+        "Running migration with %d worker(s) across %d asset(s) and %d template(s)",
+        max_workers,
+        len(asset_tasks),
+        len(template_tasks),
+    )
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            run_concurrent(executor, tasks)
+    finally:
+        runner.save_state()
+
+    logger.info("Completed parallel migration")

--- a/nominal/experimental/migration/parallel_migration_runner.py
+++ b/nominal/experimental/migration/parallel_migration_runner.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
+from typing import Callable
 
+from nominal.experimental.migration.config.migration_resources import AssetResources
 from nominal.experimental.migration.migration_runner import MigrationRunner
 from nominal.experimental.migration.migrator.asset_migrator import AssetCopyOptions, AssetMigrator
 from nominal.experimental.migration.migrator.context import MigrationContext
@@ -17,6 +19,22 @@ from nominal.experimental.migration.parallel_migration_executor import (
 from nominal.experimental.migration.parallel_migration_state import ThreadSafeMigrationState
 
 logger = logging.getLogger(__name__)
+
+
+def _make_asset_fn(
+    asset_resources: AssetResources, asset_migrator: AssetMigrator, asset_copy_options: AssetCopyOptions
+) -> Callable[[], None]:
+    def fn() -> None:
+        asset_migrator.copy_from(asset_resources.asset, asset_copy_options)
+
+    return fn
+
+
+def _make_template_fn(template: object, template_migrator: WorkbookTemplateMigrator) -> Callable[[], None]:
+    def fn() -> None:
+        template_migrator.clone(template)  # type: ignore[arg-type]
+
+    return fn
 
 
 def run_parallel_migration(runner: MigrationRunner, max_workers: int) -> None:
@@ -42,7 +60,7 @@ def run_parallel_migration(runner: MigrationRunner, max_workers: int) -> None:
         MigrationTask(
             rid=rid,
             label="asset",
-            fn=lambda ar=asset_resources: asset_migrator.copy_from(ar.asset, asset_copy_options),
+            fn=_make_asset_fn(asset_resources, asset_migrator, asset_copy_options),
         )
         for rid, asset_resources in runner.migration_resources.source_assets.items()
     ]
@@ -50,7 +68,7 @@ def run_parallel_migration(runner: MigrationRunner, max_workers: int) -> None:
         MigrationTask(
             rid=template.rid,
             label="template",
-            fn=lambda template=template: template_migrator.clone(template),
+            fn=_make_template_fn(template, template_migrator),
         )
         for template in runner.migration_resources.source_standalone_templates
     ]

--- a/nominal/experimental/migration/parallel_migration_state.py
+++ b/nominal/experimental/migration/parallel_migration_state.py
@@ -1,0 +1,25 @@
+"""Thread-safe migration state helpers for parallel resource migration."""
+
+from __future__ import annotations
+
+import threading
+
+from nominal.experimental.migration.migration_state import MigrationState
+from nominal.experimental.migration.resource_type import ResourceType
+
+
+class ThreadSafeMigrationState(MigrationState):
+    """Thread-safe wrapper around MigrationState for parallel migrations."""
+
+    def __init__(self, rid_mapping: dict[str, dict[str, str]] | None = None) -> None:
+        """Initialize the shared migration state with an internal lock."""
+        super().__init__(rid_mapping=rid_mapping if rid_mapping is not None else {})
+        self._lock = threading.Lock()
+
+    def record_mapping(self, resource_type: ResourceType, old_rid: str, new_rid: str) -> None:
+        with self._lock:
+            super().record_mapping(resource_type, old_rid, new_rid)
+
+    def get_mapped_rid(self, resource_type: ResourceType, old_rid: str) -> str | None:
+        with self._lock:
+            return super().get_mapped_rid(resource_type, old_rid)

--- a/nominal/experimental/migration/parallel_migration_state.py
+++ b/nominal/experimental/migration/parallel_migration_state.py
@@ -24,6 +24,26 @@ class ThreadSafeMigrationState(MigrationState):
         with self._lock:
             return super().get_mapped_rid(resource_type, old_rid)
 
+    def record_pending_multi_asset_workbook(self, workbook_rid: str, asset_rids: list[str]) -> None:
+        with self._lock:
+            super().record_pending_multi_asset_workbook(workbook_rid, asset_rids)
+
+    def record_pending_multi_run_workbook(self, workbook_rid: str, run_rids: list[str]) -> None:
+        with self._lock:
+            super().record_pending_multi_run_workbook(workbook_rid, run_rids)
+
+    def clear_pending_multi_asset_workbook(self, workbook_rid: str) -> None:
+        with self._lock:
+            super().clear_pending_multi_asset_workbook(workbook_rid)
+
+    def clear_pending_multi_run_workbook(self, workbook_rid: str) -> None:
+        with self._lock:
+            super().clear_pending_multi_run_workbook(workbook_rid)
+
+    def record_skip(self, resource_type: ResourceType, source_rid: str, reason: str) -> None:
+        with self._lock:
+            super().record_skip(resource_type, source_rid, reason)
+
     def to_json(self, **encoder_kwargs: object) -> str:
         # dataclass_wizard cannot resolve forward references from migration_state.py when
         # introspecting this subclass, so serialize as a plain MigrationState instead.

--- a/nominal/experimental/migration/parallel_migration_state.py
+++ b/nominal/experimental/migration/parallel_migration_state.py
@@ -23,3 +23,14 @@ class ThreadSafeMigrationState(MigrationState):
     def get_mapped_rid(self, resource_type: ResourceType, old_rid: str) -> str | None:
         with self._lock:
             return super().get_mapped_rid(resource_type, old_rid)
+
+    def to_json(self, **encoder_kwargs: object) -> str:
+        # dataclass_wizard cannot resolve forward references from migration_state.py when
+        # introspecting this subclass, so serialize as a plain MigrationState instead.
+        base = MigrationState(
+            rid_mapping=self.rid_mapping,
+            pending_multi_asset_workbooks=self.pending_multi_asset_workbooks,
+            pending_multi_run_workbooks=self.pending_multi_run_workbooks,
+            skipped_resources=self.skipped_resources,
+        )
+        return base.to_json(**encoder_kwargs)  # type: ignore[arg-type]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ video = ["nominal-video==0.1.9; platform_python_implementation=='CPython' and py
 [project.scripts]
 nom = 'nominal.cli:nom'
 nominal = 'nominal.cli:nom'
+nom-migrate = 'nominal.experimental.migration.migration_cli:migrate_cmd'
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary

This PR moves the top-level wrapper code for migration from an internal source to the nominal client so select users can run migration on their self-hosted environments. Changes made: 

- Moves the resource migration CLI and parallel execution helpers from `internal-tools` into `nominal-client` under `nominal/experimental/migration/`                                                                                          
- Adds a new `nom-migrate` entry point exposing `nom migrate copy` and `nom migrate prep` commands
- `nom migrate copy` accepts a `--config <path>` to any YAML file (no longer assumes a bundled configs directory)                                                                                                                              
- `nom migrate prep` accepts `--name` and `--output <path>` to write a starter config to a user-specified location                                                                                                                                                                                                                        

Note that after testing, we also implemented a fix to a latent bug in parallel migration with serializing and deserializing the migration state, and addresses some auto-bot PR comments.

## Testing

I ran a test form our production environment to our staging environment which used this new CLI. I ran this command twice, using the same migration state:
1. Test 1 - verified migration ran and new resources were created.
2. Test 2 - verified migration skipped all resources, since they existed in the migration state.