### PR TITLE
feat: expose deeper workspace configuration settings

### DIFF
--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -1,3 +1,4 @@
+from nominal.core._datasource_types import DataSourceType
 from nominal.core._event_types import EventType, SearchEventOriginType
 from nominal.core._stream.write_stream import DataStream, LogStream, WriteStream
 from nominal.core._utils.api_tools import LinkDict
@@ -47,6 +48,7 @@ __all__ = [
     "ChannelDataType",
     "Checklist",
     "CheckViolation",
+    "Comment",
     "Connection",
     "ContainerizedExtractor",
     "DataReview",
@@ -54,6 +56,7 @@ __all__ = [
     "Dataset",
     "DatasetFile",
     "DataSource",
+    "DataSourceType",
     "DataStream",
     "DockerImageSource",
     "Event",
@@ -67,7 +70,6 @@ __all__ = [
     "LinkDict",
     "LogPoint",
     "LogStream",
-    "Comment",
     "NominalClient",
     "poll_until_ingestion_completed",
     "Run",

--- a/nominal/core/_datasource_types.py
+++ b/nominal/core/_datasource_types.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from nominal_api import api
+
+
+class DataSourceType(Enum):
+    """Categorization for Nominal Core datasources"""
+
+    DATASET = "DATASET"
+    CONNECTION = "CONNECTION"
+    VIDEO = "VIDEO"
+    SPATIAL = "SPATIAL"
+    UNKNOWN = "UNKNOWN"
+
+    @classmethod
+    def _from_conjure(cls, datasource_type: api.DataSourceType) -> DataSourceType:
+        match datasource_type.value:
+            case "DATASET":
+                return cls.DATASET
+            case "CONNECTION":
+                return cls.CONNECTION
+            case "VIDEO":
+                return cls.VIDEO
+            case "SPATIAL":
+                return cls.SPATIAL
+            case "UNKNOWN":
+                return cls.UNKNOWN
+            case _:
+                raise ValueError(f"Unknown datasource type: {datasource_type.name}")
+
+    def _to_conjure(self) -> api.DataSourceType:
+        match self.value:
+            case "DATASET":
+                return api.DataSourceType.DATASET
+            case "CONNECTION":
+                return api.DataSourceType.CONNECTION
+            case "VIDEO":
+                return api.DataSourceType.VIDEO
+            case "SPATIAL":
+                return api.DataSourceType.SPATIAL
+            case "UNKNOWN":
+                return api.DataSourceType.UNKNOWN

--- a/nominal/core/_datasource_types.py
+++ b/nominal/core/_datasource_types.py
@@ -28,7 +28,7 @@ class DataSourceType(Enum):
             case "UNKNOWN":
                 return cls.UNKNOWN
             case _:
-                raise ValueError(f"Unknown datasource type: {datasource_type.name}")
+                raise ValueError(f"Unknown datasource type: {datasource_type.value}")
 
     def _to_conjure(self) -> api.DataSourceType:
         match self.value:
@@ -42,3 +42,5 @@ class DataSourceType(Enum):
                 return api.DataSourceType.SPATIAL
             case "UNKNOWN":
                 return api.DataSourceType.UNKNOWN
+            case _:
+                raise ValueError(f"Unknown datasource type: {self.value}")

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -292,12 +292,12 @@ class NominalClient:
             conjure_python_client.ConjureHTTPError: Requested workspace is unavailable to the user.
         """
         raw_workspace = self._clients.resolve_workspace(workspace_rid)
-        return Workspace._from_conjure(raw_workspace)
+        return Workspace._from_conjure(self._clients, raw_workspace)
 
     def list_workspaces(self) -> Sequence[Workspace]:
         """Return all workspaces visible to the current user"""
         return [
-            Workspace._from_conjure(raw_workspace)
+            Workspace._from_conjure(self._clients, raw_workspace)
             for raw_workspace in self._clients.workspace.get_workspaces(self._clients.auth_header)
         ]
 

--- a/nominal/core/workspace.py
+++ b/nominal/core/workspace.py
@@ -29,8 +29,13 @@ class Workspace(HasRid, RefreshableMixin[security_api_workspace.Workspace]):
     This is the name that users will see when selecting workspaces within the product.
     """
 
+    preferred_refnames: Mapping[str, DataSourceType]
+    """Mapping of preferred refnames to their respective datasource types they apply towards"""
+
+    preferred_procedure_rids: Sequence[str]
+    """Preferred procedure rids that are accessible from the application home page"""
+
     _clients: _Clients = field(repr=False)
-    _workspace_settings: security_api_workspace.WorkspaceSettings = field(repr=False)
 
     class _Clients(HasScoutParams, Protocol):
         @property
@@ -39,39 +44,6 @@ class Workspace(HasRid, RefreshableMixin[security_api_workspace.Workspace]):
     def _get_latest_api(self) -> security_api_workspace.Workspace:
         """Retrieve the latest state of this Workspace from the API."""
         return self._clients.workspace.get_workspace(self._clients.auth_header, self.rid)
-
-    @property
-    def preferred_refnames(self) -> Mapping[str, DataSourceType]:
-        """Get mapping of preferred refnames to their respective datasource types that they apply towards."""
-        refname_settings = self._workspace_settings.ref_names
-        if refname_settings is None:
-            return {}
-
-        v1_preferred_refnames = refname_settings.v1
-        if v1_preferred_refnames is None:
-            return {}
-
-        return {
-            refname_and_type.name: DataSourceType._from_conjure(refname_and_type.type)
-            for refname_and_type in v1_preferred_refnames
-        }
-
-    @property
-    def preferred_procedure_rids(self) -> Sequence[str]:
-        """Get the list of preferred procedure rids.
-
-        Unlike other procedures which can only be kicked off from the procedures page, preferred procedures
-        may be kicked off from the homepage of the application
-        """
-        procedure_settings = self._workspace_settings.procedures
-        if procedure_settings is None:
-            return []
-
-        v1_preferred_procedures = procedure_settings.v1
-        if v1_preferred_procedures is None:
-            return []
-
-        return v1_preferred_procedures.workspace_procedures
 
     @overload
     def update(self, *, display_name: str | None = None) -> Self: ...
@@ -152,6 +124,42 @@ class Workspace(HasRid, RefreshableMixin[security_api_workspace.Workspace]):
             id=workspace.id,
             org=workspace.org,
             display_name=workspace.display_name,
+            preferred_refnames=_parse_preferred_refnames(workspace.settings),
+            preferred_procedure_rids=_parse_preferred_procedure_rids(workspace.settings),
             _clients=clients,
-            _workspace_settings=workspace.settings,
         )
+
+
+def _parse_preferred_refnames(
+    workspace_settings: security_api_workspace.WorkspaceSettings,
+) -> Mapping[str, DataSourceType]:
+    """Get mapping of preferred refnames to their respective datasource types that they apply towards."""
+    refname_settings = workspace_settings.ref_names
+    if refname_settings is None:
+        return {}
+
+    v1_preferred_refnames = refname_settings.v1
+    if v1_preferred_refnames is None:
+        return {}
+
+    return {
+        refname_and_type.name: DataSourceType._from_conjure(refname_and_type.type)
+        for refname_and_type in v1_preferred_refnames
+    }
+
+
+def _parse_preferred_procedure_rids(workspace_settings: security_api_workspace.WorkspaceSettings) -> Sequence[str]:
+    """Get the list of preferred procedure rids.
+
+    Unlike other procedures which can only be kicked off from the procedures page, preferred procedures
+    may be kicked off from the homepage of the application
+    """
+    procedure_settings = workspace_settings.procedures
+    if procedure_settings is None:
+        return []
+
+    v1_preferred_procedures = procedure_settings.v1
+    if v1_preferred_procedures is None:
+        return []
+
+    return v1_preferred_procedures.workspace_procedures

--- a/nominal/core/workspace.py
+++ b/nominal/core/workspace.py
@@ -1,23 +1,163 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Mapping, Protocol, Sequence, overload
 
-from nominal_api import security_api_workspace
+from nominal_api import api, security_api_workspace
 from typing_extensions import Self
 
-from nominal.core._utils.api_tools import HasRid
+from nominal.core._clientsbunch import HasScoutParams
+from nominal.core._datasource_types import DataSourceType
+from nominal.core._utils.api_tools import HasRid, RefreshableMixin
 
 
 @dataclass(frozen=True)
-class Workspace(HasRid):
+class Workspace(HasRid, RefreshableMixin[security_api_workspace.Workspace]):
     rid: str
+    """RID of this workspace."""
+
     id: str
+    """Internal unique identifier for the workspace within the organization.
+    The ID must be lower case alphanumetric characters, optionally separated by hyphens.
+    """
+
     org: str
+    """RID of the Organization backing the workspace."""
+
+    display_name: str | None
+    """User-facing display name set by organization admins for this Workspace.
+    This is the name that users will see when selecting workspaces within the product.
+    """
+
+    _clients: _Clients = field(repr=False)
+    _workspace_settings: security_api_workspace.WorkspaceSettings = field(repr=False)
+
+    class _Clients(HasScoutParams, Protocol):
+        @property
+        def workspace(self) -> security_api_workspace.WorkspaceService: ...
+
+    def _get_latest_api(self) -> security_api_workspace.Workspace:
+        """Retrieve the latest state of this Workspace from the API."""
+        return self._clients.workspace.get_workspace(self._clients.auth_header, self.rid)
+
+    @property
+    def preferred_refnames(self) -> Mapping[str, DataSourceType]:
+        """Get list of preferred refnames for the given datasource type.
+
+        Args:
+            datasource_type: Optionally filter preferred refnames by datasource type
+
+        Returns:
+            List of preferred refnames for the given datasource type (or all preferred refnames if none provided)
+        """
+        refname_settings = self._workspace_settings.ref_names
+        if refname_settings is None:
+            return {}
+
+        v1_preferred_refnames = refname_settings.v1
+        if v1_preferred_refnames is None:
+            return {}
+
+        return {
+            refname_and_type.name: DataSourceType._from_conjure(refname_and_type.type)
+            for refname_and_type in v1_preferred_refnames
+        }
+
+    @property
+    def preferred_procedure_rids(self) -> Sequence[str]:
+        """Get the list of preferred procedure rids.
+
+        Unlike other procedures which can only be kicked off from the procedures page, preferred procedures
+        may be kicked off from the homepage of the application
+        """
+        procedure_settings = self._workspace_settings.procedures
+        if procedure_settings is None:
+            return []
+
+        v1_preferred_procedures = procedure_settings.v1
+        if v1_preferred_procedures is None:
+            return []
+
+        return v1_preferred_procedures.workspace_procedures
+
+    @overload
+    def update(self, *, display_name: str | None = None) -> Self: ...
+    @overload
+    def update(
+        self,
+        *,
+        display_name: str | None = None,
+        preferred_procedures: Sequence[str],
+        preferred_refnames: Mapping[str, DataSourceType],
+    ) -> Self: ...
+    def update(
+        self,
+        *,
+        display_name: str | None = None,
+        preferred_procedures: Sequence[str] | None = None,
+        preferred_refnames: Mapping[str, DataSourceType] | None = None,
+    ) -> Self:
+        """Replace workspace metadata.
+        Updates the current instance, and returns it.
+        Only the metadata passed in will be replaced, the rest will remain untouched.
+
+        Args:
+            display_name: User-visible display name for the workspace within the application when switching workspaces.
+            preferred_procedures: List of preferred procedures to expose as runnable on the frontend.
+            preferred_refnames: Mapping of preferred refnames to the types of datasource they may be used for.
+
+        Returns:
+            Updated workspace metadata
+
+
+        NOTE: This replaces the metadata rather than appending it. To append to preferred refnames,
+            merge them before calling this method, e.g.:
+
+            ```
+            workspace.update(preferred_refnames={**workspace.preferred_refnames, "apples": DataSourceType.DATASET})
+            ```
+
+        NOTE: If setting preferred procedures or preferred refnames, *both* must be set, or neither must be set.
+              Otherwise, setting one but not the other would clear out configuration for the other.
+        """
+        display_name_req = None
+        if display_name is not None:
+            display_name_req = security_api_workspace.UpdateOrRemoveWorkspaceDisplayName(display_name=display_name)
+
+        workspace_settings_req = None
+        if (preferred_procedures is not None and preferred_refnames is None) or (
+            preferred_procedures is None and preferred_refnames is not None
+        ):
+            raise ValueError(
+                "Cannot set only preferred procedures or preferred refnames-- either both or neither must be provided!"
+            )
+        elif preferred_procedures is not None and preferred_refnames is not None:
+            workspace_settings_req = security_api_workspace.WorkspaceSettings(
+                procedures=security_api_workspace.ProcedureSettings(
+                    v1=security_api_workspace.ProcedureSettingsV1(workspace_procedures=preferred_procedures)
+                ),
+                ref_names=security_api_workspace.PreferredRefNameConfiguration(
+                    v1=[
+                        api.RefNameAndType(name=refname, type=datasource_type._to_conjure())
+                        for refname, datasource_type in preferred_refnames.items()
+                    ]
+                ),
+            )
+
+        req = security_api_workspace.UpdateWorkspaceRequest(
+            display_name=display_name_req,
+            settings=workspace_settings_req,
+        )
+        resp = self._clients.workspace.update_workspace(self._clients.auth_header, req, self.rid)
+        return self._refresh_from_api(resp)
 
     @classmethod
-    def _from_conjure(cls, workspace: security_api_workspace.Workspace) -> Self:
+    def _from_conjure(cls, clients: _Clients, workspace: security_api_workspace.Workspace) -> Self:
         return cls(
             rid=workspace.rid,
             id=workspace.id,
             org=workspace.org,
+            display_name=workspace.display_name,
+            _clients=clients,
+            _workspace_settings=workspace.settings,
         )

--- a/nominal/core/workspace.py
+++ b/nominal/core/workspace.py
@@ -128,7 +128,7 @@ class Workspace(HasRid, RefreshableMixin[security_api_workspace.Workspace]):
         elif preferred_procedures is not None and preferred_refnames is not None:
             workspace_settings_req = security_api_workspace.WorkspaceSettings(
                 procedures=security_api_workspace.ProcedureSettings(
-                    v1=security_api_workspace.ProcedureSettingsV1(workspace_procedures=preferred_procedures)
+                    v1=security_api_workspace.ProcedureSettingsV1(workspace_procedures=[*preferred_procedures])
                 ),
                 ref_names=security_api_workspace.PreferredRefNameConfiguration(
                     v1=[

--- a/nominal/core/workspace.py
+++ b/nominal/core/workspace.py
@@ -42,14 +42,7 @@ class Workspace(HasRid, RefreshableMixin[security_api_workspace.Workspace]):
 
     @property
     def preferred_refnames(self) -> Mapping[str, DataSourceType]:
-        """Get list of preferred refnames for the given datasource type.
-
-        Args:
-            datasource_type: Optionally filter preferred refnames by datasource type
-
-        Returns:
-            List of preferred refnames for the given datasource type (or all preferred refnames if none provided)
-        """
+        """Get mapping of preferred refnames to their respective datasource types that they apply towards."""
         refname_settings = self._workspace_settings.ref_names
         if refname_settings is None:
             return {}
@@ -117,7 +110,7 @@ class Workspace(HasRid, RefreshableMixin[security_api_workspace.Workspace]):
             workspace.update(preferred_refnames={**workspace.preferred_refnames, "apples": DataSourceType.DATASET})
             ```
 
-        NOTE: If setting preferred procedures or preferred refnames, *both* must be set, or neither must be set.
+        NOTE: If setting preferred procedures or preferred refnames, *both* must be set, or *neither* must be set.
               Otherwise, setting one but not the other would clear out configuration for the other.
         """
         display_name_req = None
@@ -129,7 +122,8 @@ class Workspace(HasRid, RefreshableMixin[security_api_workspace.Workspace]):
             preferred_procedures is None and preferred_refnames is not None
         ):
             raise ValueError(
-                "Cannot set only preferred procedures or preferred refnames-- either both or neither must be provided!"
+                "Both preferred_procedures and preferred_refnames must be provided together, or neither should be "
+                "provided. This prevents accidentally clearing one setting when updating the other."
             )
         elif preferred_procedures is not None and preferred_refnames is not None:
             workspace_settings_req = security_api_workspace.WorkspaceSettings(

--- a/nominal/experimental/migration/migrator/base.py
+++ b/nominal/experimental/migration/migrator/base.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import Generic
+
+from typing_extensions import TypeVar
 
 from nominal.core import NominalClient
 from nominal.core._utils.api_tools import HasRid

--- a/tests/core/test_workspace_resolution.py
+++ b/tests/core/test_workspace_resolution.py
@@ -23,13 +23,22 @@ def _raw_workspace(rid: str) -> MagicMock:
     workspace.rid = rid
     workspace.id = rid.rsplit(".", 1)[-1]
     workspace.org = "test-org"
+    workspace.display_name = "test-display"
     return workspace
 
 
 def test_workspace_rid_for_search_returns_workspace_object_rid_immediately() -> None:
     """Passing a Workspace object should return its RID without any further client lookups."""
     client, clients = _make_client()
-    workspace = Workspace(rid="ri.workspace.main.workspace.manual", id="manual", org="test-org")
+    workspace = Workspace(
+        rid="ri.workspace.main.workspace.manual",
+        id="manual",
+        org="test-org",
+        display_name="test-display",
+        preferred_refnames={},
+        preferred_procedure_rids=[],
+        _clients=clients,
+    )
 
     assert client._workspace_rid_for_search(workspace) == workspace.rid
 


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

* Allow users to retrieve and set workspace display names preferred refnames & procedures programmatically

## Testing Done

Manually tested on staging / prod 