### PR TITLE
feat: preserve workbook creator RID

### DIFF
--- a/nominal/core/workbook.py
+++ b/nominal/core/workbook.py
@@ -103,6 +103,7 @@ class Workbook(HasRid, RefreshableMixin[scout_notebook_api.Notebook]):
     """
 
     _clients: _Clients = field(repr=False)
+    created_by_rid: str | None = field(default=None, repr=False)
 
     class _Clients(HasScoutParams, Protocol):
         @property
@@ -337,6 +338,7 @@ class Workbook(HasRid, RefreshableMixin[scout_notebook_api.Notebook]):
             asset_rids=notebook.metadata.data_scope.asset_rids,
             workbook_type=workbook_type,
             _clients=clients,
+            created_by_rid=notebook.metadata.created_by_rid,
         )
 
 


### PR DESCRIPTION
## Summary

Preserves the creator RID from notebook metadata when constructing `Workbook` objects.

## Root Cause

The scout notebook metadata returned by Conjure includes `created_by_rid`, but the Python `Workbook` wrapper dropped that field during deserialization. Migration impersonation resolves the destination client from attributes such as `created_by_rid`, so workbook migrations fell back to the service user instead of impersonating the workbook creator.

## Changes

- Adds `created_by_rid` to `Workbook`.
- Copies `notebook.metadata.created_by_rid` in `Workbook._from_notebook_metadata`.
- Adds a focused test covering the deserialization behavior.

## Validation

- `uv run pytest tests/core/test_workbook.py` passed.