### PR TITLE
feat: allow for excluded workbooks in asset migration

### DIFF
--- a/nominal/experimental/migration/config/migration_resources.py
+++ b/nominal/experimental/migration/config/migration_resources.py
@@ -11,6 +11,7 @@ from nominal.core.workbook_template import WorkbookTemplate
 class AssetResources:
     asset: Asset
     source_workbook_templates: Sequence[WorkbookTemplate]
+    source_workbook_rids: frozenset[str] | None = None
 
 
 @dataclass(frozen=True)

--- a/nominal/experimental/migration/migration_runner.py
+++ b/nominal/experimental/migration/migration_runner.py
@@ -108,6 +108,7 @@ class MigrationRunner:
                         include_video=self.asset_inclusion_config.include_video,
                         include_checklists=self.asset_inclusion_config.include_checklists,
                         include_workbooks=self.asset_inclusion_config.include_workbooks,
+                        workbook_rids_allowlist=asset_resources.source_workbook_rids,
                     ),
                 )
 

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -9,6 +9,7 @@ from nominal_api import scout_asset_api
 from nominal.core import NominalClient
 from nominal.core._event_types import SearchEventOriginType
 from nominal.core.asset import Asset
+from nominal.core.run import Run
 from nominal.core.workbook import Workbook
 from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
 from nominal.experimental.migration.migrator.attachment_migrator import AttachmentMigrator
@@ -88,7 +89,9 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             self._copy_asset_attachments(source_asset, new_asset)
 
         if options.include_workbooks:
-            self._copy_asset_and_run_workbooks(source_asset, new_asset, options.include_runs, options.workbook_rids_allowlist)
+            self._copy_asset_and_run_workbooks(
+                source_asset, new_asset, options.include_runs, options.workbook_rids_allowlist
+            )
         return new_asset
 
     def _get_resource_name(self, resource: Asset) -> str:
@@ -232,8 +235,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
         workbook_rids_allowlist: frozenset[str] | None = None,
     ) -> None:
         workbook_migrator = WorkbookMigrator(self.ctx)
-        asset_workbooks = source_asset.search_workbooks(include_drafts=True)
-        for workbook in asset_workbooks:
+        for workbook in source_asset.search_workbooks(include_drafts=True):
             if workbook_rids_allowlist is not None and workbook.rid not in workbook_rids_allowlist:
                 logger.debug("Skipping workbook %s (rid: %s): not in allowlist", workbook.title, workbook.rid)
                 continue
@@ -253,22 +255,35 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                 if dest_run_rid is None:
                     logger.warning("Run %s not found in migration state", source_run.rid)
                     continue
-                for workbook in source_run.search_workbooks(include_drafts=True):
-                    if workbook_rids_allowlist is not None and workbook.rid not in workbook_rids_allowlist:
-                        logger.debug("Skipping workbook %s (rid: %s): not in allowlist", workbook.title, workbook.rid)
-                        continue
-                    if not workbook.run_rids:
-                        continue
-                    if len(workbook.run_rids) == 1:
-                        workbook_migrator.copy_from(
-                            workbook,
-                            WorkbookCopyOptions(
-                                source_to_destination_asset_rid_mapping={source_asset.rid: new_asset.rid},
-                                source_to_destination_run_rid_mapping={source_run.rid: dest_run_rid},
-                            ),
-                        )
-                    else:
-                        self._enqueue_multi_run_workbook(workbook, list(workbook.run_rids))
+                self._copy_run_workbooks(
+                    source_run, source_asset, new_asset, dest_run_rid, workbook_migrator, workbook_rids_allowlist
+                )
+
+    def _copy_run_workbooks(
+        self,
+        source_run: Run,
+        source_asset: Asset,
+        new_asset: Asset,
+        dest_run_rid: str,
+        workbook_migrator: WorkbookMigrator,
+        workbook_rids_allowlist: frozenset[str] | None,
+    ) -> None:
+        for workbook in source_run.search_workbooks(include_drafts=True):
+            if workbook_rids_allowlist is not None and workbook.rid not in workbook_rids_allowlist:
+                logger.debug("Skipping workbook %s (rid: %s): not in allowlist", workbook.title, workbook.rid)
+                continue
+            if not workbook.run_rids:
+                continue
+            if len(workbook.run_rids) == 1:
+                workbook_migrator.copy_from(
+                    workbook,
+                    WorkbookCopyOptions(
+                        source_to_destination_asset_rid_mapping={source_asset.rid: new_asset.rid},
+                        source_to_destination_run_rid_mapping={source_run.rid: dest_run_rid},
+                    ),
+                )
+            else:
+                self._enqueue_multi_run_workbook(workbook, list(workbook.run_rids))
 
     def _enqueue_multi_asset_workbook(self, workbook: Workbook, source_asset_rids: list[str]) -> None:
         missing = [

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -37,6 +37,7 @@ class AssetCopyOptions(ResourceCopyOptions):
     include_video: bool = False
     include_checklists: bool = False
     include_workbooks: bool = True
+    workbook_rids_allowlist: frozenset[str] | None = None
 
 
 class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
@@ -87,7 +88,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             self._copy_asset_attachments(source_asset, new_asset)
 
         if options.include_workbooks:
-            self._copy_asset_and_run_workbooks(source_asset, new_asset, options.include_runs)
+            self._copy_asset_and_run_workbooks(source_asset, new_asset, options.include_runs, options.workbook_rids_allowlist)
         return new_asset
 
     def _get_resource_name(self, resource: Asset) -> str:
@@ -223,10 +224,19 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                     source_asset.rid,
                 )
 
