### PR TITLE
feat(polars): add PresignedExportHandler for large on-disk CSV exports

### DIFF
--- a/nominal/thirdparty/polars/presigned_export_handler.py
+++ b/nominal/thirdparty/polars/presigned_export_handler.py
@@ -1,0 +1,636 @@
+"""Export channel data to CSV files on disk via S3 presigned links + parallel multi-part downloads.
+
+Unlike :class:`~nominal.thirdparty.polars.polars_export_handler.PolarsExportHandler`, which streams
+CSV through the Nominal API server and merges everything into in-memory DataFrames, this handler
+asks the export service for an S3 **presigned link** per request
+(``generate_export_channel_data_presigned_link``) and downloads each file **straight to disk** using
+parallel ranged GETs (:class:`MultipartFileDownloader`). This lifts the API-proxy size ceiling and is
+much faster for large exports.
+
+It inherits the shared, transport-agnostic planning from :class:`ExportHandler` (per-channel point
+rates, channel grouping, time slicing, request building) and only changes how output is handled. Each
+export request maps to one file, so an export of more than ``channels_per_request`` channels (or across
+multiple datasources) produces several column-partitioned files covering the same timestamps. Use
+:meth:`PresignedExportHandler.merge` to lazily reassemble them.
+"""
+
+from __future__ import annotations
+
+import collections
+import datetime
+import logging
+import pathlib
+import time
+import typing
+from contextlib import contextmanager
+from typing import Callable, Iterator, Mapping, Sequence
+
+import requests
+from nominal_api import scout_dataexport_api
+
+if typing.TYPE_CHECKING:
+    from rich.console import Console
+
+import polars as pl
+from nominal.core._utils.multipart import DEFAULT_CHUNK_SIZE
+from nominal.core._utils.multipart_downloader import (
+    DownloadItem,
+    MultipartFileDownloader,
+    PresignedURLProvider,
+)
+from nominal.core.channel import Channel, ChannelDataType
+from nominal.core.client import NominalClient
+from nominal.core.datasource import DataSource
+from nominal.thirdparty.polars.export_handler import (
+    DEFAULT_EXPORTED_TIMESTAMP_COL_NAME,
+    MAX_NUM_BUCKETS,
+    ExportHandler,
+    _build_channel_groups,
+    _channel_data_buckets,
+    _channel_enum_buckets,
+    _ExportJob,
+    _group_channels_by_datatype,
+    _max_rate_from_buckets,
+    _TimeRange,
+)
+from nominal.ts import (
+    IntegralNanosecondsDuration,
+    IntegralNanosecondsUTC,
+    _AnyExportableTimestampType,
+)
+
+# Number of workers used across the API / download thread pool.
+DEFAULT_PRESIGNED_NUM_WORKERS = 8
+
+# Defaults are large: each presigned request becomes one file downloaded in parallel parts, so larger
+# files make multi-part downloads worthwhile. With ~50 channels/request, 50M points is roughly 1M
+# timestamps per request.
+DEFAULT_PRESIGNED_POINTS_PER_REQUEST = 50_000_000
+DEFAULT_PRESIGNED_POINTS_PER_FILE = 50_000_000
+DEFAULT_PRESIGNED_CHANNELS_PER_REQUEST = 50
+
+# Presigned links are long-lived; use a generous TTL so each link is fetched once and not proactively
+# re-signed mid-download (re-signing may re-run the export). The downloader still re-signs on a 403.
+DEFAULT_URL_TTL_SECS = 3600.0
+DEFAULT_URL_SKEW_SECS = 60.0
+
+# Large exports are materialized to S3 asynchronously: the presigned link is returned with the
+# final `file_size_bytes` before the object is fully written, and the object's served size grows
+# until complete. We poll the object until its served size reaches `file_size_bytes` before
+# downloading, so we never capture a partially-written (header-only) file.
+DEFAULT_READINESS_TIMEOUT_SECS = 600.0
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _progress_bars(
+    total: int, show: bool, console: Console | None = None
+) -> Iterator[tuple[Callable[[], None], Callable[[], None]]]:
+    """Yield ``(advance_prepare, advance_download)`` callables.
+
+    When ``show`` is set, both advance tasks on a single Rich progress display: one tracks files
+    whose presigned link is ready (planning/preallocation) and one tracks completed downloads. When
+    not shown, both are no-ops. Passing the ``console`` shared with a Rich logging handler lets logs
+    render cleanly above the live bars instead of corrupting them.
+    """
+    if not show:
+        noop: Callable[[], None] = lambda: None  # noqa: E731 - trivial no-op
+        yield noop, noop
+        return
+
+    from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn
+
+    with Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        console=console,
+    ) as progress:
+        prepare = progress.add_task("Preparing links", total=total)
+        download = progress.add_task("Downloading", total=total)
+        yield (lambda: progress.advance(prepare, 1), lambda: progress.advance(download, 1))
+
+
+def _is_transient_error(exc: Exception) -> bool:
+    """True for errors worth retrying: HTTP 5xx/429 (incl. ConjureHTTPError) or network-level errors."""
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    if isinstance(status, int):
+        return status == 429 or status >= 500
+    return isinstance(exc, requests.RequestException)
+
+
+class PresignedExportHandler(ExportHandler):
+    """Export channel data to CSV files on disk using S3 presigned links and multi-part downloads."""
+
+    def __init__(
+        self,
+        client: NominalClient,
+        *,
+        points_per_request: int = DEFAULT_PRESIGNED_POINTS_PER_REQUEST,
+        points_per_file: int = DEFAULT_PRESIGNED_POINTS_PER_FILE,
+        channels_per_request: int = DEFAULT_PRESIGNED_CHANNELS_PER_REQUEST,
+        num_workers: int = DEFAULT_PRESIGNED_NUM_WORKERS,
+        part_size: int = DEFAULT_CHUNK_SIZE,
+        url_ttl_secs: float = DEFAULT_URL_TTL_SECS,
+        url_skew_secs: float = DEFAULT_URL_SKEW_SECS,
+        max_part_retries: int = 3,
+        max_link_retries: int = 3,
+        timeout: float = 30.0,
+        readiness_timeout: float = DEFAULT_READINESS_TIMEOUT_SECS,
+    ):
+        """Initialize the presigned CSV export handler.
+
+        Args:
+            client: Nominal client for communicating with the API.
+            points_per_request: Target maximum number of points within a single export request (and
+                thus a single file).
+            points_per_file: Target maximum number of points within each written file; drives how the
+                time range is subdivided into batches.
+            channels_per_request: Maximum number of channels packed into a single request / file.
+            num_workers: Number of parallel workers used for ranged downloads.
+            part_size: Byte size of each ranged download part.
+            url_ttl_secs: How long a fetched presigned URL is considered valid before refresh.
+            url_skew_secs: Safety buffer subtracted from ``url_ttl_secs``.
+            max_part_retries: Maximum retries per download part (IO, presigned expiry, etc.).
+            max_link_retries: Maximum attempts to generate a presigned link per file, retried with
+                backoff on transient errors (5xx / 429 / network) since each file's link is a
+                separate server-side export request.
+            timeout: Per-request connection timeout, in seconds.
+            readiness_timeout: Maximum seconds to wait for a large export's S3 object to be fully
+                materialized (served size == file_size_bytes) before downloading it.
+        """
+        super().__init__(
+            client,
+            points_per_request=points_per_request,
+            points_per_dataframe=points_per_file,  # file size drives time-slice sizing
+            channels_per_request=channels_per_request,
+            num_workers=num_workers,
+            compression=None,  # uncompressed .csv keeps merge() fully lazy
+        )
+        self._part_size = part_size
+        self._url_ttl_secs = url_ttl_secs
+        self._url_skew_secs = url_skew_secs
+        self._max_part_retries = max_part_retries
+        self._max_link_retries = max_link_retries
+        self._timeout = timeout
+        self._readiness_timeout = readiness_timeout
+
+    def export(
+        self,
+        channels: Sequence[Channel],
+        start: IntegralNanosecondsUTC,
+        end: IntegralNanosecondsUTC,
+        output_dir: str | pathlib.Path,
+        *,
+        tags: Mapping[str, str] | None = None,
+        batch_duration: datetime.timedelta | None = None,
+        timestamp_type: _AnyExportableTimestampType = "epoch_seconds",
+        buckets: int | None = None,
+        resolution: IntegralNanosecondsDuration | None = None,
+        file_prefix: str = "export",
+        show_progress: bool = False,
+        console: Console | None = None,
+    ) -> list[pathlib.Path]:
+        """Export the given channels to CSV files in ``output_dir`` and return the written paths.
+
+        Each export request becomes one file; exports of more than ``channels_per_request`` channels
+        (or spanning multiple datasources) produce several column-partitioned files that share
+        timestamps. Reassemble them with :meth:`merge`.
+
+        Args:
+            channels: Channels to export.
+            start: Start of the export range, in nanoseconds since the Unix epoch (UTC).
+            end: End of the export range, in nanoseconds since the Unix epoch (UTC).
+            output_dir: Directory to write files into. Created if it does not exist.
+            tags: Key-value pairs used to filter channel data.
+            batch_duration: Optional explicit batch duration; otherwise computed from point rates.
+            timestamp_type: Timestamp format for the exported timestamp column.
+            buckets: Optional decimation by number of buckets (mutually exclusive with ``resolution``).
+            resolution: Optional decimation resolution in ns (mutually exclusive with ``buckets``).
+            file_prefix: Prefix for written file names.
+            show_progress: When True, render a Rich progress display with two bars -- one tracking
+                files whose presigned link is ready, one tracking completed downloads. Do not enable
+                while another Rich live display is already active.
+            console: Optional Rich console to render the progress display on. Pass the same console
+                your logging handler uses so log lines render cleanly above the live bars instead of
+                corrupting them.
+
+        Returns:
+            The list of written file paths, sorted.
+        """
+        output_dir = pathlib.Path(output_dir)
+        if not channels:
+            logger.warning("No channels requested for export-- returning")
+            return []
+        if None not in (buckets, resolution):
+            raise ValueError("Cannot export data decimated with both buckets and resolution")
+        tags = dict(tags or {})
+
+        batch_duration = self._clamp_batch_duration_for_resolution(batch_duration, resolution)
+
+        # Plan first (the only blocking step); rate estimation is internally multi-threaded.
+        export_jobs = self._compute_export_jobs(
+            channels, _TimeRange(start, end), timestamp_type, tags, buckets, resolution, batch_duration
+        )
+        items = self._build_download_items(export_jobs, output_dir, file_prefix)
+        if not items:
+            logger.warning("No export jobs computed-- returning")
+            return []
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        logger.info("Exporting %d channels into %d file(s) under %s", len(channels), len(items), output_dir)
+        with (
+            _progress_bars(len(items), show_progress, console) as (advance_prepare, advance_download),
+            MultipartFileDownloader.create(
+                max_workers=self._num_workers,
+                timeout=self._timeout,
+                max_part_retries=self._max_part_retries,
+                header_provider=self._client._clients.header_provider,
+            ) as downloader,
+        ):
+            results = downloader.download_files_pipelined(
+                items,
+                on_file_planned=lambda _path: advance_prepare(),
+                on_file_complete=lambda _path: advance_download(),
+            )
+
+        if results.failed:
+            for dest, ex in results.failed.items():
+                logger.error("Failed to export %s", dest, exc_info=ex)
+            raise RuntimeError(f"Failed to export {len(results.failed)} of {len(items)} file(s)")
+
+        return sorted(results.succeeded)
+
+    def _clamp_batch_duration_for_resolution(
+        self, batch_duration: datetime.timedelta | None, resolution: IntegralNanosecondsDuration | None
+    ) -> datetime.timedelta | None:
+        """Clamp batch_duration so decimated exports stay within the backend bucket limit."""
+        if resolution is None:
+            return batch_duration
+
+        computed = datetime.timedelta(seconds=(resolution * MAX_NUM_BUCKETS) / 1e9)
+        if batch_duration is None:
+            logger.info(
+                "Manually setting batch_duration to %fs (resolution=%dns)", computed.total_seconds(), resolution
+            )
+            return computed
+        elif computed < batch_duration:
+            logger.warning(
+                "Configured batch_duration of %fs would result in failing exports with resolution=%dns. "
+                "Setting batch_duration to %fs instead.",
+                batch_duration.total_seconds(),
+                resolution,
+                computed.total_seconds(),
+            )
+            return computed
+        return batch_duration
+
+    def _compute_export_jobs(
+        self,
+        channels: Sequence[Channel],
+        time_range: _TimeRange,
+        timestamp_type: _AnyExportableTimestampType,
+        tags: Mapping[str, str] | None = None,
+        buckets: int | None = None,
+        resolution: IntegralNanosecondsDuration | None = None,
+        batch_duration: datetime.timedelta | None = None,
+    ) -> Mapping[_TimeRange, Sequence[_ExportJob]]:
+        """Plan export jobs, pruning numeric channels with no data in a given time slice.
+
+        Overrides :meth:`ExportHandler._compute_export_jobs`: it runs a single bucketed-compute pass
+        (:func:`_channel_data_buckets`) to learn both each channel's rate *and* which buckets contain
+        data, then re-groups the present numeric channels per time slice so we never request (and
+        download) a numeric channel for a slice where it has no data. Empty enum-channel handling is
+        unchanged (string channels have no bucket presence to prune on).
+        """
+        if buckets is not None and resolution is not None:
+            raise ValueError("Cannot provide `buckets` and `resolution`")
+
+        partitioned = _group_channels_by_datatype(channels)
+        enum_channels = partitioned.get(ChannelDataType.STRING, [])
+        numeric_channels = [
+            *partitioned.get(ChannelDataType.DOUBLE, []),
+            *partitioned.get(ChannelDataType.INT, []),
+        ]
+        if batch_duration is None and not numeric_channels:
+            raise ValueError("If no numeric channels are provided, a `batch_duration` must be provided!")
+        unknown = partitioned.get(ChannelDataType.UNKNOWN, [])
+        if unknown:
+            logger.warning("Could not determine datatypes of %d channels-- ignoring for export", len(unknown))
+
+        rates, presence = self._rates_and_presence(numeric_channels, time_range, tags)
+        enum_presence, enum_undetermined = self._enum_presence(enum_channels, time_range, tags)
+
+        batch_duration_ns = self._compute_batch_duration(batch_duration, enum_channels, time_range, rates)
+        time_slices = time_range.subdivide_ns(batch_duration_ns)
+        batch_timedelta = datetime.timedelta(seconds=batch_duration_ns / 1e9)
+        channels_by_name = {c.name: c for c in channels}
+
+        names_by_datasource: dict[str, set[str]] = collections.defaultdict(set)
+        for group in (numeric_channels, enum_channels):
+            for channel in group:
+                names_by_datasource[channel.data_source].add(channel.name)
+
+        jobs: dict[_TimeRange, list[_ExportJob]] = collections.defaultdict(list)
+        for datasource_rid, names in names_by_datasource.items():
+            ds_enum = [c for c in enum_channels if c.name in names]
+            ds_numeric_names = [c.name for c in numeric_channels if c.name in names and c.name in rates]
+            for time_slice in time_slices:
+                present = [n for n in ds_numeric_names if self._slice_has_data(presence.get(n), time_slice)]
+                channel_groups, large_channels = _build_channel_groups(
+                    {n: rates[n] for n in present},
+                    {n: channels_by_name[n] for n in present},
+                    self._points_per_request,
+                    self._channels_per_request,
+                    batch_timedelta,
+                )
+                # Enum channels: prune those with no data in this slice; channels whose presence could
+                # not be determined (e.g. too many categories) are exported for all slices.
+                present_enum = [
+                    c
+                    for c in ds_enum
+                    if c.name in enum_undetermined or self._slice_has_data(enum_presence.get(c.name), time_slice)
+                ]
+                channel_groups.extend([[c] for c in present_enum])
+
+                for group in channel_groups:
+                    if group:
+                        jobs[time_slice].append(
+                            self._make_job(datasource_rid, group, time_slice, tags, buckets, resolution, timestamp_type)
+                        )
+
+                # Large channels (present in this slice) are subdivided into per-request sub-slices.
+                for channel in large_channels:
+                    sub_offset = datetime.timedelta(seconds=self._points_per_request / rates[channel.name])
+                    for sub_slice in time_slice.subdivide(sub_offset):
+                        jobs[time_slice].append(
+                            self._make_job(
+                                datasource_rid, [channel], sub_slice, tags, buckets, resolution, timestamp_type
+                            )
+                        )
+
+        return jobs
+
+    def _rates_and_presence(
+        self, numeric_channels: Sequence[Channel], time_range: _TimeRange, tags: Mapping[str, str] | None
+    ) -> tuple[dict[str, float], dict[str, list[int]]]:
+        """One bucketed-compute pass -> (per-channel rate, per-channel non-empty bucket timestamps).
+
+        Channels with no data in range are absent from both maps.
+        """
+        start_ns, end_ns = time_range.start_time, time_range.end_time
+        bucket_map = _channel_data_buckets(
+            self._client, numeric_channels, start_ns, end_ns, tags, num_workers=self._num_workers
+        )
+        rates: dict[str, float] = {}
+        presence: dict[str, list[int]] = {}
+        for name, bkts in bucket_map.items():
+            rate = _max_rate_from_buckets(bkts, start_ns, end_ns)
+            if rate:
+                rates[name] = rate
+            non_empty = [b.timestamp for b in bkts if b.count > 0]
+            if non_empty:
+                presence[name] = non_empty
+
+        empty = [c.name for c in numeric_channels if c.name not in rates]
+        if empty:
+            logger.info(
+                "%d of %d numeric channels have no data in the requested range and will be skipped",
+                len(empty),
+                len(numeric_channels),
+            )
+        return rates, presence
+
+    def _enum_presence(
+        self, enum_channels: Sequence[Channel], time_range: _TimeRange, tags: Mapping[str, str] | None
+    ) -> tuple[dict[str, list[int]], set[str]]:
+        """Per enum (string) channel, non-empty bucket timestamps for pruning + undetermined channels.
+
+        Returns ``(presence, undetermined)``: channels with determinable data map to their non-empty
+        bucket timestamps (channels with no data are absent), and ``undetermined`` holds channels
+        whose presence could not be computed (exported for all slices rather than dropped).
+        """
+        bucket_map, undetermined = _channel_enum_buckets(
+            self._client, enum_channels, time_range.start_time, time_range.end_time, tags, num_workers=self._num_workers
+        )
+        presence: dict[str, list[int]] = {}
+        for name, bkts in bucket_map.items():
+            non_empty = [b.timestamp for b in bkts if b.frequencies]
+            if non_empty:
+                presence[name] = non_empty
+
+        skipped = [c.name for c in enum_channels if c.name not in presence and c.name not in undetermined]
+        if skipped:
+            logger.info(
+                "%d of %d enum channels have no data in the requested range and will be skipped",
+                len(skipped),
+                len(enum_channels),
+            )
+        return presence, undetermined
+
+    def _make_job(
+        self,
+        datasource_rid: str,
+        group: Sequence[Channel],
+        time_slice: _TimeRange,
+        tags: Mapping[str, str] | None,
+        buckets: int | None,
+        resolution: IntegralNanosecondsDuration | None,
+        timestamp_type: _AnyExportableTimestampType,
+    ) -> _ExportJob:
+        return _ExportJob(
+            datasource_rid=datasource_rid,
+            channel_names=[c.name for c in group],
+            channel_types={c.name: c.data_type for c in group},
+            time_slice=time_slice,
+            tags=dict(tags or {}),
+            buckets=buckets,
+            resolution=resolution,
+            timestamp_type=timestamp_type,
+            compression=self._compression,
+        )
+
+    @staticmethod
+    def _slice_has_data(non_empty_bucket_timestamps: list[int] | None, time_slice: _TimeRange) -> bool:
+        """True if any non-empty bucket falls within the time slice."""
+        if not non_empty_bucket_timestamps:
+            return False
+        return any(time_slice.start_time <= ts < time_slice.end_time for ts in non_empty_bucket_timestamps)
+
+    def _build_download_items(
+        self,
+        export_jobs: Mapping[_TimeRange, Sequence[_ExportJob]],
+        output_dir: pathlib.Path,
+        file_prefix: str,
+    ) -> list[DownloadItem]:
+        # Resolve each datasource once (cached) since many jobs share a datasource.
+        datasource_rids = {job.datasource_rid for jobs in export_jobs.values() for job in jobs}
+        datasources = {rid: self._client.get_datasource(rid) for rid in datasource_rids}
+
+        items: list[DownloadItem] = []
+        for slice_idx, time_slice in enumerate(sorted(export_jobs.keys())):
+            for job_idx, job in enumerate(export_jobs[time_slice]):
+                destination = output_dir / self._file_name(file_prefix, job, slice_idx, job_idx)
+                provider = self._presigned_url_provider(job, datasources[job.datasource_rid])
+                items.append(DownloadItem(provider=provider, destination=destination, part_size=self._part_size))
+        return items
+
+    @staticmethod
+    def _file_name(file_prefix: str, job: _ExportJob, slice_idx: int, job_idx: int) -> str:
+        datasource_short = job.datasource_rid.split(".")[-1]
+        return f"{file_prefix}_{datasource_short}_s{slice_idx:04d}_g{job_idx:03d}.csv"
+
+    def _presigned_url_provider(self, job: _ExportJob, datasource: DataSource) -> PresignedURLProvider:
+        # Build the export request lazily on first fetch (it issues a get_channels call), then memoize
+        # so re-signing on expiry doesn't rebuild it.
+        cached_request: scout_dataexport_api.ExportDataRequest | None = None
+
+        def fetch() -> str:
+            nonlocal cached_request
+            if cached_request is None:
+                cached_request = job.export_request(datasource)
+            response = self._generate_presigned_link(cached_request)
+            url = response.presigned_url.url
+            logger.debug(
+                "Presigned export link ready (channels=%d, %.2f MB)",
+                len(job.channel_names),
+                response.file_size_bytes / 1e6,
+            )
+            # Large exports are written to S3 asynchronously; wait until the object is fully
+            # materialized so the downloader never captures a partial (header-only) file.
+            self._wait_until_materialized(url, response.file_size_bytes)
+            return url
+
+        return PresignedURLProvider(fetch_fn=fetch, ttl_secs=self._url_ttl_secs, skew_secs=self._url_skew_secs)
+
+    def _generate_presigned_link(
+        self, request: scout_dataexport_api.ExportDataRequest
+    ) -> scout_dataexport_api.GeneratePresignedLinkResponse:
+        """Generate a presigned export link, retrying transient (5xx / 429 / network) failures.
+
+        Each link is a separate server-side export request, so a transient backend error on one file
+        shouldn't fail the whole export; non-transient errors (e.g. 4xx) are raised immediately.
+        """
+        delay = 0.5
+        for attempt in range(self._max_link_retries):
+            try:
+                return self._client._clients.dataexport.generate_export_channel_data_presigned_link(
+                    self._client._clients.auth_header, request
+                )
+            except Exception as exc:
+                if attempt == self._max_link_retries - 1 or not _is_transient_error(exc):
+                    raise
+                logger.warning(
+                    "Presigned link generation failed (attempt %d/%d), retrying: %s",
+                    attempt + 1,
+                    self._max_link_retries,
+                    exc,
+                )
+                time.sleep(delay)
+                delay = min(delay * 2, 5.0)
+        raise AssertionError("unreachable")  # loop either returns or raises
+
+    def _wait_until_materialized(self, url: str, expected_size: int) -> None:
+        """Block until the object served at ``url`` reaches ``expected_size`` bytes (or timeout).
+
+        The presigned export endpoint returns the authoritative final ``file_size_bytes`` before the
+        S3 object is fully written; its served size grows until complete. Polling avoids downloading
+        a partially-written file. Empty exports (tiny ``expected_size``) satisfy this immediately.
+        """
+        deadline = time.monotonic() + self._readiness_timeout
+        delay = 0.5
+        while True:
+            served = self._served_size(url)
+            if served is not None and served >= expected_size:
+                return
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "Export object not fully materialized after %.0fs (served=%s, expected=%d); proceeding anyway",
+                    self._readiness_timeout,
+                    served,
+                    expected_size,
+                )
+                return
+            time.sleep(delay)
+            delay = min(delay * 2, 5.0)
+
+    def _served_size(self, url: str) -> int | None:
+        """Return the full object size S3 currently reports for ``url`` (via a ranged probe), or None."""
+        try:
+            resp = requests.get(url, headers={"Range": "bytes=0-0"}, timeout=self._timeout)
+        except requests.RequestException:
+            return None
+        if resp.status_code not in (200, 206):
+            return None
+        content_range = resp.headers.get("Content-Range")
+        if content_range:
+            return int(content_range.split("/")[-1])
+        content_length = resp.headers.get("Content-Length")
+        return int(content_length) if content_length is not None else None
+
+    @staticmethod
+    def merge(
+        paths: Sequence[str | pathlib.Path],
+        *,
+        timestamp_column: str = DEFAULT_EXPORTED_TIMESTAMP_COL_NAME,
+    ) -> pl.LazyFrame:
+        """Lazily reassemble exported CSV files into a unified, timestamp-sorted frame.
+
+        Each file is a timestamp-keyed *column fragment*: within a time slice several files share the
+        same timestamps but hold different channels, and (because channels are pruned/regrouped per
+        slice) the same channel can appear in different column groupings across slices. So we stack
+        every fragment (union of rows and columns, missing channels filled with null) and collapse
+        rows that share a timestamp by taking the first non-null value per channel. This is robust to
+        arbitrarily overlapping column sets (an outer-join-on-timestamp approach would mis-handle a
+        channel that appears in two different groupings).
+
+        The result is a ``pl.LazyFrame`` so the caller controls materialization: ``.collect()``,
+        ``.collect(engine="streaming")`` for larger-than-RAM data, or ``.sink_parquet()`` /
+        ``.sink_csv()`` to stream to disk.
+
+        Args:
+            paths: Paths to the CSV files to merge.
+            timestamp_column: Name of the shared timestamp column to coalesce/sort on.
+
+        Returns:
+            A lazy frame producing the unified table.
+        """
+        resolved = [pathlib.Path(p) for p in paths]
+        if not resolved:
+            raise ValueError("No paths provided to merge")
+
+        # Skip header-only files (no data rows). They contribute nothing, and because they have no
+        # values polars infers their timestamp column as str -- which then fails to align against the
+        # f64 timestamps of data-bearing files. (Header-only files can occur for channels whose
+        # per-slice presence could not be determined and were exported defensively.) The check is
+        # parse-free (no CSV type inference) so it can't trip over int-vs-float columns.
+        non_empty = [path for path in resolved if PresignedExportHandler._has_data_rows(path)]
+        if not non_empty:
+            raise ValueError("No data rows found across the provided files")
+
+        # Infer dtypes from the full file (infer_schema_length=None): exported numeric columns can look
+        # integer for thousands of rows before a float appears, so a sampled inference mis-types them
+        # as i64 and fails to parse the later float. Read only the header (infer_schema_length=0) for
+        # the timestamp-column presence check.
+        frames = []
+        for path in non_empty:
+            names = pl.scan_csv(path, infer_schema_length=0).collect_schema().names()
+            if timestamp_column not in names:
+                raise ValueError(f"File {path} has no '{timestamp_column}' column; cannot merge")
+            frames.append(pl.scan_csv(path, infer_schema_length=None))
+
+        # Union all fragments (diagonal_relaxed aligns columns by name and coerces mixed int/float
+        # dtypes), then collapse rows sharing a timestamp. Each channel is populated in exactly one
+        # fragment per timestamp, so first-non-null reconstructs the full row without conflicts.
+        unified = pl.concat(frames, how="diagonal_relaxed")
+        value_columns = [name for name in unified.collect_schema().names() if name != timestamp_column]
+        merged = unified.group_by(timestamp_column).agg(pl.col(value_columns).drop_nulls().first())
+        return merged.sort(timestamp_column)
+
+    @staticmethod
+    def _has_data_rows(path: pathlib.Path) -> bool:
+        """Return True if the CSV has at least one non-empty data row (parse-free, early-exit)."""
+        with path.open("r") as f:
+            next(f, None)  # skip header
+            return any(line.strip() for line in f)

