### PR TITLE
feat: get the last value from a channel within a time window

### DIFF
--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -5,7 +5,7 @@ from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.core.asset import Asset
 from nominal.core.attachment import Attachment
 from nominal.core.bounds import Bounds
-from nominal.core.channel import Channel, ChannelDataType
+from nominal.core.channel import Channel, ChannelDataType, LatestValue
 from nominal.core.checklist import Checklist
 from nominal.core.client import NominalClient, WorkspaceSearchType
 from nominal.core.connection import Connection
@@ -59,6 +59,7 @@ __all__ = [
     "FileType",
     "FileTypes",
     "IngestWaitType",
+    "LatestValue",
     "LinkDict",
     "LogPoint",
     "LogStream",

--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -5,7 +5,7 @@ from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.core.asset import Asset
 from nominal.core.attachment import Attachment
 from nominal.core.bounds import Bounds
-from nominal.core.channel import Channel, ChannelDataType, LatestValue
+from nominal.core.channel import Channel, ChannelDataType, LastValue
 from nominal.core.checklist import Checklist
 from nominal.core.client import NominalClient, WorkspaceSearchType
 from nominal.core.connection import Connection
@@ -59,7 +59,7 @@ __all__ = [
     "FileType",
     "FileTypes",
     "IngestWaitType",
-    "LatestValue",
+    "LastValue",
     "LinkDict",
     "LogPoint",
     "LogStream",

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -41,10 +41,10 @@ class LastValue(NamedTuple):
     """Result of `Channel.get_last_value`.
 
     `value` is `float` for DOUBLE channels, `int` for INT channels, and `str` for STRING channels.
-    `timestamp` is timezone-aware and in UTC.
+    `timestamp` is integer nanoseconds since the unix epoch (UTC).
     """
 
-    timestamp: datetime
+    timestamp: IntegralNanosecondsUTC
     value: float | int | str
 
 
@@ -290,7 +290,7 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
         point = response.single_point
         if point is None:
             raise RuntimeError(f"Expected response type to be `single_point`, received: `{response.type}`")
-        ts = _SecondsNanos.from_api(point.timestamp).to_datetime()
+        ts = _SecondsNanos.from_api(point.timestamp).to_nanoseconds()
         v = point.value
         if v.float64_value is not None:
             return LastValue(ts, v.float64_value)

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -280,8 +280,9 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
         try:
             response = self._clients.compute.compute(self._clients.auth_header, request)
         except ValueError as e:
-            # Empty windows return {"type":"singlePoint","singlePoint":null}; conjure rejects null
-            # unions with this exact message. Match exactly so we don't swallow unrelated ValueErrors.
+            # The generated conjure-python union constructor doesn't handle optional union members,
+            # raising this ValueError when the window is empty (fixed upstream in palantir/conjure-python#1050).
+            # Match exactly so we don't swallow unrelated ValueErrors.
             if str(e) == "a union value must not be None":
                 return None
             raise

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -37,8 +37,8 @@ from nominal.ts import (
 logger = logging.getLogger(__name__)
 
 
-class LatestValue(NamedTuple):
-    """Result of `Channel.get_latest_value`.
+class LastValue(NamedTuple):
+    """Result of `Channel.get_last_value`.
 
     `value` is `float` for DOUBLE channels, `int` for INT channels, and `str` for STRING channels.
     `timestamp` is timezone-aware and in UTC.
@@ -240,13 +240,13 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
             else:
                 raise RuntimeError(f"Expected response type to be `paged_log`, received: `{resp.type}`")
 
-    def get_latest_value(
+    def get_last_value(
         self,
         *,
         start: _InferrableTimestampType | None = None,
         end: _InferrableTimestampType | None = None,
         tags: Mapping[str, str] | None = None,
-    ) -> LatestValue | None:
+    ) -> LastValue | None:
         """Return the most recent ``(timestamp, value)`` for this channel within ``[start, end]``.
 
         Args:
@@ -255,14 +255,14 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
             tags: Tags to filter the channel by (exact-match). Group-by is not supported.
 
         Returns:
-            See ``LatestValue``. Returns ``None`` if the window is empty.
+            See ``LastValue``. Returns ``None`` if the window is empty.
 
         Raises:
             TypeError: If the channel is not a numeric (DOUBLE, INT) or string channel.
         """
         if self.data_type not in (ChannelDataType.DOUBLE, ChannelDataType.INT, ChannelDataType.STRING):
             raise TypeError(
-                f"get_latest_value only supports numeric (DOUBLE, INT) and STRING channels; "
+                f"get_last_value only supports numeric (DOUBLE, INT) and STRING channels; "
                 f"channel {self.name!r} has type {self.data_type}"
             )
 
@@ -293,12 +293,12 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
         ts = _SecondsNanos.from_api(point.timestamp).to_datetime()
         v = point.value
         if v.float64_value is not None:
-            return LatestValue(ts, v.float64_value)
+            return LastValue(ts, v.float64_value)
         if v.int64_value is not None:
             # int64 is wire-encoded as a string to preserve precision across JSON
-            return LatestValue(ts, int(v.int64_value))
+            return LastValue(ts, int(v.int64_value))
         if v.string_value is not None:
-            return LatestValue(ts, v.string_value)
+            return LastValue(ts, v.string_value)
         raise RuntimeError(f"Unexpected value variant in `single_point` response: `{v.type}`")
 
     def get_available_tags(

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -298,7 +298,7 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
             return LatestValue(ts, int(v.int64_value))
         if v.string_value is not None:
             return LatestValue(ts, v.string_value)
-        raise RuntimeError(f"Unexpected value variant in `single_point` response: `{type(v).__name__}`")
+        raise RuntimeError(f"Unexpected value variant in `single_point` response: `{v.type}`")
 
     def get_available_tags(
         self,

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import enum
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
-from typing import BinaryIO, Iterable, Mapping, Protocol, cast, overload
+from datetime import datetime, timedelta, timezone
+from typing import BinaryIO, Iterable, Mapping, NamedTuple, Protocol, cast, overload
 
 from nominal_api import (
     api,
@@ -35,6 +35,17 @@ from nominal.ts import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class LatestValue(NamedTuple):
+    """Result of `Channel.get_latest_value`.
+
+    `value` is `float` for DOUBLE channels, `int` for INT channels, and `str` for STRING channels.
+    `timestamp` is timezone-aware and in UTC.
+    """
+
+    timestamp: datetime
+    value: float | int | str
 
 
 class ChannelDataType(enum.Enum):
@@ -228,6 +239,91 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
                     yield LogPoint._from_compute_api(log, timestamp)
             else:
                 raise RuntimeError(f"Expected response type to be `paged_log`, received: `{resp.type}`")
+
+    def get_latest_value(
+        self,
+        *,
+        start: _InferrableTimestampType | None = None,
+        end: _InferrableTimestampType | None = None,
+        lookback: timedelta | None = None,
+        tags: Mapping[str, str] | None = None,
+    ) -> LatestValue | None:
+        """Return the most recent ``(timestamp, value)`` for this channel within a time window.
+
+        Provide exactly one of ``start`` or ``lookback`` to bound the window. ``end`` is
+        accepted in either mode:
+
+        * ``lookback``: window is ``[end - lookback, end]``; ``end`` defaults to
+          ``datetime.now(UTC)`` captured client-side at call time.
+        * ``start`` (with optional ``end``): window is ``[start, end]``; ``end`` defaults
+          to ``_MAX_TIMESTAMP``.
+
+        Args:
+            start: Lower bound of the search window. Mutually exclusive with ``lookback``.
+            end: Upper bound of the search window. Default depends on mode (see above).
+            lookback: How far back from ``end`` to search. Must be strictly positive.
+            tags: Tags to filter the channel by (exact-match). Group-by is not supported.
+
+        Returns:
+            See ``LatestValue``. Returns ``None`` if the window is empty.
+
+        Raises:
+            TypeError: If the channel is not a numeric (DOUBLE, INT) or string channel.
+            ValueError: If neither or both of ``start`` and ``lookback`` are provided, if
+                ``lookback <= timedelta(0)``, or if ``end <= start``.
+        """
+        if self.data_type not in (ChannelDataType.DOUBLE, ChannelDataType.INT, ChannelDataType.STRING):
+            raise TypeError(
+                f"get_latest_value only supports numeric (DOUBLE, INT) and STRING channels; "
+                f"channel {self.name!r} has type {self.data_type}"
+            )
+        if (start is None) == (lookback is None):
+            raise ValueError("exactly one of `start` or `lookback` must be provided")
+        if lookback is not None and lookback <= timedelta(0):
+            raise ValueError(f"lookback must be strictly positive, got {lookback!r}")
+
+        if lookback is not None:
+            end_dt = datetime.now(timezone.utc) if end is None else _SecondsNanos.from_flexible(end).to_datetime()
+            api_start = _SecondsNanos.from_flexible(end_dt - lookback).to_api()
+            api_end = _SecondsNanos.from_flexible(end_dt).to_api()
+        else:
+            start_sn = _SecondsNanos.from_flexible(start)
+            end_sn = _SecondsNanos.from_flexible(end) if end is not None else _MAX_TIMESTAMP
+            if end_sn.to_nanoseconds() <= start_sn.to_nanoseconds():
+                raise ValueError(f"`end` must be strictly after `start`, got start={start!r} end={end!r}")
+            api_start = start_sn.to_api()
+            api_end = end_sn.to_api()
+
+        request = scout_compute_api.ComputeNodeRequest(
+            start=api_start,
+            end=api_end,
+            node=scout_compute_api.ComputableNode(
+                value=scout_compute_api.SelectValue(last_value_point=self._to_compute_series(tags=tags)),
+            ),
+            context=scout_compute_api.Context(frame_references={}, variables={}, function_variables={}),
+        )
+        try:
+            response = self._clients.compute.compute(self._clients.auth_header, request)
+        except ValueError as e:
+            # Empty windows return {"type":"singlePoint","singlePoint":null}; conjure rejects null
+            # unions with this exact message. Match exactly so we don't swallow unrelated ValueErrors.
+            if str(e) == "a union value must not be None":
+                return None
+            raise
+
+        point = response.single_point
+        if point is None:
+            raise RuntimeError(f"Expected response type to be `single_point`, received: `{response.type}`")
+        ts = _SecondsNanos.from_api(point.timestamp).to_datetime()
+        v = point.value
+        if v.float64_value is not None:
+            return LatestValue(ts, v.float64_value)
+        if v.int64_value is not None:
+            # int64 is wire-encoded as a string to preserve precision across JSON
+            return LatestValue(ts, int(v.int64_value))
+        if v.string_value is not None:
+            return LatestValue(ts, v.string_value)
+        raise RuntimeError(f"Unexpected value variant in `single_point` response: `{type(v).__name__}`")
 
     def get_available_tags(
         self,

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import enum
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from typing import BinaryIO, Iterable, Mapping, NamedTuple, Protocol, cast, overload
 
 from nominal_api import (
@@ -245,23 +245,13 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
         *,
         start: _InferrableTimestampType | None = None,
         end: _InferrableTimestampType | None = None,
-        lookback: timedelta | None = None,
         tags: Mapping[str, str] | None = None,
     ) -> LatestValue | None:
-        """Return the most recent ``(timestamp, value)`` for this channel within a time window.
-
-        Provide exactly one of ``start`` or ``lookback`` to bound the window. ``end`` is
-        accepted in either mode:
-
-        * ``lookback``: window is ``[end - lookback, end]``; ``end`` defaults to
-          ``datetime.now(UTC)`` captured client-side at call time.
-        * ``start`` (with optional ``end``): window is ``[start, end]``; ``end`` defaults
-          to ``_MAX_TIMESTAMP``.
+        """Return the most recent ``(timestamp, value)`` for this channel within ``[start, end]``.
 
         Args:
-            start: Lower bound of the search window. Mutually exclusive with ``lookback``.
-            end: Upper bound of the search window. Default depends on mode (see above).
-            lookback: How far back from ``end`` to search. Must be strictly positive.
+            start: Lower bound of the search window. If not present, searches starting from unix epoch.
+            end: Upper bound of the search window. If not present, searches until end of time.
             tags: Tags to filter the channel by (exact-match). Group-by is not supported.
 
         Returns:
@@ -269,31 +259,15 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
 
         Raises:
             TypeError: If the channel is not a numeric (DOUBLE, INT) or string channel.
-            ValueError: If neither or both of ``start`` and ``lookback`` are provided, if
-                ``lookback <= timedelta(0)``, or if ``end <= start``.
         """
         if self.data_type not in (ChannelDataType.DOUBLE, ChannelDataType.INT, ChannelDataType.STRING):
             raise TypeError(
                 f"get_latest_value only supports numeric (DOUBLE, INT) and STRING channels; "
                 f"channel {self.name!r} has type {self.data_type}"
             )
-        if (start is None) == (lookback is None):
-            raise ValueError("exactly one of `start` or `lookback` must be provided")
-        if lookback is not None and lookback <= timedelta(0):
-            raise ValueError(f"lookback must be strictly positive, got {lookback!r}")
 
-        if lookback is not None:
-            end_dt = datetime.now(timezone.utc) if end is None else _SecondsNanos.from_flexible(end).to_datetime()
-            api_start = _SecondsNanos.from_flexible(end_dt - lookback).to_api()
-            api_end = _SecondsNanos.from_flexible(end_dt).to_api()
-        else:
-            assert start is not None
-            start_sn = _SecondsNanos.from_flexible(start)
-            end_sn = _SecondsNanos.from_flexible(end) if end is not None else _MAX_TIMESTAMP
-            if end_sn <= start_sn:
-                raise ValueError(f"`end` must be strictly after `start`, got start={start!r} end={end!r}")
-            api_start = start_sn.to_api()
-            api_end = end_sn.to_api()
+        api_start = (_SecondsNanos.from_flexible(start) if start else _MIN_TIMESTAMP).to_api()
+        api_end = (_SecondsNanos.from_flexible(end) if end else _MAX_TIMESTAMP).to_api()
 
         request = scout_compute_api.ComputeNodeRequest(
             start=api_start,

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -290,7 +290,7 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
             assert start is not None
             start_sn = _SecondsNanos.from_flexible(start)
             end_sn = _SecondsNanos.from_flexible(end) if end is not None else _MAX_TIMESTAMP
-            if end_sn.to_nanoseconds() <= start_sn.to_nanoseconds():
+            if end_sn <= start_sn:
                 raise ValueError(f"`end` must be strictly after `start`, got start={start!r} end={end!r}")
             api_start = start_sn.to_api()
             api_end = end_sn.to_api()

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -287,6 +287,7 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
             api_start = _SecondsNanos.from_flexible(end_dt - lookback).to_api()
             api_end = _SecondsNanos.from_flexible(end_dt).to_api()
         else:
+            assert start is not None
             start_sn = _SecondsNanos.from_flexible(start)
             end_sn = _SecondsNanos.from_flexible(end) if end is not None else _MAX_TIMESTAMP
             if end_sn.to_nanoseconds() <= start_sn.to_nanoseconds():

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -272,7 +272,7 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
         if start is not None:
             start_ts = _SecondsNanos.from_flexible(start)
         else:
-            start_ts = _SecondsNanos(max(0, end_ts.seconds - 3600), end_ts.nanos)
+            start_ts = _SecondsNanos(end_ts.seconds - 3600, end_ts.nanos)
         if start_ts > end_ts:
             raise ValueError(f"start ({start!r}) must be at or before end ({end!r})")
         api_start = start_ts.to_api()

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -247,7 +247,7 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
         end: _InferrableTimestampType | None = None,
         tags: Mapping[str, str] | None = None,
     ) -> LastValue | None:
-        """Return the most recent ``(timestamp, value)`` for this channel within ``[start, end]``.
+        """Return the last ``(timestamp, value)`` for this channel within ``[start, end]``.
 
         Args:
             start: Lower bound of the search window. Defaults to one hour before ``end``;

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import enum
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import BinaryIO, Iterable, Mapping, NamedTuple, Protocol, cast, overload
 
 from nominal_api import (
@@ -250,8 +250,9 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
         """Return the most recent ``(timestamp, value)`` for this channel within ``[start, end]``.
 
         Args:
-            start: Lower bound of the search window. If not present, searches starting from unix epoch.
-            end: Upper bound of the search window. If not present, searches until end of time.
+            start: Lower bound of the search window. Defaults to one hour before ``end``;
+                large query windows may be slower.
+            end: Upper bound of the search window. Defaults to the current UTC time at call time.
             tags: Tags to filter the channel by (exact-match). Group-by is not supported.
 
         Returns:
@@ -259,6 +260,7 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
 
         Raises:
             TypeError: If the channel is not a numeric (DOUBLE, INT) or string channel.
+            ValueError: If ``start`` is strictly after ``end``.
         """
         if self.data_type not in (ChannelDataType.DOUBLE, ChannelDataType.INT, ChannelDataType.STRING):
             raise TypeError(
@@ -266,8 +268,15 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
                 f"channel {self.name!r} has type {self.data_type}"
             )
 
-        api_start = (_SecondsNanos.from_flexible(start) if start else _MIN_TIMESTAMP).to_api()
-        api_end = (_SecondsNanos.from_flexible(end) if end else _MAX_TIMESTAMP).to_api()
+        end_ts = _SecondsNanos.from_flexible(end if end is not None else datetime.now(timezone.utc))
+        if start is not None:
+            start_ts = _SecondsNanos.from_flexible(start)
+        else:
+            start_ts = _SecondsNanos(max(0, end_ts.seconds - 3600), end_ts.nanos)
+        if start_ts > end_ts:
+            raise ValueError(f"start ({start!r}) must be at or before end ({end!r})")
+        api_start = start_ts.to_api()
+        api_end = end_ts.to_api()
 
         request = scout_compute_api.ComputeNodeRequest(
             start=api_start,
@@ -280,9 +289,10 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
         try:
             response = self._clients.compute.compute(self._clients.auth_header, request)
         except ValueError as e:
-            # The generated conjure-python union constructor doesn't handle optional union members,
-            # raising this ValueError when the window is empty (fixed upstream in palantir/conjure-python#1050).
-            # Match exactly so we don't swallow unrelated ValueErrors.
+            # TODO(palantir/conjure-python#1050): empty single-point responses raise here
+            # instead of returning None. Match exactly so we don't swallow unrelated
+            # ValueErrors. Once fixed: delete this try/except and flip the
+            # `if point is None` branch below from `raise` to `return None`.
             if str(e) == "a union value must not be None":
                 return None
             raise

--- a/tests/core/test_channel.py
+++ b/tests/core/test_channel.py
@@ -128,9 +128,7 @@ def test_get_latest_value_explicit_end_overrides_default_now(
             return fixed_now if tz is timezone.utc else datetime.now(tz)
 
     monkeypatch.setattr("nominal.core.channel.datetime", _FixedDatetime)
-    mock_clients.compute.compute.return_value = _make_response(
-        scout_compute_api.Value(float64_value=1.0), explicit_end
-    )
+    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), explicit_end)
 
     mock_channel.get_latest_value(lookback=timedelta(minutes=1), end=explicit_end)
 
@@ -199,17 +197,13 @@ def test_get_latest_value_start_only_defaults_end_to_max(mock_channel: Channel, 
     assert request.end.nanos == expected_end.nanos
 
 
-def test_get_latest_value_requires_exactly_one_of_start_or_lookback(
-    mock_channel: Channel, mock_clients: MagicMock
-):
+def test_get_latest_value_requires_exactly_one_of_start_or_lookback(mock_channel: Channel, mock_clients: MagicMock):
     """Passing neither `start` nor `lookback`, or both, is rejected up front."""
     with pytest.raises(ValueError, match="exactly one of `start` or `lookback`"):
         mock_channel.get_latest_value()
 
     with pytest.raises(ValueError, match="exactly one of `start` or `lookback`"):
-        mock_channel.get_latest_value(
-            start=datetime(2026, 1, 1, tzinfo=timezone.utc), lookback=timedelta(minutes=5)
-        )
+        mock_channel.get_latest_value(start=datetime(2026, 1, 1, tzinfo=timezone.utc), lookback=timedelta(minutes=5))
 
     mock_clients.compute.compute.assert_not_called()
 
@@ -257,7 +251,9 @@ def test_get_latest_value_unhandled_value_variant_raises(mock_channel: Channel, 
     api_ts = api.Timestamp(seconds=int(ts.timestamp()), nanos=0)
     mock_clients.compute.compute.return_value = scout_compute_api.ComputeNodeResponse(
         single_point=scout_compute_api.SinglePoint(
-            precision_loss=False, timestamp=api_ts, value=scout_compute_api.Value(array_value=[]),
+            precision_loss=False,
+            timestamp=api_ts,
+            value=scout_compute_api.Value(array_value=[]),
         ),
     )
 

--- a/tests/core/test_channel.py
+++ b/tests/core/test_channel.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from conjure_python_client import ConjureDecoder
+from nominal_api import api, scout_compute_api
+
+from nominal.core.channel import Channel, ChannelDataType, LatestValue
+from nominal.ts import _MAX_TIMESTAMP
+
+
+def _make_response(value: scout_compute_api.Value, ts: datetime) -> scout_compute_api.ComputeNodeResponse:
+    api_ts = api.Timestamp(seconds=int(ts.timestamp()), nanos=ts.microsecond * 1000)
+    return scout_compute_api.ComputeNodeResponse(
+        single_point=scout_compute_api.SinglePoint(precision_loss=False, timestamp=api_ts, value=value),
+    )
+
+
+@pytest.fixture
+def mock_clients():
+    clients = MagicMock()
+    clients.compute = MagicMock()
+    return clients
+
+
+@pytest.fixture
+def mock_channel(mock_clients):
+    return Channel(
+        name="ch1",
+        data_source="ds-rid",
+        data_type=ChannelDataType.DOUBLE,
+        unit=None,
+        description=None,
+        _clients=mock_clients,
+    )
+
+
+def test_get_latest_value_returns_float64(mock_channel: Channel, mock_clients: MagicMock):
+    """A float64 single-point response is returned as a LatestValue with a float."""
+    ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=42.5), ts)
+
+    result = mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+
+    assert result == LatestValue(ts, 42.5)
+    assert isinstance(result.value, float)
+    assert result.timestamp.tzinfo is timezone.utc
+
+
+def test_get_latest_value_returns_int64_parsed_from_string(mock_channel: Channel, mock_clients: MagicMock):
+    """int64 is wire-encoded as a string; get_latest_value parses it back to int."""
+    mock_channel.data_type = ChannelDataType.INT
+    ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    mock_clients.compute.compute.return_value = _make_response(
+        # int64_value type is Optional[str]
+        scout_compute_api.Value(int64_value="9007199254740993"),
+        ts,
+    )
+
+    result = mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+
+    assert result == LatestValue(ts, 9007199254740993)
+    assert isinstance(result.value, int)
+
+
+def test_get_latest_value_returns_string(mock_channel: Channel, mock_clients: MagicMock):
+    """A string single-point response is returned as a LatestValue with a str."""
+    mock_channel.data_type = ChannelDataType.STRING
+    ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(string_value="hello"), ts)
+
+    result = mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+
+    assert result == LatestValue(ts, "hello")
+
+
+def test_get_latest_value_empty_window_returns_none(mock_channel: Channel, mock_clients: MagicMock):
+    """An empty window surfaces as the conjure 'a union value must not be None' ValueError; treated as no data."""
+    mock_clients.compute.compute.side_effect = ValueError("a union value must not be None")
+
+    result = mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+
+    assert result is None
+
+
+def test_get_latest_value_unrelated_value_error_propagates(mock_channel: Channel, mock_clients: MagicMock):
+    """ValueErrors with a different message are not swallowed by the empty-window guard."""
+    mock_clients.compute.compute.side_effect = ValueError("some other validation error")
+
+    with pytest.raises(ValueError, match="some other validation error"):
+        mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+
+
+def test_get_latest_value_request_fields(mock_channel: Channel, mock_clients: MagicMock):
+    """Request carries start = end - lookback, the explicit end, last_value_point node, and channel identity."""
+    end = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    lookback = timedelta(minutes=10)
+    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), end)
+
+    mock_channel.get_latest_value(lookback=lookback, end=end, tags={"a": "b"})
+
+    _, request = mock_clients.compute.compute.call_args[0]
+    expected_start = end - lookback
+    assert request.start.seconds == int(expected_start.timestamp())
+    assert request.end.seconds == int(end.timestamp())
+    # The compute node must be a SelectValue with last_value_point set.
+    series = request.node.value.last_value_point
+    assert series is not None
+    # For a DOUBLE channel, the series is a NumericSeries; tags ride on its ChannelSeries.data_source.
+    data_source = series.numeric.channel.data_source
+    assert data_source.channel.literal == "ch1"
+    assert data_source.data_source_rid.literal == "ds-rid"
+    assert {k: v.literal for k, v in data_source.tags.items()} == {"a": "b"}
+
+
+def test_get_latest_value_explicit_end_overrides_default_now(
+    mock_channel: Channel, mock_clients: MagicMock, monkeypatch: pytest.MonkeyPatch
+):
+    """In lookback mode, an explicit `end` is honored instead of `datetime.now(UTC)`."""
+    fixed_now = datetime(2030, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    explicit_end = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is timezone.utc else datetime.now(tz)
+
+    monkeypatch.setattr("nominal.core.channel.datetime", _FixedDatetime)
+    mock_clients.compute.compute.return_value = _make_response(
+        scout_compute_api.Value(float64_value=1.0), explicit_end
+    )
+
+    mock_channel.get_latest_value(lookback=timedelta(minutes=1), end=explicit_end)
+
+    _, request = mock_clients.compute.compute.call_args[0]
+    assert request.end.seconds == int(explicit_end.timestamp())
+    assert request.start.seconds == int((explicit_end - timedelta(minutes=1)).timestamp())
+    assert request.end.seconds != int(fixed_now.timestamp())
+
+
+def test_get_latest_value_default_end_is_now_utc(
+    mock_channel: Channel, mock_clients: MagicMock, monkeypatch: pytest.MonkeyPatch
+):
+    """When end is omitted, the upper bound defaults to datetime.now(UTC)."""
+    fixed_now = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is timezone.utc else datetime.now(tz)
+
+    monkeypatch.setattr("nominal.core.channel.datetime", _FixedDatetime)
+    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), fixed_now)
+
+    mock_channel.get_latest_value(lookback=timedelta(seconds=30))
+
+    _, request = mock_clients.compute.compute.call_args[0]
+    assert request.end.seconds == int(fixed_now.timestamp())
+    assert request.start.seconds == int((fixed_now - timedelta(seconds=30)).timestamp())
+
+
+@pytest.mark.parametrize("bad_lookback", [timedelta(0), timedelta(seconds=-1)])
+def test_get_latest_value_non_positive_lookback_raises(
+    mock_channel: Channel, mock_clients: MagicMock, bad_lookback: timedelta
+):
+    """A non-positive lookback is rejected up front without an API call."""
+    with pytest.raises(ValueError, match="lookback must be strictly positive"):
+        mock_channel.get_latest_value(lookback=bad_lookback)
+
+    mock_clients.compute.compute.assert_not_called()
+
+
+def test_get_latest_value_start_end_mode_request_fields(mock_channel: Channel, mock_clients: MagicMock):
+    """In start/end mode, the request carries the explicit start and end."""
+    start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), end)
+
+    mock_channel.get_latest_value(start=start, end=end)
+
+    _, request = mock_clients.compute.compute.call_args[0]
+    assert request.start.seconds == int(start.timestamp())
+    assert request.end.seconds == int(end.timestamp())
+
+
+def test_get_latest_value_start_only_defaults_end_to_max(mock_channel: Channel, mock_clients: MagicMock):
+    """In start/end mode, omitting `end` falls back to `_MAX_TIMESTAMP` for parity with `search_logs`."""
+    start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), start)
+
+    mock_channel.get_latest_value(start=start)
+
+    _, request = mock_clients.compute.compute.call_args[0]
+    expected_end = _MAX_TIMESTAMP.to_api()
+    assert request.start.seconds == int(start.timestamp())
+    assert request.end.seconds == expected_end.seconds
+    assert request.end.nanos == expected_end.nanos
+
+
+def test_get_latest_value_requires_exactly_one_of_start_or_lookback(
+    mock_channel: Channel, mock_clients: MagicMock
+):
+    """Passing neither `start` nor `lookback`, or both, is rejected up front."""
+    with pytest.raises(ValueError, match="exactly one of `start` or `lookback`"):
+        mock_channel.get_latest_value()
+
+    with pytest.raises(ValueError, match="exactly one of `start` or `lookback`"):
+        mock_channel.get_latest_value(
+            start=datetime(2026, 1, 1, tzinfo=timezone.utc), lookback=timedelta(minutes=5)
+        )
+
+    mock_clients.compute.compute.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "start,end",
+    [
+        (datetime(2026, 1, 2, tzinfo=timezone.utc), datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        (datetime(2026, 1, 1, tzinfo=timezone.utc), datetime(2026, 1, 1, tzinfo=timezone.utc)),
+    ],
+)
+def test_get_latest_value_end_not_after_start_raises(
+    mock_channel: Channel, mock_clients: MagicMock, start: datetime, end: datetime
+):
+    """`end <= start` is rejected up front without an API call."""
+    with pytest.raises(ValueError, match="`end` must be strictly after `start`"):
+        mock_channel.get_latest_value(start=start, end=end)
+
+    mock_clients.compute.compute.assert_not_called()
+
+
+def test_get_latest_value_unsupported_data_type_raises(mock_channel: Channel, mock_clients: MagicMock):
+    """Non-numeric, non-string channels are rejected up front without an API call."""
+    mock_channel.data_type = ChannelDataType.LOG
+
+    with pytest.raises(TypeError, match="get_latest_value only supports numeric"):
+        mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+
+    mock_clients.compute.compute.assert_not_called()
+
+
+def test_get_latest_value_missing_single_point_raises(mock_channel: Channel, mock_clients: MagicMock):
+    """A response without `single_point` set should not be silently accepted."""
+    mock_clients.compute.compute.return_value = scout_compute_api.ComputeNodeResponse(
+        numeric=scout_compute_api.NumericPlot(timestamps=[], values=[]),
+    )
+
+    with pytest.raises(RuntimeError, match="Expected response type to be `single_point`"):
+        mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+
+
+def test_get_latest_value_unhandled_value_variant_raises(mock_channel: Channel, mock_clients: MagicMock):
+    """A Value carrying an unhandled variant (array/struct) raises rather than returning junk."""
+    ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    api_ts = api.Timestamp(seconds=int(ts.timestamp()), nanos=0)
+    mock_clients.compute.compute.return_value = scout_compute_api.ComputeNodeResponse(
+        single_point=scout_compute_api.SinglePoint(
+            precision_loss=False, timestamp=api_ts, value=scout_compute_api.Value(array_value=[]),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Unexpected value variant in `single_point` response"):
+        mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+
+
+def test_conjure_empty_singlepoint_error_message_unchanged():
+    """Pins the conjure decode-error string that `get_latest_value` matches for empty windows.
+
+    Fails at CI if a `nominal-api` or `conjure-python-client` bump rewords the message.
+    """
+    payload = {"type": "singlePoint", "singlePoint": None}
+    with pytest.raises(ValueError, match="^a union value must not be None$"):
+        ConjureDecoder().decode(payload, scout_compute_api.ComputeNodeResponse)

--- a/tests/core/test_channel.py
+++ b/tests/core/test_channel.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,7 +8,7 @@ from conjure_python_client import ConjureDecoder
 from nominal_api import api, scout_compute_api
 
 from nominal.core.channel import Channel, ChannelDataType, LatestValue
-from nominal.ts import _MAX_TIMESTAMP
+from nominal.ts import _MAX_TIMESTAMP, _MIN_TIMESTAMP
 
 
 def _make_response(value: scout_compute_api.Value, ts: datetime) -> scout_compute_api.ComputeNodeResponse:
@@ -42,7 +42,7 @@ def test_get_latest_value_returns_float64(mock_channel: Channel, mock_clients: M
     ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=42.5), ts)
 
-    result = mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+    result = mock_channel.get_latest_value()
 
     assert result == LatestValue(ts, 42.5)
     assert isinstance(result.value, float)
@@ -59,7 +59,7 @@ def test_get_latest_value_returns_int64_parsed_from_string(mock_channel: Channel
         ts,
     )
 
-    result = mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+    result = mock_channel.get_latest_value()
 
     assert result == LatestValue(ts, 9007199254740993)
     assert isinstance(result.value, int)
@@ -71,7 +71,7 @@ def test_get_latest_value_returns_string(mock_channel: Channel, mock_clients: Ma
     ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(string_value="hello"), ts)
 
-    result = mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+    result = mock_channel.get_latest_value()
 
     assert result == LatestValue(ts, "hello")
 
@@ -80,7 +80,7 @@ def test_get_latest_value_empty_window_returns_none(mock_channel: Channel, mock_
     """An empty window surfaces as the conjure 'a union value must not be None' ValueError; treated as no data."""
     mock_clients.compute.compute.side_effect = ValueError("a union value must not be None")
 
-    result = mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+    result = mock_channel.get_latest_value()
 
     assert result is None
 
@@ -90,20 +90,19 @@ def test_get_latest_value_unrelated_value_error_propagates(mock_channel: Channel
     mock_clients.compute.compute.side_effect = ValueError("some other validation error")
 
     with pytest.raises(ValueError, match="some other validation error"):
-        mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+        mock_channel.get_latest_value()
 
 
 def test_get_latest_value_request_fields(mock_channel: Channel, mock_clients: MagicMock):
-    """Request carries start = end - lookback, the explicit end, last_value_point node, and channel identity."""
+    """Request carries the explicit start, the explicit end, last_value_point node, and channel identity."""
+    start = datetime(2026, 1, 2, 2, 54, 5, tzinfo=timezone.utc)
     end = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
-    lookback = timedelta(minutes=10)
     mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), end)
 
-    mock_channel.get_latest_value(lookback=lookback, end=end, tags={"a": "b"})
+    mock_channel.get_latest_value(start=start, end=end, tags={"a": "b"})
 
     _, request = mock_clients.compute.compute.call_args[0]
-    expected_start = end - lookback
-    assert request.start.seconds == int(expected_start.timestamp())
+    assert request.start.seconds == int(start.timestamp())
     assert request.end.seconds == int(end.timestamp())
     # The compute node must be a SelectValue with last_value_point set.
     series = request.node.value.last_value_point
@@ -115,76 +114,24 @@ def test_get_latest_value_request_fields(mock_channel: Channel, mock_clients: Ma
     assert {k: v.literal for k, v in data_source.tags.items()} == {"a": "b"}
 
 
-def test_get_latest_value_explicit_end_overrides_default_now(
-    mock_channel: Channel, mock_clients: MagicMock, monkeypatch: pytest.MonkeyPatch
-):
-    """In lookback mode, an explicit `end` is honored instead of `datetime.now(UTC)`."""
-    fixed_now = datetime(2030, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    explicit_end = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+def test_get_latest_value_defaults_to_full_time_range(mock_channel: Channel, mock_clients: MagicMock):
+    """Omitting both `start` and `end` searches the full `[_MIN_TIMESTAMP, _MAX_TIMESTAMP]` window."""
+    ts = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), ts)
 
-    class _FixedDatetime(datetime):
-        @classmethod
-        def now(cls, tz=None):
-            return fixed_now if tz is timezone.utc else datetime.now(tz)
-
-    monkeypatch.setattr("nominal.core.channel.datetime", _FixedDatetime)
-    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), explicit_end)
-
-    mock_channel.get_latest_value(lookback=timedelta(minutes=1), end=explicit_end)
+    mock_channel.get_latest_value()
 
     _, request = mock_clients.compute.compute.call_args[0]
-    assert request.end.seconds == int(explicit_end.timestamp())
-    assert request.start.seconds == int((explicit_end - timedelta(minutes=1)).timestamp())
-    assert request.end.seconds != int(fixed_now.timestamp())
-
-
-def test_get_latest_value_default_end_is_now_utc(
-    mock_channel: Channel, mock_clients: MagicMock, monkeypatch: pytest.MonkeyPatch
-):
-    """When end is omitted, the upper bound defaults to datetime.now(UTC)."""
-    fixed_now = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
-
-    class _FixedDatetime(datetime):
-        @classmethod
-        def now(cls, tz=None):
-            return fixed_now if tz is timezone.utc else datetime.now(tz)
-
-    monkeypatch.setattr("nominal.core.channel.datetime", _FixedDatetime)
-    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), fixed_now)
-
-    mock_channel.get_latest_value(lookback=timedelta(seconds=30))
-
-    _, request = mock_clients.compute.compute.call_args[0]
-    assert request.end.seconds == int(fixed_now.timestamp())
-    assert request.start.seconds == int((fixed_now - timedelta(seconds=30)).timestamp())
-
-
-@pytest.mark.parametrize("bad_lookback", [timedelta(0), timedelta(seconds=-1)])
-def test_get_latest_value_non_positive_lookback_raises(
-    mock_channel: Channel, mock_clients: MagicMock, bad_lookback: timedelta
-):
-    """A non-positive lookback is rejected up front without an API call."""
-    with pytest.raises(ValueError, match="lookback must be strictly positive"):
-        mock_channel.get_latest_value(lookback=bad_lookback)
-
-    mock_clients.compute.compute.assert_not_called()
-
-
-def test_get_latest_value_start_end_mode_request_fields(mock_channel: Channel, mock_clients: MagicMock):
-    """In start/end mode, the request carries the explicit start and end."""
-    start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    end = datetime(2026, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
-    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), end)
-
-    mock_channel.get_latest_value(start=start, end=end)
-
-    _, request = mock_clients.compute.compute.call_args[0]
-    assert request.start.seconds == int(start.timestamp())
-    assert request.end.seconds == int(end.timestamp())
+    expected_start = _MIN_TIMESTAMP.to_api()
+    expected_end = _MAX_TIMESTAMP.to_api()
+    assert request.start.seconds == expected_start.seconds
+    assert request.start.nanos == expected_start.nanos
+    assert request.end.seconds == expected_end.seconds
+    assert request.end.nanos == expected_end.nanos
 
 
 def test_get_latest_value_start_only_defaults_end_to_max(mock_channel: Channel, mock_clients: MagicMock):
-    """In start/end mode, omitting `end` falls back to `_MAX_TIMESTAMP` for parity with `search_logs`."""
+    """Omitting `end` falls back to `_MAX_TIMESTAMP` for parity with `search_logs`."""
     start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), start)
 
@@ -197,32 +144,18 @@ def test_get_latest_value_start_only_defaults_end_to_max(mock_channel: Channel, 
     assert request.end.nanos == expected_end.nanos
 
 
-def test_get_latest_value_requires_exactly_one_of_start_or_lookback(mock_channel: Channel, mock_clients: MagicMock):
-    """Passing neither `start` nor `lookback`, or both, is rejected up front."""
-    with pytest.raises(ValueError, match="exactly one of `start` or `lookback`"):
-        mock_channel.get_latest_value()
+def test_get_latest_value_end_only_defaults_start_to_min(mock_channel: Channel, mock_clients: MagicMock):
+    """Omitting `start` falls back to `_MIN_TIMESTAMP` for parity with `search_logs`."""
+    end = datetime(2026, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), end)
 
-    with pytest.raises(ValueError, match="exactly one of `start` or `lookback`"):
-        mock_channel.get_latest_value(start=datetime(2026, 1, 1, tzinfo=timezone.utc), lookback=timedelta(minutes=5))
+    mock_channel.get_latest_value(end=end)
 
-    mock_clients.compute.compute.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    "start,end",
-    [
-        (datetime(2026, 1, 2, tzinfo=timezone.utc), datetime(2026, 1, 1, tzinfo=timezone.utc)),
-        (datetime(2026, 1, 1, tzinfo=timezone.utc), datetime(2026, 1, 1, tzinfo=timezone.utc)),
-    ],
-)
-def test_get_latest_value_end_not_after_start_raises(
-    mock_channel: Channel, mock_clients: MagicMock, start: datetime, end: datetime
-):
-    """`end <= start` is rejected up front without an API call."""
-    with pytest.raises(ValueError, match="`end` must be strictly after `start`"):
-        mock_channel.get_latest_value(start=start, end=end)
-
-    mock_clients.compute.compute.assert_not_called()
+    _, request = mock_clients.compute.compute.call_args[0]
+    expected_start = _MIN_TIMESTAMP.to_api()
+    assert request.start.seconds == expected_start.seconds
+    assert request.start.nanos == expected_start.nanos
+    assert request.end.seconds == int(end.timestamp())
 
 
 def test_get_latest_value_unsupported_data_type_raises(mock_channel: Channel, mock_clients: MagicMock):
@@ -230,7 +163,7 @@ def test_get_latest_value_unsupported_data_type_raises(mock_channel: Channel, mo
     mock_channel.data_type = ChannelDataType.LOG
 
     with pytest.raises(TypeError, match="get_latest_value only supports numeric"):
-        mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+        mock_channel.get_latest_value()
 
     mock_clients.compute.compute.assert_not_called()
 
@@ -242,7 +175,7 @@ def test_get_latest_value_missing_single_point_raises(mock_channel: Channel, moc
     )
 
     with pytest.raises(RuntimeError, match="Expected response type to be `single_point`"):
-        mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+        mock_channel.get_latest_value()
 
 
 def test_get_latest_value_unhandled_value_variant_raises(mock_channel: Channel, mock_clients: MagicMock):
@@ -258,7 +191,7 @@ def test_get_latest_value_unhandled_value_variant_raises(mock_channel: Channel, 
     )
 
     with pytest.raises(RuntimeError, match="Unexpected value variant in `single_point` response"):
-        mock_channel.get_latest_value(lookback=timedelta(minutes=5))
+        mock_channel.get_latest_value()
 
 
 def test_conjure_empty_singlepoint_error_message_unchanged():

--- a/tests/core/test_channel.py
+++ b/tests/core/test_channel.py
@@ -7,7 +7,7 @@ import pytest
 from conjure_python_client import ConjureDecoder
 from nominal_api import api, scout_compute_api
 
-from nominal.core.channel import Channel, ChannelDataType, LatestValue
+from nominal.core.channel import Channel, ChannelDataType, LastValue
 from nominal.ts import _MAX_TIMESTAMP, _MIN_TIMESTAMP
 
 
@@ -37,20 +37,20 @@ def mock_channel(mock_clients):
     )
 
 
-def test_get_latest_value_returns_float64(mock_channel: Channel, mock_clients: MagicMock):
-    """A float64 single-point response is returned as a LatestValue with a float."""
+def test_get_last_value_returns_float64(mock_channel: Channel, mock_clients: MagicMock):
+    """A float64 single-point response is returned as a LastValue with a float."""
     ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=42.5), ts)
 
-    result = mock_channel.get_latest_value()
+    result = mock_channel.get_last_value()
 
-    assert result == LatestValue(ts, 42.5)
+    assert result == LastValue(ts, 42.5)
     assert isinstance(result.value, float)
     assert result.timestamp.tzinfo is timezone.utc
 
 
-def test_get_latest_value_returns_int64_parsed_from_string(mock_channel: Channel, mock_clients: MagicMock):
-    """int64 is wire-encoded as a string; get_latest_value parses it back to int."""
+def test_get_last_value_returns_int64_parsed_from_string(mock_channel: Channel, mock_clients: MagicMock):
+    """int64 is wire-encoded as a string; get_last_value parses it back to int."""
     mock_channel.data_type = ChannelDataType.INT
     ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     mock_clients.compute.compute.return_value = _make_response(
@@ -59,47 +59,47 @@ def test_get_latest_value_returns_int64_parsed_from_string(mock_channel: Channel
         ts,
     )
 
-    result = mock_channel.get_latest_value()
+    result = mock_channel.get_last_value()
 
-    assert result == LatestValue(ts, 9007199254740993)
+    assert result == LastValue(ts, 9007199254740993)
     assert isinstance(result.value, int)
 
 
-def test_get_latest_value_returns_string(mock_channel: Channel, mock_clients: MagicMock):
-    """A string single-point response is returned as a LatestValue with a str."""
+def test_get_last_value_returns_string(mock_channel: Channel, mock_clients: MagicMock):
+    """A string single-point response is returned as a LastValue with a str."""
     mock_channel.data_type = ChannelDataType.STRING
     ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(string_value="hello"), ts)
 
-    result = mock_channel.get_latest_value()
+    result = mock_channel.get_last_value()
 
-    assert result == LatestValue(ts, "hello")
+    assert result == LastValue(ts, "hello")
 
 
-def test_get_latest_value_empty_window_returns_none(mock_channel: Channel, mock_clients: MagicMock):
+def test_get_last_value_empty_window_returns_none(mock_channel: Channel, mock_clients: MagicMock):
     """An empty window surfaces as the conjure 'a union value must not be None' ValueError; treated as no data."""
     mock_clients.compute.compute.side_effect = ValueError("a union value must not be None")
 
-    result = mock_channel.get_latest_value()
+    result = mock_channel.get_last_value()
 
     assert result is None
 
 
-def test_get_latest_value_unrelated_value_error_propagates(mock_channel: Channel, mock_clients: MagicMock):
+def test_get_last_value_unrelated_value_error_propagates(mock_channel: Channel, mock_clients: MagicMock):
     """ValueErrors with a different message are not swallowed by the empty-window guard."""
     mock_clients.compute.compute.side_effect = ValueError("some other validation error")
 
     with pytest.raises(ValueError, match="some other validation error"):
-        mock_channel.get_latest_value()
+        mock_channel.get_last_value()
 
 
-def test_get_latest_value_request_fields(mock_channel: Channel, mock_clients: MagicMock):
+def test_get_last_value_request_fields(mock_channel: Channel, mock_clients: MagicMock):
     """Request carries the explicit start, the explicit end, last_value_point node, and channel identity."""
     start = datetime(2026, 1, 2, 2, 54, 5, tzinfo=timezone.utc)
     end = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), end)
 
-    mock_channel.get_latest_value(start=start, end=end, tags={"a": "b"})
+    mock_channel.get_last_value(start=start, end=end, tags={"a": "b"})
 
     _, request = mock_clients.compute.compute.call_args[0]
     assert request.start.seconds == int(start.timestamp())
@@ -114,12 +114,12 @@ def test_get_latest_value_request_fields(mock_channel: Channel, mock_clients: Ma
     assert {k: v.literal for k, v in data_source.tags.items()} == {"a": "b"}
 
 
-def test_get_latest_value_defaults_to_full_time_range(mock_channel: Channel, mock_clients: MagicMock):
+def test_get_last_value_defaults_to_full_time_range(mock_channel: Channel, mock_clients: MagicMock):
     """Omitting both `start` and `end` searches the full `[_MIN_TIMESTAMP, _MAX_TIMESTAMP]` window."""
     ts = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), ts)
 
-    mock_channel.get_latest_value()
+    mock_channel.get_last_value()
 
     _, request = mock_clients.compute.compute.call_args[0]
     expected_start = _MIN_TIMESTAMP.to_api()
@@ -130,12 +130,12 @@ def test_get_latest_value_defaults_to_full_time_range(mock_channel: Channel, moc
     assert request.end.nanos == expected_end.nanos
 
 
-def test_get_latest_value_start_only_defaults_end_to_max(mock_channel: Channel, mock_clients: MagicMock):
+def test_get_last_value_start_only_defaults_end_to_max(mock_channel: Channel, mock_clients: MagicMock):
     """Omitting `end` falls back to `_MAX_TIMESTAMP` for parity with `search_logs`."""
     start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), start)
 
-    mock_channel.get_latest_value(start=start)
+    mock_channel.get_last_value(start=start)
 
     _, request = mock_clients.compute.compute.call_args[0]
     expected_end = _MAX_TIMESTAMP.to_api()
@@ -144,12 +144,12 @@ def test_get_latest_value_start_only_defaults_end_to_max(mock_channel: Channel, 
     assert request.end.nanos == expected_end.nanos
 
 
-def test_get_latest_value_end_only_defaults_start_to_min(mock_channel: Channel, mock_clients: MagicMock):
+def test_get_last_value_end_only_defaults_start_to_min(mock_channel: Channel, mock_clients: MagicMock):
     """Omitting `start` falls back to `_MIN_TIMESTAMP` for parity with `search_logs`."""
     end = datetime(2026, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
     mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), end)
 
-    mock_channel.get_latest_value(end=end)
+    mock_channel.get_last_value(end=end)
 
     _, request = mock_clients.compute.compute.call_args[0]
     expected_start = _MIN_TIMESTAMP.to_api()
@@ -158,27 +158,27 @@ def test_get_latest_value_end_only_defaults_start_to_min(mock_channel: Channel, 
     assert request.end.seconds == int(end.timestamp())
 
 
-def test_get_latest_value_unsupported_data_type_raises(mock_channel: Channel, mock_clients: MagicMock):
+def test_get_last_value_unsupported_data_type_raises(mock_channel: Channel, mock_clients: MagicMock):
     """Non-numeric, non-string channels are rejected up front without an API call."""
     mock_channel.data_type = ChannelDataType.LOG
 
-    with pytest.raises(TypeError, match="get_latest_value only supports numeric"):
-        mock_channel.get_latest_value()
+    with pytest.raises(TypeError, match="get_last_value only supports numeric"):
+        mock_channel.get_last_value()
 
     mock_clients.compute.compute.assert_not_called()
 
 
-def test_get_latest_value_missing_single_point_raises(mock_channel: Channel, mock_clients: MagicMock):
+def test_get_last_value_missing_single_point_raises(mock_channel: Channel, mock_clients: MagicMock):
     """A response without `single_point` set should not be silently accepted."""
     mock_clients.compute.compute.return_value = scout_compute_api.ComputeNodeResponse(
         numeric=scout_compute_api.NumericPlot(timestamps=[], values=[]),
     )
 
     with pytest.raises(RuntimeError, match="Expected response type to be `single_point`"):
-        mock_channel.get_latest_value()
+        mock_channel.get_last_value()
 
 
-def test_get_latest_value_unhandled_value_variant_raises(mock_channel: Channel, mock_clients: MagicMock):
+def test_get_last_value_unhandled_value_variant_raises(mock_channel: Channel, mock_clients: MagicMock):
     """A Value carrying an unhandled variant (array/struct) raises rather than returning junk."""
     ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     api_ts = api.Timestamp(seconds=int(ts.timestamp()), nanos=0)
@@ -191,11 +191,11 @@ def test_get_latest_value_unhandled_value_variant_raises(mock_channel: Channel, 
     )
 
     with pytest.raises(RuntimeError, match="Unexpected value variant in `single_point` response"):
-        mock_channel.get_latest_value()
+        mock_channel.get_last_value()
 
 
 def test_conjure_empty_singlepoint_error_message_unchanged():
-    """Pins the conjure decode-error string that `get_latest_value` matches for empty windows.
+    """Pins the conjure decode-error string that `get_last_value` matches for empty windows.
 
     Fails at CI if a `nominal-api` or `conjure-python-client` bump rewords the message.
     """

--- a/tests/core/test_channel.py
+++ b/tests/core/test_channel.py
@@ -8,7 +8,7 @@ from conjure_python_client import ConjureDecoder
 from nominal_api import api, scout_compute_api
 
 from nominal.core.channel import Channel, ChannelDataType, LastValue
-from nominal.ts import _MAX_TIMESTAMP, _MIN_TIMESTAMP
+from nominal.ts import _MAX_TIMESTAMP, _MIN_TIMESTAMP, _SecondsNanos
 
 
 def _make_response(value: scout_compute_api.Value, ts: datetime) -> scout_compute_api.ComputeNodeResponse:
@@ -16,6 +16,10 @@ def _make_response(value: scout_compute_api.Value, ts: datetime) -> scout_comput
     return scout_compute_api.ComputeNodeResponse(
         single_point=scout_compute_api.SinglePoint(precision_loss=False, timestamp=api_ts, value=value),
     )
+
+
+def _ns(ts: datetime) -> int:
+    return _SecondsNanos.from_datetime(ts).to_nanoseconds()
 
 
 @pytest.fixture
@@ -44,9 +48,9 @@ def test_get_last_value_returns_float64(mock_channel: Channel, mock_clients: Mag
 
     result = mock_channel.get_last_value()
 
-    assert result == LastValue(ts, 42.5)
+    assert result == LastValue(_ns(ts), 42.5)
     assert isinstance(result.value, float)
-    assert result.timestamp.tzinfo is timezone.utc
+    assert isinstance(result.timestamp, int)
 
 
 def test_get_last_value_returns_int64_parsed_from_string(mock_channel: Channel, mock_clients: MagicMock):
@@ -61,7 +65,7 @@ def test_get_last_value_returns_int64_parsed_from_string(mock_channel: Channel, 
 
     result = mock_channel.get_last_value()
 
-    assert result == LastValue(ts, 9007199254740993)
+    assert result == LastValue(_ns(ts), 9007199254740993)
     assert isinstance(result.value, int)
 
 
@@ -73,7 +77,7 @@ def test_get_last_value_returns_string(mock_channel: Channel, mock_clients: Magi
 
     result = mock_channel.get_last_value()
 
-    assert result == LastValue(ts, "hello")
+    assert result == LastValue(_ns(ts), "hello")
 
 
 def test_get_last_value_empty_window_returns_none(mock_channel: Channel, mock_clients: MagicMock):

--- a/tests/core/test_channel.py
+++ b/tests/core/test_channel.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,7 +8,7 @@ from conjure_python_client import ConjureDecoder
 from nominal_api import api, scout_compute_api
 
 from nominal.core.channel import Channel, ChannelDataType, LastValue
-from nominal.ts import _MAX_TIMESTAMP, _MIN_TIMESTAMP, _SecondsNanos
+from nominal.ts import _SecondsNanos
 
 
 def _make_response(value: scout_compute_api.Value, ts: datetime) -> scout_compute_api.ComputeNodeResponse:
@@ -41,48 +41,46 @@ def mock_channel(mock_clients):
     )
 
 
-def test_get_last_value_returns_float64(mock_channel: Channel, mock_clients: MagicMock):
-    """A float64 single-point response is returned as a LastValue with a float."""
+@pytest.mark.parametrize(
+    ("data_type", "value", "expected"),
+    [
+        # int64 is wire-encoded as a string to preserve precision; pick a value larger than the
+        # JS-safe-integer / float64-mantissa range so a regression that routes through float fails.
+        (ChannelDataType.DOUBLE, scout_compute_api.Value(float64_value=42.5), 42.5),
+        (ChannelDataType.INT, scout_compute_api.Value(int64_value="9007199254740993"), 9007199254740993),
+        (ChannelDataType.STRING, scout_compute_api.Value(string_value="hello"), "hello"),
+    ],
+    ids=["double", "int", "string"],
+)
+def test_get_last_value_returns_value(
+    mock_channel: Channel,
+    mock_clients: MagicMock,
+    data_type: ChannelDataType,
+    value: scout_compute_api.Value,
+    expected: float | int | str,
+):
+    """A single-point response is returned as a LastValue with the correctly-typed value."""
+    mock_channel.data_type = data_type
     ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
-    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=42.5), ts)
+    mock_clients.compute.compute.return_value = _make_response(value, ts)
 
     result = mock_channel.get_last_value()
 
-    assert result == LastValue(_ns(ts), 42.5)
-    assert isinstance(result.value, float)
+    assert result == LastValue(_ns(ts), expected)
+    assert type(result.value) is type(expected)
     assert isinstance(result.timestamp, int)
 
 
-def test_get_last_value_returns_int64_parsed_from_string(mock_channel: Channel, mock_clients: MagicMock):
-    """int64 is wire-encoded as a string; get_last_value parses it back to int."""
-    mock_channel.data_type = ChannelDataType.INT
-    ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
-    mock_clients.compute.compute.return_value = _make_response(
-        # int64_value type is Optional[str]
-        scout_compute_api.Value(int64_value="9007199254740993"),
-        ts,
-    )
-
-    result = mock_channel.get_last_value()
-
-    assert result == LastValue(_ns(ts), 9007199254740993)
-    assert isinstance(result.value, int)
-
-
-def test_get_last_value_returns_string(mock_channel: Channel, mock_clients: MagicMock):
-    """A string single-point response is returned as a LastValue with a str."""
-    mock_channel.data_type = ChannelDataType.STRING
-    ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
-    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(string_value="hello"), ts)
-
-    result = mock_channel.get_last_value()
-
-    assert result == LastValue(_ns(ts), "hello")
-
-
 def test_get_last_value_empty_window_returns_none(mock_channel: Channel, mock_clients: MagicMock):
-    """An empty window surfaces as the conjure 'a union value must not be None' ValueError; treated as no data."""
-    mock_clients.compute.compute.side_effect = ValueError("a union value must not be None")
+    """End-to-end: an empty single-point response goes through the real conjure decoder and is treated as no data."""
+
+    def _decode_empty_singlepoint(*_args, **_kwargs):
+        ConjureDecoder().decode(
+            {"type": "singlePoint", "singlePoint": None},
+            scout_compute_api.ComputeNodeResponse,
+        )
+
+    mock_clients.compute.compute.side_effect = _decode_empty_singlepoint
 
     result = mock_channel.get_last_value()
 
@@ -98,16 +96,22 @@ def test_get_last_value_unrelated_value_error_propagates(mock_channel: Channel, 
 
 
 def test_get_last_value_request_fields(mock_channel: Channel, mock_clients: MagicMock):
-    """Request carries the explicit start, the explicit end, last_value_point node, and channel identity."""
-    start = datetime(2026, 1, 2, 2, 54, 5, tzinfo=timezone.utc)
-    end = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    """Request carries the explicit start, the explicit end, last_value_point node, and channel identity.
+
+    Uses non-zero microsecond components on `start` and `end` to also exercise sub-second round-trip
+    from `datetime` -> `_SecondsNanos` -> `api.Timestamp.nanos` on the request side.
+    """
+    start = datetime(2026, 1, 2, 2, 54, 5, 123456, tzinfo=timezone.utc)
+    end = datetime(2026, 1, 2, 3, 4, 5, 789012, tzinfo=timezone.utc)
     mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), end)
 
     mock_channel.get_last_value(start=start, end=end, tags={"a": "b"})
 
     _, request = mock_clients.compute.compute.call_args[0]
     assert request.start.seconds == int(start.timestamp())
+    assert request.start.nanos == start.microsecond * 1000
     assert request.end.seconds == int(end.timestamp())
+    assert request.end.nanos == end.microsecond * 1000
     # The compute node must be a SelectValue with last_value_point set.
     series = request.node.value.last_value_point
     assert series is not None
@@ -118,47 +122,56 @@ def test_get_last_value_request_fields(mock_channel: Channel, mock_clients: Magi
     assert {k: v.literal for k, v in data_source.tags.items()} == {"a": "b"}
 
 
-def test_get_last_value_defaults_to_full_time_range(mock_channel: Channel, mock_clients: MagicMock):
-    """Omitting both `start` and `end` searches the full `[_MIN_TIMESTAMP, _MAX_TIMESTAMP]` window."""
-    ts = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), ts)
-
-    mock_channel.get_last_value()
-
-    _, request = mock_clients.compute.compute.call_args[0]
-    expected_start = _MIN_TIMESTAMP.to_api()
-    expected_end = _MAX_TIMESTAMP.to_api()
-    assert request.start.seconds == expected_start.seconds
-    assert request.start.nanos == expected_start.nanos
-    assert request.end.seconds == expected_end.seconds
-    assert request.end.nanos == expected_end.nanos
-
-
-def test_get_last_value_start_only_defaults_end_to_max(mock_channel: Channel, mock_clients: MagicMock):
-    """Omitting `end` falls back to `_MAX_TIMESTAMP` for parity with `search_logs`."""
-    start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), start)
-
-    mock_channel.get_last_value(start=start)
-
-    _, request = mock_clients.compute.compute.call_args[0]
-    expected_end = _MAX_TIMESTAMP.to_api()
-    assert request.start.seconds == int(start.timestamp())
-    assert request.end.seconds == expected_end.seconds
-    assert request.end.nanos == expected_end.nanos
-
-
-def test_get_last_value_end_only_defaults_start_to_min(mock_channel: Channel, mock_clients: MagicMock):
-    """Omitting `start` falls back to `_MIN_TIMESTAMP` for parity with `search_logs`."""
+def test_get_last_value_end_only_defaults_start_to_end_minus_one_hour(
+    mock_channel: Channel, mock_clients: MagicMock
+):
+    """Omitting `start` falls back to `end - 1hr` (anchored to the provided end, not wall-clock now)."""
     end = datetime(2026, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
     mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), end)
 
     mock_channel.get_last_value(end=end)
 
     _, request = mock_clients.compute.compute.call_args[0]
-    expected_start = _MIN_TIMESTAMP.to_api()
+    expected_start = _SecondsNanos.from_flexible(end - timedelta(hours=1)).to_api()
     assert request.start.seconds == expected_start.seconds
     assert request.start.nanos == expected_start.nanos
+    assert request.end.seconds == int(end.timestamp())
+
+
+def test_get_last_value_start_after_end_raises(mock_channel: Channel, mock_clients: MagicMock):
+    """`start > end` is rejected before any API call."""
+    start = datetime(2026, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(ValueError, match="start .* must be at or before end"):
+        mock_channel.get_last_value(start=start, end=end)
+
+    mock_clients.compute.compute.assert_not_called()
+
+
+def test_get_last_value_zero_width_window_allowed(mock_channel: Channel, mock_clients: MagicMock):
+    """`start == end` is a legal "value at exactly T" query; the server decides whether a point exists."""
+    instant = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), instant)
+
+    mock_channel.get_last_value(start=instant, end=instant)
+
+    _, request = mock_clients.compute.compute.call_args[0]
+    assert request.start.seconds == int(instant.timestamp())
+    assert request.start.nanos == 0
+    assert request.end.seconds == int(instant.timestamp())
+    assert request.end.nanos == 0
+
+
+def test_get_last_value_default_start_clamps_at_epoch(mock_channel: Channel, mock_clients: MagicMock):
+    """When `end` is within the first hour of the unix epoch, the default-start clamp avoids negative seconds."""
+    end = datetime(1970, 1, 1, 0, 30, 0, tzinfo=timezone.utc)  # 30 minutes after epoch
+    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), end)
+
+    mock_channel.get_last_value(end=end)
+
+    _, request = mock_clients.compute.compute.call_args[0]
+    assert request.start.seconds == 0
+    assert request.start.nanos == 0
     assert request.end.seconds == int(end.timestamp())
 
 
