### PR TITLE
feat: add parameters to include/exclude child resources to migrate

### DIFF
--- a/nominal/experimental/migration/config/migration_data_config.py
+++ b/nominal/experimental/migration/config/migration_data_config.py
@@ -1,3 +1,16 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AssetInclusionConfig:
+    include_video: bool = True
+    include_runs: bool = True
+    include_events: bool = True
+    include_attachments: bool = True
+    include_checklists: bool = True
+    include_workbooks: bool = True
+
+
 class MigrationDatasetConfig:
     preserve_dataset_uuid: bool
     include_dataset_files: bool

--- a/nominal/experimental/migration/migration_cli.py
+++ b/nominal/experimental/migration/migration_cli.py
@@ -13,7 +13,7 @@ from nominal_api.scout_sandbox_api import SandboxWorkspaceService, SetDemoWorkbo
 from nominal.cli.util.global_decorators import client_options, global_options
 from nominal.core import Asset, NominalClient
 from nominal.experimental import as_user
-from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
+from nominal.experimental.migration.config.migration_data_config import AssetInclusionConfig, MigrationDatasetConfig
 from nominal.experimental.migration.config.migration_resources import AssetResources, MigrationResources
 from nominal.experimental.migration.migration_decorators import migration_client_options
 from nominal.experimental.migration.migration_runner import MigrationRunner
@@ -91,6 +91,14 @@ def _require_non_empty_string(value: Any, label: str) -> str:
 
 
 def _require_bool(value: Any, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise click.UsageError(f"'{label}' must be a boolean.")
+    return value
+
+
+def _optional_bool(value: Any, label: str, default: bool) -> bool:
+    if value is None:
+        return default
     if not isinstance(value, bool):
         raise click.UsageError(f"'{label}' must be a boolean.")
     return value
@@ -327,7 +335,7 @@ def _extract_user_rid_from_identity(value: Any) -> str | None:
 
 def _load_migration_config(
     source_client: NominalClient, config_path: Path
-) -> tuple[str, MigrationResources, MigrationDatasetConfig, bool, ImpersonationConfig | None]:
+) -> tuple[str, MigrationResources, MigrationDatasetConfig, AssetInclusionConfig, bool, ImpersonationConfig | None]:
     with config_path.open("r", encoding="utf-8") as f:
         raw: Any = yaml.safe_load(f)
 
