### PR TITLE
feat: update e2e testing for new migration features

### DIFF
--- a/tests/core/test_run_migrator.py
+++ b/tests/core/test_run_migrator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -30,6 +30,11 @@ def _run_rid(n: int) -> str:
 def _asset_rid(n: int) -> str:
     hex8 = f"{n:08x}"
     return f"ri.scout.{_STACK}.asset.{hex8}-0000-0000-0000-000000000000"
+
+
+def _att_rid(n: int) -> str:
+    hex8 = f"{n:08x}"
+    return f"ri.attachments.{_STACK}.attachment.{hex8}-0000-0000-0000-000000000000"
 
 
 def _make_run(rid: str, name: str = "Run", asset_rids: list[str] | None = None) -> MagicMock:
@@ -239,3 +244,62 @@ class TestRunMigratorEnsureAssetsAdded:
         run = _make_run(_run_rid(1), asset_rids=[_asset_rid(10)])
         with pytest.raises(ValueError, match="non-empty"):
             migrator._ensure_assets_added(run, [])
+
+
+# ---------------------------------------------------------------------------
+# Attachment migration
+# ---------------------------------------------------------------------------
+
+
+class TestRunMigratorAttachments:
+    @patch("nominal.experimental.migration.migrator.run_migrator.AttachmentMigrator")
+    def test_new_run_attachments_are_migrated(self, mock_att_cls: MagicMock) -> None:
+        """When creating a new run, each source attachment is migrated and passed to create_run."""
+        ctx = _make_context()
+        migrator = RunMigrator(ctx)
+
+        src_att_1, src_att_2 = MagicMock(rid=_att_rid(1)), MagicMock(rid=_att_rid(2))
+        new_att_1, new_att_2 = MagicMock(rid=_att_rid(101)), MagicMock(rid=_att_rid(102))
+
+        mock_att_migrator = mock_att_cls.return_value
+        mock_att_migrator.copy_from.side_effect = [new_att_1, new_att_2]
+
+        source_run = _make_run(_run_rid(1))
+        source_run.list_attachments.return_value = [src_att_1, src_att_2]
+
+        dest_run = _make_run(_run_rid(100))
+        ctx.destination_client.create_run.return_value = dest_run
+
+        migrator.copy_from(source_run, RunCopyOptions())
+
+        # AttachmentMigrator was instantiated with the shared context
+        mock_att_cls.assert_called_once_with(ctx)
+
+        # Each attachment was migrated in order
+        mock_att_migrator.copy_from.assert_any_call(src_att_1)
+        mock_att_migrator.copy_from.assert_any_call(src_att_2)
+        assert mock_att_migrator.copy_from.call_count == 2
+
+        # create_run received the migrated attachments
+        call_kwargs = ctx.destination_client.create_run.call_args.kwargs
+        assert set(a.rid for a in call_kwargs["attachments"]) == {_att_rid(101), _att_rid(102)}
+
+    @patch("nominal.experimental.migration.migrator.run_migrator.AttachmentMigrator")
+    def test_existing_run_does_not_remigrate_attachments(self, mock_att_cls: MagicMock) -> None:
+        """When the run already exists in state, AttachmentMigrator is never instantiated."""
+        ctx = _make_context()
+        migrator = RunMigrator(ctx)
+
+        source_rid, dest_rid = _run_rid(1), _run_rid(100)
+        ctx.migration_state.record_mapping(ResourceType.RUN, source_rid, dest_rid)
+
+        existing_run = _make_run(dest_rid)
+        ctx.destination_client.get_run.return_value = existing_run
+
+        source_run = _make_run(source_rid)
+        source_run.list_attachments.return_value = [MagicMock(rid=_att_rid(1))]
+
+        migrator.copy_from(source_run, RunCopyOptions())
+
+        mock_att_cls.assert_not_called()
+        ctx.destination_client.create_run.assert_not_called()