@@ -199,9 +212,13 @@ def test_get_last_value_unhandled_value_variant_raises(mock_channel: Channel, mo
 
 
 def test_conjure_empty_singlepoint_error_message_unchanged():
-    """Pins the conjure decode-error string that `get_last_value` matches for empty windows.
+    """Pin on the conjure decode-error string that `Channel.get_last_value` matches.
 
-    Fails at CI if a `nominal-api` or `conjure-python-client` bump rewords the message.
+    If this test fails after a `nominal-api` or `conjure-python-client` bump, it likely
+    means the upstream fix from palantir/conjure-python#1050 has propagated, meaning
+    `ComputeNodeResponse.single_point` is now `None` on empty windows instead of raising.
+    In that case, remove the `try/except ValueError` workaround in `Channel.get_last_value`
+    along with this test.
     """
     payload = {"type": "singlePoint", "singlePoint": None}
     with pytest.raises(ValueError, match="^a union value must not be None$"):

--- a/tests/core/test_channel.py
+++ b/tests/core/test_channel.py
@@ -122,9 +122,7 @@ def test_get_last_value_request_fields(mock_channel: Channel, mock_clients: Magi
     assert {k: v.literal for k, v in data_source.tags.items()} == {"a": "b"}
 
 
-def test_get_last_value_end_only_defaults_start_to_end_minus_one_hour(
-    mock_channel: Channel, mock_clients: MagicMock
-):
+def test_get_last_value_default_window_is_one_hour(mock_channel: Channel, mock_clients: MagicMock):
     """Omitting `start` falls back to `end - 1hr` (anchored to the provided end, not wall-clock now)."""
     end = datetime(2026, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
     mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), end)
@@ -146,33 +144,6 @@ def test_get_last_value_start_after_end_raises(mock_channel: Channel, mock_clien
         mock_channel.get_last_value(start=start, end=end)
 
     mock_clients.compute.compute.assert_not_called()
-
-
-def test_get_last_value_zero_width_window_allowed(mock_channel: Channel, mock_clients: MagicMock):
-    """`start == end` is a legal "value at exactly T" query; the server decides whether a point exists."""
-    instant = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), instant)
-
-    mock_channel.get_last_value(start=instant, end=instant)
-
-    _, request = mock_clients.compute.compute.call_args[0]
-    assert request.start.seconds == int(instant.timestamp())
-    assert request.start.nanos == 0
-    assert request.end.seconds == int(instant.timestamp())
-    assert request.end.nanos == 0
-
-
-def test_get_last_value_default_start_clamps_at_epoch(mock_channel: Channel, mock_clients: MagicMock):
-    """When `end` is within the first hour of the unix epoch, the default-start clamp avoids negative seconds."""
-    end = datetime(1970, 1, 1, 0, 30, 0, tzinfo=timezone.utc)  # 30 minutes after epoch
-    mock_clients.compute.compute.return_value = _make_response(scout_compute_api.Value(float64_value=1.0), end)
-
-    mock_channel.get_last_value(end=end)
-
-    _, request = mock_clients.compute.compute.call_args[0]
-    assert request.start.seconds == 0
-    assert request.start.nanos == 0
-    assert request.end.seconds == int(end.timestamp())
 
 
 def test_get_last_value_unsupported_data_type_raises(mock_channel: Channel, mock_clients: MagicMock):


### PR DESCRIPTION
**Summary**

Adds `Channel.get_last_value()`, a method to fetch the last `(timestamp, value)` for a numeric or string channel within a bounded time window. Motivated by the common need to read a channel's current state without pulling a full series, e.g. for status displays, alerting checks, or coupling Nominal data with external systems.

**Implementation**

- New `Channel.get_last_value(*, start, end, tags)` on `nominal/core/channel.py`. Returns a `LastValue(timestamp, value)` named tuple, or `None` if the window is empty.
- Restricted to `DOUBLE`, `INT`, and `STRING` channels; others raise `TypeError`.
- If `end` is omitted it defaults to the current UTC time; if `start` is omitted it defaults to `end - 1h`. `start > end` is rejected with `ValueError` before any API call.
- Uses `scout_compute_api.SelectValue(last_value_point=...)` against the compute service. Empty windows are detected by matching the conjure `"a union value must not be None"` `ValueError` and returning `None`.
- `LastValue` is exported from `nominal.core`.

**Testing**

- Unit tests in `tests/core/test_channel.py` cover each return-value branch, the 1-hour default window fallback, `start > end` validation, empty-window `None`, the conjure error match, unsupported channel types, missing/unhandled response variants, and the request payload sent to compute.
- End-to-end smoke test against staging exercising the DOUBLE and STRING paths, the LOG `TypeError` guard, empty-window `None` handling, and concurrent fan-out via `ThreadPoolExecutor`. INT was not covered end-to-end because seeded INT channels surfaced as DOUBLE; the int64 wire-decoding branch is covered by unit tests.