### PR TITLE
chore: clarify README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ pip install nominal
 
 ### Usage
 Please refer to usage examples in the [documentation](https://docs.nominal.io/core/sdk/python-client/quickstart).
+
+<!-- Declarative environment verification: README-only PR. -->

--- a/README.md
+++ b/README.md
@@ -9,7 +9,5 @@ View on [docs.nominal.io](https://docs.nominal.io/).
 pip install nominal
 ```
 
-### Usage
+### Usage Examples
 Please refer to usage examples in the [documentation](https://docs.nominal.io/core/sdk/python-client/quickstart).
-
-<!-- Declarative environment verification: README-only PR. -->


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

## Summary

- Clarifies the README usage section heading from “Usage” to “Usage Examples”.
- Keeps the PR README-only for declarative environment verification.

## Verification

- Ran `just install`
- Ran `just test`
- Ran `just check`

## Review focus

- Confirm this trivial visible README wording change is acceptable for the environment-verification workflow.
- Confirm the diff remains README-only and does not include hidden or generated-file changes.

Link to Devin session: https://app.devin.ai/sessions/2b3d9c5224d54eb894de5e3ee1e06ca6
Requested by: @Leundai