### PR TITLE
feat: consolidate workbook migration between single and multi asset/run

### DIFF
--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -230,22 +230,30 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             if not workbook.asset_rids:
                 continue
             if len(workbook.asset_rids) == 1:
-                workbook_migrator.copy_from(workbook, WorkbookCopyOptions(destination_asset=new_asset))
+                workbook_migrator.copy_from(
+                    workbook,
+                    WorkbookCopyOptions(source_to_destination_asset_rid_mapping={source_asset.rid: new_asset.rid}),
+                )
             else:
                 self._enqueue_multi_asset_workbook(workbook, list(workbook.asset_rids))
 
         if include_runs:
             for source_run in source_asset.list_runs():
-                destination_run_rid = self.ctx.migration_state.get_mapped_rid(ResourceType.RUN, source_run.rid)
-                if destination_run_rid is None:
+                dest_run_rid = self.ctx.migration_state.get_mapped_rid(ResourceType.RUN, source_run.rid)
+                if dest_run_rid is None:
                     logger.warning("Run %s not found in migration state", source_run.rid)
                     continue
-                destination_run = self.ctx.destination_client_for(source_run).get_run(destination_run_rid)
                 for workbook in source_run.search_workbooks(include_drafts=True):
                     if not workbook.run_rids:
                         continue
                     if len(workbook.run_rids) == 1:
-                        workbook_migrator.copy_from(workbook, WorkbookCopyOptions(destination_run=destination_run))
+                        workbook_migrator.copy_from(
+                            workbook,
+                            WorkbookCopyOptions(
+                                source_to_destination_asset_rid_mapping={source_asset.rid: new_asset.rid},
+                                source_to_destination_run_rid_mapping={source_run.rid: dest_run_rid},
+                            ),
+                        )
                     else:
                         self._enqueue_multi_run_workbook(workbook, list(workbook.run_rids))
 

--- a/nominal/experimental/migration/migrator/workbook_migrator.py
+++ b/nominal/experimental/migration/migrator/workbook_migrator.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
+import json
 import logging
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Mapping, Sequence, cast
 
+from conjure_python_client._serde.decoder import ConjureDecoder
+from conjure_python_client._serde.encoder import ConjureEncoder
 from nominal_api import api as nominal_api
 from nominal_api import scout_notebook_api, scout_workbookcommon_api
 
 from nominal.core import NominalClient
 from nominal.core._clientsbunch import ClientsBunch
-from nominal.core.asset import Asset
-from nominal.core.run import Run
 from nominal.core.workbook import Workbook
 from nominal.experimental.id_utils.id_utils import UUID_RE
 from nominal.experimental.migration.migrator.attachment_migrator import AttachmentMigrator