-    def _copy_asset_and_run_workbooks(self, source_asset: Asset, new_asset: Asset, include_runs: bool) -> None:
+    def _copy_asset_and_run_workbooks(
+        self,
+        source_asset: Asset,
+        new_asset: Asset,
+        include_runs: bool,
+        workbook_rids_allowlist: frozenset[str] | None = None,
+    ) -> None:
         workbook_migrator = WorkbookMigrator(self.ctx)
         asset_workbooks = source_asset.search_workbooks(include_drafts=True)
         for workbook in asset_workbooks:
+            if workbook_rids_allowlist is not None and workbook.rid not in workbook_rids_allowlist:
+                logger.debug("Skipping workbook %s (rid: %s): not in allowlist", workbook.title, workbook.rid)
+                continue
             if not workbook.asset_rids:
                 continue
             if len(workbook.asset_rids) == 1:
@@ -244,6 +254,9 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                     logger.warning("Run %s not found in migration state", source_run.rid)
                     continue
                 for workbook in source_run.search_workbooks(include_drafts=True):
+                    if workbook_rids_allowlist is not None and workbook.rid not in workbook_rids_allowlist:
+                        logger.debug("Skipping workbook %s (rid: %s): not in allowlist", workbook.title, workbook.rid)
+                        continue
                     if not workbook.run_rids:
                         continue
                     if len(workbook.run_rids) == 1:

--- a/tests/core/test_asset_migrator.py
+++ b/tests/core/test_asset_migrator.py
@@ -315,9 +315,9 @@ class TestAssetMigratorWorkbookRouting:
         a1 = _asset_rid(1)
         r1 = _run_rid(1)
         new_r1 = _run_rid(101)
-        wb_asset = _wb_rid(1)       # allowlisted
-        wb_run_allowed = _wb_rid(2) # allowlisted
-        wb_run_blocked = _wb_rid(3) # not allowlisted
+        wb_asset = _wb_rid(1)  # allowlisted
+        wb_run_allowed = _wb_rid(2)  # allowlisted
+        wb_run_blocked = _wb_rid(3)  # not allowlisted
 
         ctx = _make_context(source_asset_rids=frozenset([a1]))
         ctx.migration_state.record_mapping(ResourceType.RUN, r1, new_r1)

--- a/tests/core/test_asset_migrator.py
+++ b/tests/core/test_asset_migrator.py
@@ -241,6 +241,111 @@ class TestAssetMigratorWorkbookRouting:
         assert len(state.skipped_resources) == 1
         assert a_out in state.skipped_resources[0].reason
 
