### PR TITLE
chore: bump nominal-api

### DIFF
--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -195,7 +195,9 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
 
         def request_factory(page_token: scout_compute_api.PageToken | None) -> scout_compute_api.ComputeNodeRequest:
             return scout_compute_api.ComputeNodeRequest(
-                context=scout_compute_api.Context(frame_references={}, variables={}, function_variables={}),
+                context=scout_compute_api.Context(
+                    dataset_references={}, frame_references={}, variables={}, function_variables={}
+                ),
                 start=api_start,
                 end=api_end,
                 node=scout_compute_api.ComputableNode(
@@ -357,6 +359,7 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
                 )
             ),
             context=scout_compute_api.Context(
+                dataset_references={},
                 frame_references={},
                 variables={},
                 function_variables={},
@@ -405,6 +408,7 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
             start_time=start,
             end_time=end,
             context=scout_compute_api.Context(
+                dataset_references={},
                 frame_references={},
                 variables={},
                 function_variables={},

--- a/nominal/core/channel.py
+++ b/nominal/core/channel.py
@@ -195,9 +195,7 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
 
         def request_factory(page_token: scout_compute_api.PageToken | None) -> scout_compute_api.ComputeNodeRequest:
             return scout_compute_api.ComputeNodeRequest(
-                context=scout_compute_api.Context(
-                    dataset_references={}, frame_references={}, variables={}, function_variables={}
-                ),
+                context=scout_compute_api.Context(dataset_references={}, variables={}, function_variables={}),
                 start=api_start,
                 end=api_end,
                 node=scout_compute_api.ComputableNode(
@@ -360,7 +358,6 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
             ),
             context=scout_compute_api.Context(
                 dataset_references={},
-                frame_references={},
                 variables={},
                 function_variables={},
             ),
@@ -409,7 +406,6 @@ class Channel(RefreshableMixin[timeseries_channelmetadata_api.ChannelMetadata]):
             end_time=end,
             context=scout_compute_api.Context(
                 dataset_references={},
-                frame_references={},
                 variables={},
                 function_variables={},
             ),

--- a/nominal/core/datasource.py
+++ b/nominal/core/datasource.py
@@ -410,6 +410,7 @@ def _construct_export_request(
         start_time=start,
         end_time=end,
         context=scout_compute_api.Context(
+            dataset_references={},
             frame_references={},
             variables={},
             function_variables={},

--- a/nominal/core/datasource.py
+++ b/nominal/core/datasource.py
@@ -411,7 +411,6 @@ def _construct_export_request(
         end_time=end,
         context=scout_compute_api.Context(
             dataset_references={},
-            frame_references={},
             variables={},
             function_variables={},
         ),

--- a/nominal/experimental/compute/_buckets.py
+++ b/nominal/experimental/compute/_buckets.py
@@ -410,11 +410,14 @@ def _create_compute_request_buckets(
 ) -> scout_compute_api.ComputeNodeRequest:
     return scout_compute_api.ComputeNodeRequest(
         context=scout_compute_api.Context(
+            dataset_references={},
             frame_references={},
             variables={
                 k: scout_compute_api.VariableValue(
                     compute_node=scout_compute_api.ComputeNodeWithContext(
-                        context=scout_compute_api.Context(frame_references={}, variables={}, function_variables={}),
+                        context=scout_compute_api.Context(
+                            dataset_references={}, frame_references={}, variables={}, function_variables={}
+                        ),
                         series_node=_to_compute_node(v),
                     )
                 )

--- a/nominal/experimental/compute/_buckets.py
+++ b/nominal/experimental/compute/_buckets.py
@@ -411,13 +411,10 @@ def _create_compute_request_buckets(
     return scout_compute_api.ComputeNodeRequest(
         context=scout_compute_api.Context(
             dataset_references={},
-            frame_references={},
             variables={
                 k: scout_compute_api.VariableValue(
                     compute_node=scout_compute_api.ComputeNodeWithContext(
-                        context=scout_compute_api.Context(
-                            dataset_references={}, frame_references={}, variables={}, function_variables={}
-                        ),
+                        context=scout_compute_api.Context(dataset_references={}, variables={}, function_variables={}),
                         series_node=_to_compute_node(v),
                     )
                 )

--- a/nominal/experimental/compute/dsl/params.py
+++ b/nominal/experimental/compute/dsl/params.py
@@ -57,14 +57,14 @@ def _threshold_operator_to_conjure(operator: ThresholdOperatorLiteral) -> scout_
     return mapping[operator]
 
 
-def _rolling_operation_to_conjure(operator: RollingOperationLiteral) -> scout_compute_api.NumericAggregation:
+def _rolling_operation_to_conjure(operator: RollingOperationLiteral) -> scout_compute_api.NumericAggregationOperator:
     mapping = {
-        "mean": scout_compute_api.NumericAggregation(average=scout_compute_api.Average()),
-        "sum": scout_compute_api.NumericAggregation(sum=scout_compute_api.Summation()),
-        "min": scout_compute_api.NumericAggregation(min=scout_compute_api.Minimum()),
-        "max": scout_compute_api.NumericAggregation(max=scout_compute_api.Maximum()),
-        "count": scout_compute_api.NumericAggregation(count=scout_compute_api.Count()),
-        "std": scout_compute_api.NumericAggregation(standard_deviation=scout_compute_api.StandardDeviation()),
+        "mean": scout_compute_api.NumericAggregationOperator(average=scout_compute_api.Average()),
+        "sum": scout_compute_api.NumericAggregationOperator(sum=scout_compute_api.Summation()),
+        "min": scout_compute_api.NumericAggregationOperator(min=scout_compute_api.Minimum()),
+        "max": scout_compute_api.NumericAggregationOperator(max=scout_compute_api.Maximum()),
+        "count": scout_compute_api.NumericAggregationOperator(count=scout_compute_api.Count()),
+        "std": scout_compute_api.NumericAggregationOperator(standard_deviation=scout_compute_api.StandardDeviation()),
     }
     return mapping[operator]
 

--- a/nominal/thirdparty/matlab/_matlab.py
+++ b/nominal/thirdparty/matlab/_matlab.py
@@ -249,7 +249,9 @@ def export_channels_to_matlab(
             end_time=api_end,
             resolution=api_resolution,
             channels=export_channels,
-            context=scout_compute_api.Context(frame_references={}, variables={}, function_variables={}),
+            context=scout_compute_api.Context(
+                dataset_references={}, frame_references={}, variables={}, function_variables={}
+            ),
         ),
     )
     bin_resp = cast(BinaryIO, resp)

--- a/nominal/thirdparty/matlab/_matlab.py
+++ b/nominal/thirdparty/matlab/_matlab.py
@@ -249,9 +249,7 @@ def export_channels_to_matlab(
             end_time=api_end,
             resolution=api_resolution,
             channels=export_channels,
-            context=scout_compute_api.Context(
-                dataset_references={}, frame_references={}, variables={}, function_variables={}
-            ),
+            context=scout_compute_api.Context(dataset_references={}, variables={}, function_variables={}),
         ),
     )
     bin_resp = cast(BinaryIO, resp)

--- a/nominal/thirdparty/polars/polars_export_handler.py
+++ b/nominal/thirdparty/polars/polars_export_handler.py
@@ -370,9 +370,7 @@ class _ExportJob:
         """Construct conjure export request given the provided configuration options."""
         return scout_dataexport_api.ExportDataRequest(
             channels=self.export_channels(datasource),
-            context=scout_compute_api.Context(
-                dataset_references={}, frame_references={}, variables={}, function_variables={}
-            ),
+            context=scout_compute_api.Context(dataset_references={}, variables={}, function_variables={}),
             end_time=self.time_slice.end_api,
             start_time=self.time_slice.start_api,
             resolution=self.resolution_options(),

--- a/nominal/thirdparty/polars/polars_export_handler.py
+++ b/nominal/thirdparty/polars/polars_export_handler.py
@@ -370,7 +370,9 @@ class _ExportJob:
         """Construct conjure export request given the provided configuration options."""
         return scout_dataexport_api.ExportDataRequest(
             channels=self.export_channels(datasource),
-            context=scout_compute_api.Context(frame_references={}, variables={}, function_variables={}),
+            context=scout_compute_api.Context(
+                dataset_references={}, frame_references={}, variables={}, function_variables={}
+            ),
             end_time=self.time_slice.end_api,
             start_time=self.time_slice.start_api,
             resolution=self.resolution_options(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "dataclass-wizard>=0.39.1",
     "exceptiongroup>=1.3.0",
     "ffmpeg-python>=0.2.0",
-    "nominal-api==0.1224.0",
+    "nominal-api==0.1259.1",
     "rich>=14.1.0",
     "tabulate>=0.9.0,<0.10",
     "truststore>=0.10.4",

--- a/uv.lock
+++ b/uv.lock
@@ -1228,7 +1228,7 @@ requires-dist = [
     { name = "dataclass-wizard", specifier = ">=0.39.1" },
     { name = "exceptiongroup", specifier = ">=1.3.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
-    { name = "nominal-api", specifier = "==0.1224.0" },
+    { name = "nominal-api", specifier = "==0.1259.1" },
     { name = "nominal-api-protos", marker = "extra == 'protos'", specifier = ">=0.1090.0" },
     { name = "nominal-streaming", marker = "(python_full_version >= '3.10' and platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (python_full_version >= '3.10' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.10' and platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.10' and platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.10' and platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.10' and platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')", specifier = "==0.8.2" },
     { name = "nominal-tdms", marker = "extra == 'tdms'", editable = "packages/nominal-tdms" },
@@ -1275,15 +1275,14 @@ dev = [
 
 [[package]]
 name = "nominal-api"
-version = "0.1224.0"
+version = "0.1259.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "conjure-python-client" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/05/92c0cae50722685b9d86189cc850c66bc9cbd3e3a4d89361feb82baec834/nominal_api-0.1224.0.tar.gz", hash = "sha256:b26679daafa77bb6f5185e8c079238feb32ac2631c1b6cea1eba4a9c4e84cdc7", size = 777985, upload-time = "2026-05-04T11:09:35.64Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/5d/98194d2f1b45bf78b2e6f000b23a384c024ef7337336ecb4d82bb79afeb2/nominal_api-0.1224.0-py3-none-any.whl", hash = "sha256:7d9d0e7631d611d3615700c740453d1bd57dfab4088141ae418f36dbbf2f9ac6", size = 814389, upload-time = "2026-05-04T11:09:33.73Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/2e/a76eff9e1e50cb67fa77dd043e2797b3c4efb58dd6eec49601c345ef4957/nominal_api-0.1259.1-py3-none-any.whl", hash = "sha256:f300cbb9c2296350ff2bae77c162d7baf1992710b09bca9953d73f0771078932", size = 880460, upload-time = "2026-06-09T04:22:45.277Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Support for derived datasets is present in this version of the nominal API; bumping dependency to allow for client-side implementation.

Note that the E2E tests have been failing for a while; already discussing fixes in a separate thread.