### PR TITLE
feat: allow additional header passthru

### DIFF
--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -1,6 +1,7 @@
 from nominal.core._event_types import EventType, SearchEventOriginType
 from nominal.core._stream.write_stream import DataStream, LogStream, WriteStream
 from nominal.core._utils.api_tools import LinkDict
+from nominal.core._utils.networking import HeaderProvider
 from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.core.asset import Asset
 from nominal.core.attachment import Attachment
@@ -58,6 +59,7 @@ __all__ = [
     "FileExtractionInput",
     "FileType",
     "FileTypes",
+    "HeaderProvider",
     "IngestWaitType",
     "LinkDict",
     "LogPoint",

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -159,6 +159,8 @@ class ClientsBunch:
     containerized_extractors: ingest_api.ContainerizedExtractorService
     secrets: secrets_api.SecretService
 
+    default_headers: Mapping[str, str] = field(default_factory=dict, repr=False)
+
     def with_default_request_headers(self, headers: Mapping[str, str]) -> Self:
         return type(self).from_config(
             self._service_config,
@@ -299,6 +301,7 @@ class ClientsBunch:
             workspace=client_factory(security_api_workspace.WorkspaceService),
             containerized_extractors=client_factory(ingest_api.ContainerizedExtractorService),
             secrets=client_factory(secrets_api.SecretService),
+            default_headers=dict(default_headers) if default_headers is not None else {},
         )
 
 
@@ -309,6 +312,8 @@ class HasScoutParams(Protocol):
     def workspace_rid(self) -> str | None: ...
     @property
     def app_base_url(self) -> str: ...
+    @property
+    def default_headers(self) -> Mapping[str, str]: ...
     def resolve_workspace(self, workspace_rid: str | None = None) -> security_api_workspace.Workspace: ...
     def resolve_default_workspace_rid(self) -> str: ...
 

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -118,6 +118,7 @@ class ClientsBunch:
     auth_header: str
     workspace_rid: str | None
     app_base_url: str
+    default_headers: Mapping[str, str]
     _api_base_url: str = field(repr=False)
     _user_agent: str = field(repr=False)
     _token: str = field(repr=False)
@@ -158,8 +159,6 @@ class ClientsBunch:
     workspace: security_api_workspace.WorkspaceService
     containerized_extractors: ingest_api.ContainerizedExtractorService
     secrets: secrets_api.SecretService
-
-    default_headers: Mapping[str, str] = field(default_factory=dict, repr=False)
 
     def with_default_request_headers(self, headers: Mapping[str, str]) -> Self:
         return type(self).from_config(
@@ -269,6 +268,7 @@ class ClientsBunch:
             auth_header=f"Bearer {token}",
             workspace_rid=workspace_rid,
             app_base_url=app_base_url,
+            default_headers=dict(default_headers) if default_headers is not None else {},
             _api_base_url=base_url,
             _user_agent=agent,
             _token=token,
@@ -301,7 +301,6 @@ class ClientsBunch:
             workspace=client_factory(security_api_workspace.WorkspaceService),
             containerized_extractors=client_factory(ingest_api.ContainerizedExtractorService),
             secrets=client_factory(secrets_api.SecretService),
-            default_headers=dict(default_headers) if default_headers is not None else {},
         )
 
 

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -163,16 +163,6 @@ class ClientsBunch:
     containerized_extractors: ingest_api.ContainerizedExtractorService
     secrets: secrets_api.SecretService
 
-    def with_header_provider(self, header_provider: HeaderProvider | None) -> Self:
-        return type(self).from_config(
-            self._service_config,
-            self._api_base_url,
-            self._user_agent,
-            self._token,
-            self.workspace_rid,
-            header_provider=header_provider,
-        )
-
     def _fetch_default_workspace(self) -> security_api_workspace.Workspace:
         """Fetch the workspace object this client should treat as its default.
 

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import time
 from dataclasses import dataclass, field
-from typing import Mapping, Protocol, TypeVar
+from typing import Protocol, TypeVar
 
 from conjure_python_client import Service, ServiceConfiguration
 from nominal_api import (
@@ -33,7 +33,10 @@ from nominal_api import (
 from typing_extensions import Self
 
 from nominal._utils.dataclass_tools import LazyField
-from nominal.core._utils.networking import create_conjure_client_factory
+from nominal.core._utils.networking import (
+    HeaderProvider,
+    create_conjure_client_factory,
+)
 from nominal.core.exceptions import NominalConfigError
 from nominal.ts import IntegralNanosecondsUTC
 
@@ -118,7 +121,7 @@ class ClientsBunch:
     auth_header: str
     workspace_rid: str | None
     app_base_url: str
-    default_headers: Mapping[str, str]
+    header_provider: HeaderProvider | None
     _api_base_url: str = field(repr=False)
     _user_agent: str = field(repr=False)
     _token: str = field(repr=False)
@@ -160,14 +163,14 @@ class ClientsBunch:
     containerized_extractors: ingest_api.ContainerizedExtractorService
     secrets: secrets_api.SecretService
 
-    def with_default_request_headers(self, headers: Mapping[str, str]) -> Self:
+    def with_header_provider(self, header_provider: HeaderProvider | None) -> Self:
         return type(self).from_config(
             self._service_config,
             self._api_base_url,
             self._user_agent,
             self._token,
             self.workspace_rid,
-            default_headers=headers,
+            header_provider=header_provider,
         )
 
     def _fetch_default_workspace(self) -> security_api_workspace.Workspace:
@@ -253,7 +256,7 @@ class ClientsBunch:
         token: str,
         workspace_rid: str | None,
         *,
-        default_headers: Mapping[str, str] | None = None,
+        header_provider: HeaderProvider | None = None,
     ) -> Self:
         app_base_url = api_base_url_to_app_base_url(base_url)
 
@@ -261,14 +264,14 @@ class ClientsBunch:
             return create_conjure_client_factory(
                 user_agent=agent,
                 service_config=cfg,
-                default_headers=default_headers,
+                header_provider=header_provider,
             )(service_class)
 
         return cls(
             auth_header=f"Bearer {token}",
             workspace_rid=workspace_rid,
             app_base_url=app_base_url,
-            default_headers=dict(default_headers) if default_headers is not None else {},
+            header_provider=header_provider,
             _api_base_url=base_url,
             _user_agent=agent,
             _token=token,
@@ -312,7 +315,7 @@ class HasScoutParams(Protocol):
     @property
     def app_base_url(self) -> str: ...
     @property
-    def default_headers(self) -> Mapping[str, str]: ...
+    def header_provider(self) -> HeaderProvider | None: ...
     def resolve_workspace(self, workspace_rid: str | None = None) -> security_api_workspace.Workspace: ...
     def resolve_default_workspace_rid(self) -> str: ...
 

--- a/nominal/core/_utils/multipart.py
+++ b/nominal/core/_utils/multipart.py
@@ -6,12 +6,12 @@ import pathlib
 import urllib.parse
 from functools import partial
 from queue import Queue
-from typing import BinaryIO, Iterable, Mapping
+from typing import BinaryIO, Iterable
 
 import requests
 from nominal_api import ingest_api, upload_api
 
-from nominal.core._utils.networking import create_multipart_request_session
+from nominal.core._utils.networking import HeaderProvider, create_multipart_request_session
 from nominal.core.exceptions import NominalMultipartUploadError, NominalMultipartUploadFailed
 from nominal.core.filetype import FileType
 
@@ -138,7 +138,7 @@ def put_multipart_upload(
     upload_client: upload_api.UploadService,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     max_workers: int = DEFAULT_NUM_WORKERS,
-    default_headers: Mapping[str, str] | None = None,
+    header_provider: HeaderProvider | None = None,
 ) -> str:
     """Execute a multipart upload to S3.
 
@@ -154,7 +154,7 @@ def put_multipart_upload(
         upload_client: Conjure upload client
         chunk_size: Maximum size of chunk to upload to S3 at once
         max_workers: Number of worker threads to use when processing and uploading data
-        default_headers: Optional mapping of headers to include in all requests to object store
+        header_provider: Optional provider for headers to include in all requests to object store
 
     Returns: Path to the uploaded object in S3
 
@@ -179,7 +179,7 @@ def put_multipart_upload(
     key, upload_id = initiate_response.key, initiate_response.upload_id
 
     # One session shared across all part jobs for this upload.
-    session = create_multipart_request_session(pool_size=max_workers, default_headers=default_headers)
+    session = create_multipart_request_session(pool_size=max_workers, header_provider=header_provider)
 
     # Prefill arguments for helper function
     _sign_and_upload_part = partial(_sign_and_upload_part_job, upload_client, session, auth_header, key, upload_id, q)
@@ -233,7 +233,7 @@ def upload_multipart_io(
     upload_client: upload_api.UploadService,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     max_workers: int = DEFAULT_NUM_WORKERS,
-    default_headers: Mapping[str, str] | None = None,
+    header_provider: HeaderProvider | None = None,
 ) -> str:
     """Execute a multipart upload to S3 proxied via Nominal servers
 
@@ -247,7 +247,7 @@ def upload_multipart_io(
         upload_client: Conjure upload client
         chunk_size: Maximum size of chunk to upload to S3 at once
         max_workers: Number of worker threads to use when processing and uploading data
-        default_headers: Optional mapping of headers to include in all requests to object store
+        header_provider: Optional provider for headers to include in all requests to object store
 
     Returns: Path to the uploaded object in S3
 
@@ -265,7 +265,7 @@ def upload_multipart_io(
         upload_client,
         chunk_size=chunk_size,
         max_workers=max_workers,
-        default_headers=default_headers,
+        header_provider=header_provider,
     )
 
 
@@ -277,7 +277,7 @@ def upload_multipart_file(
     file_type: FileType | None = None,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     max_workers: int = DEFAULT_NUM_WORKERS,
-    default_headers: Mapping[str, str] | None = None,
+    header_provider: HeaderProvider | None = None,
 ) -> str:
     """Execute a multipart upload to S3 proxied via Nominal servers.
 
@@ -289,7 +289,7 @@ def upload_multipart_file(
         file_type: Manually override inferred file type for the given file
         chunk_size: Maximum size of chunk to upload to S3 at once
         max_workers: Number of worker threads to use when processing and uploading data
-        default_headers: Optional mapping of headers to include in all requests to object store
+        header_provider: Optional provider for headers to include in all requests to object store
 
     Returns: Path to the uploaded object in S3
 
@@ -310,7 +310,7 @@ def upload_multipart_file(
             upload_client,
             chunk_size=chunk_size,
             max_workers=max_workers,
-            default_headers=default_headers,
+            header_provider=header_provider,
         )
 
 

--- a/nominal/core/_utils/multipart.py
+++ b/nominal/core/_utils/multipart.py
@@ -6,7 +6,7 @@ import pathlib
 import urllib.parse
 from functools import partial
 from queue import Queue
-from typing import BinaryIO, Iterable
+from typing import BinaryIO, Iterable, Mapping
 
 import requests
 from nominal_api import ingest_api, upload_api
@@ -138,6 +138,7 @@ def put_multipart_upload(
     upload_client: upload_api.UploadService,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     max_workers: int = DEFAULT_NUM_WORKERS,
+    default_headers: Mapping[str, str] | None = None,
 ) -> str:
     """Execute a multipart upload to S3.
 
@@ -153,6 +154,7 @@ def put_multipart_upload(
         upload_client: Conjure upload client
         chunk_size: Maximum size of chunk to upload to S3 at once
         max_workers: Number of worker threads to use when processing and uploading data
+        default_headers: Optional mapping of headers to include in all requests to object store
 
     Returns: Path to the uploaded object in S3
 
@@ -177,7 +179,7 @@ def put_multipart_upload(
     key, upload_id = initiate_response.key, initiate_response.upload_id
 
     # One session shared across all part jobs for this upload.
-    session = create_multipart_request_session(pool_size=max_workers)
+    session = create_multipart_request_session(pool_size=max_workers, default_headers=default_headers)
 
     # Prefill arguments for helper function
     _sign_and_upload_part = partial(_sign_and_upload_part_job, upload_client, session, auth_header, key, upload_id, q)
@@ -231,6 +233,7 @@ def upload_multipart_io(
     upload_client: upload_api.UploadService,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     max_workers: int = DEFAULT_NUM_WORKERS,
+    default_headers: Mapping[str, str] | None = None,
 ) -> str:
     """Execute a multipart upload to S3 proxied via Nominal servers
 
@@ -244,6 +247,7 @@ def upload_multipart_io(
         upload_client: Conjure upload client
         chunk_size: Maximum size of chunk to upload to S3 at once
         max_workers: Number of worker threads to use when processing and uploading data
+        default_headers: Optional mapping of headers to include in all requests to object store
 
     Returns: Path to the uploaded object in S3
 
@@ -261,6 +265,7 @@ def upload_multipart_io(
         upload_client,
         chunk_size=chunk_size,
         max_workers=max_workers,
+        default_headers=default_headers,
     )
 
 
@@ -272,6 +277,7 @@ def upload_multipart_file(
     file_type: FileType | None = None,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     max_workers: int = DEFAULT_NUM_WORKERS,
+    default_headers: Mapping[str, str] | None = None,
 ) -> str:
     """Execute a multipart upload to S3 proxied via Nominal servers.
 
@@ -283,6 +289,7 @@ def upload_multipart_file(
         file_type: Manually override inferred file type for the given file
         chunk_size: Maximum size of chunk to upload to S3 at once
         max_workers: Number of worker threads to use when processing and uploading data
+        default_headers: Optional mapping of headers to include in all requests to object store
 
     Returns: Path to the uploaded object in S3
 
@@ -303,6 +310,7 @@ def upload_multipart_file(
             upload_client,
             chunk_size=chunk_size,
             max_workers=max_workers,
+            default_headers=default_headers,
         )
 
 

--- a/nominal/core/_utils/multipart_downloader.py
+++ b/nominal/core/_utils/multipart_downloader.py
@@ -111,7 +111,14 @@ class MultipartFileDownloader:
     _closed: bool = field(default=False, repr=False)
 
     @classmethod
-    def create(cls, *, max_workers: int | None = None, timeout: float = 30.0, max_part_retries: int = 3) -> Self:
+    def create(
+        cls,
+        *,
+        max_workers: int | None = None,
+        timeout: float = 30.0,
+        max_part_retries: int = 3,
+        default_headers: Mapping[str, str] | None = None,
+    ) -> Self:
         """Factor for MultipartFileDownloader
 
         Args:
@@ -120,6 +127,7 @@ class MultipartFileDownloader:
             timeout: Maximum amount of time before considering a connection dead
             max_part_retries: Maximum amount of retries to perform per part download (IO, presigned url expiry,
                 4xx error, and source file changing mid download are all things that may cause a retry)
+            default_headers: Additional default headers to attach to every request issued by the session.
 
         Returns:
             Constructed MultipartFileDownloader prepared to begin downloading.
@@ -128,7 +136,7 @@ class MultipartFileDownloader:
             max_workers = multiprocessing.cpu_count()
             logger.info("Inferring core count as %d", max_workers)
 
-        session = create_multipart_request_session(pool_size=max_workers)
+        session = create_multipart_request_session(pool_size=max_workers, default_headers=default_headers)
         pool = ThreadPoolExecutor(max_workers=max_workers)
         return cls(max_workers, timeout, max_part_retries, _session=session, _pool=pool, _closed=False)
 

--- a/nominal/core/_utils/multipart_downloader.py
+++ b/nominal/core/_utils/multipart_downloader.py
@@ -16,7 +16,7 @@ import requests
 from typing_extensions import Self
 
 from nominal.core._utils.multipart import DEFAULT_CHUNK_SIZE
-from nominal.core._utils.networking import create_multipart_request_session
+from nominal.core._utils.networking import HeaderProvider, create_multipart_request_session
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +117,7 @@ class MultipartFileDownloader:
         max_workers: int | None = None,
         timeout: float = 30.0,
         max_part_retries: int = 3,
-        default_headers: Mapping[str, str] | None = None,
+        header_provider: HeaderProvider | None = None,
     ) -> Self:
         """Factor for MultipartFileDownloader
 
@@ -127,7 +127,7 @@ class MultipartFileDownloader:
             timeout: Maximum amount of time before considering a connection dead
             max_part_retries: Maximum amount of retries to perform per part download (IO, presigned url expiry,
                 4xx error, and source file changing mid download are all things that may cause a retry)
-            default_headers: Additional default headers to attach to every request issued by the session.
+            header_provider: Additional headers to attach to every request issued by the session.
 
         Returns:
             Constructed MultipartFileDownloader prepared to begin downloading.
@@ -136,7 +136,7 @@ class MultipartFileDownloader:
             max_workers = multiprocessing.cpu_count()
             logger.info("Inferring core count as %d", max_workers)
 
-        session = create_multipart_request_session(pool_size=max_workers, default_headers=default_headers)
+        session = create_multipart_request_session(pool_size=max_workers, header_provider=header_provider)
         pool = ThreadPoolExecutor(max_workers=max_workers)
         return cls(max_workers, timeout, max_part_retries, _session=session, _pool=pool, _closed=False)
 

--- a/nominal/core/_utils/networking.py
+++ b/nominal/core/_utils/networking.py
@@ -4,7 +4,9 @@ import gzip
 import logging
 import ssl
 import threading
-from typing import Any, Callable, Mapping, Type, TypeVar
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Type, TypeAlias, TypeVar
 
 import requests
 import truststore
@@ -15,11 +17,59 @@ from requests.adapters import DEFAULT_POOLSIZE, CaseInsensitiveDict, HTTPAdapter
 from urllib3.connection import HTTPConnection
 from urllib3.util.retry import Retry
 
+from nominal.core.exceptions import HeaderConflictError
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
 GZIP_COMPRESSION_LEVEL = 1
+
+
+class HeaderProvider(ABC):
+    @abstractmethod
+    def headers(self) -> Mapping[str, str]: ...
+
+
+@dataclass(frozen=True)
+class StaticHeaderProvider(HeaderProvider):
+    _headers: Mapping[str, str]
+
+    def headers(self) -> Mapping[str, str]:
+        return self._headers
+
+
+HeadersLike: TypeAlias = HeaderProvider | Mapping[str, str]
+
+
+def normalize_header_provider(headers: HeadersLike | None) -> HeaderProvider | None:
+    if headers is None:
+        return None
+    if isinstance(headers, HeaderProvider):
+        return headers
+    return StaticHeaderProvider(headers)
+
+
+class HeaderProviderSession(requests.Session):
+    def __init__(self, header_provider: HeaderProvider | None = None) -> None:
+        super().__init__()
+        self._header_provider = header_provider
+
+    @typing_extensions.override
+    def prepare_request(self, request: requests.Request) -> requests.PreparedRequest:
+        prepared = super().prepare_request(request)
+        if self._header_provider is None:
+            return prepared
+
+        request_headers = CaseInsensitiveDict(request.headers or {})
+        for key, value in self._header_provider.headers().items():
+            if key in request_headers:
+                raise HeaderConflictError(
+                    f"HeaderProvider returned header {key!r}, but the request already set that header; "
+                    "HeaderProvider cannot override explicit request headers."
+                )
+            prepared.headers[key] = value
+        return prepared
 
 
 class ThreadSafeSSLContext(truststore.SSLContext):
@@ -141,7 +191,7 @@ def create_conjure_service_client(
     user_agent: str,
     service_config: ServiceConfiguration,
     return_none_for_unknown_union_types: bool = False,
-    default_headers: Mapping[str, str] | None = None,
+    header_provider: HeaderProvider | None = None,
 ) -> T:
     """Wrapper around logic found in the conjure_python_client for creating conjure clients
     that automatically gzip data being sent to services.
@@ -158,7 +208,7 @@ def create_conjure_service_client(
             settings, and timeout settings.
         return_none_for_unknown_union_types: If true, returns None instead of raising an exception when an unknown
             union type is encountered during decoding API responses.
-        default_headers: Additional default headers to attach to the service session.
+        header_provider: Additional default headers to attach to each request.
         enable_keep_alive: If true, enable keep alive in connections with the service.
 
     Returns:
@@ -176,8 +226,8 @@ def create_conjure_service_client(
     # No ssl_context passed: defaults to ThreadSafeSSLContext, which is
     # required since this session is shared across threads via ClientsBunch.
     transport_adapter = NominalRequestsAdapter(max_retries=retry)
-    session = requests.Session()
-    session.headers = CaseInsensitiveDict({"User-Agent": user_agent, **(default_headers or {})})
+    session = HeaderProviderSession(header_provider)
+    session.headers = CaseInsensitiveDict({"User-Agent": user_agent})
     if service_config.security is not None:
         verify = service_config.security.trust_store_path
     else:
@@ -198,7 +248,7 @@ def create_conjure_client_factory(
     user_agent: str,
     service_config: ServiceConfiguration,
     return_none_for_unknown_union_types: bool = False,
-    default_headers: Mapping[str, str] | None = None,
+    header_provider: HeaderProvider | None = None,
 ) -> Callable[[Type[T]], T]:
     """Create factory method for creating conjure clients given the respective conjure service type
 
@@ -211,7 +261,7 @@ def create_conjure_client_factory(
             user_agent=user_agent,
             service_config=service_config,
             return_none_for_unknown_union_types=return_none_for_unknown_union_types,
-            default_headers=default_headers,
+            header_provider=header_provider,
         )
 
     return factory
@@ -221,7 +271,7 @@ def create_multipart_request_session(
     *,
     pool_size: int = DEFAULT_POOLSIZE,
     num_retries: int = 5,
-    default_headers: Mapping[str, str] | None = None,
+    header_provider: HeaderProvider | None = None,
 ) -> requests.Session:
     """Create a requests Session configured for multipart uploads to S3.
 
@@ -232,7 +282,7 @@ def create_multipart_request_session(
         pool_size: Number of concurrent workers. Controls the number of cached host pools
             and the per-host connection limit (2 * pool_size).
         num_retries: Number of times to retry failed requests.
-        default_headers: Additional default headers to attach to every request issued by the session.
+        header_provider: Additional default headers to attach to every request issued by the session.
     """
     if pool_size <= 0:
         raise ValueError(f"pool_size must be positive, got {pool_size}")
@@ -242,9 +292,7 @@ def create_multipart_request_session(
         backoff_factor=0.5,
         status_forcelist=(429, 500, 502, 503, 504),
     )
-    session = requests.Session()
-    if default_headers:
-        session.headers.update(default_headers)
+    session = HeaderProviderSession(header_provider)
     adapter = SslBypassRequestsAdapter(
         max_retries=retries,
         # Match the number of cached host pools to the thread count to avoid LRU eviction.

--- a/nominal/core/_utils/networking.py
+++ b/nominal/core/_utils/networking.py
@@ -6,7 +6,7 @@ import ssl
 import threading
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable, Mapping, Type, TypeAlias, TypeVar
+from typing import Any, Callable, Mapping, Type, TypeVar
 
 import requests
 import truststore
@@ -39,10 +39,7 @@ class StaticHeaderProvider(HeaderProvider):
         return self._headers
 
 
-HeadersLike: TypeAlias = HeaderProvider | Mapping[str, str]
-
-
-def normalize_header_provider(headers: HeadersLike | None) -> HeaderProvider | None:
+def normalize_header_provider(headers: HeaderProvider | Mapping[str, str] | None) -> HeaderProvider | None:
     if headers is None:
         return None
     if isinstance(headers, HeaderProvider):

--- a/nominal/core/_utils/networking.py
+++ b/nominal/core/_utils/networking.py
@@ -221,6 +221,7 @@ def create_multipart_request_session(
     *,
     pool_size: int = DEFAULT_POOLSIZE,
     num_retries: int = 5,
+    default_headers: Mapping[str, str] | None = None,
 ) -> requests.Session:
     """Create a requests Session configured for multipart uploads to S3.
 
@@ -231,6 +232,7 @@ def create_multipart_request_session(
         pool_size: Number of concurrent workers. Controls the number of cached host pools
             and the per-host connection limit (2 * pool_size).
         num_retries: Number of times to retry failed requests.
+        default_headers: Additional default headers to attach to every request issued by the session.
     """
     if pool_size <= 0:
         raise ValueError(f"pool_size must be positive, got {pool_size}")
@@ -241,6 +243,8 @@ def create_multipart_request_session(
         status_forcelist=(429, 500, 502, 503, 504),
     )
     session = requests.Session()
+    if default_headers:
+        session.headers.update(default_headers)
     adapter = SslBypassRequestsAdapter(
         max_retries=retries,
         # Match the number of cached host pools to the thread count to avoid LRU eviction.

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -46,6 +46,7 @@ from nominal.core._utils.api_tools import (
 from nominal.core._utils.multipart import (
     upload_multipart_io,
 )
+from nominal.core._utils.networking import HeadersLike, normalize_header_provider
 from nominal.core._utils.pagination_tools import (
     search_assets_paginated,
     search_checklists_paginated,
@@ -134,7 +135,7 @@ class NominalClient:
         *,
         trust_store_path: str | None = None,
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
-        additional_headers: Mapping[str, str] | None = None,
+        header_provider: HeadersLike | None = None,
     ) -> Self:
         """Create a connection to the Nominal platform from a named profile in the Nominal config.
 
@@ -143,7 +144,7 @@ class NominalClient:
             trust_store_path: path to a trust store certificate chain to initiate SSL connections. If not provided,
                 certifi's trust store is used.
             connect_timeout: Request connection timeout.
-            additional_headers: Extra headers to attach to every request issued by the client.
+            header_provider: Extra headers, or a provider for dynamic headers, to attach to every request.
         """
         config = NominalConfig.from_yaml()
         prof = config.get_profile(profile)
@@ -153,7 +154,7 @@ class NominalClient:
             workspace_rid=prof.workspace_rid,
             trust_store_path=trust_store_path,
             connect_timeout=connect_timeout,
-            additional_headers=additional_headers,
+            header_provider=header_provider,
             _profile=profile,
         )
         return client
@@ -167,7 +168,7 @@ class NominalClient:
         workspace_rid: str | None = None,
         trust_store_path: str | None = None,
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
-        additional_headers: Mapping[str, str] | None = None,
+        header_provider: HeadersLike | None = None,
         _profile: str | None = None,
     ) -> Self:
         """Create a connection to the Nominal platform from a token.
@@ -180,7 +181,7 @@ class NominalClient:
             trust_store_path: path to a trust store certificate chain to initiate SSL connections. If not provided,
                 certifi's trust store is used.
             connect_timeout: Request connection timeout.
-            additional_headers: Extra headers to attach to every request issued by the client.
+            header_provider: Extra headers, or a provider for dynamic headers, to attach to every request.
         """
         trust_store_path = certifi.where() if trust_store_path is None else trust_store_path
         timeout_seconds = connect_timeout.total_seconds() if isinstance(connect_timeout, timedelta) else connect_timeout
@@ -192,7 +193,12 @@ class NominalClient:
         agent = construct_user_agent_string()
         return cls(
             _clients=ClientsBunch.from_config(
-                cfg, base_url, agent, token, workspace_rid, default_headers=additional_headers
+                cfg,
+                base_url,
+                agent,
+                token,
+                workspace_rid,
+                header_provider=normalize_header_provider(header_provider),
             ),
             _profile=_profile,
         )
@@ -206,7 +212,7 @@ class NominalClient:
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
         *,
         workspace_rid: str | None = None,
-        additional_headers: Mapping[str, str] | None = None,
+        header_provider: HeadersLike | None = None,
     ) -> Self:
         """Create a connection to the Nominal platform.
 
@@ -217,7 +223,7 @@ class NominalClient:
         connect_timeout: Timeout for any single request to the Nominal API.
         workspace_rid: Optional workspace RID to pin the client to for operations that require a single
             workspace. If not provided, those operations resolve a default workspace client-side when needed.
-        additional_headers: Extra headers to attach to every request issued by the client.
+        header_provider: Extra headers, or a provider for dynamic headers, to attach to every request.
         """
         if token is None:
             token = _config.get_token(base_url)
@@ -227,7 +233,7 @@ class NominalClient:
             trust_store_path=trust_store_path,
             connect_timeout=connect_timeout,
             workspace_rid=workspace_rid,
-            additional_headers=additional_headers,
+            header_provider=header_provider,
         )
 
     def __repr__(self) -> str:
@@ -981,7 +987,7 @@ class NominalClient:
             name,
             file_type,
             self._clients.upload,
-            default_headers=self._clients.default_headers,
+            header_provider=self._clients.header_provider,
         )
         request = attachments_api.CreateAttachmentRequest(
             description=description or "",

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -46,7 +46,7 @@ from nominal.core._utils.api_tools import (
 from nominal.core._utils.multipart import (
     upload_multipart_io,
 )
-from nominal.core._utils.networking import HeadersLike, normalize_header_provider
+from nominal.core._utils.networking import HeaderProvider, normalize_header_provider
 from nominal.core._utils.pagination_tools import (
     search_assets_paginated,
     search_checklists_paginated,
@@ -135,7 +135,7 @@ class NominalClient:
         *,
         trust_store_path: str | None = None,
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
-        extra_headers: HeadersLike | None = None,
+        extra_headers: HeaderProvider | Mapping[str, str] | None = None,
     ) -> Self:
         """Create a connection to the Nominal platform from a named profile in the Nominal config.
 
@@ -168,7 +168,7 @@ class NominalClient:
         workspace_rid: str | None = None,
         trust_store_path: str | None = None,
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
-        extra_headers: HeadersLike | None = None,
+        extra_headers: HeaderProvider | Mapping[str, str] | None = None,
         _profile: str | None = None,
     ) -> Self:
         """Create a connection to the Nominal platform from a token.
@@ -212,7 +212,7 @@ class NominalClient:
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
         *,
         workspace_rid: str | None = None,
-        extra_headers: HeadersLike | None = None,
+        extra_headers: HeaderProvider | Mapping[str, str] | None = None,
     ) -> Self:
         """Create a connection to the Nominal platform.
 

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -134,7 +134,7 @@ class NominalClient:
         *,
         trust_store_path: str | None = None,
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
-        additional_headers: Iterable[tuple[str, str]] = (),
+        additional_headers: Mapping[str, str] | None = None,
     ) -> Self:
         """Create a connection to the Nominal platform from a named profile in the Nominal config.
 
@@ -143,8 +143,7 @@ class NominalClient:
             trust_store_path: path to a trust store certificate chain to initiate SSL connections. If not provided,
                 certifi's trust store is used.
             connect_timeout: Request connection timeout.
-            additional_headers: Extra headers to attach to every request issued by the client, as (name, value)
-                pairs.
+            additional_headers: Extra headers to attach to every request issued by the client.
         """
         config = NominalConfig.from_yaml()
         prof = config.get_profile(profile)
@@ -168,7 +167,7 @@ class NominalClient:
         workspace_rid: str | None = None,
         trust_store_path: str | None = None,
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
-        additional_headers: Iterable[tuple[str, str]] = (),
+        additional_headers: Mapping[str, str] | None = None,
         _profile: str | None = None,
     ) -> Self:
         """Create a connection to the Nominal platform from a token.
@@ -181,8 +180,7 @@ class NominalClient:
             trust_store_path: path to a trust store certificate chain to initiate SSL connections. If not provided,
                 certifi's trust store is used.
             connect_timeout: Request connection timeout.
-            additional_headers: Extra headers to attach to every request issued by the client, as (name, value)
-                pairs.
+            additional_headers: Extra headers to attach to every request issued by the client.
         """
         trust_store_path = certifi.where() if trust_store_path is None else trust_store_path
         timeout_seconds = connect_timeout.total_seconds() if isinstance(connect_timeout, timedelta) else connect_timeout
@@ -194,7 +192,7 @@ class NominalClient:
         agent = construct_user_agent_string()
         return cls(
             _clients=ClientsBunch.from_config(
-                cfg, base_url, agent, token, workspace_rid, default_headers=dict(additional_headers)
+                cfg, base_url, agent, token, workspace_rid, default_headers=additional_headers
             ),
             _profile=_profile,
         )
@@ -208,7 +206,7 @@ class NominalClient:
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
         *,
         workspace_rid: str | None = None,
-        additional_headers: Iterable[tuple[str, str]] = (),
+        additional_headers: Mapping[str, str] | None = None,
     ) -> Self:
         """Create a connection to the Nominal platform.
 
@@ -219,7 +217,7 @@ class NominalClient:
         connect_timeout: Timeout for any single request to the Nominal API.
         workspace_rid: Optional workspace RID to pin the client to for operations that require a single
             workspace. If not provided, those operations resolve a default workspace client-side when needed.
-        additional_headers: Extra headers to attach to every request issued by the client, as (name, value) pairs.
+        additional_headers: Extra headers to attach to every request issued by the client.
         """
         if token is None:
             token = _config.get_token(base_url)

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -983,6 +983,7 @@ class NominalClient:
             name,
             file_type,
             self._clients.upload,
+            default_headers=self._clients.default_headers,
         )
         request = attachments_api.CreateAttachmentRequest(
             description=description or "",

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -134,6 +134,7 @@ class NominalClient:
         *,
         trust_store_path: str | None = None,
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
+        additional_headers: Iterable[tuple[str, str]] = (),
     ) -> Self:
         """Create a connection to the Nominal platform from a named profile in the Nominal config.
 
@@ -142,6 +143,8 @@ class NominalClient:
             trust_store_path: path to a trust store certificate chain to initiate SSL connections. If not provided,
                 certifi's trust store is used.
             connect_timeout: Request connection timeout.
+            additional_headers: Extra headers to attach to every request issued by the client, as (name, value)
+                pairs.
         """
         config = NominalConfig.from_yaml()
         prof = config.get_profile(profile)
@@ -151,6 +154,7 @@ class NominalClient:
             workspace_rid=prof.workspace_rid,
             trust_store_path=trust_store_path,
             connect_timeout=connect_timeout,
+            additional_headers=additional_headers,
             _profile=profile,
         )
         return client
@@ -164,6 +168,7 @@ class NominalClient:
         workspace_rid: str | None = None,
         trust_store_path: str | None = None,
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
+        additional_headers: Iterable[tuple[str, str]] = (),
         _profile: str | None = None,
     ) -> Self:
         """Create a connection to the Nominal platform from a token.
@@ -176,6 +181,8 @@ class NominalClient:
             trust_store_path: path to a trust store certificate chain to initiate SSL connections. If not provided,
                 certifi's trust store is used.
             connect_timeout: Request connection timeout.
+            additional_headers: Extra headers to attach to every request issued by the client, as (name, value)
+                pairs.
         """
         trust_store_path = certifi.where() if trust_store_path is None else trust_store_path
         timeout_seconds = connect_timeout.total_seconds() if isinstance(connect_timeout, timedelta) else connect_timeout
@@ -185,7 +192,12 @@ class NominalClient:
             connect_timeout=timeout_seconds,
         )
         agent = construct_user_agent_string()