+    # ---------------------------------------------------------------------------
+    # Workbook allowlist
+    # ---------------------------------------------------------------------------
+
+    @patch("nominal.experimental.migration.migrator.asset_migrator.WorkbookMigrator")
+    def test_allowlist_none_copies_all_asset_workbooks(self, mock_wm_cls: MagicMock) -> None:
+        """When allowlist is None, all single-asset workbooks are copied (default behaviour preserved)."""
+        a1 = _asset_rid(1)
+        wb1, wb2 = _wb_rid(1), _wb_rid(2)
+
+        ctx = _make_context(source_asset_rids=frozenset([a1]))
+        source_asset = _make_source_asset(rid=a1)
+        new_asset = _make_dest_asset()
+        source_asset.search_workbooks.return_value = [
+            _stub_workbook(wb1, asset_rids=[a1]),
+            _stub_workbook(wb2, asset_rids=[a1]),
+        ]
+        source_asset.list_runs.return_value = []
+
+        AssetMigrator(ctx)._copy_asset_and_run_workbooks(
+            source_asset, new_asset, include_runs=False, workbook_rids_allowlist=None
+        )
+
+        assert mock_wm_cls.return_value.copy_from.call_count == 2
+
+    @patch("nominal.experimental.migration.migrator.asset_migrator.WorkbookMigrator")
+    def test_allowlist_skips_non_allowlisted_asset_workbooks(self, mock_wm_cls: MagicMock) -> None:
+        """Only workbooks whose RID is in the allowlist are copied; others are silently skipped."""
+        a1 = _asset_rid(1)
+        wb1, wb2 = _wb_rid(1), _wb_rid(2)
+
+        ctx = _make_context(source_asset_rids=frozenset([a1]))
+        source_asset = _make_source_asset(rid=a1)
+        new_asset = _make_dest_asset()
+        source_asset.search_workbooks.return_value = [
+            _stub_workbook(wb1, asset_rids=[a1]),
+            _stub_workbook(wb2, asset_rids=[a1]),
+        ]
+        source_asset.list_runs.return_value = []
+
+        AssetMigrator(ctx)._copy_asset_and_run_workbooks(
+            source_asset, new_asset, include_runs=False, workbook_rids_allowlist=frozenset([wb1])
+        )
+
+        mock_wm = mock_wm_cls.return_value
+        assert mock_wm.copy_from.call_count == 1
+        assert mock_wm.copy_from.call_args[0][0].rid == wb1
+
+    @patch("nominal.experimental.migration.migrator.asset_migrator.WorkbookMigrator")
+    def test_allowlist_empty_skips_all_workbooks(self, mock_wm_cls: MagicMock) -> None:
+        """An empty frozenset allowlist causes all workbooks to be skipped."""
+        a1 = _asset_rid(1)
+
+        ctx = _make_context(source_asset_rids=frozenset([a1]))
+        source_asset = _make_source_asset(rid=a1)
+        new_asset = _make_dest_asset()
+        source_asset.search_workbooks.return_value = [
+            _stub_workbook(_wb_rid(1), asset_rids=[a1]),
+            _stub_workbook(_wb_rid(2), asset_rids=[a1]),
+        ]
+        source_asset.list_runs.return_value = []
+
+        AssetMigrator(ctx)._copy_asset_and_run_workbooks(
+            source_asset, new_asset, include_runs=False, workbook_rids_allowlist=frozenset()
+        )
+
+        mock_wm_cls.return_value.copy_from.assert_not_called()
+
+    @patch("nominal.experimental.migration.migrator.asset_migrator.WorkbookMigrator")
+    def test_allowlist_applies_to_run_workbooks(self, mock_wm_cls: MagicMock) -> None:
+        """Allowlist filters run-level workbooks with the same logic as asset-level workbooks."""
+        a1 = _asset_rid(1)
+        r1 = _run_rid(1)
+        new_r1 = _run_rid(101)
+        wb_asset = _wb_rid(1)       # allowlisted
+        wb_run_allowed = _wb_rid(2) # allowlisted
+        wb_run_blocked = _wb_rid(3) # not allowlisted
+
+        ctx = _make_context(source_asset_rids=frozenset([a1]))
+        ctx.migration_state.record_mapping(ResourceType.RUN, r1, new_r1)
+
+        source_asset = _make_source_asset(rid=a1)
+        new_asset = _make_dest_asset()
+        source_asset.search_workbooks.return_value = [_stub_workbook(wb_asset, asset_rids=[a1])]
+
+        run1 = MagicMock()
+        run1.rid = r1
+        run1.search_workbooks.return_value = [
+            _stub_workbook(wb_run_allowed, run_rids=[r1]),
+            _stub_workbook(wb_run_blocked, run_rids=[r1]),
+        ]
+        source_asset.list_runs.return_value = [run1]
+
+        AssetMigrator(ctx)._copy_asset_and_run_workbooks(
+            source_asset,
+            new_asset,
+            include_runs=True,
+            workbook_rids_allowlist=frozenset([wb_asset, wb_run_allowed]),
+        )
+
+        mock_wm = mock_wm_cls.return_value
+        assert mock_wm.copy_from.call_count == 2
+        copied_rids = {c[0][0].rid for c in mock_wm.copy_from.call_args_list}
+        assert copied_rids == {wb_asset, wb_run_allowed}
+
     @patch("nominal.experimental.migration.migrator.asset_migrator.WorkbookMigrator")
     def test_multi_run_workbook_always_enqueued_single_run_uses_copy_from(self, mock_wm_cls: MagicMock) -> None:
         """Single-run workbooks go to copy_from; multi-run workbooks are always enqueued

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -443,6 +443,7 @@ def test_migrate_asset_maximal(  # noqa: PLR0915
     - All child resources exist on the destination with RID mappings in state
     - Metadata (name, description, labels, properties) is preserved for each resource
     - Resources are correctly linked to the migrated destination asset
+    - Workbooks not in source_workbook_rids are excluded from migration
     """
     # --- source setup ---
     start = datetime(2024, 1, 1)
