### PR TITLE
chore: update release-please to include uv.lock version bump

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,8 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         uses: actions/checkout@v4
         with:
+          # Using fromJSON since github refnames don't provide the release-please
+          # branch, which is what this next commit needs to be based off of
           ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
           token: ${{ secrets.NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,33 @@ jobs:
     runs-on: depot-ubuntu-24.04-small
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN }}
           release-type: python
+
+      - name: Check out release PR branch
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          token: ${{ secrets.NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN }}
+
+      - name: Install uv
+        if: ${{ steps.release.outputs.pr }}
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.x"
+
+      - name: Sync uv.lock to release PR
+        if: ${{ steps.release.outputs.pr }}
+        run: |
+          uv lock
+          if git diff --quiet uv.lock; then
+            echo "uv.lock already in sync with pyproject.toml"
+            exit 0
+          fi
+          git config user.name NomBot
+          git config user.email 117409387+nominal-bot@users.noreply.github.com
+          git commit -m "chore: update uv.lock" uv.lock
+          git push

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Sync uv.lock to release PR
         if: ${{ steps.release.outputs.pr }}
         run: |
+          set -euo pipefail
+          uv lock
           uv lock
           if git diff --quiet uv.lock; then
             echo "uv.lock already in sync with pyproject.toml"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,5 +43,6 @@ jobs:
           fi
           git config user.name NomBot
           git config user.email 117409387+nominal-bot@users.noreply.github.com
-          git commit -m "chore: update uv.lock" uv.lock
+          git add uv.lock
+          git commit -m "chore: update uv.lock"
           git push

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,13 +36,10 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         run: |
           set -euo pipefail
-          uv lock
-          if git diff --quiet uv.lock; then
+          if uv lock --check; then
             echo "uv.lock already in sync with pyproject.toml"
             exit 0
           fi
-          git config user.name NomBot
-          git config user.email 117409387+nominal-bot@users.noreply.github.com
-          git add uv.lock
-          git commit -m "chore: update uv.lock"
+          uv lock
+          git -c user.name=NomBot -c user.email=117409387+nominal-bot@users.noreply.github.com commit -m "chore: update uv.lock" uv.lock
           git push

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,7 +37,6 @@ jobs:
         run: |
           set -euo pipefail
           uv lock
-          uv lock
           if git diff --quiet uv.lock; then
             echo "uv.lock already in sync with pyproject.toml"
             exit 0

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "nominal"
-version = "1.136.0"
+version = "1.136.1"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
Updates the release-please process to include a step bumping the `uv.lock` version such that it no longer pollutes new branches.