### PR TITLE
feat: allow specifying marking rids when creating a dataset from the NominalClient

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -782,6 +782,7 @@ class NominalClient:
         labels: Sequence[str] = (),
         properties: Mapping[str, str] | None = None,
         prefix_tree_delimiter: str | None = None,
+        markings: Sequence[str] | None = None,
     ) -> Dataset:
         """Create an empty dataset.
 
@@ -791,6 +792,7 @@ class NominalClient:
             labels: Text labels to apply to the created dataset
             properties: Key-value properties to apply to the cleated dataset
             prefix_tree_delimiter: If present, the delimiter to represent tiers when viewing channels hierarchically.
+            markings: If present, RIDs of markings to apply to the created dataset
 
         Returns:
             Reference to the created dataset in Nominal.
@@ -803,6 +805,7 @@ class NominalClient:
             labels=labels,
             properties=properties,
             workspace_rid=self._clients.resolve_default_workspace_rid(),
+            marking_rids=markings,
         )
         dataset = Dataset._from_conjure(self._clients, response)
 

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -1122,6 +1122,7 @@ def _create_dataset(
     labels: Sequence[str] = (),
     properties: Mapping[str, str] | None = None,
     workspace_rid: str | None = None,
+    marking_rids: Sequence[str] | None = None,
 ) -> scout_catalog.EnrichedDataset:
     request = scout_catalog.CreateDataset(
         name=name,
@@ -1132,7 +1133,7 @@ def _create_dataset(
         metadata={},
         origin_metadata=scout_catalog.DatasetOriginMetadata(),
         workspace=workspace_rid,
-        marking_rids=[],
+        marking_rids=list(marking_rids or []),
     )
     return client.create_dataset(auth_header, request)
 


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->