@@ -459,9 +460,21 @@ def test_migrate_asset_maximal(  # noqa: PLR0915
     source_workbook = _create_source_workbook(source_client, register_cleanup, source_asset)
     source_run_b = _create_source_run(source_client, register_cleanup, source_asset, start, end)
     source_multi_run_wb = _create_multi_run_workbook(source_client, register_cleanup, source_run, source_run_b)
+    wb_excluded = _create_source_workbook(source_client, register_cleanup, source_asset)
 
     # --- migrate ---
-    runner = _make_runner(_make_resources(source_asset), _no_files_config(), dest_client, tmp_path / "state.json")
+    # source_workbook_rids restricts migration to the two intended workbooks; wb_excluded is omitted.
+    resources = MigrationResources(
+        source_assets={
+            source_asset.rid: AssetResources(
+                asset=source_asset,
+                source_workbook_templates=[],
+                source_workbook_rids=frozenset([source_workbook.rid, source_multi_run_wb.rid]),
+            )
+        },
+        source_standalone_templates=[],
+    )
+    runner = _make_runner(resources, _no_files_config(), dest_client, tmp_path / "state.json")
     runner.run_migration()
     state = runner.migration_state
 
@@ -538,6 +551,9 @@ def test_migrate_asset_maximal(  # noqa: PLR0915
     dest_multi_run_wb = dest_client.get_workbook(dest_multi_run_wb_rid)
     register_cleanup(dest_multi_run_wb.archive)
     _assert_workbook_migrated_multi_run(source_multi_run_wb, dest_multi_run_wb, [dest_run, dest_run_b])
+
+    # --- workbook allowlist: excluded workbook is absent from migration state ---
+    assert state.get_mapped_rid(ResourceType.WORKBOOK, wb_excluded.rid) is None
 
 
 def test_migrate_asset_minimal(


### PR DESCRIPTION
During the sandbox hydration migration, we discovered that the migration was inadvertently copying draft workbooks from the source asset into the destination workspace. While these drafts were never being promoted to the demo workbooks list
(that logic was already correct), they were still being created in the destination, cluttering the sandbox with incomplete workbooks that customers shouldn't see.

The root cause is that `AssetMigrator._copy_asset_and_run_workbooks` calls `search_workbooks(include_drafts=True)` and blindly copies every workbook it finds on the source asset, regardless of whether it belongs to the curated demo set. The right
fix is to give callers a way to restrict which workbooks get migrated rather than cleaning up the mess post-hoc.

Rather than making nominal-client aware of the concept of "demo workbooks" (which belongs in internal-tools), we introduced a generic workbook allowlist: AssetResources now carries an optional source_workbook_rids: frozenset[str] | None
field. When None, behavior is unchanged and all workbooks are migrated. When populated, only workbooks whose RIDs appear in the set are copied — both at the asset level and for run-scoped workbooks. AssetCopyOptions gains a matching
workbook_rids_allowlist field that MigrationRunner passes through from AssetResources. This pattern is intentionally symmetric so it can be replicated for other resource types (runs, checklists) in the future by following the same shape.

On the internal-tools side, when set_to_demo_workbook is true, we now fetch the source demo workbook RIDs from the API once upfront and use them to populate source_workbook_rids on every AssetResources before migration begins. This
pre-fetched set is reused for validation (so that draft workbooks with missing metadata no longer cause spurious validation failures) and passed directly into _update_demo_workbooks to avoid a redundant API call on each destination profile.

Test coverage was added at both levels. Four unit test cases were added to `test_asset_migrator.py` covering the None (all-pass), populated allowlist, empty allowlist, and run-workbook filtering scenarios. The existing
test_migrate_asset_maximal e2e test was extended to exercise this path in a real migration: a third workbook is created on the source asset and intentionally omitted from source_workbook_rids, with a final assertion confirming it has no
mapping in the migration state after the run.

<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