-        return cls(_clients=ClientsBunch.from_config(cfg, base_url, agent, token, workspace_rid), _profile=_profile)
+        return cls(
+            _clients=ClientsBunch.from_config(
+                cfg, base_url, agent, token, workspace_rid, default_headers=dict(additional_headers)
+            ),
+            _profile=_profile,
+        )
 
     @classmethod
     def create(
@@ -196,6 +208,7 @@ class NominalClient:
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
         *,
         workspace_rid: str | None = None,
+        additional_headers: Iterable[tuple[str, str]] = (),
     ) -> Self:
         """Create a connection to the Nominal platform.
 
@@ -206,6 +219,7 @@ class NominalClient:
         connect_timeout: Timeout for any single request to the Nominal API.
         workspace_rid: Optional workspace RID to pin the client to for operations that require a single
             workspace. If not provided, those operations resolve a default workspace client-side when needed.
+        additional_headers: Extra headers to attach to every request issued by the client, as (name, value) pairs.
         """
         if token is None:
             token = _config.get_token(base_url)
@@ -215,6 +229,7 @@ class NominalClient:
             trust_store_path=trust_store_path,
             connect_timeout=connect_timeout,
             workspace_rid=workspace_rid,
+            additional_headers=additional_headers,
         )
 
     def __repr__(self) -> str:

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -135,7 +135,7 @@ class NominalClient:
         *,
         trust_store_path: str | None = None,
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
-        header_provider: HeadersLike | None = None,
+        extra_headers: HeadersLike | None = None,
     ) -> Self:
         """Create a connection to the Nominal platform from a named profile in the Nominal config.
 
@@ -144,7 +144,7 @@ class NominalClient:
             trust_store_path: path to a trust store certificate chain to initiate SSL connections. If not provided,
                 certifi's trust store is used.
             connect_timeout: Request connection timeout.
-            header_provider: Extra headers, or a provider for dynamic headers, to attach to every request.
+            extra_headers: Extra request headers, either as a mapping or HeaderProvider.
         """
         config = NominalConfig.from_yaml()
         prof = config.get_profile(profile)