@@ -341,6 +349,21 @@ def _load_migration_config(
     if not isinstance(set_to_demo_workbook_raw, bool):
         raise click.UsageError("'migration.set_to_demo_workbook' must be a boolean.")
     set_to_demo_workbook: bool = set_to_demo_workbook_raw
+
+    asset_inclusion_config = AssetInclusionConfig(
+        include_video=_optional_bool(m.get("include_video"), "migration.include_video", default=True),
+        include_runs=_optional_bool(m.get("include_runs"), "migration.include_runs", default=True),
+        include_events=_optional_bool(m.get("include_events"), "migration.include_events", default=True),
+        include_attachments=_optional_bool(
+            m.get("include_attachments"), "migration.include_attachments", default=True
+        ),
+        include_checklists=_optional_bool(
+            m.get("include_checklists"), "migration.include_checklists", default=True
+        ),
+        include_workbooks=_optional_bool(
+            m.get("include_workbooks"), "migration.include_workbooks", default=True
+        ),
+    )
 
     asset_resources_by_rid = _load_asset_resources(
         source_client,
@@ -366,6 +389,7 @@ def _load_migration_config(
             source_standalone_templates=standalone_workbook_templates,
         ),
         dataset_config,
+        asset_inclusion_config,
         set_to_demo_workbook,
         impersonation_config,
     )
@@ -477,9 +501,14 @@ def copy(
 ) -> None:
     source_client, target_client = clients
     logger.info("Loading migration config from: %s", config_path)
-    name, migration_resources, dataset_config, set_to_demo_workbook, impersonation_config = _load_migration_config(
-        source_client, config_path
-    )
+    (
+        name,
+        migration_resources,
+        dataset_config,
+        asset_inclusion_config,
+        set_to_demo_workbook,
+        impersonation_config,
+    ) = _load_migration_config(source_client, config_path)
 
     if set_to_demo_workbook:
         workspace = target_client.get_workspace()
@@ -507,6 +536,7 @@ def copy(
     runner = MigrationRunner(
         migration_resources=migration_resources,
         dataset_config=dataset_config,
+        asset_inclusion_config=asset_inclusion_config,
         destination_client=target_client,
         destination_client_resolver=destination_client_resolver,
         migration_state_path=migration_state_path,
@@ -606,6 +636,12 @@ def prep(client: NominalClient, migration_name: str, output_path: Path) -> None:
             "name": migration_name,
             "include_dataset_files": False,
             "preserve_dataset_uuid": True,
+            "include_video": True,
+            "include_runs": True,
+            "include_events": True,
+            "include_attachments": True,
+            "include_checklists": True,
+            "include_workbooks": True,
             "set_to_demo_workbook": False,
             "source_asset_rids": [{"asset_rid": rid} for rid in sorted(all_assets)],
         }

--- a/nominal/experimental/migration/migration_cli.py
+++ b/nominal/experimental/migration/migration_cli.py
@@ -354,15 +354,9 @@ def _load_migration_config(
         include_video=_optional_bool(m.get("include_video"), "migration.include_video", default=True),
         include_runs=_optional_bool(m.get("include_runs"), "migration.include_runs", default=True),
         include_events=_optional_bool(m.get("include_events"), "migration.include_events", default=True),
-        include_attachments=_optional_bool(
-            m.get("include_attachments"), "migration.include_attachments", default=True
-        ),
-        include_checklists=_optional_bool(
-            m.get("include_checklists"), "migration.include_checklists", default=True
-        ),
-        include_workbooks=_optional_bool(
-            m.get("include_workbooks"), "migration.include_workbooks", default=True
-        ),
+        include_attachments=_optional_bool(m.get("include_attachments"), "migration.include_attachments", default=True),
+        include_checklists=_optional_bool(m.get("include_checklists"), "migration.include_checklists", default=True),
+        include_workbooks=_optional_bool(m.get("include_workbooks"), "migration.include_workbooks", default=True),
     )
 
     asset_resources_by_rid = _load_asset_resources(

--- a/nominal/experimental/migration/migration_runner.py
+++ b/nominal/experimental/migration/migration_runner.py
@@ -60,7 +60,9 @@ class MigrationRunner:
         """
         self.migration_resources = migration_resources
         self.dataset_config = dataset_config
-        self.asset_inclusion_config = asset_inclusion_config if asset_inclusion_config is not None else AssetInclusionConfig()
+        self.asset_inclusion_config = (
+            asset_inclusion_config if asset_inclusion_config is not None else AssetInclusionConfig()
+        )
         self.destination_client = destination_client
         self.destination_client_resolver = destination_client_resolver
         resolved_path = Path(migration_state_path) if migration_state_path is not None else Path("migration_state.json")

--- a/nominal/experimental/migration/migration_runner.py
+++ b/nominal/experimental/migration/migration_runner.py
@@ -8,7 +8,7 @@ from typing import cast
 
 from nominal.core import NominalClient
 from nominal.core._clientsbunch import ClientsBunch
-from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
+from nominal.experimental.migration.config.migration_data_config import AssetInclusionConfig, MigrationDatasetConfig
 from nominal.experimental.migration.config.migration_resources import MigrationResources
 from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.migrator.asset_migrator import AssetCopyOptions, AssetMigrator
@@ -33,6 +33,7 @@ class MigrationRunner:
     migration_state: MigrationState
     migration_resources: MigrationResources
     dataset_config: MigrationDatasetConfig
+    asset_inclusion_config: AssetInclusionConfig
     destination_client: NominalClient
     destination_client_resolver: DestinationClientResolver | None
 
@@ -41,6 +42,7 @@ class MigrationRunner:
         migration_resources: MigrationResources,
         dataset_config: MigrationDatasetConfig,
         destination_client: NominalClient,
+        asset_inclusion_config: AssetInclusionConfig | None = None,
         destination_client_resolver: DestinationClientResolver | None = None,
         migration_state_path: Path | str | None = None,
     ) -> None:
@@ -50,12 +52,15 @@ class MigrationRunner:
             migration_resources (MigrationResources): _description_
             dataset_config (MigrationDatasetConfig): _description_
             destination_client (NominalClient): _description_
+            asset_inclusion_config (AssetInclusionConfig | None): Controls which resource types are copied per
+                asset. Defaults to including all resource types.
             destination_client_resolver (DestinationClientResolver | None): Optional callback that resolves the
                 destination client for each source resource. Defaults to None.
             migration_state_path (Path | str | None, optional): _description_. Defaults to None.
         """
         self.migration_resources = migration_resources
         self.dataset_config = dataset_config
+        self.asset_inclusion_config = asset_inclusion_config if asset_inclusion_config is not None else AssetInclusionConfig()
         self.destination_client = destination_client
         self.destination_client_resolver = destination_client_resolver
         resolved_path = Path(migration_state_path) if migration_state_path is not None else Path("migration_state.json")
@@ -95,11 +100,12 @@ class MigrationRunner:
                     source_asset,
                     AssetCopyOptions(
                         dataset_config=self.dataset_config,
-                        include_attachments=True,
-                        include_events=True,
-                        include_runs=True,
-                        include_video=True,
-                        include_checklists=True,
+                        include_attachments=self.asset_inclusion_config.include_attachments,
+                        include_events=self.asset_inclusion_config.include_events,
+                        include_runs=self.asset_inclusion_config.include_runs,
+                        include_video=self.asset_inclusion_config.include_video,
+                        include_checklists=self.asset_inclusion_config.include_checklists,
+                        include_workbooks=self.asset_inclusion_config.include_workbooks,
                     ),
                 )
 
@@ -110,7 +116,8 @@ class MigrationRunner:
                 asset_rid: cast(ClientsBunch, asset_resources.asset._clients)
                 for asset_rid, asset_resources in self.migration_resources.source_assets.items()
             }
-            WorkbookMigrator(migration_context).migrate_deferred_workbooks(source_clients_by_asset_rid)
+            if self.asset_inclusion_config.include_workbooks:
+                WorkbookMigrator(migration_context).migrate_deferred_workbooks(source_clients_by_asset_rid)
         finally:
             self.save_state()
         logger.info("Completed migration")

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -36,6 +36,7 @@ class AssetCopyOptions(ResourceCopyOptions):
     include_runs: bool = False
     include_video: bool = False
     include_checklists: bool = False
+    include_workbooks: bool = True
 
 
 class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
@@ -50,6 +51,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             include_events=True,
             include_runs=True,
             include_video=True,
+            include_workbooks=True,
         )
 
     def _copy_from_impl(self, source_asset: Asset, options: AssetCopyOptions) -> Asset:
