### PR TITLE
feat: preserve creator rids on migrated resources

### DIFF
--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -56,6 +56,7 @@ class Asset(_DatasetWrapper, HasRid, RefreshableMixin[scout_asset_api.Asset]):
     created_at: IntegralNanosecondsUTC
 
     _clients: _Clients = field(repr=False)
+    created_by_rid: str | None = field(default=None, repr=False)
 
     class _Clients(
         DataSource._Clients,
@@ -675,6 +676,7 @@ class Asset(_DatasetWrapper, HasRid, RefreshableMixin[scout_asset_api.Asset]):
             labels=tuple(asset.labels),
             created_at=_SecondsNanos.from_flexible(asset.created_at).to_nanoseconds(),
             _clients=clients,
+            created_by_rid=asset.created_by,
         )
 
 

--- a/nominal/core/attachment.py
+++ b/nominal/core/attachment.py
@@ -25,6 +25,7 @@ class Attachment(HasRid, RefreshableMixin[attachments_api.Attachment]):
     created_at: IntegralNanosecondsUTC
 
     _clients: _Clients = field(repr=False)
+    created_by_rid: str | None = field(default=None, repr=False)
 
     class _Clients(HasScoutParams, Protocol):
         @property
@@ -101,6 +102,7 @@ class Attachment(HasRid, RefreshableMixin[attachments_api.Attachment]):
             labels=tuple(attachment.labels),
             created_at=_SecondsNanos.from_flexible(attachment.created_at).to_nanoseconds(),
             _clients=clients,
+            created_by_rid=attachment.created_by,
         )
 
 

--- a/nominal/core/checklist.py
+++ b/nominal/core/checklist.py
@@ -30,6 +30,7 @@ class Checklist(HasRid, RefreshableMixin[scout_checks_api.VersionedChecklist]):
     properties: Mapping[str, str]
     labels: Sequence[str]
     _clients: _Clients = field(repr=False)
+    author_rid: str | None = field(default=None, repr=False)
 
     class _Clients(HasScoutParams, Protocol):
         @property
@@ -56,6 +57,7 @@ class Checklist(HasRid, RefreshableMixin[scout_checks_api.VersionedChecklist]):
             properties=checklist.metadata.properties,
             labels=checklist.metadata.labels,
             _clients=clients,
+            author_rid=checklist.metadata.author_rid,
         )
 
     def _get_latest_api(self) -> scout_checks_api.VersionedChecklist:

--- a/nominal/core/data_review.py
+++ b/nominal/core/data_review.py
@@ -43,6 +43,7 @@ class DataReview(HasRid):
     created_at: IntegralNanosecondsUTC
 
     _clients: _Clients = field(repr=False)
+    created_by_rid: str | None = field(default=None, repr=False)
 
     class _Clients(HasScoutParams, Protocol):
         @property
@@ -70,6 +71,7 @@ class DataReview(HasRid):
             completed=completed,
             created_at=_SecondsNanos.from_flexible(data_review.created_at).to_nanoseconds(),
             _clients=clients,
+            created_by_rid=data_review.created_by,
         )
 
     def get_checklist(self) -> "Checklist":

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -54,6 +54,7 @@ class Run(HasRid, RefreshableMixin[scout_run_api.Run], _DatasetWrapper):
     created_at: IntegralNanosecondsUTC
 
     _clients: _Clients = field(repr=False)
+    author_rid: str | None = field(default=None, repr=False)
 
     class _Clients(
         Attachment._Clients,
@@ -459,6 +460,7 @@ class Run(HasRid, RefreshableMixin[scout_run_api.Run], _DatasetWrapper):
             assets=tuple(run.assets),
             created_at=_SecondsNanos.from_flexible(run.created_at).to_nanoseconds(),
             _clients=clients,
+            author_rid=run.author_rid,
         )
 
 

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -35,6 +35,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
     labels: Sequence[str]
     created_at: IntegralNanosecondsUTC
     _clients: _Clients = field(repr=False)
+    created_by_rid: str | None = field(default=None, repr=False)
 
     class _Clients(HasScoutParams, Protocol):
         @property
@@ -417,6 +418,7 @@ class Video(HasRid, RefreshableMixin[scout_video_api.Video]):
             labels=tuple(video.labels),
             created_at=_SecondsNanos.from_flexible(video.created_at).to_nanoseconds(),
             _clients=clients,
+            created_by_rid=video.created_by,
         )
 
 

--- a/nominal/core/workbook_template.py
+++ b/nominal/core/workbook_template.py
@@ -72,6 +72,7 @@ class WorkbookTemplate(HasRid, RefreshableMixin[scout_template_api.Template]):
     properties: Mapping[str, str]
     workbook_type: WorkbookType
     _clients: _Clients = field(repr=False)
+    created_by_rid: str | None = field(default=None, repr=False)
 
     class _Clients(HasScoutParams, Protocol):
         @property
@@ -255,6 +256,7 @@ class WorkbookTemplate(HasRid, RefreshableMixin[scout_template_api.Template]):
             properties=template.metadata.properties,
             workbook_type=WorkbookType.COMPARISON_WORKBOOK,
             _clients=clients,
+            created_by_rid=template.metadata.created_by,
         )
 
 


### PR DESCRIPTION
## Summary
- expose creator/author RIDs on resource objects returned from Conjure where available
- covers assets, runs, checklists, data reviews, attachments, videos, and workbook templates
- lets the migration impersonation resolver choose the destination user for these copied resources

## Test plan
- uv run ruff check nominal/core/asset.py nominal/core/attachment.py nominal/core/checklist.py nominal/core/data_review.py nominal/core/run.py nominal/core/video.py nominal/core/workbook_template.py
- imported the updated dataclasses and verified the new fields exist