### PR TITLE
feat: add PUT response headers in S3 multipart upload exception

### DIFF
--- a/nominal/core/_utils/multipart.py
+++ b/nominal/core/_utils/multipart.py
@@ -30,6 +30,11 @@ def _wrap_multipart_retry_exception(
     attempt: int,
     previous_attempt_ex: Exception | None,
 ) -> NominalMultipartUploadFailed:
+    """Wrap failed multipart upload attempts so that we can:
+    - chain exceptions across retries to preserve the full history of failures for debugging
+    - add contextual information, especially response headers so that we can debug S3 errors
+    - AWS will want x-amz-request-id and x-amz-id-2 headers for debugging
+    """
     response = getattr(ex, "response", None)
     response_headers = (
         ", ".join(f"{header}={value!r}" for header, value in sorted(response.headers.items()))

--- a/nominal/core/_utils/multipart.py
+++ b/nominal/core/_utils/multipart.py
@@ -21,6 +21,30 @@ DEFAULT_CHUNK_SIZE = 64_000_000
 DEFAULT_NUM_WORKERS = 8
 
 
+def _wrap_multipart_retry_exception(
+    *,
+    ex: Exception,
+    key: str,
+    part: int,
+    upload_id: str,
+    attempt: int,
+    previous_attempt_ex: Exception | None,
+) -> NominalMultipartUploadFailed:
+    response = getattr(ex, "response", None)
+    response_headers = (
+        ", ".join(f"{header}={value!r}" for header, value in sorted(response.headers.items()))
+        if response is not None and response.headers is not None
+        else "none"
+    )
+    wrapped = NominalMultipartUploadFailed(
+        f"Multipart upload failed for key={key}, upload_id={upload_id}, part={part}, "
+        f"attempt={attempt}: {type(ex).__name__}: {ex}. Response headers: {response_headers}"
+    )
+    if previous_attempt_ex is not None:
+        wrapped.__cause__ = previous_attempt_ex
+    return wrapped
+
+
 def _sign_and_upload_part_job(
     upload_client: upload_api.UploadService,
     multipart_session: requests.Session,
@@ -34,7 +58,7 @@ def _sign_and_upload_part_job(
     data = q.get()
 
     try:
-        last_ex: Exception | None = None
+        last_ex: NominalMultipartUploadFailed | None = None
         for attempt in range(num_retries):
             try:
                 log_extras = {"key": key, "part": part, "upload_id": upload_id, "attempt": attempt + 1}
@@ -54,22 +78,20 @@ def _sign_and_upload_part_job(
                     headers=sign_response.headers,
                     verify=upload_client._verify,
                 )
+                put_response.raise_for_status()
                 logger.debug(
                     "Finished pushing part %d for multipart upload with status %d",
                     part,
                     put_response.status_code,
                     extra={"response.url": put_response.url, **log_extras},
                 )
-                put_response.raise_for_status()
                 return put_response
             except Exception as ex:
-                logger.warning(
-                    "Failed to upload part %d: %s",
-                    part,
-                    ex,
-                    extra=log_extras,
+                logger.warning("Failed to upload part %d: %s", part, ex, extra=log_extras)
+                wrapped_ex = _wrap_multipart_retry_exception(
+                    ex=ex, key=key, part=part, upload_id=upload_id, attempt=attempt + 1, previous_attempt_ex=last_ex
                 )
-                last_ex = ex
+                last_ex = wrapped_ex
 
         raise (
             last_ex

--- a/nominal/core/_utils/multipart.py
+++ b/nominal/core/_utils/multipart.py
@@ -21,6 +21,10 @@ DEFAULT_CHUNK_SIZE = 64_000_000
 DEFAULT_NUM_WORKERS = 8
 
 
+class _MultipartUploadError(Exception):
+    """A single failed multipart upload attempt."""
+
+
 def _wrap_multipart_retry_exception(
     *,
     ex: Exception,
@@ -28,10 +32,8 @@ def _wrap_multipart_retry_exception(
     part: int,
     upload_id: str,
     attempt: int,
-    previous_attempt_ex: Exception | None,
-) -> NominalMultipartUploadFailed:
-    """Wrap failed multipart upload attempts so that we can:
-    - chain exceptions across retries to preserve the full history of failures for debugging
+) -> _MultipartUploadError:
+    """Wrap a failed multipart upload attempt so that we can:
     - add contextual information, especially response headers so that we can debug S3 errors
     - AWS will want x-amz-request-id and x-amz-id-2 headers for debugging
     """
@@ -41,12 +43,11 @@ def _wrap_multipart_retry_exception(
         if response is not None and response.headers is not None
         else "none"
     )
-    wrapped = NominalMultipartUploadFailed(
+    wrapped = _MultipartUploadError(
         f"Multipart upload failed for key={key}, upload_id={upload_id}, part={part}, "
         f"attempt={attempt}: {type(ex).__name__}: {ex}. Response headers: {response_headers}"
     )
-    if previous_attempt_ex is not None:
-        wrapped.__cause__ = previous_attempt_ex
+    wrapped.__cause__ = ex
     return wrapped
 
 
@@ -63,7 +64,7 @@ def _sign_and_upload_part_job(
     data = q.get()
 
     try:
-        last_ex: NominalMultipartUploadFailed | None = None
+        attempt_errors: list[_MultipartUploadError] = []
         for attempt in range(num_retries):
             try:
                 log_extras = {"key": key, "part": part, "upload_id": upload_id, "attempt": attempt + 1}
@@ -93,16 +94,24 @@ def _sign_and_upload_part_job(
                 return put_response
             except Exception as ex:
                 logger.warning("Failed to upload part %d: %s", part, ex, extra=log_extras)
-                wrapped_ex = _wrap_multipart_retry_exception(
-                    ex=ex, key=key, part=part, upload_id=upload_id, attempt=attempt + 1, previous_attempt_ex=last_ex
+                attempt_errors.append(
+                    _wrap_multipart_retry_exception(
+                        ex=ex,
+                        key=key,
+                        part=part,
+                        upload_id=upload_id,
+                        attempt=attempt + 1,
+                    )
                 )
-                last_ex = wrapped_ex
 
-        raise (
-            last_ex
-            if last_ex
-            else RuntimeError(f"Unknown error uploading part {part} for upload_id={upload_id} and key={key}")
-        )
+        if attempt_errors:
+            raise NominalMultipartUploadFailed(
+                f"Multipart upload failed for key={key}, upload_id={upload_id}, part={part} "
+                f"after {num_retries} attempts",
+                attempt_errors,
+            )
+
+        raise RuntimeError(f"Unknown error uploading part {part} for upload_id={upload_id} and key={key}")
     finally:
         q.task_done()
 
@@ -207,7 +216,10 @@ def put_multipart_upload(
         parts = [ingest_api.Part(etag=p.etag, part_number=p.part_number) for p in parts_with_size]
         complete_response = upload_client.complete_multipart_upload(auth_header, key, upload_id, parts)
         if complete_response.location is None:
-            raise NominalMultipartUploadFailed("completing multipart upload failed: no location on response")
+            raise NominalMultipartUploadFailed(
+                "completing multipart upload failed: no location on response",
+                [RuntimeError("Multipart upload completion returned no location")],
+            )
         return complete_response.location
     except Exception as e:
         _abort(upload_client, auth_header, key, upload_id, e)

--- a/nominal/core/_utils/multipart.py
+++ b/nominal/core/_utils/multipart.py
@@ -12,17 +12,13 @@ import requests
 from nominal_api import ingest_api, upload_api
 
 from nominal.core._utils.networking import create_multipart_request_session
-from nominal.core.exceptions import NominalMultipartUploadFailed
+from nominal.core.exceptions import NominalMultipartUploadError, NominalMultipartUploadFailed
 from nominal.core.filetype import FileType
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_CHUNK_SIZE = 64_000_000
 DEFAULT_NUM_WORKERS = 8
-
-
-class _MultipartUploadError(Exception):
-    """A single failed multipart upload attempt."""
 
 
 def _wrap_multipart_retry_exception(
@@ -32,7 +28,7 @@ def _wrap_multipart_retry_exception(
     part: int,
     upload_id: str,
     attempt: int,
-) -> _MultipartUploadError:
+) -> NominalMultipartUploadError:
     """Wrap a failed multipart upload attempt so that we can:
     - add contextual information, especially response headers so that we can debug S3 errors
     - AWS will want x-amz-request-id and x-amz-id-2 headers for debugging
@@ -43,7 +39,7 @@ def _wrap_multipart_retry_exception(
         if response is not None and response.headers is not None
         else "none"
     )
-    wrapped = _MultipartUploadError(
+    wrapped = NominalMultipartUploadError(
         f"Multipart upload failed for key={key}, upload_id={upload_id}, part={part}, "
         f"attempt={attempt}: {type(ex).__name__}: {ex}. Response headers: {response_headers}"
     )
@@ -64,7 +60,7 @@ def _sign_and_upload_part_job(
     data = q.get()
 
     try:
-        attempt_errors: list[_MultipartUploadError] = []
+        attempt_errors: list[NominalMultipartUploadError] = []
         for attempt in range(num_retries):
             try:
                 log_extras = {"key": key, "part": part, "upload_id": upload_id, "attempt": attempt + 1}

--- a/nominal/core/exceptions.py
+++ b/nominal/core/exceptions.py
@@ -34,8 +34,12 @@ class NominalIngestFailed(NominalIngestError):
     """The ingest failed."""
 
 
+class NominalMultipartUploadError(Exception):
+    """A single failed multipart upload attempt."""
+
+
 class NominalMultipartUploadFailed(NominalError, ExceptionGroup):
-    """The multipart upload failed."""
+    """The multipart upload failed after retries."""
 
 
 class NominalConfigError(NominalError):

--- a/nominal/core/exceptions.py
+++ b/nominal/core/exceptions.py
@@ -1,5 +1,8 @@
 from typing import Mapping
 
+# Remove this import once the minimum supported Python version is 3.11+.
+from exceptiongroup import ExceptionGroup
+
 
 class NominalError(Exception):
     """Base class for Nominal exceptions."""
@@ -31,7 +34,7 @@ class NominalIngestFailed(NominalIngestError):
     """The ingest failed."""
 
 
-class NominalMultipartUploadFailed(NominalError):
+class NominalMultipartUploadFailed(NominalError, ExceptionGroup):
     """The multipart upload failed."""
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "click>=8,<9",
     "conjure-python-client>=3.1.0,<4",
     "dataclass-wizard>=0.39.1",
+    "exceptiongroup>=1.3.0",
     "ffmpeg-python>=0.2.0",
     "nominal-api==0.1193.0",
     "rich>=14.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1161,6 +1161,7 @@ dependencies = [
     { name = "click" },
     { name = "conjure-python-client" },
     { name = "dataclass-wizard" },
+    { name = "exceptiongroup" },
     { name = "ffmpeg-python" },
     { name = "nominal-api" },
     { name = "nominal-streaming", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')" },
@@ -1218,6 +1219,7 @@ requires-dist = [
     { name = "click", specifier = ">=8,<9" },
     { name = "conjure-python-client", specifier = ">=3.1.0,<4" },
     { name = "dataclass-wizard", specifier = ">=0.39.1" },
+    { name = "exceptiongroup", specifier = ">=1.3.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "nominal-api", specifier = "==0.1193.0" },
     { name = "nominal-api-protos", marker = "extra == 'protos'", specifier = ">=0.1090.0" },


### PR DESCRIPTION
This allows us to follow up with AWS on any 500 errors that are encountered. 

As per https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html, we'd want to collect `x-amz-id-2` and `x-amz-request-id`:

Name | Description
-- | --
x-amz-id-2 | A special token that is used together with the x-amz-request-id header to help AWS troubleshoot problems. For information about Support using these request IDs, see Troubleshooting Amazon S3. <br />Type: String <br />Default: None
x-amz-request-id | A value created by Amazon S3 that uniquely identifies the request. This value is used together with the x-amz-id-2 header to help AWS troubleshoot problems. For information about Support using these request IDs, see Troubleshooting Amazon S3. <br />Type: String <br />Default: None