@@ -154,7 +154,7 @@ class NominalClient:
             workspace_rid=prof.workspace_rid,
             trust_store_path=trust_store_path,
             connect_timeout=connect_timeout,
-            header_provider=header_provider,
+            extra_headers=extra_headers,
             _profile=profile,
         )
         return client
@@ -168,7 +168,7 @@ class NominalClient:
         workspace_rid: str | None = None,
         trust_store_path: str | None = None,
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
-        header_provider: HeadersLike | None = None,
+        extra_headers: HeadersLike | None = None,
         _profile: str | None = None,
     ) -> Self:
         """Create a connection to the Nominal platform from a token.
@@ -181,7 +181,7 @@ class NominalClient:
             trust_store_path: path to a trust store certificate chain to initiate SSL connections. If not provided,
                 certifi's trust store is used.
             connect_timeout: Request connection timeout.
-            header_provider: Extra headers, or a provider for dynamic headers, to attach to every request.
+            extra_headers: Extra request headers, either as a mapping or HeaderProvider.
         """
         trust_store_path = certifi.where() if trust_store_path is None else trust_store_path
         timeout_seconds = connect_timeout.total_seconds() if isinstance(connect_timeout, timedelta) else connect_timeout
@@ -198,7 +198,7 @@ class NominalClient:
                 agent,
                 token,
                 workspace_rid,