@@ -84,7 +86,8 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             logger.info("Copying attachments for asset %s (rid: %s)", source_asset.name, source_asset.rid)
             self._copy_asset_attachments(source_asset, new_asset)
 
-        self._copy_asset_and_run_workbooks(source_asset, new_asset, options.include_runs)
+        if options.include_workbooks:
+            self._copy_asset_and_run_workbooks(source_asset, new_asset, options.include_runs)
         return new_asset
 
     def _get_resource_name(self, resource: Asset) -> str:

--- a/nominal/experimental/migration/sample_migration_config.yml
+++ b/nominal/experimental/migration/sample_migration_config.yml
@@ -1,0 +1,79 @@
+migration:
+  # Human-readable name for this migration run. Appears in logs.
+  name: "my-migration"
+
+  # -------------------------------------------------------------------------
+  # Dataset options
+  # -------------------------------------------------------------------------
+
+  # Sets whether to copy the raw data files attached to each dataset.
+  # Set to false for a resource-only migration.
+  include_dataset_files: false
+
+  # Sets whether to preserve the original dataset UUID on the destination. 
+  # If true, this will manually create channels in the new dataset.
+  # Set to true when using an external data backup method which requires same UUID.
+  preserve_dataset_uuid: true
+
+  # -------------------------------------------------------------------------
+  # Asset child-resource inclusion
+  # All fields below default to true when omitted.
+  # Set any to false to skip that resource type entirely.
+  # -------------------------------------------------------------------------
+
+  # Copy runs (and their associated datasets) linked to each asset.
+  include_runs: true
+
+  # Copy manually-created events linked to each asset.
+  include_events: true
+
+  # Copy video datasets linked to each asset.
+  include_video: true
+
+  # Copy file attachments linked to each asset.
+  include_attachments: true
+
+  # Copy checklists (data reviews) executed against runs on each asset.
+  # Requires include_runs: true — checklists are re-executed against the
+  # migrated destination runs.
+  include_checklists: true
+
+  # Copy workbooks scoped to each asset or its runs.
+  include_workbooks: true
+
+  # -------------------------------------------------------------------------
+  # Source assets
+  #
+  # Use ONE of the two forms below: a list (source_asset_rids) or a map
+  # (source_assets).  The list form is simpler; the map form lets you attach
+  # per-asset workbook templates using the asset RID as the key.
+  # -------------------------------------------------------------------------
+
+  # List form: each entry requires an asset_rid.
+  source_asset_rids:
+    - asset_rid: "ri.scout.gov-staging.asset.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    - asset_rid: "ri.scout.gov-staging.asset.yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy"
+    
+  # -------------------------------------------------------------------------
+  # Standalone workbook templates (optional)
+  # Templates listed here are cloned to the destination independently of any
+  # asset — useful for shared/library templates that are not tied to a single asset.
+  # -------------------------------------------------------------------------
+  # standalone_workbook_template_rids:
+  #   - "ri.scout.gov-staging.notebook-template.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+  # -------------------------------------------------------------------------
+  # Impersonation (optional)
+  # When enabled, resources are created on the destination under the mapped
+  # destination user rather than the service account running the migration.
+  # Requires the service account to have impersonation privileges.
+  # -------------------------------------------------------------------------
+  # impersonation:
+  #   enabled: true
+  #   # What to do when a source resource's creator has no entry in the map below.
+  #   # Currently the only supported value is "service_user" (fall back to the
+  #   # service account).
+  #   unmapped_source_user_behavior: service_user
+  #   # Map of source user RID -> destination user RID.
+  #   source_to_destination_user_rids:
+  #     "ri.gotham.gov-prod.user.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx": "ri.gotham.gov-staging.user.yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy"

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -39,7 +39,7 @@ from nominal.core.run import Run
 from nominal.core.video import Video
 from nominal.core.workbook import Workbook
 from nominal.experimental.checklist_utils.checklist_utils import _create_checklist_with_content