--- a/tests/e2e/migration/conftest.py
+++ b/tests/e2e/migration/conftest.py
@@ -54,6 +54,16 @@ def pytest_addoption(parser):
         default="https://api-staging.gov.nominal.io/api",
         help="Destination base URL (default: staging)",
     )
+    parser.addoption(
+        "--impersonation-source-user-rid",
+        default=None,
+        help="Source user RID for impersonation e2e test (must match the creator of source resources)",
+    )
+    parser.addoption(
+        "--impersonation-dest-user-rid",
+        default=None,
+        help="Destination user RID to impersonate in impersonation e2e test",
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -18,11 +18,14 @@ Run with:
 
 from __future__ import annotations
 
+import pytest
 from datetime import datetime, timedelta
 from io import BytesIO
 from pathlib import Path
 from typing import Callable
 from uuid import uuid4
+
+from nominal_api import scout_notebook_api, scout_workbookcommon_api
 
 from nominal.core import NominalClient
 from nominal.core._event_types import EventType
@@ -31,12 +34,14 @@ from nominal.core.checklist import Checklist
 from nominal.core.data_review import DataReview
 from nominal.core.dataset import Dataset
 from nominal.core.event import Event
+from nominal.core.filetype import FileTypes
 from nominal.core.run import Run
 from nominal.core.video import Video
 from nominal.core.workbook import Workbook
 from nominal.experimental.checklist_utils.checklist_utils import _create_checklist_with_content
 from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
 from nominal.experimental.migration.config.migration_resources import AssetResources, MigrationResources
+from nominal.experimental.migration.migration_cli import ImpersonatingDestinationClientResolver, ImpersonationConfig
 from nominal.experimental.migration.migration_runner import MigrationRunner
 from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.resource_type import ResourceType
@@ -142,13 +147,30 @@ def _create_source_events(
     return event_a, event_b
 
 
+def _create_source_attachment(source_client: NominalClient, register_cleanup: RegisterCleanup):  # type: ignore[return]
+    att = source_client.create_attachment_from_io(
+        BytesIO(b"migration-e2e-attachment-data"),
+        f"migration-e2e-attachment-{uuid4()}.bin",
+        FileTypes.BINARY,
+        description="attachment description",
+        properties={"att-prop": "att-val"},
+        labels=["migration-e2e"],
+    )
+    register_cleanup(att.archive)
+    return att
+
+
 def _create_source_run(
     source_client: NominalClient,
     register_cleanup: RegisterCleanup,
     source_asset: Asset,
     start: datetime,
     end: datetime,
+    attachments: list | None = None,
 ) -> Run:
+    kwargs = {}
+    if attachments:
+        kwargs["attachments"] = attachments
     run = source_client.create_run(
         f"migration-e2e-run-{uuid4()}",
         start,
@@ -157,6 +179,7 @@ def _create_source_run(
         description="run description",
         properties={"run-prop": "run-val"},
         labels=["migration-e2e"],
+        **kwargs,
     )
     register_cleanup(run.archive)
     return run
@@ -215,6 +238,82 @@ def _create_source_workbook(
     register_cleanup(workbook.archive)
     template.archive()
     return workbook
+
+
+def _create_multi_run_workbook(
+    source_client: NominalClient,
+    register_cleanup: RegisterCleanup,
+    run_a: Run,
+    run_b: Run,
+) -> Workbook:
+    """Create a workbook scoped to two runs via the raw notebook API.
+
+    Uses a temporary single-run workbook to obtain a valid content structure, then creates
+    a new workbook with both runs in the data scope.  The temp workbook and its template are
+    archived immediately after reading their content.
+    """
+    clients = source_client._clients
+    template = source_client.create_workbook_template(f"migration-e2e-tmp-template-{uuid4()}")
+    tmp_wb = template.create_workbook(run=run_a, title=f"tmp-{uuid4()}")
+    raw = clients.notebook.get(clients.auth_header, tmp_wb.rid)
+    request = scout_notebook_api.CreateNotebookRequest(
+        title=f"migration-e2e-multi-run-wb-{uuid4()}",
+        description="",
+        is_draft=False,
+        state_as_json="{}",
+        data_scope=scout_notebook_api.NotebookDataScope(
+            asset_rids=None,
+            run_rids=[run_a.rid, run_b.rid],
+        ),
+        layout=raw.layout,
+        content_v2=raw.content_v2,
+        event_refs=[],
+        workspace=clients.resolve_default_workspace_rid(),
+    )
+    raw_multi = clients.notebook.create(clients.auth_header, request)
+    multi_wb = Workbook._from_conjure(clients, raw_multi)
+    register_cleanup(multi_wb.archive)
+    tmp_wb.archive()
+    template.archive()
+    return multi_wb
+
+
+def _create_multi_asset_workbook(
+    source_client: NominalClient,
+    register_cleanup: RegisterCleanup,
+    asset_a: Asset,
+    asset_b: Asset,
+) -> Workbook:
+    """Create a workbook scoped to two assets via the raw notebook API.
+
+    Uses a temporary single-asset workbook to obtain a valid content structure, then creates
+    a new workbook with both assets in the data scope.  The temp workbook and its template are
+    archived immediately after reading their content.
+    """
+    clients = source_client._clients
+    template = source_client.create_workbook_template(f"migration-e2e-tmp-template-{uuid4()}")
+    tmp_wb = template.create_workbook(asset=asset_a, title=f"tmp-{uuid4()}")
+    raw = clients.notebook.get(clients.auth_header, tmp_wb.rid)
+    request = scout_notebook_api.CreateNotebookRequest(
+        title=f"migration-e2e-multi-asset-wb-{uuid4()}",
+        description="",
+        is_draft=False,
+        state_as_json="{}",
+        data_scope=scout_notebook_api.NotebookDataScope(
+            asset_rids=[asset_a.rid, asset_b.rid],
+            run_rids=None,
+        ),
+        layout=raw.layout,
+        content_v2=raw.content_v2,
+        event_refs=[],
+        workspace=clients.resolve_default_workspace_rid(),
+    )
+    raw_multi = clients.notebook.create(clients.auth_header, request)
+    multi_wb = Workbook._from_conjure(clients, raw_multi)
+    register_cleanup(multi_wb.archive)
+    tmp_wb.archive()
+    template.archive()
+    return multi_wb
 
 
 # ---------------------------------------------------------------------------
@@ -300,6 +399,28 @@ def _assert_workbook_migrated(source: Workbook, dest: Workbook, dest_asset: Asse
     assert set(dest.asset_rids) == {dest_asset.rid}
 
 
+def _assert_workbook_migrated_multi_run(source: Workbook, dest: Workbook, dest_runs: list[Run]) -> None:
+    assert dest.title == source.title
+    assert dest.run_rids is not None
+    assert set(dest.run_rids) == {r.rid for r in dest_runs}
+
+
+def _assert_workbook_migrated_multi_asset(source: Workbook, dest: Workbook, dest_assets: list[Asset]) -> None:
+    assert dest.title == source.title
+    assert dest.asset_rids is not None
+    assert set(dest.asset_rids) == {a.rid for a in dest_assets}
+
+
+def _assert_run_migrated_multi_asset(source: Run, dest: Run, dest_assets: list[Asset]) -> None:
+    assert dest.name == source.name
+    assert dest.description == source.description
+    assert set(dest.labels) == set(source.labels)
+    assert dest.properties == source.properties
+    assert dest.start == source.start
+    assert dest.end == source.end
+    assert set(dest.assets) == {a.rid for a in dest_assets}
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -325,12 +446,15 @@ def test_migrate_asset(
     source_asset = _create_source_asset(source_client, register_cleanup)
     source_ds = _create_source_dataset(source_client, register_cleanup, source_asset)
     event_a, event_b = _create_source_events(source_client, register_cleanup, source_asset, start)
-    source_run = _create_source_run(source_client, register_cleanup, source_asset, start, end)
+    source_att = _create_source_attachment(source_client, register_cleanup)
+    source_run = _create_source_run(source_client, register_cleanup, source_asset, start, end, attachments=[source_att])
     source_checklist, source_data_review = _create_source_checklist_and_review(
         source_client, register_cleanup, source_run
     )
     source_video = _create_source_video(source_client, register_cleanup, source_asset, mp4_data, start)
     source_workbook = _create_source_workbook(source_client, register_cleanup, source_asset)
+    source_run_b = _create_source_run(source_client, register_cleanup, source_asset, start, end)
+    source_multi_run_wb = _create_multi_run_workbook(source_client, register_cleanup, source_run, source_run_b)
 
     # --- migrate ---
     runner = _make_runner(_make_resources(source_asset), _no_files_config(), dest_client, tmp_path / "state.json")
@@ -389,6 +513,27 @@ def test_migrate_asset(
     dest_workbook = dest_client.get_workbook(dest_workbook_rid)
     register_cleanup(dest_workbook.archive)
     _assert_workbook_migrated(source_workbook, dest_workbook, dest_asset)
+
+    # --- run attachment ---
+    dest_att_rid = state.get_mapped_rid(ResourceType.ATTACHMENT, source_att.rid)
+    assert dest_att_rid is not None
+    dest_att = dest_client.get_attachment(dest_att_rid)
+    register_cleanup(dest_att.archive)
+    assert dest_att.name == source_att.name
+
+    # --- second run ---
+    dest_run_b_rid = state.get_mapped_rid(ResourceType.RUN, source_run_b.rid)
+    assert dest_run_b_rid is not None
+    dest_run_b = dest_client.get_run(dest_run_b_rid)
+    register_cleanup(dest_run_b.archive)
+    _assert_run_migrated(source_run_b, dest_run_b, dest_asset)
+
+    # --- multi-run workbook ---
+    dest_multi_run_wb_rid = state.get_mapped_rid(ResourceType.WORKBOOK, source_multi_run_wb.rid)
+    assert dest_multi_run_wb_rid is not None
+    dest_multi_run_wb = dest_client.get_workbook(dest_multi_run_wb_rid)
+    register_cleanup(dest_multi_run_wb.archive)
+    _assert_workbook_migrated_multi_run(source_multi_run_wb, dest_multi_run_wb, [dest_run, dest_run_b])
 
 
 def test_migrate_asset_with_dataset_files(
@@ -586,3 +731,122 @@ def test_resume_complete_migration(
     assert "secondary" in dest_datasets
     assert dest_datasets["primary"].rid == dest_ds1_rid
     assert dest_datasets["secondary"].rid == dest_ds2_rid
+
+
+def test_migrate_multi_asset_scenario(
+    source_client: NominalClient,
+    dest_client: NominalClient,
+    register_cleanup: RegisterCleanup,
+    tmp_path: Path,
+):
+    """Migration of a run linked to two assets and a workbook scoped to two assets.
+
+    Verifies:
+    - Multi-asset run: after migrating both assets, the destination run references both
+      destination asset RIDs (the second asset is added via _ensure_assets_added on the
+      second pass).
+    - Multi-asset workbook: deferred migration produces a workbook with both destination
+      asset RIDs in its data scope, and the pending queue is cleared.
+    """
+    start = datetime(2024, 1, 1)
+    end = start + timedelta(hours=1)
+
+    source_asset_a = _create_source_asset(source_client, register_cleanup)
+    source_asset_b = _create_source_asset(source_client, register_cleanup)
+
+    source_run = source_client.create_run(
+        f"migration-e2e-multi-asset-run-{uuid4()}",
+        start,
+        end,
+        assets=[source_asset_a, source_asset_b],
+        description="multi-asset run description",
+        properties={"run-prop": "run-val"},
+        labels=["migration-e2e"],
+    )
+    register_cleanup(source_run.archive)
+
+    source_multi_asset_wb = _create_multi_asset_workbook(
+        source_client, register_cleanup, source_asset_a, source_asset_b
+    )
+
+    runner = _make_runner(
+        _make_resources(source_asset_a, source_asset_b),
+        _no_files_config(),
+        dest_client,
+        tmp_path / "state.json",
+    )
+    runner.run_migration()
+    state = runner.migration_state
+
+    dest_asset_a = _dest_asset(runner, source_asset_a, dest_client)
+    dest_asset_b = _dest_asset(runner, source_asset_b, dest_client)
+    register_cleanup(dest_asset_a.archive)
+    register_cleanup(dest_asset_b.archive)
+
+    # --- multi-asset run ---
+    dest_run_rid = state.get_mapped_rid(ResourceType.RUN, source_run.rid)
+    assert dest_run_rid is not None
+    dest_run = dest_client.get_run(dest_run_rid)
+    register_cleanup(dest_run.archive)
+    _assert_run_migrated_multi_asset(source_run, dest_run, [dest_asset_a, dest_asset_b])
+
+    # --- multi-asset workbook ---
+    dest_wb_rid = state.get_mapped_rid(ResourceType.WORKBOOK, source_multi_asset_wb.rid)
+    assert dest_wb_rid is not None
+    dest_wb = dest_client.get_workbook(dest_wb_rid)
+    register_cleanup(dest_wb.archive)
+    _assert_workbook_migrated_multi_asset(source_multi_asset_wb, dest_wb, [dest_asset_a, dest_asset_b])
+    assert source_multi_asset_wb.rid not in state.pending_multi_asset_workbooks
+
+
+def test_migrate_with_impersonation(
+    source_client: NominalClient,
+    dest_client: NominalClient,
+    register_cleanup: RegisterCleanup,
+    tmp_path: Path,
+    pytestconfig,
+):
+    """Migration succeeds end-to-end when an ImpersonatingDestinationClientResolver is in use.
+
+    Requires --impersonation-source-user-rid and --impersonation-dest-user-rid.  The source
+    user RID must be the creator of resources on the source environment (i.e. the RID of the
+    service account or user whose token is passed via --source-profile / --source-auth-token).
+    The dest user RID must be a valid, active user on the destination environment.
+
+    Verifies that the migration completes without error and that assets and datasets are
+    correctly reflected in the migration state, confirming the resolver is wired through the
+    full MigrationRunner path.
+    """
+    source_user_rid = pytestconfig.getoption("impersonation_source_user_rid")
+    dest_user_rid = pytestconfig.getoption("impersonation_dest_user_rid")
+    if not source_user_rid or not dest_user_rid:
+        pytest.skip("--impersonation-source-user-rid and --impersonation-dest-user-rid required")
+
+    source_asset = _create_source_asset(source_client, register_cleanup)
+    source_ds = _create_source_dataset(source_client, register_cleanup, source_asset)
+
+    impersonation_config = ImpersonationConfig(
+        enabled=True,
+        source_to_destination_user_rids={source_user_rid: dest_user_rid},
+    )
+    resolver = ImpersonatingDestinationClientResolver(dest_client, impersonation_config)
+
+    runner = MigrationRunner(
+        migration_resources=_make_resources(source_asset),
+        dataset_config=_no_files_config(),
+        destination_client=dest_client,
+        destination_client_resolver=resolver,
+        migration_state_path=tmp_path / "state.json",
+    )
+    runner.run_migration()
+    state = runner.migration_state
+
+    dest_asset = _dest_asset(runner, source_asset, dest_client)
+    register_cleanup(dest_asset.archive)
+    _assert_asset_migrated(source_asset, dest_asset)
+
+    dest_ds_rid = state.get_mapped_rid(ResourceType.DATASET, source_ds.rid)
+    assert dest_ds_rid is not None
+    dest_ds = dest_client.get_dataset(dest_ds_rid)
+    register_cleanup(dest_ds.archive)
+    _assert_dataset_migrated(source_ds, dest_ds, "primary", dest_asset)

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -18,14 +18,14 @@ Run with:
 
 from __future__ import annotations
 
-import pytest
 from datetime import datetime, timedelta
 from io import BytesIO
 from pathlib import Path
 from typing import Callable
 from uuid import uuid4
 
-from nominal_api import scout_notebook_api, scout_workbookcommon_api
+import pytest
+from nominal_api import scout_notebook_api
 
 from nominal.core import NominalClient
 from nominal.core._event_types import EventType
@@ -426,7 +426,7 @@ def _assert_run_migrated_multi_asset(source: Run, dest: Run, dest_assets: list[A
 # ---------------------------------------------------------------------------
 
 
-def test_migrate_asset(
+def test_migrate_asset(  # noqa: PLR0915
     source_client: NominalClient,
     dest_client: NominalClient,
     register_cleanup: RegisterCleanup,

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.132.1"
+version = "1.133.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Background                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                               
  The migration library recently gained several new capabilities: multi-asset and multi-run workbook migration (using a deferred find/replace strategy), multi-asset run migration, and impersonation support for preserving resource attribution
   across tenants. The existing e2e test suite and unit tests did not cover any of these paths, leaving the new features unvalidated end-to-end and in some migrator-level unit tests.
                                                                                                                                                                                                                                                 
  ## Summary of Changes                                     

  ### Unit tests (`tests/core/test_run_migrator.py`)
  - Added `TestRunMigratorAttachments` with two tests covering the attachment migration path in `RunMigrator`, which was previously always bypassed by stubbing `list_attachments` to return an empty list:
    - Verifies that `AttachmentMigrator.copy_from` is called for each source attachment on a new run, and the migrated attachments are passed to `create_run`                                                                                    
    - Verifies that `AttachmentMigrator` is never instantiated when the run already exists in migration state                                                                                                                                    
                                                                                                                                                                                                                                                 
  ### E2E tests (`tests/e2e/migration/`)                                                                                                                                                                                                         
  **`conftest.py`**                                         
  - Added `--impersonation-source-user-rid` and `--impersonation-dest-user-rid` opt-in CLI flags for the impersonation test                                                                                                                      
   
  **`test_migration.py`**                                                                                                                                                                                                                        
  - Extended `test_migrate_asset` to cover three previously untested paths (folded in to keep the single-asset migration test as the canonical full-coverage test):
    - **Run attachment migration**: source run is created with an attachment; asserts the attachment appears in migration state and on the destination run                                                                                       
    - **Second run**: a second run on the same asset; asserts it migrates correctly
    - **Multi-run workbook**: a workbook scoped to both runs created via the raw notebook API; asserts the destination workbook references both destination run RIDs after deferred migration                                                    
  - Added `test_migrate_multi_asset_scenario` (new test):                                                                                                                                                                                        
    - Creates two assets, a run linked to both, and a workbook scoped to both                                                                                                                                                                    
    - Validates that the destination run accumulates both destination asset RIDs (exercising `_ensure_assets_added`)                                                                                                                             
    - Validates that the deferred multi-asset workbook is migrated with both destination asset RIDs and the pending queue is cleared                                                                                                             
  - Added `test_migrate_with_impersonation` (new test, opt-in):
    - Runs a simple asset + dataset migration through a real `ImpersonatingDestinationClientResolver`                                                                                                                                            
    - Skipped automatically unless both impersonation flags are provided                                                                                                                                                                         
    - Asserts migration completes correctly end-to-end with the resolver wired through `MigrationRunner`
  - Added helpers: `_create_source_attachment`, `_create_multi_run_workbook`, `_create_multi_asset_workbook`, `_assert_workbook_migrated_multi_run`, `_assert_workbook_migrated_multi_asset`, `_assert_run_migrated_multi_asset`