-                header_provider=normalize_header_provider(header_provider),
+                header_provider=normalize_header_provider(extra_headers),
             ),
             _profile=_profile,
         )
@@ -212,7 +212,7 @@ class NominalClient:
         connect_timeout: timedelta | float = DEFAULT_CONNECT_TIMEOUT,
         *,
         workspace_rid: str | None = None,
-        header_provider: HeadersLike | None = None,
+        extra_headers: HeadersLike | None = None,
     ) -> Self:
         """Create a connection to the Nominal platform.
 
@@ -223,7 +223,7 @@ class NominalClient:
         connect_timeout: Timeout for any single request to the Nominal API.
         workspace_rid: Optional workspace RID to pin the client to for operations that require a single
             workspace. If not provided, those operations resolve a default workspace client-side when needed.
-        header_provider: Extra headers, or a provider for dynamic headers, to attach to every request.
+        extra_headers: Extra request headers, either as a mapping or HeaderProvider.
         """
         if token is None:
             token = _config.get_token(base_url)
@@ -233,7 +233,7 @@ class NominalClient:
             trust_store_path=trust_store_path,
             connect_timeout=connect_timeout,
             workspace_rid=workspace_rid,
-            header_provider=header_provider,
+            extra_headers=extra_headers,
         )
 
     def __repr__(self) -> str:

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -218,6 +218,7 @@ class Dataset(DataSource, RefreshableMixin[scout_catalog.EnrichedDataset]):
             file_name,
             file_type,
             self._clients.upload,