-from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
+from nominal.experimental.migration.config.migration_data_config import AssetInclusionConfig, MigrationDatasetConfig
 from nominal.experimental.migration.config.migration_resources import AssetResources, MigrationResources
 from nominal.experimental.migration.migration_cli import ImpersonatingDestinationClientResolver, ImpersonationConfig
 from nominal.experimental.migration.migration_runner import MigrationRunner
@@ -76,11 +76,13 @@ def _make_runner(
     config: MigrationDatasetConfig,
     dest_client: NominalClient,
     state_path: Path,
+    asset_inclusion_config: AssetInclusionConfig | None = None,
 ) -> MigrationRunner:
     return MigrationRunner(
         migration_resources=resources,
         dataset_config=config,
         destination_client=dest_client,
+        asset_inclusion_config=asset_inclusion_config,
         migration_state_path=state_path,
     )
 
@@ -426,14 +428,14 @@ def _assert_run_migrated_multi_asset(source: Run, dest: Run, dest_assets: list[A
 # ---------------------------------------------------------------------------
 
 
-def test_migrate_asset(  # noqa: PLR0915
+def test_migrate_asset_maximal(  # noqa: PLR0915
     source_client: NominalClient,
     dest_client: NominalClient,
     register_cleanup: RegisterCleanup,
     mp4_data: bytes,
     tmp_path: Path,
 ):
-    """Full migration of an asset covering all resource types: dataset, events, run, checklist, video, and workbook.
+    """Full (maximal) migration of an asset covering all resource types: dataset, events, run, checklist, video, and workbook.
 
     Verifies:
     - All child resources exist on the destination with RID mappings in state
@@ -534,6 +536,61 @@ def test_migrate_asset(  # noqa: PLR0915
     dest_multi_run_wb = dest_client.get_workbook(dest_multi_run_wb_rid)
     register_cleanup(dest_multi_run_wb.archive)
     _assert_workbook_migrated_multi_run(source_multi_run_wb, dest_multi_run_wb, [dest_run, dest_run_b])
+
+
+def test_migrate_asset_minimal(
+    source_client: NominalClient,
+    dest_client: NominalClient,
+    register_cleanup: RegisterCleanup,
+    tmp_path: Path,
+):
+    """Minimal migration: only the asset and its datasets are copied; all other resource types are excluded.
+
+    Sets every AssetInclusionConfig flag to False and verifies that events, runs, and workbooks
+    are absent from the migration state while the asset and dataset are still migrated.
+    """
+    start = datetime(2024, 1, 1)
+    end = start + timedelta(hours=1)
+    source_asset = _create_source_asset(source_client, register_cleanup)
+    source_ds = _create_source_dataset(source_client, register_cleanup, source_asset)
+    event_a, _ = _create_source_events(source_client, register_cleanup, source_asset, start)
+    source_run = _create_source_run(source_client, register_cleanup, source_asset, start, end)
+    source_workbook = _create_source_workbook(source_client, register_cleanup, source_asset)
+
+    runner = _make_runner(
+        _make_resources(source_asset),
+        _no_files_config(),
+        dest_client,
+        tmp_path / "state.json",
+        asset_inclusion_config=AssetInclusionConfig(
+            include_video=False,
+            include_runs=False,
+            include_events=False,
+            include_attachments=False,
+            include_checklists=False,
+            include_workbooks=False,
+        ),
+    )
+    runner.run_migration()
+    state = runner.migration_state
+
+    dest_asset = _dest_asset(runner, source_asset, dest_client)
+    register_cleanup(dest_asset.archive)
+
+    # Asset is always migrated.
+    _assert_asset_migrated(source_asset, dest_asset)
+
+    # Dataset is always migrated (controlled by dataset_config, not inclusion flags).
+    dest_ds_rid = state.get_mapped_rid(ResourceType.DATASET, source_ds.rid)
+    assert dest_ds_rid is not None
+    dest_ds = dest_client.get_dataset(dest_ds_rid)
+    register_cleanup(dest_ds.archive)
+    _assert_dataset_migrated(source_ds, dest_ds, "primary", dest_asset)
+
+    # All excluded resource types must be absent from the migration state.
+    assert state.get_mapped_rid(ResourceType.EVENT, event_a.rid) is None
+    assert state.get_mapped_rid(ResourceType.RUN, source_run.rid) is None
+    assert state.get_mapped_rid(ResourceType.WORKBOOK, source_workbook.rid) is None
 
 
 def test_migrate_asset_with_dataset_files(

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -435,7 +435,9 @@ def test_migrate_asset_maximal(  # noqa: PLR0915
     mp4_data: bytes,
     tmp_path: Path,
 ):
-    """Full (maximal) migration of an asset covering all resource types: dataset, events, run, checklist, video, and workbook.
+    """Full (maximal) migration of an asset covering all resource types.
+
+    Resource types covered: dataset, events, run, checklist, video, and workbook.
 
     Verifies:
     - All child resources exist on the destination with RID mappings in state

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.133.0"
+version = "1.135.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
@@ -1308,6 +1308,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/11/f8/1fb981538aa2dd88ae89fd61809faef78b7833e136892e25de4101cc25cc/nominal_streaming-0.8.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:73bd1f409be625c4bbbb6980c1933dbc018ee4a7fc508c31b9ffbf05f56ec9cd", size = 3667455, upload-time = "2026-04-22T19:31:42.507Z" },
     { url = "https://files.pythonhosted.org/packages/f6/76/11432cab1657762dbd4521e4e7645c680c8253bd0f9bd6135b697cca43de/nominal_streaming-0.8.2-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:043eeff479a8703468de42df3d402f3ba5577af14592542b9795f9a56d20ce4f", size = 3466574, upload-time = "2026-04-22T19:31:39.485Z" },
     { url = "https://files.pythonhosted.org/packages/16/8d/6d2a87e913d14a4fe3505362ffd43462b38eefeb330e9b84f409d5598940/nominal_streaming-0.8.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8ed2acfd893efa7ef7e05a19334280ef782b8f1356dbc6895cc2f6ca55ad8d01", size = 3917023, upload-time = "2026-04-22T19:31:48.446Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c9/1ca3193ddc848ad46a6c2599a9dd937e3deb1eb0f7e9b5ac3a809058632f/nominal_streaming-0.8.2-cp310-abi3-win_amd64.whl", hash = "sha256:4f857aca078b24c28e40a28178ed39bf71e685e11b7822954084bece1b5355d1", size = 3412398, upload-time = "2026-04-22T19:39:29.93Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

## Description

This PR adds several new parameters to the migration config, all defaulting to true - 

- include_video
- include_runs
- include_events
- include_attachments
- include_checklists
- include_workbooks

This allows for more flexible "partial" migration configurations.  

As a bonus, this change also adds an example .yml file to aid in users creating a migration config, now that there are more levers.

## Testing

Added new end-to-end testing to validate proper flow of params.