### PR TITLE
feat: add Run.add_comment to post to a run's discussion

### DIFF
--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -9,7 +9,7 @@ from nominal.core.bounds import Bounds
 from nominal.core.channel import Channel, ChannelDataType
 from nominal.core.checklist import Checklist
 from nominal.core.client import NominalClient, WorkspaceSearchType
-from nominal.core.comment import Message
+from nominal.core.comment import Comment
 from nominal.core.connection import Connection
 from nominal.core.containerized_extractors import (
     ContainerizedExtractor,
@@ -65,7 +65,7 @@ __all__ = [
     "LinkDict",
     "LogPoint",
     "LogStream",
-    "Message",
+    "Comment",
     "NominalClient",
     "poll_until_ingestion_completed",
     "Run",

--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -9,6 +9,7 @@ from nominal.core.bounds import Bounds
 from nominal.core.channel import Channel, ChannelDataType
 from nominal.core.checklist import Checklist
 from nominal.core.client import NominalClient, WorkspaceSearchType
+from nominal.core.comment import Message
 from nominal.core.connection import Connection
 from nominal.core.containerized_extractors import (
     ContainerizedExtractor,
@@ -64,6 +65,7 @@ __all__ = [
     "LinkDict",
     "LogPoint",
     "LogStream",
+    "Message",
     "NominalClient",
     "poll_until_ingestion_completed",
     "Run",

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -9,6 +9,7 @@ from conjure_python_client import Service, ServiceConfiguration
 from nominal_api import (
     attachments_api,
     authentication_api,
+    comments_api,
     event,
     ingest_api,
     scout,
@@ -157,6 +158,7 @@ class ClientsBunch:
     datareview: scout_datareview_api.DataReviewService
     proto_write: ProtoWriteService
     event: event.EventService
+    comments: comments_api.CommentsService
     channel_metadata: timeseries_channelmetadata.ChannelMetadataService
     series_metadata: timeseries_metadata.SeriesMetadataService
     workspace: security_api_workspace.WorkspaceService
@@ -289,6 +291,7 @@ class ClientsBunch:
             datareview=client_factory(scout_datareview_api.DataReviewService),
             proto_write=client_factory(ProtoWriteService),
             event=client_factory(event.EventService),
+            comments=client_factory(comments_api.CommentsService),
             channel_metadata=client_factory(timeseries_channelmetadata.ChannelMetadataService),
             series_metadata=client_factory(timeseries_metadata.SeriesMetadataService),
             workspace=client_factory(security_api_workspace.WorkspaceService),

--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -7,6 +7,7 @@ from types import MappingProxyType
 from typing import Iterable, Mapping, Protocol, Sequence, TypeAlias
 
 from nominal_api import (
+    comments_api,
     event,
     scout,
     scout_asset_api,
@@ -70,6 +71,8 @@ class Asset(_DatasetWrapper, HasRid, RefreshableMixin[scout_asset_api.Asset]):
     ):
         @property
         def assets(self) -> scout_assets.AssetService: ...
+        @property
+        def comments(self) -> comments_api.CommentsService: ...
         @property
         def run(self) -> scout.RunService: ...
         @property

--- a/nominal/core/comment.py
+++ b/nominal/core/comment.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 
 from nominal_api import comments_api
 from typing_extensions import Self
 
+from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
+
 
 @dataclass(frozen=True)
-class Message:
-    """A message posted to a resource's discussion."""
+class Comment:
+    """A comment posted to a resource's discussion."""
 
     rid: str
     author_rid: str
     content: str
-    created_at: datetime
+    created_at: IntegralNanosecondsUTC
 
     @classmethod
     def _from_conjure(cls, api: comments_api.Comment) -> Self:
@@ -22,10 +23,5 @@ class Message:
             rid=api.rid,
             author_rid=api.author_rid,
             content=api.content,
-            created_at=_parse_iso8601(api.created_at),
+            created_at=_SecondsNanos.from_flexible(api.created_at).to_nanoseconds(),
         )
-
-
-def _parse_iso8601(value: str) -> datetime:
-    # conjure datetimes are ISO-8601; Python <3.11 doesn't accept the trailing 'Z'.
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/nominal/core/comment.py
+++ b/nominal/core/comment.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from nominal_api import comments_api
+from typing_extensions import Self
+
+
+@dataclass(frozen=True)
+class Message:
+    """A message posted to a resource's discussion."""
+
+    rid: str
+    author_rid: str
+    content: str
+    created_at: datetime
+
+    @classmethod
+    def _from_conjure(cls, api: comments_api.Comment) -> Self:
+        return cls(
+            rid=api.rid,
+            author_rid=api.author_rid,
+            content=api.content,
+            created_at=_parse_iso8601(api.created_at),
+        )
+
+
+def _parse_iso8601(value: str) -> datetime:
+    # conjure datetimes are ISO-8601; Python <3.11 doesn't accept the trailing 'Z'.
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -126,7 +126,23 @@ class Run(HasRid, RefreshableMixin[scout_run_api.Run], _DatasetWrapper):
         updated_run = self._clients.run.update_run(self._clients.auth_header, request, self.rid)
         return self._refresh_from_api(updated_run)
 
-    def add_message(self, content: str) -> Message:
+def add_message(self, content: str) -> Message:
+    """Post a markdown message to this run's discussion.
+
+    Args:
+        content: Markdown content for the message. The backend rejects empty content and
+            content longer than 65535 characters.
+
+    Returns:
+        The created `Message`.
+        
+    Raises:
+        ValueError: If content is empty or exceeds length limits.
+    """
+    if not content.strip():
+        raise ValueError("Message content cannot be empty")
+    if len(content) > 65535:
+        raise ValueError(f"Message content exceeds maximum length of 65535 characters (got {len(content)})")
         """Post a markdown message to this run's discussion.
 
         Args:

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -28,7 +28,7 @@ from nominal.core._utils.api_tools import (
 )
 from nominal.core._utils.query_tools import ArchiveStatusFilter, resolve_effective_archive_status
 from nominal.core.attachment import Attachment, _iter_get_attachments
-from nominal.core.comment import Message
+from nominal.core.comment import Comment
 from nominal.core.connection import Connection, _get_connections
 from nominal.core.dataset import Dataset, _DatasetWrapper, _get_datasets
 from nominal.core.datasource import DataSource
@@ -126,31 +126,14 @@ class Run(HasRid, RefreshableMixin[scout_run_api.Run], _DatasetWrapper):
         updated_run = self._clients.run.update_run(self._clients.auth_header, request, self.rid)
         return self._refresh_from_api(updated_run)
 
-def add_message(self, content: str) -> Message:
-    """Post a markdown message to this run's discussion.
-
-    Args:
-        content: Markdown content for the message. The backend rejects empty content and
-            content longer than 65535 characters.
-
-    Returns:
-        The created `Message`.
-        
-    Raises:
-        ValueError: If content is empty or exceeds length limits.
-    """
-    if not content.strip():
-        raise ValueError("Message content cannot be empty")
-    if len(content) > 65535:
-        raise ValueError(f"Message content exceeds maximum length of 65535 characters (got {len(content)})")
-        """Post a markdown message to this run's discussion.
+    def add_comment(self, content: str) -> Comment:
+        """Post a markdown comment to this run's discussion.
 
         Args:
-            content: Markdown content for the message. The backend rejects empty content and
-                content longer than 65535 characters.
+            content: Markdown content for the comment.
 
         Returns:
-            The created `Message`.
+            The created `Comment`.
         """
         request = comments_api.CreateCommentRequest(
             parent=comments_api.CommentParent(
@@ -163,7 +146,7 @@ def add_message(self, content: str) -> Message:
             attachments=[],
         )
         api_comment = self._clients.comments.create_comment(self._clients.auth_header, request)
-        return Message._from_conjure(api_comment)
+        return Comment._from_conjure(api_comment)
 
     def _list_dataset_scopes(self) -> Sequence[scout_asset_api.DataScope]:
         api_run = self._get_latest_api()

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -6,6 +6,7 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Iterable, Mapping, Protocol, Sequence, cast
 
 from nominal_api import (
+    comments_api,
     event,
     scout,
     scout_asset_api,
@@ -27,6 +28,7 @@ from nominal.core._utils.api_tools import (
 )
 from nominal.core._utils.query_tools import ArchiveStatusFilter, resolve_effective_archive_status
 from nominal.core.attachment import Attachment, _iter_get_attachments
+from nominal.core.comment import Message
 from nominal.core.connection import Connection, _get_connections
 from nominal.core.dataset import Dataset, _DatasetWrapper, _get_datasets
 from nominal.core.datasource import DataSource
@@ -65,6 +67,8 @@ class Run(HasRid, RefreshableMixin[scout_run_api.Run], _DatasetWrapper):
     ):
         @property
         def assets(self) -> scout_assets.AssetService: ...
+        @property
+        def comments(self) -> comments_api.CommentsService: ...
         @property
         def event(self) -> event.EventService: ...
         @property
@@ -121,6 +125,29 @@ class Run(HasRid, RefreshableMixin[scout_run_api.Run], _DatasetWrapper):
         )
         updated_run = self._clients.run.update_run(self._clients.auth_header, request, self.rid)
         return self._refresh_from_api(updated_run)
+
+    def add_message(self, content: str) -> Message:
+        """Post a markdown message to this run's discussion.
+
+        Args:
+            content: Markdown content for the message. The backend rejects empty content and
+                content longer than 65535 characters.
+
+        Returns:
+            The created `Message`.
+        """
+        request = comments_api.CreateCommentRequest(
+            parent=comments_api.CommentParent(
+                resource=comments_api.CommentParentResource(
+                    resource_type=comments_api.ResourceType.RUN,
+                    resource_rid=self.rid,
+                )
+            ),
+            content=content,
+            attachments=[],
+        )
+        api_comment = self._clients.comments.create_comment(self._clients.auth_header, request)
+        return Message._from_conjure(api_comment)
 
     def _list_dataset_scopes(self) -> Sequence[scout_asset_api.DataScope]:
         api_run = self._get_latest_api()

--- a/tests/core/test_run_message.py
+++ b/tests/core/test_run_message.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from nominal_api import comments_api
+
+from nominal.core.comment import Message
+from nominal.core.run import Run
+
+RUN_RID = "ri.scout.test.run.abc"
+
+
+@pytest.fixture
+def mock_clients():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_run(mock_clients):
+    return Run(
+        rid=RUN_RID,
+        name="Test Run",
+        description="",
+        properties={},
+        labels=[],
+        links=[],
+        start=0,
+        end=None,
+        run_number=1,
+        assets=[],
+        created_at=0,
+        _clients=mock_clients,
+    )
+
+
+def _stub_comment() -> comments_api.Comment:
+    return comments_api.Comment(
+        rid="ri.scout.test.comment.123",
+        parent=comments_api.CommentParent(
+            resource=comments_api.CommentParentResource(
+                resource_type=comments_api.ResourceType.RUN,
+                resource_rid=RUN_RID,
+            )
+        ),
+        author_rid="ri.users.user.42",
+        created_at="2026-05-07T12:00:00Z",
+        content="hello",
+        attachments=[],
+        reactions=[],
+    )
+
+
+def test_add_message_sends_run_parented_request(mock_run, mock_clients):
+    mock_clients.comments.create_comment.return_value = _stub_comment()
+
+    mock_run.add_message("hello")
+
+    mock_clients.comments.create_comment.assert_called_once()
+    auth_header, request = mock_clients.comments.create_comment.call_args.args
+    assert auth_header == mock_clients.auth_header
+    assert isinstance(request, comments_api.CreateCommentRequest)
+    assert request.content == "hello"
+    assert request.attachments == []
+    parent_resource = request.parent.resource
+    assert parent_resource is not None
+    assert parent_resource.resource_type == comments_api.ResourceType.RUN
+    assert parent_resource.resource_rid == RUN_RID
+
+
+def test_add_message_returns_message_dataclass(mock_run, mock_clients):
+    mock_clients.comments.create_comment.return_value = _stub_comment()
+
+    message = mock_run.add_message("hello")
+
+    assert isinstance(message, Message)
+    assert message.rid == "ri.scout.test.comment.123"
+    assert message.author_rid == "ri.users.user.42"
+    assert message.content == "hello"
+    assert message.created_at == datetime(2026, 5, 7, 12, 0, 0, tzinfo=timezone.utc)

--- a/tests/core/test_run_message.py
+++ b/tests/core/test_run_message.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
 from nominal_api import comments_api
 
-from nominal.core.comment import Message
+from nominal.core.comment import Comment
 from nominal.core.run import Run
 
 RUN_RID = "ri.scout.test.run.abc"
@@ -52,10 +51,10 @@ def _stub_comment() -> comments_api.Comment:
     )
 
 
-def test_add_message_sends_run_parented_request(mock_run, mock_clients):
+def test_add_comment_sends_run_parented_request(mock_run, mock_clients):
     mock_clients.comments.create_comment.return_value = _stub_comment()
 
-    mock_run.add_message("hello")
+    mock_run.add_comment("hello")
 
     mock_clients.comments.create_comment.assert_called_once()
     auth_header, request = mock_clients.comments.create_comment.call_args.args
@@ -69,13 +68,14 @@ def test_add_message_sends_run_parented_request(mock_run, mock_clients):
     assert parent_resource.resource_rid == RUN_RID
 
 
-def test_add_message_returns_message_dataclass(mock_run, mock_clients):
+def test_add_comment_returns_comment_dataclass(mock_run, mock_clients):
     mock_clients.comments.create_comment.return_value = _stub_comment()
 
-    message = mock_run.add_message("hello")
+    comment = mock_run.add_comment("hello")
 
-    assert isinstance(message, Message)
-    assert message.rid == "ri.scout.test.comment.123"
-    assert message.author_rid == "ri.users.user.42"
-    assert message.content == "hello"
-    assert message.created_at == datetime(2026, 5, 7, 12, 0, 0, tzinfo=timezone.utc)
+    assert isinstance(comment, Comment)
+    assert comment.rid == "ri.scout.test.comment.123"
+    assert comment.author_rid == "ri.users.user.42"
+    assert comment.content == "hello"
+    # 2026-05-07T12:00:00Z in nanoseconds since epoch
+    assert comment.created_at == 1_778_155_200_000_000_000


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

## Summary
- Add `Run.add_comment(content)` which posts a markdown comment to a run's discussion via the scout `CommentsService` and returns a new `Comment` dataclass.
- Wire up `comments_api.CommentsService` on `ClientsBunch` and export `Comment` from `nominal.core`.
- Replies, attachments, and listing/editing are intentionally out of scope for this initial pass.

## Changes addressing review feedback (alkasm)
- Renamed `Message` → `Comment` for consistency with the API type
- Changed `created_at` from `datetime` to `IntegralNanosecondsUTC` to match the universal convention for timestamps on resources
- Renamed `add_message()` → `add_comment()` to align with the class name
- Fixed `Asset._Clients` protocol to include `comments` property (resolves mypy errors)
- Fixed broken indentation and duplicate docstring in the method

## Test plan
- [x] Unit tests covering request shape and return value (`tests/core/test_run_message.py`)
- [x] End-to-end smoke test against cerulean-staging — successfully created a comment on a real run via `NominalClient.from_profile("default")`


Link to Devin session: https://app.devin.ai/sessions/7c442fa116c948cbaa29bd90ef35b348
Requested by: @brianburrous-nominal