--- a/tests/thirdparty/polars/test_presigned_export_handler.py
+++ b/tests/thirdparty/polars/test_presigned_export_handler.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import datetime
+import pathlib
+from types import SimpleNamespace
+from typing import Callable, Mapping, Sequence, cast
+from unittest.mock import MagicMock, patch
+
+import polars as pl
+import pytest
+import requests
+
+from nominal.core._utils.multipart_downloader import DownloadItem, DownloadResults
+from nominal.core.channel import Channel, ChannelDataType
+from nominal.thirdparty.polars.export_handler import _ExportJob, _TimeRange
+from nominal.thirdparty.polars.presigned_export_handler import PresignedExportHandler
+
+_DOWNLOADER_PATH = "nominal.thirdparty.polars.presigned_export_handler.MultipartFileDownloader"
+_BUCKETS_PATH = "nominal.thirdparty.polars.presigned_export_handler._channel_data_buckets"
+_ENUM_BUCKETS_PATH = "nominal.thirdparty.polars.presigned_export_handler._channel_enum_buckets"
+
+
+def _handler() -> PresignedExportHandler:
+    return PresignedExportHandler(MagicMock())
+
+
+def _ch(name: str) -> Channel:
+    return cast(Channel, SimpleNamespace(name=name, data_source="ds1", data_type=ChannelDataType.DOUBLE))
+
+
+def _enum_ch(name: str) -> Channel:
+    return cast(Channel, SimpleNamespace(name=name, data_source="ds1", data_type=ChannelDataType.STRING))
+
+
+def _bucket(timestamp: int, count: int) -> object:
+    return SimpleNamespace(timestamp=timestamp, count=count)
+
+
+def _enum_bucket(timestamp: int) -> object:
+    return SimpleNamespace(timestamp=timestamp, frequencies={"value": 1})
+
+
+def _job(datasource_rid: str, channel_names: list[str]) -> _ExportJob:
+    return _ExportJob(
+        datasource_rid=datasource_rid,
+        channel_names=channel_names,
+        channel_types={name: ChannelDataType.DOUBLE for name in channel_names},
+        time_slice=_TimeRange(0, 1_000_000_000),
+        tags={},
+    )
+
+
+def _echo_download() -> Callable[..., DownloadResults]:
+    """A download_files_pipelined stand-in: 'succeeds' every item and fires both callbacks."""
+
+    def _dl(
+        items: Sequence[DownloadItem],
+        *,
+        on_file_planned: Callable[[pathlib.Path], None] | None = None,
+        on_file_complete: Callable[[pathlib.Path], None] | None = None,
+    ) -> DownloadResults:
+        for item in items:
+            if on_file_planned is not None:
+                on_file_planned(item.destination)
+            if on_file_complete is not None:
+                on_file_complete(item.destination)
+        return DownloadResults(succeeded=[item.destination for item in items], failed={})
+
+    return _dl
+
+
+# ---- export() ----
+
+
+def test_export_returns_sorted_paths_and_wires_progress_callback(tmp_path: pathlib.Path) -> None:
+    """A successful export returns sorted written paths and passes an on_file_complete callback."""
+    handler = _handler()
+    jobs: Mapping[_TimeRange, Sequence[_ExportJob]] = {
+        _TimeRange(0, 1_000_000_000): [_job("ri.a.b.datasource.ds1", ["a"]), _job("ri.a.b.datasource.ds1", ["b"])]
+    }
+
+    with (
+        patch.object(handler, "_compute_export_jobs", return_value=jobs),
+        patch(_DOWNLOADER_PATH) as mock_dl_cls,
+    ):
+        downloader = mock_dl_cls.create.return_value.__enter__.return_value
+        downloader.download_files_pipelined.side_effect = _echo_download()
+        paths = handler.export([MagicMock()], 0, 1_000_000_000, tmp_path)
+
+    assert paths == sorted([tmp_path / "export_ds1_s0000_g000.csv", tmp_path / "export_ds1_s0000_g001.csv"])
+    assert tmp_path.exists()
+    kwargs = downloader.download_files_pipelined.call_args.kwargs
+    assert callable(kwargs["on_file_planned"])
+    assert callable(kwargs["on_file_complete"])
+
+
+def test_export_raises_on_download_failure(tmp_path: pathlib.Path) -> None:
+    """Any failed file surfaces as a RuntimeError naming the failure count."""
+    handler = _handler()
+    jobs: Mapping[_TimeRange, Sequence[_ExportJob]] = {
+        _TimeRange(0, 1_000_000_000): [_job("ri.a.b.datasource.ds1", ["a"])]
+    }
+    failed_path = tmp_path / "export_ds1_s0000_g000.csv"
+
+    with (
+        patch.object(handler, "_compute_export_jobs", return_value=jobs),
+        patch(_DOWNLOADER_PATH) as mock_dl_cls,
+    ):
+        downloader = mock_dl_cls.create.return_value.__enter__.return_value
+        downloader.download_files_pipelined.return_value = DownloadResults(
+            succeeded=[], failed={failed_path: RuntimeError("boom")}
+        )
+        with pytest.raises(RuntimeError, match="Failed to export 1 of 1 file"):
+            handler.export([MagicMock()], 0, 1_000_000_000, tmp_path)
+
+
+def test_export_empty_channels_short_circuits(tmp_path: pathlib.Path) -> None:
+    """No channels returns an empty list without touching the downloader."""
+    handler = _handler()
+    with patch(_DOWNLOADER_PATH) as mock_dl_cls:
+        assert handler.export([], 0, 1_000_000_000, tmp_path) == []
+        mock_dl_cls.create.assert_not_called()
+
+
+def test_export_rejects_buckets_and_resolution(tmp_path: pathlib.Path) -> None:
+    """Requesting both decimation modes is rejected."""
+    handler = _handler()
+    with pytest.raises(ValueError, match="both buckets and resolution"):
+        handler.export([MagicMock()], 0, 1_000_000_000, tmp_path, buckets=10, resolution=1_000)
+
+
+def test_build_download_items_names_one_file_per_job(tmp_path: pathlib.Path) -> None:
+    """Each (slice, job) maps to one DownloadItem with a deterministic, ordered file name."""
+    handler = _handler()
+    jobs: Mapping[_TimeRange, Sequence[_ExportJob]] = {
+        _TimeRange(0, 1_000_000_000): [_job("ri.a.b.datasource.ds1", ["a"]), _job("ri.a.b.datasource.ds1", ["b"])]
+    }
+
+    items = handler._build_download_items(jobs, tmp_path, "export")
+
+    assert [item.destination.name for item in items] == [
+        "export_ds1_s0000_g000.csv",
+        "export_ds1_s0000_g001.csv",
+    ]
+
+
+# ---- _compute_export_jobs pruning ----
+
+
+def test_compute_export_jobs_prunes_channels_absent_from_a_slice() -> None:
+    """A numeric channel is only exported for slices where its buckets show data."""
+    handler = _handler()
+    a, b = _ch("a"), _ch("b")
+    # a has data only in the first 1s slice; b only in the second.
+    buckets = {"a": [_bucket(500_000_000, 10)], "b": [_bucket(1_500_000_000, 10)]}
+
+    with patch(_BUCKETS_PATH, return_value=buckets):
+        jobs = handler._compute_export_jobs(
+            [a, b],
+            _TimeRange(0, 2_000_000_000),
+            "epoch_seconds",
+            batch_duration=datetime.timedelta(seconds=1),  # -> two 1s slices
+        )
+
+    by_slice = {(slc.start_time, slc.end_time): [j.channel_names for j in js] for slc, js in jobs.items()}
+    assert by_slice[(0, 1_000_000_000)] == [["a"]]
+    assert by_slice[(1_000_000_000, 2_000_000_000)] == [["b"]]
+
+
+def test_compute_export_jobs_prunes_enum_channels_absent_from_a_slice() -> None:
+    """Enum (string) channels are also pruned per slice using enum bucket presence."""
+    handler = _handler()
+    e1, e2 = _enum_ch("e1"), _enum_ch("e2")
+    enum_buckets = ({"e1": [_enum_bucket(500_000_000)], "e2": [_enum_bucket(1_500_000_000)]}, set())
+
+    with patch(_ENUM_BUCKETS_PATH, return_value=enum_buckets), patch(_BUCKETS_PATH, return_value={}):
+        jobs = handler._compute_export_jobs(
+            [e1, e2],
+            _TimeRange(0, 2_000_000_000),
+            "epoch_seconds",
+            batch_duration=datetime.timedelta(seconds=1),
+        )
+
+    by_slice = {(slc.start_time, slc.end_time): [j.channel_names for j in js] for slc, js in jobs.items()}
+    assert by_slice[(0, 1_000_000_000)] == [["e1"]]
+    assert by_slice[(1_000_000_000, 2_000_000_000)] == [["e2"]]
+
+
+def test_compute_export_jobs_exports_undetermined_enum_in_all_slices() -> None:
+    """Enum channels whose presence couldn't be computed are exported for every slice (not dropped)."""
+    handler = _handler()
+    e = _enum_ch("e")
+    # No presence data, but flagged undetermined (e.g. Compute:TooManyCategories).
+    with patch(_ENUM_BUCKETS_PATH, return_value=({}, {"e"})), patch(_BUCKETS_PATH, return_value={}):
+        jobs = handler._compute_export_jobs(
+            [e], _TimeRange(0, 2_000_000_000), "epoch_seconds", batch_duration=datetime.timedelta(seconds=1)
+        )
+
+    by_slice = {(slc.start_time, slc.end_time): [j.channel_names for j in js] for slc, js in jobs.items()}
+    assert by_slice[(0, 1_000_000_000)] == [["e"]]
+    assert by_slice[(1_000_000_000, 2_000_000_000)] == [["e"]]
+
+
+def test_compute_export_jobs_skips_empty_channels_entirely() -> None:
+    """Channels with no data anywhere produce no jobs."""
+    handler = _handler()
+    a, b = _ch("a"), _ch("b")
+
+    with patch(_BUCKETS_PATH, return_value={"a": [_bucket(500_000_000, 10)]}):  # b absent -> no data
+        jobs = handler._compute_export_jobs(
+            [a, b], _TimeRange(0, 1_000_000_000), "epoch_seconds", batch_duration=datetime.timedelta(seconds=1)
+        )
+
+    all_names = [name for js in jobs.values() for j in js for name in j.channel_names]
+    assert all_names == ["a"]
+
+
+# ---- presigned link retry ----
+
+
+def _http_error(status: int) -> requests.HTTPError:
+    return requests.HTTPError(response=cast(requests.Response, SimpleNamespace(status_code=status)))
+
+
+def test_generate_presigned_link_retries_transient_5xx() -> None:
+    """A transient 5xx on link generation is retried and then succeeds."""
+    handler = _handler()
+    ok = SimpleNamespace(presigned_url=SimpleNamespace(url="https://s3/obj"), file_size_bytes=10)
+    dataexport = handler._client._clients.dataexport
+    dataexport.generate_export_channel_data_presigned_link.side_effect = [_http_error(500), ok]
+
+    with patch("nominal.thirdparty.polars.presigned_export_handler.time.sleep"):
+        result = handler._generate_presigned_link(MagicMock())
+
+    assert result is ok
+    assert dataexport.generate_export_channel_data_presigned_link.call_count == 2
+
+
+def test_generate_presigned_link_raises_immediately_on_4xx() -> None:
+    """A non-transient 4xx is raised without retrying."""
+    handler = _handler()
+    dataexport = handler._client._clients.dataexport
+    dataexport.generate_export_channel_data_presigned_link.side_effect = _http_error(400)
+
+    with patch("nominal.thirdparty.polars.presigned_export_handler.time.sleep"), pytest.raises(Exception):
+        handler._generate_presigned_link(MagicMock())
+
+    assert dataexport.generate_export_channel_data_presigned_link.call_count == 1
+
+
+def test_generate_presigned_link_gives_up_after_max_retries() -> None:
+    """Persistent transient errors raise after exhausting retries."""
+    handler = PresignedExportHandler(MagicMock(), max_link_retries=3)
+    dataexport = handler._client._clients.dataexport
+    dataexport.generate_export_channel_data_presigned_link.side_effect = _http_error(503)
+
+    with patch("nominal.thirdparty.polars.presigned_export_handler.time.sleep"), pytest.raises(Exception):
+        handler._generate_presigned_link(MagicMock())
+
+    assert dataexport.generate_export_channel_data_presigned_link.call_count == 3
+
+
+# ---- readiness wait ----
+
+
+def test_wait_until_materialized_polls_until_full_size() -> None:
+    """The readiness wait polls the object size until it reaches the authoritative file_size_bytes."""
+    handler = _handler()
+    with (
+        patch.object(handler, "_served_size", side_effect=[100, 100, 1000]) as served,
+        patch("nominal.thirdparty.polars.presigned_export_handler.time.sleep"),
+    ):
+        handler._wait_until_materialized("https://s3/obj", expected_size=1000)
+    assert served.call_count == 3
+
+
+def test_wait_until_materialized_gives_up_after_timeout() -> None:
+    """If the object never reaches the expected size, the wait returns (proceeds) instead of hanging."""
+    handler = PresignedExportHandler(MagicMock(), readiness_timeout=0.0)
+    with (
+        patch.object(handler, "_served_size", return_value=100) as served,
+        patch("nominal.thirdparty.polars.presigned_export_handler.time.sleep"),
+    ):
+        handler._wait_until_materialized("https://s3/obj", expected_size=1000)
+    assert served.call_count == 1  # one probe, then deadline (timeout=0) is hit
+
+
+# ---- merge() ----
+
+
+def test_merge_concats_same_schema_and_outer_joins_differing(tmp_path: pathlib.Path) -> None:
+    """Same-schema files are vertically concatenated; differing schemas are outer-joined on timestamp."""
+    (tmp_path / "f0.csv").write_text("timestamp,a\n0,1\n1,2\n")
+    (tmp_path / "f1.csv").write_text("timestamp,a\n2,3\n")  # same schema as f0 -> vertical concat
+    (tmp_path / "f2.csv").write_text("timestamp,b\n0,10\n1,11\n")  # differing schema -> outer join
+
+    merged = PresignedExportHandler.merge([tmp_path / "f0.csv", tmp_path / "f1.csv", tmp_path / "f2.csv"]).collect()
+
+    assert set(merged.columns) == {"timestamp", "a", "b"}
+    assert merged["timestamp"].to_list() == [0, 1, 2]
+    assert merged["a"].to_list() == [1, 2, 3]
+    assert merged["b"].to_list() == [10, 11, None]
+
+
+def test_merge_handles_integer_then_float_columns(tmp_path: pathlib.Path) -> None:
+    """A numeric column that looks integer for many rows then turns float must not mis-infer as i64."""
+    # Column 'a' is integer for the first rows, float later (and split across two same-schema files),
+    # which trips polars' sampled schema inference unless we infer over the full file.
+    header = "timestamp,a\n"
+    early = "".join(f"{i}.0,0\n" for i in range(200))
+    (tmp_path / "f0.csv").write_text(header + early)
+    (tmp_path / "f1.csv").write_text(header + "200.0,0.14173234\n201.0,1\n")
+
+    merged = PresignedExportHandler.merge([tmp_path / "f0.csv", tmp_path / "f1.csv"]).collect()
+
+    assert merged.schema["a"] == pl.Float64
+    assert merged.height == 202
+    assert merged["timestamp"].to_list()[:2] == [0.0, 1.0]
+
+
+def test_merge_handles_channel_in_different_groupings_across_slices(tmp_path: pathlib.Path) -> None:
+    """A channel that appears in different column groupings across slices must coalesce, not collide."""
+    # slice 0 grouped [a, b]; slice 1 grouped [a, c] (a regrouped). Overlapping on 'a', different
+    # timestamps. The old outer-join-on-timestamp produced an 'a_right' duplicate column and failed.
+    (tmp_path / "s0_g0.csv").write_text("timestamp,a,b\n0,1,10\n")
+    (tmp_path / "s1_g0.csv").write_text("timestamp,a,c\n1,2,20\n")
+
+    merged = PresignedExportHandler.merge([tmp_path / "s0_g0.csv", tmp_path / "s1_g0.csv"]).collect()
+
+    assert set(merged.columns) == {"timestamp", "a", "b", "c"}
+    assert merged["timestamp"].to_list() == [0, 1]
+    assert merged["a"].to_list() == [1, 2]
+    assert merged["b"].to_list() == [10, None]
+    assert merged["c"].to_list() == [None, 20]
+
+
+def test_merge_coalesces_column_fragments_within_a_slice(tmp_path: pathlib.Path) -> None:
+    """Files sharing timestamps but holding different channels collapse into one row per timestamp."""
+    (tmp_path / "g0.csv").write_text("timestamp,a\n0,1\n1,2\n")
+    (tmp_path / "g1.csv").write_text("timestamp,b\n0,10\n1,11\n")
+
+    merged = PresignedExportHandler.merge([tmp_path / "g0.csv", tmp_path / "g1.csv"]).collect()
+
+    assert set(merged.columns) == {"timestamp", "a", "b"}
+    assert merged["timestamp"].to_list() == [0, 1]
+    assert merged["a"].to_list() == [1, 2]
+    assert merged["b"].to_list() == [10, 11]
+
+
+def test_merge_skips_header_only_files(tmp_path: pathlib.Path) -> None:
+    """Header-only files (no data rows, str-typed timestamp) are skipped instead of breaking the join."""
+    (tmp_path / "data.csv").write_text("timestamp,a\n0,1\n1,2\n")
+    (tmp_path / "empty_same.csv").write_text("timestamp,a\n")  # header only, same schema
+    (tmp_path / "empty_diff.csv").write_text("timestamp,b\n")  # header only, differing schema
+
+    merged = PresignedExportHandler.merge(
+        [tmp_path / "data.csv", tmp_path / "empty_same.csv", tmp_path / "empty_diff.csv"]
+    ).collect()
+
+    assert merged.columns == ["timestamp", "a"]
+    assert merged["timestamp"].to_list() == [0, 1]
+    assert merged["a"].to_list() == [1, 2]
+
+
+def test_merge_raises_when_all_files_empty(tmp_path: pathlib.Path) -> None:
+    """If every file is header-only there is nothing to merge."""
+    (tmp_path / "e1.csv").write_text("timestamp,a\n")
+    (tmp_path / "e2.csv").write_text("timestamp,b\n")
+    with pytest.raises(ValueError, match="No data rows found"):
+        PresignedExportHandler.merge([tmp_path / "e1.csv", tmp_path / "e2.csv"])
+
+
+def test_merge_raises_on_missing_timestamp_column(tmp_path: pathlib.Path) -> None:
+    """A file without the timestamp column cannot be merged."""
+    (tmp_path / "bad.csv").write_text("x,y\n1,2\n")
+    with pytest.raises(ValueError, match="no 'timestamp' column"):
+        PresignedExportHandler.merge([tmp_path / "bad.csv"])
+
+
+def test_merge_raises_on_empty_paths() -> None:
+    """Merging nothing is an error."""
+    with pytest.raises(ValueError, match="No paths provided"):
+        PresignedExportHandler.merge([])