+            default_headers=self._clients.default_headers,
         )
 
         request = ingest_api.IngestRequest(
@@ -304,6 +305,7 @@ class Dataset(DataSource, RefreshableMixin[scout_catalog.EnrichedDataset]):
             avro_path,
             self._clients.upload,
             file_type=FileTypes.AVRO_STREAM,
+            default_headers=self._clients.default_headers,
         )
         target = ingest_api.DatasetIngestTarget(
             existing=ingest_api.ExistingDatasetIngestDestination(dataset_rid=self.rid)
@@ -352,6 +354,7 @@ class Dataset(DataSource, RefreshableMixin[scout_catalog.EnrichedDataset]):
             log_path,
             self._clients.upload,
             file_type=file_type,
+            default_headers=self._clients.default_headers,
         )
         target = ingest_api.DatasetIngestTarget(
             existing=ingest_api.ExistingDatasetIngestDestination(dataset_rid=self.rid)
@@ -445,6 +448,7 @@ class Dataset(DataSource, RefreshableMixin[scout_catalog.EnrichedDataset]):
             file_name,
             file_type=FileTypes.MCAP,
             upload_client=self._clients.upload,
+            default_headers=self._clients.default_headers,
         )
 
         channels = _create_mcap_channels(include_topics, exclude_topics)
