### PR TITLE
fix: add missing allowlist link for parallel migration

### DIFF
--- a/nominal/experimental/migration/parallel_migration_runner.py
+++ b/nominal/experimental/migration/parallel_migration_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import dataclasses
 import logging
 from typing import Callable
 
@@ -24,16 +25,7 @@ logger = logging.getLogger(__name__)
 def _make_asset_fn(
     asset_resources: AssetResources, asset_migrator: AssetMigrator, asset_copy_options: AssetCopyOptions
 ) -> Callable[[], None]:
-    options = AssetCopyOptions(
-        dataset_config=asset_copy_options.dataset_config,
-        include_attachments=asset_copy_options.include_attachments,
-        include_events=asset_copy_options.include_events,
-        include_runs=asset_copy_options.include_runs,
-        include_video=asset_copy_options.include_video,
-        include_checklists=asset_copy_options.include_checklists,
-        include_workbooks=asset_copy_options.include_workbooks,
-        workbook_rids_allowlist=asset_resources.source_workbook_rids,
-    )
+    options = dataclasses.replace(asset_copy_options, workbook_rids_allowlist=asset_resources.source_workbook_rids)
 
     def fn() -> None:
         asset_migrator.copy_from(asset_resources.asset, options)

--- a/nominal/experimental/migration/parallel_migration_runner.py
+++ b/nominal/experimental/migration/parallel_migration_runner.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import concurrent.futures
-import dataclasses
 import logging
 from typing import Callable
 
@@ -25,10 +24,8 @@ logger = logging.getLogger(__name__)
 def _make_asset_fn(
     asset_resources: AssetResources, asset_migrator: AssetMigrator, asset_copy_options: AssetCopyOptions
 ) -> Callable[[], None]:
-    options = dataclasses.replace(asset_copy_options, workbook_rids_allowlist=asset_resources.source_workbook_rids)
-
     def fn() -> None:
-        asset_migrator.copy_from(asset_resources.asset, options)
+        asset_migrator.copy_from(asset_resources.asset, asset_copy_options)
 
     return fn
 
@@ -54,20 +51,24 @@ def run_parallel_migration(runner: MigrationRunner, max_workers: int) -> None:
         setattr(ctx, "destination_client_resolver", runner.destination_client_resolver)
     asset_migrator = AssetMigrator(ctx)
     template_migrator = WorkbookTemplateMigrator(ctx)
-    asset_copy_options = AssetCopyOptions(
-        dataset_config=runner.dataset_config,
-        include_attachments=True,
-        include_events=True,
-        include_runs=True,
-        include_video=True,
-        include_checklists=True,
-    )
-
     asset_tasks = [
         MigrationTask(
             rid=rid,
             label="asset",
-            fn=_make_asset_fn(asset_resources, asset_migrator, asset_copy_options),
+            fn=_make_asset_fn(
+                asset_resources,
+                asset_migrator,
+                AssetCopyOptions(
+                    dataset_config=runner.dataset_config,
+                    include_attachments=runner.asset_inclusion_config.include_attachments,
+                    include_events=runner.asset_inclusion_config.include_events,
+                    include_runs=runner.asset_inclusion_config.include_runs,
+                    include_video=runner.asset_inclusion_config.include_video,
+                    include_checklists=runner.asset_inclusion_config.include_checklists,
+                    include_workbooks=runner.asset_inclusion_config.include_workbooks,
+                    workbook_rids_allowlist=asset_resources.source_workbook_rids,
+                ),
+            ),
         )
         for rid, asset_resources in runner.migration_resources.source_assets.items()
     ]

--- a/nominal/experimental/migration/parallel_migration_runner.py
+++ b/nominal/experimental/migration/parallel_migration_runner.py
@@ -24,8 +24,19 @@ logger = logging.getLogger(__name__)
 def _make_asset_fn(
     asset_resources: AssetResources, asset_migrator: AssetMigrator, asset_copy_options: AssetCopyOptions
 ) -> Callable[[], None]:
+    options = AssetCopyOptions(
+        dataset_config=asset_copy_options.dataset_config,
+        include_attachments=asset_copy_options.include_attachments,
+        include_events=asset_copy_options.include_events,
+        include_runs=asset_copy_options.include_runs,
+        include_video=asset_copy_options.include_video,
+        include_checklists=asset_copy_options.include_checklists,
+        include_workbooks=asset_copy_options.include_workbooks,
+        workbook_rids_allowlist=asset_resources.source_workbook_rids,
+    )
+
     def fn() -> None:
-        asset_migrator.copy_from(asset_resources.asset, asset_copy_options)
+        asset_migrator.copy_from(asset_resources.asset, options)
 
     return fn
 


### PR DESCRIPTION
PR [804](https://app.graphite.com/github/pr/nominal-io/nominal-client/804) introduced the concept of allowlists for migration capabilities, starting with workbooks.  That PR missed passing in this allowlist during parallel migration.  This PR rectifies that, and also ensures complete linkage of all other migraiton options from a client to the migration library.

I also noticed that we hardcode some options to True when invoking parallel migrator. Fixed that as well.

### Testing

Ran a migration from an internal client library. Verified that logs appeared that we skipped out-of-scope workbooks and only migrated the ones on the allowlist. 