### PR TITLE
fix: some minor bugs in migration prep cli

### DIFF
--- a/nominal/cli/__init__.py
+++ b/nominal/cli/__init__.py
@@ -1,9 +1,9 @@
 import importlib.metadata
+import sys
 
 import click
 
 from nominal.cli import attachment, config, dataset, download, mis, run
-from nominal.experimental.migration.migration_cli import migrate_cmd
 
 
 @click.group(context_settings={"show_default": True, "help_option_names": ("-h", "--help")})
@@ -18,4 +18,11 @@ nom.add_command(dataset.dataset_cmd)
 nom.add_command(download.download_cmd)
 nom.add_command(mis.mis_cmd)
 nom.add_command(run.run_cmd)
-nom.add_command(migrate_cmd)
+
+# migration_cli imports nominal.cli.util.global_decorators, which requires this package
+# to be initialized — guard against the circular import when migration_cli is imported
+# directly (e.g. in tests) before nominal.cli has finished loading.
+if "nominal.experimental.migration.migration_cli" not in sys.modules:
+    from nominal.experimental.migration.migration_cli import migrate_cmd
+
+    nom.add_command(migrate_cmd)

--- a/nominal/cli/__init__.py
+++ b/nominal/cli/__init__.py
@@ -3,6 +3,7 @@ import importlib.metadata
 import click
 
 from nominal.cli import attachment, config, dataset, download, mis, run
+from nominal.experimental.migration.migration_cli import migrate_cmd
 
 
 @click.group(context_settings={"show_default": True, "help_option_names": ("-h", "--help")})
@@ -17,3 +18,4 @@ nom.add_command(dataset.dataset_cmd)
 nom.add_command(download.download_cmd)
 nom.add_command(mis.mis_cmd)
 nom.add_command(run.run_cmd)
+nom.add_command(migrate_cmd)

--- a/nominal/experimental/migration/README.md
+++ b/nominal/experimental/migration/README.md
@@ -39,7 +39,7 @@ nom config profile add <profile-name> \
 
 ```sh
 nom migrate prep \
-  --source-profile SOURCE \
+  --profile SOURCE \
   --name my_migration \
   --output my_migration.yml
 ```

--- a/nominal/experimental/migration/migration_cli.py
+++ b/nominal/experimental/migration/migration_cli.py
@@ -593,6 +593,8 @@ def prep(client: NominalClient, migration_name: str, output_path: Path) -> None:
             all_assets.add(asset_rid)
 
     logger.info("  Auto-created assets: %d", len(auto_created_assets))
+    for rid in sorted(auto_created_assets)[:3]:
+        logger.info("    e.g. %s", rid)
     logger.info("  All assets: %d", len(all_assets))
 
     datasets = client.search_datasets()
@@ -603,25 +605,23 @@ def prep(client: NominalClient, migration_name: str, output_path: Path) -> None:
 
     logger.info("  Total videos: %d", len(videos))
 
-    channel_count = 0
-
     for asset_rid in all_assets:
         asset = client.get_asset(asset_rid)
         for _data_scope, dataset in asset.list_datasets():
             datasets_with_assets.add(dataset.rid)
-            channel_count += sum(1 for _ in dataset.search_channels())
 
     logger.info("  Datasets with assets: %d", len(datasets_with_assets))
-    logger.info("  Total channels: %d", channel_count)
 
     workbook_templates = client.search_workbook_templates(archive_status=ArchiveStatusFilter.NOT_ARCHIVED)
     logger.info("  Workbook templates (non-archived): %d", len(workbook_templates))
+    logger.info("  Workbooks with multiple asset/runs: %d", len(workbooks_with_multi_asset_run))
 
     orphaned_datasets: set[str] = {d.rid for d in datasets if d.rid not in datasets_with_assets}
 
     logger.info("Out-of-scope migration numbers:")
-    logger.info("  Workbooks with multiple asset/runs: %d", len(workbooks_with_multi_asset_run))
     logger.info("  Orphaned datasets: %d", len(orphaned_datasets))
+    for rid in sorted(orphaned_datasets)[:3]:
+        logger.info("    e.g. %s", rid)
 
     streaming_checklists = client.list_streaming_checklists()
     logger.info("  Streaming checklists: %d", len(streaming_checklists))

--- a/nominal/experimental/migration/migrator/base.py
+++ b/nominal/experimental/migration/migrator/base.py
@@ -11,7 +11,7 @@ from nominal.experimental.migration.migrator.context import MigrationContext
 from nominal.experimental.migration.resource_type import ResourceType
 
 Resource = TypeVar("Resource", bound=HasRid)
-CopyOptions = TypeVar("CopyOptions", bound="ResourceCopyOptions", default="ResourceCopyOptions")
+CopyOptions = TypeVar("CopyOptions", bound="ResourceCopyOptions")
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Description

Few fixes for the migration prep library:

1. Channel search doesn't work for huge datasets, so removing that
2. Fixed a broken link in **init** for the migration command
3. Moved multi-asset/run workbooks to "in-scope"
4. Added a few examples of auto-created assets and orphaned datasets.

Tested using a migration prep script for a customer.