@@ -484,6 +488,7 @@ class Dataset(DataSource, RefreshableMixin[scout_catalog.EnrichedDataset]):
             dataflash_path,
             self._clients.upload,
             file_type=FileTypes.DATAFLASH,
+            default_headers=self._clients.default_headers,
         )
         target = ingest_api.DatasetIngestTarget(
             existing=ingest_api.ExistingDatasetIngestDestination(dataset_rid=self.rid)
@@ -578,6 +583,7 @@ class Dataset(DataSource, RefreshableMixin[scout_catalog.EnrichedDataset]):
                 workspace_rid,
                 Path(source_path),
                 self._clients.upload,
+                default_headers=self._clients.default_headers,
             )
             logger.info("Uploaded %s -> %s", source_path, s3_path)
             s3_inputs[source] = s3_path

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -218,7 +218,7 @@ class Dataset(DataSource, RefreshableMixin[scout_catalog.EnrichedDataset]):
             file_name,
             file_type,
             self._clients.upload,
-            default_headers=self._clients.default_headers,
+            header_provider=self._clients.header_provider,
         )
 
         request = ingest_api.IngestRequest(
@@ -305,7 +305,7 @@ class Dataset(DataSource, RefreshableMixin[scout_catalog.EnrichedDataset]):
             avro_path,
             self._clients.upload,
             file_type=FileTypes.AVRO_STREAM,
-            default_headers=self._clients.default_headers,
+            header_provider=self._clients.header_provider,
         )
         target = ingest_api.DatasetIngestTarget(
             existing=ingest_api.ExistingDatasetIngestDestination(dataset_rid=self.rid)
@@ -354,7 +354,7 @@ class Dataset(DataSource, RefreshableMixin[scout_catalog.EnrichedDataset]):
             log_path,
             self._clients.upload,
             file_type=file_type,
-            default_headers=self._clients.default_headers,
+            header_provider=self._clients.header_provider,
         )
         target = ingest_api.DatasetIngestTarget(
             existing=ingest_api.ExistingDatasetIngestDestination(dataset_rid=self.rid)
@@ -448,7 +448,7 @@ class Dataset(DataSource, RefreshableMixin[scout_catalog.EnrichedDataset]):
             file_name,
             file_type=FileTypes.MCAP,
             upload_client=self._clients.upload,
-            default_headers=self._clients.default_headers,
+            header_provider=self._clients.header_provider,
         )
 
         channels = _create_mcap_channels(include_topics, exclude_topics)
@@ -488,7 +488,7 @@ class Dataset(DataSource, RefreshableMixin[scout_catalog.EnrichedDataset]):
             dataflash_path,
             self._clients.upload,
             file_type=FileTypes.DATAFLASH,
-            default_headers=self._clients.default_headers,
+            header_provider=self._clients.header_provider,
         )
         target = ingest_api.DatasetIngestTarget(
             existing=ingest_api.ExistingDatasetIngestDestination(dataset_rid=self.rid)
@@ -583,7 +583,7 @@ class Dataset(DataSource, RefreshableMixin[scout_catalog.EnrichedDataset]):
                 workspace_rid,
                 Path(source_path),
                 self._clients.upload,
-                default_headers=self._clients.default_headers,
+                header_provider=self._clients.header_provider,
             )
             logger.info("Uploaded %s -> %s", source_path, s3_path)
             s3_inputs[source] = s3_path

--- a/nominal/core/dataset_file.py
+++ b/nominal/core/dataset_file.py
@@ -171,7 +171,7 @@ class DatasetFile(RefreshableMixin[scout_catalog.DatasetFile]):
         destination = output_directory / filename_from_uri(file_uri)
         item = DownloadItem(provider=self._presigned_url_provider(), destination=destination, part_size=part_size)
         with MultipartFileDownloader.create(
-            max_part_retries=num_retries, default_headers=self._clients.default_headers
+            max_part_retries=num_retries, header_provider=self._clients.header_provider
         ) as dl:
             return dl.download_file(item)
 
@@ -226,7 +226,7 @@ class DatasetFile(RefreshableMixin[scout_catalog.DatasetFile]):
             return []
 
         with MultipartFileDownloader.create(
-            max_part_retries=num_retries, default_headers=self._clients.default_headers
+            max_part_retries=num_retries, header_provider=self._clients.header_provider
         ) as dl:
             results = dl.download_files(items)
 
@@ -243,7 +243,7 @@ class DatasetFile(RefreshableMixin[scout_catalog.DatasetFile]):
               self-hosted environments-- a RuntimeError will be thrown in this case.
         """
         # TODO(drake): pull out functionality in a more re-usable way without requiring the downloader class
-        with MultipartFileDownloader.create(max_workers=1, default_headers=self._clients.default_headers) as downloader:
+        with MultipartFileDownloader.create(max_workers=1, header_provider=self._clients.header_provider) as downloader:
             size, _ = downloader._head_or_probe(self._presigned_url_provider())
             return size
 

--- a/nominal/core/dataset_file.py
+++ b/nominal/core/dataset_file.py
@@ -170,7 +170,9 @@ class DatasetFile(RefreshableMixin[scout_catalog.DatasetFile]):
         file_uri = self._clients.catalog.get_dataset_file_uri(self._clients.auth_header, self.dataset_rid, self.id).uri
         destination = output_directory / filename_from_uri(file_uri)
         item = DownloadItem(provider=self._presigned_url_provider(), destination=destination, part_size=part_size)
-        with MultipartFileDownloader.create(max_part_retries=num_retries) as dl:
+        with MultipartFileDownloader.create(
+            max_part_retries=num_retries, default_headers=self._clients.default_headers
+        ) as dl:
             return dl.download_file(item)
 
     def download_original_files(
@@ -223,7 +225,9 @@ class DatasetFile(RefreshableMixin[scout_catalog.DatasetFile]):
             )
             return []
 
-        with MultipartFileDownloader.create(max_part_retries=num_retries) as dl:
+        with MultipartFileDownloader.create(
+            max_part_retries=num_retries, default_headers=self._clients.default_headers
+        ) as dl:
             results = dl.download_files(items)
 
         for failed_path, ex in results.failed.items():
@@ -239,7 +243,7 @@ class DatasetFile(RefreshableMixin[scout_catalog.DatasetFile]):
               self-hosted environments-- a RuntimeError will be thrown in this case.
         """
         # TODO(drake): pull out functionality in a more re-usable way without requiring the downloader class
-        with MultipartFileDownloader.create(max_workers=1) as downloader:
+        with MultipartFileDownloader.create(max_workers=1, default_headers=self._clients.default_headers) as downloader:
             size, _ = downloader._head_or_probe(self._presigned_url_provider())
             return size
 