@@ -26,8 +27,8 @@ ATTACHMENT_RID_PATTERN = re.compile(rf"ri\.attachments\.[^.]+\.attachment\.{UUID
 
 @dataclass(frozen=True)
 class WorkbookCopyOptions(ResourceCopyOptions):
-    destination_asset: Asset | None = None
-    destination_run: Run | None = None
+    source_to_destination_asset_rid_mapping: Mapping[str, str] = field(default_factory=dict)
+    source_to_destination_run_rid_mapping: Mapping[str, str] = field(default_factory=dict)
     new_labels: Sequence[str] | None = None
     new_properties: Mapping[str, str] | None = None
 
@@ -38,6 +39,7 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
         return ResourceType.WORKBOOK
 
     def clone(self, source: Workbook) -> Workbook:
+        """Not supported — workbooks must be copied with an explicit RID mapping via copy_from."""
         raise NotImplementedError("Workbook clone is unsupported; use copy_from with destination asset/run.")
 
     def default_copy_options(self) -> WorkbookCopyOptions | None:
@@ -51,24 +53,31 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
         if existing_workbook is not None:
             return existing_workbook
 
-        if (options.destination_asset is None) == (options.destination_run is None):
-            raise ValueError("Exactly one of destination_asset or destination_run must be provided.")
-
         source_clients = cast(ClientsBunch, source._clients)
         raw_notebook = source_clients.notebook.get(source_clients.auth_header, source.rid)
 
-        asset_rid_map = dict(self.ctx.migration_state.rid_mapping.get(ResourceType.ASSET.value, {}))
+        source_run_rids = raw_notebook.metadata.data_scope.run_rids or []
+        source_asset_rids = raw_notebook.metadata.data_scope.asset_rids or []
+        rid_overrides: dict[str, str] = {
+            **options.source_to_destination_asset_rid_mapping,
+            **options.source_to_destination_run_rid_mapping,
+        }
 
-        if options.destination_run is not None:
-            dest_run_rid = options.destination_run.rid
-            source_run_rids = raw_notebook.metadata.data_scope.run_rids or []
-            rid_overrides = {**asset_rid_map, **{r: dest_run_rid for r in source_run_rids}}
-            data_scope = scout_notebook_api.NotebookDataScope(run_rids=[dest_run_rid], asset_rids=None)
+        if source_run_rids:
+            missing = [r for r in source_run_rids if r not in options.source_to_destination_run_rid_mapping]
+            if missing:
+                raise ValueError(f"Run RIDs not provided for workbook {source.rid}: {missing}")
+            data_scope = scout_notebook_api.NotebookDataScope(
+                run_rids=[options.source_to_destination_run_rid_mapping[r] for r in source_run_rids], asset_rids=None
+            )
         else:
-            dest_asset_rid = options.destination_asset.rid  # type: ignore[union-attr]
-            source_asset_rids = raw_notebook.metadata.data_scope.asset_rids or []
-            rid_overrides = {**asset_rid_map, **{r: dest_asset_rid for r in source_asset_rids}}
-            data_scope = scout_notebook_api.NotebookDataScope(run_rids=None, asset_rids=[dest_asset_rid])
+            missing = [r for r in source_asset_rids if r not in options.source_to_destination_asset_rid_mapping]
+            if missing:
+                raise ValueError(f"Asset RIDs not provided for workbook {source.rid}: {missing}")
+            data_scope = scout_notebook_api.NotebookDataScope(
+                run_rids=None,
+                asset_rids=[options.source_to_destination_asset_rid_mapping[r] for r in source_asset_rids],
+            )
 
         return self._copy_workbook(
             source,
@@ -88,9 +97,12 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
         labels: Sequence[str] | None = None,
         properties: Mapping[str, str] | None = None,
     ) -> Workbook:
+        """Create a new workbook in the destination by find/replacing RIDs in the source content.
+
+        Handles RID substitution, content attachment migration, preview image migration,
+        and metadata (labels/properties) propagation.
+        """
         content_v2 = raw_notebook.content_v2
-        if content_v2 is not None and not isinstance(content_v2, scout_workbookcommon_api.UnifiedWorkbookContent):
-            raise ValueError(f"Unexpected content_v2 type for workbook {source.rid}")
         content = (content_v2.workbook if content_v2 is not None else None) or raw_notebook.content
         if content is None:
             raise ValueError(f"Missing content for workbook {source.rid}")
@@ -98,6 +110,7 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
         new_layout, new_content = clone_conjure_objects_with_rid_overrides(
             (raw_notebook.layout, content), rid_overrides=rid_overrides
         )
+        new_content = self._migrate_content_attachments(source, new_content)
 
         destination_client = self.destination_client_for(source)
         dest_clients = destination_client._clients
@@ -125,6 +138,38 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
 
         self._migrate_preview_image(source, new_workbook)
         return new_workbook
+
+    def _migrate_content_attachments(
+        self,
+        source: Workbook,
+        content: scout_workbookcommon_api.WorkbookContent,
+    ) -> scout_workbookcommon_api.WorkbookContent:
+        """Migrate attachment RIDs embedded in workbook content (e.g. images in markdown panels).
+
+        Attachment RIDs appear inside markdown strings, so they cannot be handled by the structured
+        RID find/replace in clone_conjure_objects_with_rid_overrides — a regex pass is needed.
+        """
+        content_json = json.dumps(ConjureEncoder.do_encode(content))
+        attachment_rids = set(ATTACHMENT_RID_PATTERN.findall(content_json))
+        if not attachment_rids:
+            return content
+
+        source_clients = cast(ClientsBunch, source._clients)
+        attachment_migrator = AttachmentMigrator(self.ctx)
+        rid_map: dict[str, str] = {}
+        for old_rid in attachment_rids:
+            new_attachment = attachment_migrator.migrate_by_rid(source_clients, old_rid)
+            rid_map[old_rid] = new_attachment.rid
+            logger.debug("Migrated content attachment %s -> %s", old_rid, new_attachment.rid)
+
+        def _replace_rid(match: re.Match[str]) -> str:
+            return rid_map.get(match.group(0), match.group(0))
+
+        content_json = ATTACHMENT_RID_PATTERN.sub(_replace_rid, content_json)
+        result: scout_workbookcommon_api.WorkbookContent = ConjureDecoder().do_decode(
+            json.loads(content_json), scout_workbookcommon_api.WorkbookContent
+        )
+        return result
 
     def _migrate_preview_image(self, source: Workbook, dest: Workbook) -> None:
         """Migrate preview image attachment RIDs from source to destination workbook.
@@ -174,74 +219,6 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
 
         logger.info("Migrated preview image for workbook %s", dest.title)
 
-    def copy_multi_asset_workbook(self, source: Workbook, source_asset_rids: list[str]) -> Workbook | None:
-        """Copy a multi-asset workbook by find/replacing asset RIDs in the serialized content.
-
-        All source_asset_rids must already be present in the migration state before calling this.
-        Returns None if any asset RID is missing from the migration state (already logged as a skip).
-        """
-        existing = self.get_existing_destination_resource(source)
-        if existing is not None:
-            return existing
-
-        rid_map: dict[str, str] = {}
-        for old_rid in source_asset_rids:
-            new_rid = self.ctx.migration_state.get_mapped_rid(ResourceType.ASSET, old_rid)
-            if new_rid is None:
-                reason = f"asset {old_rid} not found in migration state"
-                logger.warning("Skipping multi-asset workbook %s: %s", source.rid, reason)
-                self.ctx.migration_state.record_skip(ResourceType.WORKBOOK, source.rid, reason)
-                self.ctx.migration_state.clear_pending_multi_asset_workbook(source.rid)
-                return None
-            rid_map[old_rid] = new_rid
-
-        source_clients = cast(ClientsBunch, source._clients)
-        raw_notebook = source_clients.notebook.get(source_clients.auth_header, source.rid)
-        data_scope = scout_notebook_api.NotebookDataScope(
-            asset_rids=[rid_map[r] for r in source_asset_rids], run_rids=None
-        )
-        new_workbook = self._copy_workbook(source, raw_notebook, rid_map, data_scope)
-
-        self.ctx.migration_state.clear_pending_multi_asset_workbook(source.rid)
-        logger.info("Migrated multi-asset workbook %s -> %s", source.rid, new_workbook.rid)
-        return new_workbook
-
-    def copy_multi_run_workbook(self, source: Workbook, source_run_rids: list[str]) -> Workbook | None:
-        """Copy a multi-run workbook by find/replacing run RIDs in the serialized content.
-
-        All source_run_rids must already be present in the migration state before calling this.
-        Returns None if any run RID is missing from the migration state (already logged as a skip).
-        """
-        existing = self.get_existing_destination_resource(source)
-        if existing is not None:
-            return existing
-
-        rid_map: dict[str, str] = {}
-        for old_rid in source_run_rids:
-            new_rid = self.ctx.migration_state.get_mapped_rid(ResourceType.RUN, old_rid)
-            if new_rid is None:
-                reason = f"run {old_rid} not found in migration state"
-                logger.warning("Skipping multi-run workbook %s: %s", source.rid, reason)
-                self.ctx.migration_state.record_skip(ResourceType.WORKBOOK, source.rid, reason)
-                self.ctx.migration_state.clear_pending_multi_run_workbook(source.rid)
-                return None
-            rid_map[old_rid] = new_rid
-
-        # Also remap any asset RIDs embedded in the content (channels resolve against both
-        # run RIDs and asset RIDs, so both must be substituted).
-        asset_rid_map = dict(self.ctx.migration_state.rid_mapping.get(ResourceType.ASSET.value, {}))
-
-        source_clients = cast(ClientsBunch, source._clients)
-        raw_notebook = source_clients.notebook.get(source_clients.auth_header, source.rid)
-        data_scope = scout_notebook_api.NotebookDataScope(
-            asset_rids=None, run_rids=[rid_map[r] for r in source_run_rids]
-        )
-        new_workbook = self._copy_workbook(source, raw_notebook, {**asset_rid_map, **rid_map}, data_scope)
-
-        self.ctx.migration_state.clear_pending_multi_run_workbook(source.rid)
-        logger.info("Migrated multi-run workbook %s -> %s", source.rid, new_workbook.rid)
-        return new_workbook
-
     def migrate_deferred_workbooks(self, source_clients_by_asset_rid: dict[str, ClientsBunch]) -> None:
         """Migrate all pending multi-asset and multi-run workbooks recorded in the migration state.
 
@@ -250,6 +227,9 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
         """
         pending_multi_asset = dict(self.ctx.migration_state.pending_multi_asset_workbooks)
         pending_multi_run = dict(self.ctx.migration_state.pending_multi_run_workbooks)
+
+        asset_rid_map = dict(self.ctx.migration_state.rid_mapping.get(ResourceType.ASSET.value, {}))
+        run_rid_map = dict(self.ctx.migration_state.rid_mapping.get(ResourceType.RUN.value, {}))
 
         if pending_multi_asset:
             logger.info("Migrating %d deferred multi-asset workbook(s)", len(pending_multi_asset))
@@ -261,18 +241,30 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
                     continue
                 raw_notebook = source_clients.notebook.get(source_clients.auth_header, workbook_rid)
                 source_workbook = Workbook._from_conjure(source_clients, raw_notebook)
-                self.copy_multi_asset_workbook(source_workbook, source_asset_rids)
+                self.copy_from(
+                    source_workbook, WorkbookCopyOptions(source_to_destination_asset_rid_mapping=asset_rid_map)
+                )
+                self.ctx.migration_state.clear_pending_multi_asset_workbook(workbook_rid)
+                logger.info("Migrated multi-asset workbook %s", workbook_rid)
 
         if pending_multi_run:
             logger.info("Migrating %d deferred multi-run workbook(s)", len(pending_multi_run))
-            for workbook_rid, source_run_rids in pending_multi_run.items():
+            for workbook_rid in pending_multi_run:
                 source_clients = next(iter(source_clients_by_asset_rid.values()), None)
                 if source_clients is None:
                     logger.warning("No source assets available to fetch multi-run workbook %s — skipping", workbook_rid)
                     continue
                 raw_notebook = source_clients.notebook.get(source_clients.auth_header, workbook_rid)
                 source_workbook = Workbook._from_conjure(source_clients, raw_notebook)
-                self.copy_multi_run_workbook(source_workbook, source_run_rids)
+                self.copy_from(
+                    source_workbook,
+                    WorkbookCopyOptions(
+                        source_to_destination_asset_rid_mapping=asset_rid_map,
+                        source_to_destination_run_rid_mapping=run_rid_map,
+                    ),
+                )
+                self.ctx.migration_state.clear_pending_multi_run_workbook(workbook_rid)
+                logger.info("Migrated multi-run workbook %s", workbook_rid)
 
     def _resolve_source_clients(
         self,

--- a/nominal/experimental/migration/migrator/workbook_migrator.py
+++ b/nominal/experimental/migration/migrator/workbook_migrator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import Mapping, Sequence, cast
+from typing import Any, Mapping, Sequence, cast
 
 from nominal_api import api as nominal_api
 from nominal_api import scout_notebook_api, scout_workbookcommon_api
@@ -13,14 +13,9 @@ from nominal.core._clientsbunch import ClientsBunch
 from nominal.core.asset import Asset
 from nominal.core.run import Run
 from nominal.core.workbook import Workbook
-from nominal.core.workbook_template import WorkbookTemplate
 from nominal.experimental.id_utils.id_utils import UUID_RE
 from nominal.experimental.migration.migrator.attachment_migrator import AttachmentMigrator
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
-from nominal.experimental.migration.migrator.workbook_template_migrator import (
-    WorkbookTemplateCopyOptions,
-    WorkbookTemplateMigrator,
-)
 from nominal.experimental.migration.resource_type import ResourceType
 from nominal.experimental.migration.utils.conjure_clone_utils import clone_conjure_objects_with_rid_overrides
 
@@ -52,11 +47,6 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
         return destination_client.get_workbook(mapped_rid)
 
     def _copy_from_impl(self, source: Workbook, options: WorkbookCopyOptions) -> Workbook:
-        """This method copies content from an old workbook to a new workbook by use of templates, in order to
-        modify hardcoded variables in workbook content. We do this by creating a template in the source
-        client, copying the template to the destination client, creating a new workbook from the template in the
-        destination client, and then archiving the template in both clients.
-        """
         existing_workbook = self.get_existing_destination_resource(source)
         if existing_workbook is not None:
             return existing_workbook
@@ -64,62 +54,83 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
         if (options.destination_asset is None) == (options.destination_run is None):
             raise ValueError("Exactly one of destination_asset or destination_run must be provided.")
 
-        # NOTE: source_template is ephemeral — _create_template_from_workbook() assigns it a new rid
-        # on every call. If the process crashes after new_template is created but before new_workbook
-        # is recorded below, the destination template from the previous run becomes orphaned (not
-        # archived) and a fresh one is created on resume. This does not cause duplicate workbooks
-        # (the early-return above handles that), but orphaned templates may accumulate. Fixing this
-        # properly requires a stable dedup key derived from source.rid rather than the ephemeral
-        # source_template.rid.
-        source_template = source._create_template_from_workbook()
-        template_migrator = WorkbookTemplateMigrator(self.ctx)
-        new_template = template_migrator.copy_from(
-            source_template,
-            WorkbookTemplateCopyOptions(include_content_and_layout=True),
+        source_clients = cast(ClientsBunch, source._clients)
+        raw_notebook = source_clients.notebook.get(source_clients.auth_header, source.rid)
+
+        asset_rid_map = dict(self.ctx.migration_state.rid_mapping.get(ResourceType.ASSET.value, {}))
+
+        if options.destination_run is not None:
+            dest_run_rid = options.destination_run.rid
+            source_run_rids = raw_notebook.metadata.data_scope.run_rids or []
+            rid_overrides = {**asset_rid_map, **{r: dest_run_rid for r in source_run_rids}}
+            data_scope = scout_notebook_api.NotebookDataScope(run_rids=[dest_run_rid], asset_rids=None)
+        else:
+            dest_asset_rid = options.destination_asset.rid  # type: ignore[union-attr]
+            source_asset_rids = raw_notebook.metadata.data_scope.asset_rids or []
+            rid_overrides = {**asset_rid_map, **{r: dest_asset_rid for r in source_asset_rids}}
+            data_scope = scout_notebook_api.NotebookDataScope(run_rids=None, asset_rids=[dest_asset_rid])
+
+        return self._copy_workbook(
+            source,
+            raw_notebook,
+            rid_overrides,
+            data_scope,
+            labels=options.new_labels,
+            properties=options.new_properties,
         )
-        new_workbook = self._create_destination_workbook(source, new_template, options)
-        self.ctx.migration_state.record_mapping(self.resource_type, source.rid, new_workbook.rid)
 
-        source_metadata = source._get_latest_api().metadata
-        labels = options.new_labels if options.new_labels is not None else source_metadata.labels
-        properties = options.new_properties if options.new_properties is not None else source_metadata.properties
-        new_workbook.update(labels=labels, properties=properties)
-
-        self._migrate_preview_image(source, new_workbook)
-
-        new_template.archive()
-        source_template.archive()
-        return new_workbook
-
-    def _create_destination_workbook(
+    def _copy_workbook(
         self,
         source: Workbook,
-        new_template: WorkbookTemplate,
-        options: WorkbookCopyOptions,
+        raw_notebook: Any,
+        rid_overrides: dict[str, str],
+        data_scope: scout_notebook_api.NotebookDataScope,
+        labels: Sequence[str] | None = None,
+        properties: Mapping[str, str] | None = None,
     ) -> Workbook:
-        if options.destination_asset is not None:
-            return new_template.create_workbook(
-                asset=options.destination_asset,
-                title=source.title,
-                is_draft=source.is_draft(),
-            )
+        content_v2 = raw_notebook.content_v2
+        if content_v2 is not None and not isinstance(content_v2, scout_workbookcommon_api.UnifiedWorkbookContent):
+            raise ValueError(f"Unexpected content_v2 type for workbook {source.rid}")
+        content = (content_v2.workbook if content_v2 is not None else None) or raw_notebook.content
+        if content is None:
+            raise ValueError(f"Missing content for workbook {source.rid}")
 
-        destination_run = options.destination_run
-        if destination_run is None:
-            raise ValueError("Exactly one of destination_asset or destination_run must be provided.")
-
-        return new_template.create_workbook(
-            run=destination_run,
-            title=source.title,
-            is_draft=source.is_draft(),
+        new_layout, new_content = clone_conjure_objects_with_rid_overrides(
+            (raw_notebook.layout, content), rid_overrides=rid_overrides
         )
+
+        destination_client = self.destination_client_for(source)
+        dest_clients = destination_client._clients
+        request = scout_notebook_api.CreateNotebookRequest(
+            title=raw_notebook.metadata.title,
+            description=raw_notebook.metadata.description,
+            is_draft=source.is_draft(),
+            state_as_json="{}",
+            data_scope=data_scope,
+            layout=new_layout,
+            content_v2=scout_workbookcommon_api.UnifiedWorkbookContent(workbook=new_content),
+            event_refs=[],
+            workspace=dest_clients.resolve_default_workspace_rid(),
+        )
+        raw_new_notebook = dest_clients.notebook.create(dest_clients.auth_header, request)
+        new_workbook = Workbook._from_conjure(dest_clients, raw_new_notebook)
+
+        self.ctx.migration_state.record_mapping(ResourceType.WORKBOOK, source.rid, new_workbook.rid)
+
+        source_metadata = raw_notebook.metadata
+        new_workbook.update(
+            labels=labels if labels is not None else source_metadata.labels,
+            properties=properties if properties is not None else source_metadata.properties,
+        )
+
+        self._migrate_preview_image(source, new_workbook)
+        return new_workbook
 
     def _migrate_preview_image(self, source: Workbook, dest: Workbook) -> None:
         """Migrate preview image attachment RIDs from source to destination workbook.
 
         Reads the source workbook's preview image metadata, migrates any referenced
         attachments, and updates the destination workbook with the remapped RIDs.
-        Content attachments are handled by the template migrator.
         """
         source_clients = cast(ClientsBunch, source._clients)
         source_raw = source_clients.notebook.get(source_clients.auth_header, source.rid)
@@ -186,44 +197,12 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
 
         source_clients = cast(ClientsBunch, source._clients)
         raw_notebook = source_clients.notebook.get(source_clients.auth_header, source.rid)
-
-        content_v2 = raw_notebook.content_v2
-        if content_v2 is not None and not isinstance(content_v2, scout_workbookcommon_api.UnifiedWorkbookContent):
-            raise ValueError(f"Unexpected content_v2 type for workbook {source.rid}")
-        content = (content_v2.workbook if content_v2 is not None else None) or raw_notebook.content
-        if content is None:
-            raise ValueError(f"Missing content for workbook {source.rid}")
-
-        new_layout, new_content = clone_conjure_objects_with_rid_overrides(
-            (raw_notebook.layout, content), rid_overrides=rid_map
+        data_scope = scout_notebook_api.NotebookDataScope(
+            asset_rids=[rid_map[r] for r in source_asset_rids], run_rids=None
         )
+        new_workbook = self._copy_workbook(source, raw_notebook, rid_map, data_scope)
 
-        destination_client = self.destination_client_for(source)
-        dest_clients = destination_client._clients
-        request = scout_notebook_api.CreateNotebookRequest(
-            title=raw_notebook.metadata.title,
-            description=raw_notebook.metadata.description,
-            is_draft=source.is_draft(),
-            state_as_json="{}",
-            data_scope=scout_notebook_api.NotebookDataScope(
-                asset_rids=[rid_map[r] for r in source_asset_rids],
-                run_rids=None,
-            ),
-            layout=new_layout,
-            content_v2=scout_workbookcommon_api.UnifiedWorkbookContent(workbook=new_content),
-            event_refs=[],
-            workspace=dest_clients.resolve_default_workspace_rid(),
-        )
-        raw_new_notebook = dest_clients.notebook.create(dest_clients.auth_header, request)
-        new_workbook = Workbook._from_conjure(dest_clients, raw_new_notebook)
-
-        self.ctx.migration_state.record_mapping(ResourceType.WORKBOOK, source.rid, new_workbook.rid)
         self.ctx.migration_state.clear_pending_multi_asset_workbook(source.rid)
-
-        source_metadata = raw_notebook.metadata
-        new_workbook.update(labels=source_metadata.labels, properties=source_metadata.properties)
-        self._migrate_preview_image(source, new_workbook)
-
         logger.info("Migrated multi-asset workbook %s -> %s", source.rid, new_workbook.rid)
         return new_workbook
 
@@ -251,48 +230,15 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
         # Also remap any asset RIDs embedded in the content (channels resolve against both
         # run RIDs and asset RIDs, so both must be substituted).
         asset_rid_map = dict(self.ctx.migration_state.rid_mapping.get(ResourceType.ASSET.value, {}))
-        rid_overrides = {**asset_rid_map, **rid_map}
 
         source_clients = cast(ClientsBunch, source._clients)
         raw_notebook = source_clients.notebook.get(source_clients.auth_header, source.rid)
-
-        content_v2 = raw_notebook.content_v2
-        if content_v2 is not None and not isinstance(content_v2, scout_workbookcommon_api.UnifiedWorkbookContent):
-            raise ValueError(f"Unexpected content_v2 type for workbook {source.rid}")
-        content = (content_v2.workbook if content_v2 is not None else None) or raw_notebook.content
-        if content is None:
-            raise ValueError(f"Missing content for workbook {source.rid}")
-
-        new_layout, new_content = clone_conjure_objects_with_rid_overrides(
-            (raw_notebook.layout, content), rid_overrides=rid_overrides
+        data_scope = scout_notebook_api.NotebookDataScope(
+            asset_rids=None, run_rids=[rid_map[r] for r in source_run_rids]
         )
+        new_workbook = self._copy_workbook(source, raw_notebook, {**asset_rid_map, **rid_map}, data_scope)
 
-        destination_client = self.destination_client_for(source)
-        dest_clients = destination_client._clients
-        request = scout_notebook_api.CreateNotebookRequest(
-            title=raw_notebook.metadata.title,
-            description=raw_notebook.metadata.description,
-            is_draft=source.is_draft(),
-            state_as_json="{}",
-            data_scope=scout_notebook_api.NotebookDataScope(
-                asset_rids=None,
-                run_rids=[rid_map[r] for r in source_run_rids],
-            ),
-            layout=new_layout,
-            content_v2=scout_workbookcommon_api.UnifiedWorkbookContent(workbook=new_content),
-            event_refs=[],
-            workspace=dest_clients.resolve_default_workspace_rid(),
-        )
-        raw_new_notebook = dest_clients.notebook.create(dest_clients.auth_header, request)
-        new_workbook = Workbook._from_conjure(dest_clients, raw_new_notebook)
-
-        self.ctx.migration_state.record_mapping(ResourceType.WORKBOOK, source.rid, new_workbook.rid)
         self.ctx.migration_state.clear_pending_multi_run_workbook(source.rid)
-
-        source_metadata = raw_notebook.metadata
-        new_workbook.update(labels=source_metadata.labels, properties=source_metadata.properties)
-        self._migrate_preview_image(source, new_workbook)
-
         logger.info("Migrated multi-run workbook %s -> %s", source.rid, new_workbook.rid)
         return new_workbook
 

--- a/tests/core/test_migration_destination_client_resolution.py
+++ b/tests/core/test_migration_destination_client_resolution.py
@@ -117,8 +117,6 @@ def test_nested_migrations_resolve_destination_client_per_child_resource() -> No
     destination_run = MagicMock(rid="run-destination")
     asset_client.create_asset.return_value = destination_asset
     run_client.create_run.return_value = destination_run
-    run_client.get_run.return_value = destination_run
-
     ctx = MigrationContext(
         destination_client=default_client,
         migration_state=MigrationState(),
@@ -143,6 +141,6 @@ def test_nested_migrations_resolve_destination_client_per_child_resource() -> No
     asset_client.create_run.assert_not_called()
     default_client.create_asset.assert_not_called()
     default_client.create_run.assert_not_called()
-    run_client.get_run.assert_called_once_with(destination_run.rid)
+    run_client.get_run.assert_not_called()
     assert ctx.migration_state.get_mapped_rid(ResourceType.ASSET, source_asset.rid) == destination_asset.rid
     assert ctx.migration_state.get_mapped_rid(ResourceType.RUN, source_run.rid) == destination_run.rid

--- a/tests/core/test_multi_workbook_migration.py
+++ b/tests/core/test_multi_workbook_migration.py
@@ -112,93 +112,161 @@ class TestMigrationStatePendingAndSkips:
 
 
 # ---------------------------------------------------------------------------
-# WorkbookMigrator.copy_multi_asset_workbook
+# WorkbookMigrator._copy_from_impl (via copy_from)
 # ---------------------------------------------------------------------------
 
 
-class TestCopyMultiAssetWorkbook:
+class TestCopyFromImpl:
     def _make_migrator(self, **ctx_kwargs: Any) -> tuple[WorkbookMigrator, MigrationContext]:
         ctx = _make_context(**ctx_kwargs)
         return WorkbookMigrator(ctx), ctx
 
     @patch("nominal.experimental.migration.migrator.workbook_migrator.clone_conjure_objects_with_rid_overrides")
     @patch("nominal.experimental.migration.migrator.workbook_migrator.Workbook._from_conjure")
-    def test_happy_path_remaps_rids_records_state_and_copies_metadata(
-        self, mock_from_conjure: MagicMock, mock_clone: MagicMock
+    @patch.object(WorkbookMigrator, "_migrate_content_attachments")
+    def test_asset_workbook_looks_up_rids_from_state(
+        self, mock_migrate_attachments: MagicMock, mock_from_conjure: MagicMock, mock_clone: MagicMock
     ) -> None:
-        """All assets present: RID map is built correctly, clone called with overrides,
-        notebook created with remapped data_scope, mapping recorded, pending cleared,
-        labels/properties copied from source.
+        """Multi-asset workbook: all mapped RIDs are read from migration state, clone called with
+        full asset map as overrides, data_scope contains the new asset RIDs.
         """
+        mock_migrate_attachments.side_effect = lambda source, content: content
         old_a1, old_a2 = _asset_rid(1), _asset_rid(2)
         new_a1, new_a2 = _asset_rid(101), _asset_rid(102)
-        wb_src = _wb_rid(1)
-        wb_dst = _wb_rid(100)
+        wb_src, wb_dst = _wb_rid(1), _wb_rid(100)
 
         migrator, ctx = self._make_migrator()
         ctx.migration_state.record_mapping(ResourceType.ASSET, old_a1, new_a1)
         ctx.migration_state.record_mapping(ResourceType.ASSET, old_a2, new_a2)
-        ctx.migration_state.record_pending_multi_asset_workbook(wb_src, [old_a1, old_a2])
 
         source = _stub_source_workbook(wb_src, asset_rids=[old_a1, old_a2])
         raw_nb = _stub_raw_notebook(labels=["lbl"], properties={"k": "v"})
+        raw_nb.metadata.data_scope.asset_rids = [old_a1, old_a2]
+        raw_nb.metadata.data_scope.run_rids = []
         source._clients.notebook.get.return_value = raw_nb
 
-        new_layout, new_content = MagicMock(), MagicMock()
-        mock_clone.return_value = (new_layout, new_content)
         new_wb = MagicMock()
         new_wb.rid = wb_dst
+        mock_clone.return_value = (MagicMock(), MagicMock())
         mock_from_conjure.return_value = new_wb
 
-        result = migrator.copy_multi_asset_workbook(source, [old_a1, old_a2])
+        from nominal.experimental.migration.migrator.workbook_migrator import WorkbookCopyOptions
 
-        # clone called with the correct RID overrides
-        mock_clone.assert_called_once()
+        result = migrator.copy_from(
+            source, WorkbookCopyOptions(source_to_destination_asset_rid_mapping={old_a1: new_a1, old_a2: new_a2})
+        )
+
         _, kwargs = mock_clone.call_args
         assert kwargs["rid_overrides"] == {old_a1: new_a1, old_a2: new_a2}
 
-        # notebook created with new asset RIDs in data_scope
         create_req = ctx.destination_client._clients.notebook.create.call_args[0][1]  # type: ignore[attr-defined]
         assert set(create_req.data_scope.asset_rids) == {new_a1, new_a2}
         assert create_req.data_scope.run_rids is None
 
-        # state: mapping recorded, pending cleared
         assert ctx.migration_state.get_mapped_rid(ResourceType.WORKBOOK, wb_src) == wb_dst
-        assert wb_src not in ctx.migration_state.pending_multi_asset_workbooks
-
-        # metadata copied
         new_wb.update.assert_called_once_with(labels=["lbl"], properties={"k": "v"})
         assert result is new_wb
 
-    def test_missing_assets_returns_none_and_records_skip(self) -> None:
-        """When one or more asset RIDs are absent from the migration state, returns None,
-        records a skip entry, clears the pending entry, and creates no notebook.
-        """
-        old_a1, old_a2 = _asset_rid(1), _asset_rid(2)
-        new_a1 = _asset_rid(101)
-        wb_src = _wb_rid(1)
-        # old_a2 intentionally not mapped
-
-        migrator, ctx = self._make_migrator()
-        ctx.migration_state.record_mapping(ResourceType.ASSET, old_a1, new_a1)
-        ctx.migration_state.record_pending_multi_asset_workbook(wb_src, [old_a1, old_a2])
-
-        source = _stub_source_workbook(wb_src, asset_rids=[old_a1, old_a2])
-        source._clients.notebook.get.return_value = _stub_raw_notebook()
-
-        result = migrator.copy_multi_asset_workbook(source, [old_a1, old_a2])
-
-        assert result is None
-        assert len(ctx.migration_state.skipped_resources) == 1
-        assert old_a2 in ctx.migration_state.skipped_resources[0].reason
-        assert wb_src not in ctx.migration_state.pending_multi_asset_workbooks
-        ctx.destination_client._clients.notebook.create.assert_not_called()  # type: ignore[attr-defined]
-
     @patch("nominal.experimental.migration.migrator.workbook_migrator.clone_conjure_objects_with_rid_overrides")
     @patch("nominal.experimental.migration.migrator.workbook_migrator.Workbook._from_conjure")
-    def test_idempotent_returns_existing_workbook_without_creating(
-        self, mock_from_conjure: MagicMock, mock_clone: MagicMock
+    @patch.object(WorkbookMigrator, "_migrate_content_attachments")
+    def test_run_workbook_looks_up_rids_from_state(
+        self, mock_migrate_attachments: MagicMock, mock_from_conjure: MagicMock, mock_clone: MagicMock
     ) -> None:
+        """Multi-run workbook: run RIDs looked up from state, asset map also included in overrides,
+        data_scope contains the new run RIDs.
+        """
+        mock_migrate_attachments.side_effect = lambda source, content: content
+        old_r1, old_r2 = _run_rid(1), _run_rid(2)
+        new_r1, new_r2 = _run_rid(101), _run_rid(102)
+        old_a1, new_a1 = _asset_rid(1), _asset_rid(101)
+        wb_src, wb_dst = _wb_rid(1), _wb_rid(100)
+
+        migrator, ctx = self._make_migrator()
+        ctx.migration_state.record_mapping(ResourceType.RUN, old_r1, new_r1)
+        ctx.migration_state.record_mapping(ResourceType.RUN, old_r2, new_r2)
+        ctx.migration_state.record_mapping(ResourceType.ASSET, old_a1, new_a1)
+
+        source = _stub_source_workbook(wb_src, run_rids=[old_r1, old_r2])
+        raw_nb = _stub_raw_notebook()
+        raw_nb.metadata.data_scope.run_rids = [old_r1, old_r2]
+        raw_nb.metadata.data_scope.asset_rids = []
+        source._clients.notebook.get.return_value = raw_nb
+
+        new_wb = MagicMock()
+        new_wb.rid = wb_dst
+        mock_clone.return_value = (MagicMock(), MagicMock())
+        mock_from_conjure.return_value = new_wb
+
+        from nominal.experimental.migration.migrator.workbook_migrator import WorkbookCopyOptions
+
+        result = migrator.copy_from(
+            source,
+            WorkbookCopyOptions(
+                source_to_destination_run_rid_mapping={old_r1: new_r1, old_r2: new_r2},
+                source_to_destination_asset_rid_mapping={old_a1: new_a1},
+            ),
+        )
+
+        _, kwargs = mock_clone.call_args
+        assert kwargs["rid_overrides"] == {old_r1: new_r1, old_r2: new_r2, old_a1: new_a1}
+
+        create_req = ctx.destination_client._clients.notebook.create.call_args[0][1]  # type: ignore[attr-defined]
+        assert set(create_req.data_scope.run_rids) == {new_r1, new_r2}
+        assert create_req.data_scope.asset_rids is None
+
+        assert ctx.migration_state.get_mapped_rid(ResourceType.WORKBOOK, wb_src) == wb_dst
+        assert result is new_wb
+
+    def test_missing_asset_rid_raises(self) -> None:
+        """If a source asset RID is absent from migration state, ValueError is raised."""
+        old_a1, old_a2 = _asset_rid(1), _asset_rid(2)
+        wb_src = _wb_rid(1)
+
+        migrator, ctx = self._make_migrator()
+        ctx.migration_state.record_mapping(ResourceType.ASSET, old_a1, _asset_rid(101))
+        # old_a2 intentionally not mapped
+
+        source = _stub_source_workbook(wb_src, asset_rids=[old_a1, old_a2])
+        raw_nb = _stub_raw_notebook()
+        raw_nb.metadata.data_scope.asset_rids = [old_a1, old_a2]
+        raw_nb.metadata.data_scope.run_rids = []
+        source._clients.notebook.get.return_value = raw_nb
+
+        from nominal.experimental.migration.migrator.workbook_migrator import WorkbookCopyOptions
+
+        with pytest.raises(ValueError, match=old_a2):
+            migrator.copy_from(
+                source, WorkbookCopyOptions(source_to_destination_asset_rid_mapping={old_a1: _asset_rid(101)})
+            )
+
+        ctx.destination_client._clients.notebook.create.assert_not_called()  # type: ignore[attr-defined]
+
+    def test_missing_run_rid_raises(self) -> None:
+        """If a source run RID is absent from migration state, ValueError is raised."""
+        old_r1, old_r2 = _run_rid(1), _run_rid(2)
+        wb_src = _wb_rid(1)
+
+        migrator, ctx = self._make_migrator()
+        ctx.migration_state.record_mapping(ResourceType.RUN, old_r1, _run_rid(101))
+        # old_r2 intentionally not mapped
+
+        source = _stub_source_workbook(wb_src, run_rids=[old_r1, old_r2])
+        raw_nb = _stub_raw_notebook()
+        raw_nb.metadata.data_scope.run_rids = [old_r1, old_r2]
+        raw_nb.metadata.data_scope.asset_rids = []
+        source._clients.notebook.get.return_value = raw_nb
+
+        from nominal.experimental.migration.migrator.workbook_migrator import WorkbookCopyOptions
+
+        with pytest.raises(ValueError, match=old_r2):
+            migrator.copy_from(
+                source, WorkbookCopyOptions(source_to_destination_run_rid_mapping={old_r1: _run_rid(101)})
+            )
+
+        ctx.destination_client._clients.notebook.create.assert_not_called()  # type: ignore[attr-defined]
+
+    def test_idempotent_returns_existing_workbook_without_creating(self) -> None:
         """If the workbook is already in the migration state, the existing destination workbook
         is returned and no new notebook is created.
         """
@@ -211,82 +279,14 @@ class TestCopyMultiAssetWorkbook:
         existing_wb.rid = wb_dst
         ctx.destination_client.get_workbook.return_value = existing_wb  # type: ignore[attr-defined]
 
+        from nominal.experimental.migration.migrator.workbook_migrator import WorkbookCopyOptions
+
         source = _stub_source_workbook(wb_src, asset_rids=[_asset_rid(1)])
-        result = migrator.copy_multi_asset_workbook(source, [_asset_rid(1)])
+        result = migrator.copy_from(
+            source, WorkbookCopyOptions(source_to_destination_asset_rid_mapping={_asset_rid(1): _asset_rid(101)})
+        )
 
         assert result is existing_wb
-        mock_clone.assert_not_called()
-        ctx.destination_client._clients.notebook.create.assert_not_called()  # type: ignore[attr-defined]
-
-
-# ---------------------------------------------------------------------------
-# WorkbookMigrator.copy_multi_run_workbook
-# ---------------------------------------------------------------------------
-
-
-class TestCopyMultiRunWorkbook:
-    def _make_migrator(self) -> tuple[WorkbookMigrator, MigrationContext]:
-        ctx = _make_context()
-        return WorkbookMigrator(ctx), ctx
-
-    @patch("nominal.experimental.migration.migrator.workbook_migrator.clone_conjure_objects_with_rid_overrides")
-    @patch("nominal.experimental.migration.migrator.workbook_migrator.Workbook._from_conjure")
-    def test_happy_path_remaps_run_rids(self, mock_from_conjure: MagicMock, mock_clone: MagicMock) -> None:
-        """All runs present: RID map built, data_scope has new run RIDs, mapping recorded, pending cleared."""
-        old_r1, old_r2 = _run_rid(1), _run_rid(2)
-        new_r1, new_r2 = _run_rid(101), _run_rid(102)
-        wb_src, wb_dst = _wb_rid(1), _wb_rid(100)
-
-        migrator, ctx = self._make_migrator()
-        ctx.migration_state.record_mapping(ResourceType.RUN, old_r1, new_r1)
-        ctx.migration_state.record_mapping(ResourceType.RUN, old_r2, new_r2)
-        ctx.migration_state.record_pending_multi_run_workbook(wb_src, [old_r1, old_r2])
-
-        source = _stub_source_workbook(wb_src, run_rids=[old_r1, old_r2])
-        source._clients.notebook.get.return_value = _stub_raw_notebook()
-        mock_clone.return_value = (MagicMock(), MagicMock())
-        new_wb = MagicMock()
-        new_wb.rid = wb_dst
-        mock_from_conjure.return_value = new_wb
-
-        # Also record a migrated asset to verify it's included in rid_overrides
-        old_a1 = _asset_rid(1)
-        new_a1 = _asset_rid(101)
-        ctx.migration_state.record_mapping(ResourceType.ASSET, old_a1, new_a1)
-
-        result = migrator.copy_multi_run_workbook(source, [old_r1, old_r2])
-
-        _, kwargs = mock_clone.call_args
-        assert kwargs["rid_overrides"] == {old_r1: new_r1, old_r2: new_r2, old_a1: new_a1}
-
-        create_req = ctx.destination_client._clients.notebook.create.call_args[0][1]  # type: ignore[attr-defined]
-        assert set(create_req.data_scope.run_rids) == {new_r1, new_r2}
-        assert create_req.data_scope.asset_rids is None
-
-        assert ctx.migration_state.get_mapped_rid(ResourceType.WORKBOOK, wb_src) == wb_dst
-        assert wb_src not in ctx.migration_state.pending_multi_run_workbooks
-        assert result is new_wb
-
-    def test_missing_run_returns_none_and_records_skip(self) -> None:
-        """A run RID absent from the migration state causes the workbook to be skipped,
-        clears the pending entry, and creates no notebook.
-        """
-        old_r1, old_r2 = _run_rid(1), _run_rid(2)
-        wb_src = _wb_rid(1)
-        migrator, ctx = self._make_migrator()
-        ctx.migration_state.record_mapping(ResourceType.RUN, old_r1, _run_rid(101))
-        ctx.migration_state.record_pending_multi_run_workbook(wb_src, [old_r1, old_r2])
-        # old_r2 not mapped
-
-        source = _stub_source_workbook(wb_src, run_rids=[old_r1, old_r2])
-        source._clients.notebook.get.return_value = _stub_raw_notebook()
-
-        result = migrator.copy_multi_run_workbook(source, [old_r1, old_r2])
-
-        assert result is None
-        assert len(ctx.migration_state.skipped_resources) == 1
-        assert old_r2 in ctx.migration_state.skipped_resources[0].reason
-        assert wb_src not in ctx.migration_state.pending_multi_run_workbooks
         ctx.destination_client._clients.notebook.create.assert_not_called()  # type: ignore[attr-defined]
 
 
@@ -305,19 +305,18 @@ class TestMigrateDeferredWorkbooks:
         migrator.migrate_deferred_workbooks(source_clients)
         # Nothing to assert beyond no exceptions raised
 
-    @patch.object(WorkbookMigrator, "copy_multi_run_workbook")
-    @patch.object(WorkbookMigrator, "copy_multi_asset_workbook")
+    @patch.object(WorkbookMigrator, "copy_from")
     @patch("nominal.experimental.migration.migrator.workbook_migrator.Workbook._from_conjure")
     def test_routes_pending_asset_and_run_workbooks(
         self,
         mock_from_conjure: MagicMock,
-        mock_copy_asset: MagicMock,
-        mock_copy_run: MagicMock,
+        mock_copy_from: MagicMock,
     ) -> None:
-        """Pending asset and run workbooks are fetched from source clients and routed to the
-        correct copy method. The correct source_asset_rids / source_run_rids are forwarded.
-        Multi-run workbook falls back to first available client when no asset RID matches.
+        """Pending asset and run workbooks are fetched from source clients and copy_from is called
+        for each. Multi-run workbook falls back to first available client when no asset RID matches.
         """
+        from nominal.experimental.migration.migrator.workbook_migrator import WorkbookCopyOptions
+
         asset_rid_1 = _asset_rid(1)
         wb_asset = _wb_rid(1)
         wb_run = _wb_rid(2)
@@ -345,9 +344,13 @@ class TestMigrateDeferredWorkbooks:
         source_clients.notebook.get.assert_any_call(source_clients.auth_header, wb_asset)
         source_clients.notebook.get.assert_any_call(source_clients.auth_header, wb_run)
 
-        # Each routed to the correct copy method with the right RID lists
-        mock_copy_asset.assert_called_once_with(source_wb_asset, [asset_rid_1])
-        mock_copy_run.assert_called_once_with(source_wb_run, run_rids)
+        # copy_from called for each with explicit RID mappings built from migration state
+        assert mock_copy_from.call_count == 2
+        mock_copy_from.assert_any_call(source_wb_asset, WorkbookCopyOptions(source_to_destination_asset_rid_mapping={}))
+        mock_copy_from.assert_any_call(
+            source_wb_run,
+            WorkbookCopyOptions(source_to_destination_asset_rid_mapping={}, source_to_destination_run_rid_mapping={}),
+        )
 
     @patch("nominal.experimental.migration.migrator.workbook_migrator.Workbook._from_conjure")
     def test_missing_source_client_for_asset_workbook_skips_gracefully(self, mock_from_conjure: MagicMock) -> None:


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                     
                                                            
  The workbook migrator previously had two strategies for copying workbooks: a template-based path for single-asset/run workbooks, and a find/replace path for multi-asset/run workbooks. We were planning to consolidate these anyway, but a concrete failure case made it the right time to do it now.
                                                                                                                                                                                                                                                 
**The problem with the template path**                    

Using templates introduces another potential failure point, especially if RIDs are still hardcoded in the template's JSON.  Using the template path ignores any hardcoded RIDs that should be re-mapped.  We ran into this issue when hydrating demo workbooks into a another account, where we were still pointing to the old RID when populating channels.

Now that we have a path that uses the find/replace strategy (multi-asset/run workbooks), we should use that and bypass this issue.
                                                                                                                                                                                                                                                 
### The fix                                                                                                                                                                                                                                        
  
  The find/replace path (clone_conjure_objects_with_rid_overrides) does an unconditional value replacement across the entire serialized JSON — it replaces any string value matching a known RID regardless of which field it appears in. This correctly handles both the symbolic "assetRid" style (no replacement needed, travels through unchanged) and the hardcoded RID style (gets remapped to the destination environment).
                                                                                                                                                                                                                                                 
Single-asset/run workbooks now use the same find/replace approach as multi-asset/run workbooks. The copy-immediately vs defer-to-end-of-migration distinction is preserved exactly as before — the routing in asset_migrator.py is unchanged.  
  
As part of the same change, the shared logic across all three copy paths (content extraction, clone, create request, record mapping, update metadata, migrate preview image) is extracted into a _copy_workbook helper, reducing the three methods to just their distinct concerns: building rid_overrides and data_scope.
                                                                                                                                                                                                                                                 
## Test plan                                                 

  - All existing workbook unit tests pass (43/43)
  - ruff format, ruff check, and mypy clean on changed file
  - Performed a manual end-to-end test and verified that workbooks successfully migrated.