### PR TITLE
feat: preserve auto-created status in asset migration

### DIFF
--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -4,6 +4,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Sequence
 
+from nominal_api import scout_asset_api
+
 from nominal.core import NominalClient
 from nominal.core._event_types import SearchEventOriginType
 from nominal.core.asset import Asset
@@ -96,7 +98,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
         if existing_asset is not None:
             return existing_asset
 
-        return self.destination_client_for(source_asset).create_asset(
+        new_asset = self.destination_client_for(source_asset).create_asset(
             name=options.new_asset_name if options.new_asset_name is not None else source_asset.name,
             description=options.new_asset_description
             if options.new_asset_description is not None
@@ -106,6 +108,15 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             else source_asset.properties,
             labels=options.new_asset_labels if options.new_asset_labels is not None else source_asset.labels,
         )
+
+        if source_asset._get_latest_api().is_staged:
+            new_asset._clients.assets.update_asset(
+                new_asset._clients.auth_header,
+                scout_asset_api.UpdateAssetRequest(is_staged=True),
+                new_asset.rid,
+            )
+
+        return new_asset
 
     def _copy_asset_datasets(self, source_asset: Asset, destination_asset: Asset, options: AssetCopyOptions) -> None:
         if options.dataset_config is None:


### PR DESCRIPTION
### Background                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                 
  When a Run is created in Nominal without linking it to an existing asset, the backend                                                                                                                                                          
  automatically creates a "staged" asset behind the scenes. Staged assets are hidden from
  search results and the asset browser — they're backend implementation details unless a
  user explicitly promotes them. The `is_staged` flag on the API's `Asset` type tracks                                                                                                                                                           
  this state.
                                                                                                                                                                                                                                                 
  ### Problem                                               

  `AssetMigrator._resolve_destination_asset` always called `create_asset`, which creates
  assets as non-staged by default (since `CreateAssetRequest` has no `is_staged` field).
  As a result, migrating an auto-created (staged) asset would silently promote it in the                                                                                                                                                         
  destination — making it visible in search and the asset browser when it shouldn't be.
                                                                                                                                                                                                                                                 
  ### Fix                                                                                                                                                                                                                                        
  
  After creating the destination asset, check whether the source asset's `is_staged` flag                                                                                                                                                        
  is `True`. If so, immediately follow up with an `update_asset` call to mark the new
  asset as staged. Since `UpdateAssetRequest` supports `is_staged`, this correctly
  preserves the auto-created status.                                                                                                                                                                                                                                                                                                                                                                                                                                 
                                                            
  This only applies to freshly created assets — the existing early-return path for                                                                                                                                                               
  already-migrated assets (via `get_existing_destination_resource`) is unaffected.
                                                                                                                                                                                                                                                 
  ### Testing                                               

  Tested end-to-end by running `AssetMigrator.copy_from` against a known auto-created
  asset with minimal copy options (no datasets, runs, events, or videos). Verified that:
                                                                                                                                                                                                                                                 
  - The source asset had `is_staged = True`
  - The migrated destination asset also had `is_staged = True` after migration 