--- a/nominal/core/exceptions.py
+++ b/nominal/core/exceptions.py
@@ -46,6 +46,10 @@ class NominalConfigError(NominalError):
     """An error occurred reading or writing the configuration."""
 
 
+class HeaderConflictError(NominalError):
+    """A header provider attempted to override an explicit request header."""
+
+
 class NominalMethodRemovedError(NominalError):
     """An error raised when a method has been deprecated and now removed.
     Error informs users of the new method to use instead.

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -17,6 +17,7 @@ from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._types import PathLike
 from nominal.core._utils.api_tools import HasRid, RefreshableMixin
 from nominal.core._utils.multipart import path_upload_name, upload_multipart_io
+from nominal.core._utils.networking import HeaderProvider
 from nominal.core.exceptions import NominalIngestError, NominalIngestFailed
 from nominal.core.filetype import FileType, FileTypes
 from nominal.core.video_file import VideoFile
@@ -256,7 +257,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
             self._clients.upload,
             start,
             frame_timestamps,
-            default_headers=self._clients.default_headers,
+            header_provider=self._clients.header_provider,
         )
         file_type = FileType(*file_type)
         s3_path = upload_multipart_io(
@@ -266,7 +267,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
             name,
             file_type,
             self._clients.upload,
-            default_headers=self._clients.default_headers,
+            header_provider=self._clients.header_provider,
         )
         request = ingest_api.IngestRequest(
             ingest_api.IngestOptions(
@@ -367,7 +368,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
             name,
             file_type,
             self._clients.upload,
-            default_headers=self._clients.default_headers,
+            header_provider=self._clients.header_provider,
         )
         request = ingest_api.IngestRequest(
             options=ingest_api.IngestOptions(
@@ -424,7 +425,7 @@ def _upload_frame_timestamps(
     workspace_rid: str | None,
     upload_client: upload_api.UploadService,
     frame_timestamps: Sequence[IntegralNanosecondsUTC],
-    default_headers: Mapping[str, str] | None = None,
+    header_provider: HeaderProvider | None = None,
 ) -> str:
     """Uploads per-frame video timestamps to S3 and provides a path to the uploaded resource."""
     # Dump timestamp array into an in-memory file-like IO object
@@ -442,7 +443,7 @@ def _upload_frame_timestamps(
         "timestamp_manifest",
         FileTypes.JSON,
         upload_client,
-        default_headers=default_headers,
+        header_provider=header_provider,
     )
 
 
@@ -452,13 +453,13 @@ def _build_video_file_timestamp_manifest(
     upload_client: upload_api.UploadService,
     start: datetime | IntegralNanosecondsUTC | None = None,
     frame_timestamps: Sequence[IntegralNanosecondsUTC] | None = None,
-    default_headers: Mapping[str, str] | None = None,
+    header_provider: HeaderProvider | None = None,
 ) -> scout_video_api.VideoFileTimestampManifest:
     if None not in (start, frame_timestamps):
         raise ValueError("Only one of 'start' or 'frame_timestamps' are allowed")
     elif frame_timestamps is not None:
         manifest_s3_path = _upload_frame_timestamps(
-            auth_header, workspace_rid, upload_client, frame_timestamps, default_headers=default_headers
+            auth_header, workspace_rid, upload_client, frame_timestamps, header_provider=header_provider
         )
         return scout_video_api.VideoFileTimestampManifest(s3path=manifest_s3_path)
     elif start is not None:

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -251,11 +251,22 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
 
         workspace_rid = self._clients.resolve_default_workspace_rid()
         timestamp_manifest = _build_video_file_timestamp_manifest(
-            self._clients.auth_header, workspace_rid, self._clients.upload, start, frame_timestamps
+            self._clients.auth_header,
+            workspace_rid,
+            self._clients.upload,
+            start,
+            frame_timestamps,
+            default_headers=self._clients.default_headers,
         )
         file_type = FileType(*file_type)
         s3_path = upload_multipart_io(
-            self._clients.auth_header, workspace_rid, video, name, file_type, self._clients.upload
+            self._clients.auth_header,
+            workspace_rid,
+            video,
+            name,
+            file_type,
+            self._clients.upload,
+            default_headers=self._clients.default_headers,
         )
         request = ingest_api.IngestRequest(
             ingest_api.IngestOptions(
@@ -356,6 +367,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
             name,
             file_type,
             self._clients.upload,
+            default_headers=self._clients.default_headers,
         )
         request = ingest_api.IngestRequest(
             options=ingest_api.IngestOptions(
@@ -412,6 +424,7 @@ def _upload_frame_timestamps(
     workspace_rid: str | None,
     upload_client: upload_api.UploadService,
     frame_timestamps: Sequence[IntegralNanosecondsUTC],
+    default_headers: Mapping[str, str] | None = None,
 ) -> str:
     """Uploads per-frame video timestamps to S3 and provides a path to the uploaded resource."""
     # Dump timestamp array into an in-memory file-like IO object
@@ -429,6 +442,7 @@ def _upload_frame_timestamps(
         "timestamp_manifest",
         FileTypes.JSON,
         upload_client,
+        default_headers=default_headers,
     )
 
 
@@ -438,11 +452,14 @@ def _build_video_file_timestamp_manifest(
     upload_client: upload_api.UploadService,
     start: datetime | IntegralNanosecondsUTC | None = None,
     frame_timestamps: Sequence[IntegralNanosecondsUTC] | None = None,
+    default_headers: Mapping[str, str] | None = None,
 ) -> scout_video_api.VideoFileTimestampManifest:
     if None not in (start, frame_timestamps):
         raise ValueError("Only one of 'start' or 'frame_timestamps' are allowed")
     elif frame_timestamps is not None:
-        manifest_s3_path = _upload_frame_timestamps(auth_header, workspace_rid, upload_client, frame_timestamps)
+        manifest_s3_path = _upload_frame_timestamps(
+            auth_header, workspace_rid, upload_client, frame_timestamps, default_headers=default_headers
+        )
         return scout_video_api.VideoFileTimestampManifest(s3path=manifest_s3_path)
     elif start is not None:
         # TODO(drake): expose scale parameter to users

--- a/nominal/experimental/impersonation/__init__.py
+++ b/nominal/experimental/impersonation/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from nominal.core._clientsbunch import ON_BEHALF_OF_USER_RID_HEADER
+from nominal.core._utils.networking import StaticHeaderProvider
 from nominal.core.client import NominalClient
 
 
@@ -9,5 +10,5 @@ def as_user(client: NominalClient, user_rid: str) -> NominalClient:
 
     The returned client injects the on-behalf-of header for all service requests.
     """
-    clients = client._clients.with_default_request_headers({ON_BEHALF_OF_USER_RID_HEADER: user_rid})
+    clients = client._clients.with_header_provider(StaticHeaderProvider({ON_BEHALF_OF_USER_RID_HEADER: user_rid}))
     return NominalClient(_clients=clients, _profile=client._profile)

--- a/nominal/experimental/impersonation/__init__.py
+++ b/nominal/experimental/impersonation/__init__.py
@@ -16,6 +16,6 @@ def as_user(client: NominalClient, user_rid: str) -> NominalClient:
         workspace_rid=client._clients.workspace_rid,
         trust_store_path=security.trust_store_path if security is not None else None,
         connect_timeout=client._clients._service_config.connect_timeout,
-        header_provider={ON_BEHALF_OF_USER_RID_HEADER: user_rid},
+        extra_headers={ON_BEHALF_OF_USER_RID_HEADER: user_rid},
         _profile=client._profile,
     )

--- a/nominal/experimental/impersonation/__init__.py
+++ b/nominal/experimental/impersonation/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from nominal.core._clientsbunch import ON_BEHALF_OF_USER_RID_HEADER
-from nominal.core._utils.networking import StaticHeaderProvider
 from nominal.core.client import NominalClient
 
 
