### PR TITLE
feat: deprecate streaming connection creation

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -1084,7 +1084,8 @@ class NominalClient:
         return video
 
     @deprecated(
-        "NominalClient.create_streaming_connection is deprecated and will be removed in a future version."
+        "NominalClient.create_streaming_connection is deprecated and will be removed in a future version. "
+        "Use `NominalClient.create_dataset` instead."
     )
     def create_streaming_connection(
         self,

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -1083,6 +1083,9 @@ class NominalClient:
         video.add_mcap_from_io(mcap, file_name or name, topic, description, file_type)
         return video
 
+    @deprecated(
+        "NominalClient.create_streaming_connection is deprecated and will be removed in a future version."
+    )
     def create_streaming_connection(
         self,
         datasource_id: str,

--- a/nominal/nominal.py
+++ b/nominal/nominal.py
@@ -580,7 +580,7 @@ def upload_mcap_video(
 
 @typing_extensions.deprecated(
     "nominal.create_streaming_connection is deprecated and will be removed in a future version. "
-    f"Use `nominal.NominalClient.create_streaming_connection` instead, see {AUTHENTICATION_DOCS_LINK}"
+    f"Use `nominal.NominalClient.create_dataset` instead, see {AUTHENTICATION_DOCS_LINK}"
 )
 def create_streaming_connection(
     datasource_id: str,


### PR DESCRIPTION
## Summary

- Mark `NominalClient.create_streaming_connection` as deprecated.
- Update both streaming connection deprecation messages to direct users to `NominalClient.create_dataset`.
- Keeps the existing top-level `nominal.create_streaming_connection` deprecation intact.

## Validation

- `uv run pytest tests/test_deprecation_tools.py tests/test_write_stream.py`
- `uv run ruff check nominal/core/client.py nominal/nominal.py`
- `just fix-format`