### PR DESCRIPTION
## Summary
A new SDK handler that exports channel data to CSV files on disk via the presigned-link endpoint (`generate_export_channel_data_presigned_link`) + the pipelined `MultipartFileDownloader`. `export()` returns the written paths; a static `merge()` reassembles the timestamp-keyed column fragments into a lazy, sorted `pl.LazyFrame`.

Inherits the shared `ExportHandler` planning. Key behaviors:
- **Per-slice pruning** — one bucketed-compute pass skips numeric *and* enum channels with no data in a given time slice, so empty slices/channels are never requested or downloaded.
- **Readiness wait** — large exports materialize to S3 asynchronously, so we poll until the object's served size reaches the response's `file_size_bytes` before downloading (avoids header-only files).
- **Transient retry** — presigned-link generation is retried with backoff on 5xx/429/network errors, so a one-off backend error on one file doesn't fail the whole export.
- **Robust `merge()`** — stacks fragments (diagonal) and coalesces rows per timestamp, so a channel grouped differently across slices reassembles without duplicate-column collisions; header-only files are skipped and full schema inference avoids int-vs-float CSV parse errors.

Defaults are large (50M points/request, 50M/file, 50 channels/request); output is uncompressed `.csv` so `merge()` stays lazy.

## Stack
1. `sroustom/export-pipelined-download` → `main`
2. `sroustom/export-handler-base` → PR #814
3. **this PR** → PR #815

## Testing
`tests/thirdparty/polars/test_presigned_export_handler.py` (API + downloader mocked): per-slice numeric/enum pruning, undetermined-enum exported for all slices, readiness wait polling/timeout, link-retry (transient retried, 4xx raised, give-up after max), and `merge()` (coalesce fragments, overlapping groupings across slices, int-then-float columns, header-only skip, all-empty). Full suite: 294 passing; `just check` clean.

## Follow-up (not in this PR)
Replace the per-channel `Compute:TooManyCategories` fallback in enum bucketing with recursive bisection (planned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)