@@ -10,5 +9,13 @@ def as_user(client: NominalClient, user_rid: str) -> NominalClient:
 
     The returned client injects the on-behalf-of header for all service requests.
     """
-    clients = client._clients.with_header_provider(StaticHeaderProvider({ON_BEHALF_OF_USER_RID_HEADER: user_rid}))
-    return NominalClient(_clients=clients, _profile=client._profile)
+    security = client._clients._service_config.security
+    return NominalClient.from_token(
+        client._clients._token,
+        client._clients._api_base_url,
+        workspace_rid=client._clients.workspace_rid,
+        trust_store_path=security.trust_store_path if security is not None else None,
+        connect_timeout=client._clients._service_config.connect_timeout,
+        header_provider={ON_BEHALF_OF_USER_RID_HEADER: user_rid},
+        _profile=client._profile,
+    )

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -12,7 +12,6 @@ from nominal.core._clientsbunch import (
     ClientsBunch,
     api_base_url_to_app_base_url,
 )
-from nominal.core._utils.networking import StaticHeaderProvider
 from nominal.core.client import NominalClient
 from nominal.core.exceptions import NominalConfigError
 from nominal.experimental import as_user
@@ -212,29 +211,6 @@ def test_resolve_workspace_reuses_the_cached_configured_default_workspace_object
 
     workspace_service.get_workspace.assert_called_once_with("Bearer token", configured_workspace_rid)
     workspace_service.get_default_workspace.assert_not_called()
-
-
-def test_with_header_provider_recreates_clients_from_config(monkeypatch):
-    monkeypatch.setattr("nominal.core._clientsbunch.create_conjure_client_factory", _fake_create_conjure_client_factory)
-
-    clients = ClientsBunch.from_config(
-        ServiceConfiguration(uris=["https://api.nominal.test"]),
-        "https://api.nominal.test",
-        "test-agent",
-        "token",
-        None,
-    )
-
-    cloned = clients.with_header_provider(
-        StaticHeaderProvider({ON_BEHALF_OF_USER_RID_HEADER: "ri.authn.dev.user.target"})
-    )
-
-    assert cloned is not clients
-    assert cloned.catalog is not clients.catalog
-    assert ON_BEHALF_OF_USER_RID_HEADER not in clients.catalog._requests_session.headers
-    assert cloned.catalog._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
-    assert cloned.assets._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
-    assert cloned.attachment._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
 
 
 def test_experimental_as_user_returns_derived_nominal_client(monkeypatch):

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -12,6 +12,7 @@ from nominal.core._clientsbunch import (
     ClientsBunch,
     api_base_url_to_app_base_url,
 )
+from nominal.core._utils.networking import StaticHeaderProvider
 from nominal.core.client import NominalClient
 from nominal.core.exceptions import NominalConfigError
 from nominal.experimental import as_user
@@ -28,6 +29,7 @@ def _make_clients_bunch(*, workspace_rid: str | None) -> ClientsBunch:
             "auth_header",
             "workspace_rid",
             "app_base_url",
+            "header_provider",
             "_api_base_url",
             "_user_agent",
             "_token",
@@ -39,6 +41,7 @@ def _make_clients_bunch(*, workspace_rid: str | None) -> ClientsBunch:
         auth_header="Bearer token",
         workspace_rid=workspace_rid,
         app_base_url="https://app.nominal.test",
+        header_provider=None,
         _api_base_url="https://api.nominal.test",
         _user_agent="test-agent",
         _token="token",
@@ -76,14 +79,15 @@ def _fake_create_conjure_client_factory(
     user_agent,
     service_config,
     return_none_for_unknown_union_types=False,
-    default_headers=None,
+    header_provider=None,
 ):
     del user_agent, service_config, return_none_for_unknown_union_types
+    headers = header_provider.headers() if header_provider is not None else None
 
     def factory(service_class):
         if service_class.__name__ == "CatalogService":
-            return _FakeCatalogService(default_headers)
-        return _FakeService(default_headers)
+            return _FakeCatalogService(headers)
+        return _FakeService(headers)
 
     return factory
 
@@ -210,7 +214,7 @@ def test_resolve_workspace_reuses_the_cached_configured_default_workspace_object
     workspace_service.get_default_workspace.assert_not_called()
 
 
-def test_with_default_request_headers_recreates_clients_from_config(monkeypatch):
+def test_with_header_provider_recreates_clients_from_config(monkeypatch):
     monkeypatch.setattr("nominal.core._clientsbunch.create_conjure_client_factory", _fake_create_conjure_client_factory)
 
     clients = ClientsBunch.from_config(
@@ -221,7 +225,9 @@ def test_with_default_request_headers_recreates_clients_from_config(monkeypatch)
         None,
     )
 
-    cloned = clients.with_default_request_headers({ON_BEHALF_OF_USER_RID_HEADER: "ri.authn.dev.user.target"})
+    cloned = clients.with_header_provider(
+        StaticHeaderProvider({ON_BEHALF_OF_USER_RID_HEADER: "ri.authn.dev.user.target"})
+    )
 
     assert cloned is not clients
     assert cloned.catalog is not clients.catalog

--- a/tests/core/test_networking.py
+++ b/tests/core/test_networking.py
@@ -3,16 +3,19 @@ from __future__ import annotations
 import gzip
 from unittest.mock import MagicMock, patch, sentinel
 
+import pytest
 import requests
 from conjure_python_client import ServiceConfiguration
 from conjure_python_client._http.configuration import SslConfiguration
 from requests.adapters import HTTPAdapter
 
 from nominal.core._utils.networking import (
+    HeaderProviderSession,
     NominalRequestsAdapter,
     SslBypassRequestsAdapter,
     create_conjure_service_client,
 )
+from nominal.core.exceptions import HeaderConflictError
 
 
 def _prepared_request(body: object) -> requests.PreparedRequest:
@@ -121,4 +124,53 @@ def test_create_conjure_service_client_passes_none_verify_when_security_is_absen
 
     session, _uris, _ct, _rt, verify, _rn = service_class.call_args.args
     assert verify is None
+    session.close()
+
+
+def test_header_provider_session_evaluates_headers_per_request() -> None:
+    class DynamicHeaders:
+        value = "first"
+
+        def headers(self) -> dict[str, str]:
+            return {"X-Test": self.value}
+
+    provider = DynamicHeaders()
+    session = HeaderProviderSession(provider)
+
+    first = session.prepare_request(requests.Request("GET", "https://example.com"))
+    provider.value = "second"
+    second = session.prepare_request(requests.Request("GET", "https://example.com"))
+
+    assert first.headers["X-Test"] == "first"
+    assert second.headers["X-Test"] == "second"
+    session.close()
+
+
+def test_header_provider_session_raises_for_explicit_request_header_conflict() -> None:
+    class DynamicHeaders:
+        def headers(self) -> dict[str, str]:
+            return {"X-Test": "default"}
+
+    session = HeaderProviderSession(DynamicHeaders())
+
+    with pytest.raises(
+        HeaderConflictError,
+        match="HeaderProvider returned header 'X-Test', but the request already set that header; "
+        "HeaderProvider cannot override explicit request headers.",
+    ):
+        session.prepare_request(requests.Request("GET", "https://example.com", headers={"X-Test": "explicit"}))
+    session.close()
+
+
+def test_header_provider_session_can_override_session_default_headers() -> None:
+    class DynamicHeaders:
+        def headers(self) -> dict[str, str]:
+            return {"User-Agent": "provider-agent"}
+
+    session = HeaderProviderSession(DynamicHeaders())
+    session.headers["User-Agent"] = "session-agent"
+
+    prepared = session.prepare_request(requests.Request("GET", "https://example.com"))
+
+    assert prepared.headers["User-Agent"] == "provider-agent"
     session.close()

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.135.0"
+version = "1.136.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Allow users to specify arbitrary additional (key, value) metadata to pass to all requests, statically or dynamically:

```py
client = NominalClient.from_profile(profile, extra_headers={"Some-Header", "value"})
```


```py
import random
from nominal.core import HeaderProvider

class DynamicHeaderProvider(HeaderProvider):
    def headers(self) -> dict[str, str]:
        return {"Some-Header", random.choice(["red", "green", "blue"])}

client = NominalClient.from_profile(profile, extra_headers=DynamicHeaderProvider())
```