### PR TITLE
feat: multi-thread presigned export planning + PresignedURL passthrough

### DIFF
--- a/nominal/core/_utils/multipart_downloader.py
+++ b/nominal/core/_utils/multipart_downloader.py
@@ -21,36 +21,54 @@ from nominal.core._utils.networking import HeaderProvider, create_multipart_requ
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class PresignedURL:
+    """A fetched presigned URL plus any object metadata discovered while fetching it.
+
+    When ``total_size`` is known up front (e.g. the export service returns the authoritative file
+    size, or a readiness probe already learned it), the downloader skips its own size/ETag probe,
+    saving a round-trip per file. Providers that don't know the size ahead of time return just the
+    url and the downloader probes as before.
+    """
+
+    url: str
+    total_size: int | None = None
+    etag: str | None = None
+
+
 @dataclasses.dataclass
 class PresignedURLProvider:
     """Thread-safe presigned URL cache that refreshes on schedule or when invalidated."""
 
-    fetch_fn: Callable[[], str]
-    """Function used to fetch a fresh presigned URL when the current one expires"""
+    fetch_fn: Callable[[], PresignedURL]
+    """Function used to fetch a fresh presigned URL (and any known metadata) when the current one expires"""
     ttl_secs: float
     """Time-to-Live for the presigned URLs"""
     skew_secs: float
     """Buffer around TTL to ensure that URLs are still fresh by the time they are used"""
 
-    # Pair of url + deadline, where the deadline is the latest monotonic clock time we consider the URL valid for
-    _stamped_url: tuple[str, float] | None = dataclasses.field(default=None, repr=False)
+    # Pair of presigned + deadline, where the deadline is the latest monotonic clock time we consider it valid for
+    _stamped: tuple[PresignedURL, float] | None = dataclasses.field(default=None, repr=False)
     _lock: threading.Lock = dataclasses.field(default_factory=threading.Lock, repr=False)
 
-    def get_url(self, *, force: bool = False) -> str:
+    def get(self, *, force: bool = False) -> PresignedURL:
         now = time.monotonic()
         with self._lock:
-            if force or self._stamped_url is None or now >= self._stamped_url[1]:
-                url = self.fetch_fn()
+            if force or self._stamped is None or now >= self._stamped[1]:
+                presigned = self.fetch_fn()
                 deadline = now + max(0.0, self.ttl_secs - self.skew_secs)
-                self._stamped_url = (url, deadline)
-                logger.debug("Refreshed presigned url with deadline of %f ('%s')", deadline, url)
+                self._stamped = (presigned, deadline)
+                logger.debug("Refreshed presigned url with deadline of %f ('%s')", deadline, presigned.url)
 
-            return self._stamped_url[0]
+            return self._stamped[0]
+
+    def get_url(self, *, force: bool = False) -> str:
+        return self.get(force=force).url
 
     def invalidate(self) -> None:
         with self._lock:
             logger.info("Invalidating presigned URL")
-            self._stamped_url = None
+            self._stamped = None
 
 
 @dataclass(frozen=True)
@@ -185,19 +203,23 @@ class MultipartFileDownloader:
         for it in items:
             self._check_destination(it.destination)
 
-        # Probe & preallocate files to generate a plan
-        plans: list[_PlannedDownload] = []
-        for it in items:
-            if it.destination in plan_failures:
-                continue
-
+        # Probe & preallocate files to generate plans. Planning is multi-threaded on the shared pool:
+        # each file's link generation and (possibly long) S3 materialization wait happen concurrently
+        # rather than one file at a time. This is a barrier -- all planning completes before any byte
+        # download starts -- so reusing the download pool here cannot deadlock against _run_downloads.
+        plan_by_dest: dict[pathlib.Path, _PlannedDownload] = {}
+        plan_futs = {self._pool.submit(self._plan_and_preallocate, it): it for it in items}
+        for fut in as_completed(plan_futs):
+            it = plan_futs[fut]
             try:
-                plan = self._plan_item(it)
-                self._preallocate(it.destination, plan.total_size)
-                plans.append(plan)
+                plan_by_dest[it.destination] = fut.result()
             except Exception as ex:
                 plan_failures[it.destination] = ex
                 logger.error("Planning failed for %s", it.destination, exc_info=ex)
+
+        # Rebuild in input order so downstream submission/logging is deterministic regardless of the
+        # order planning futures happened to complete in.
+        plans = [plan_by_dest[it.destination] for it in items if it.destination in plan_by_dest]
 
         if plan_failures:
             logger.warning("Failed to plan downloads for %d files!", len(plan_failures))
@@ -306,12 +328,27 @@ class MultipartFileDownloader:
         raise RuntimeError("Could not determine object size/ETag (presigned URL kept failing)")
 
     def _plan_item(self, item: DownloadItem) -> _PlannedDownload:
+        # If the provider already knows the object size (e.g. an export service returned it), skip
+        # the size/ETag probe entirely -- one fewer round-trip per file, which adds up over many files.
+        presigned = item.provider.get()
+        if presigned.total_size is not None:
+            return _PlannedDownload(item=item, total_size=presigned.total_size, etag=presigned.etag)
         total_size, etag = self._head_or_probe(item.provider)
         return _PlannedDownload(
             item=item,
             total_size=total_size,
             etag=etag,
         )
+
+    def _plan_and_preallocate(self, item: DownloadItem) -> _PlannedDownload:
+        """Fetch the presigned link, probe size/etag if needed, and preallocate the destination file.
+
+        Runs on the download pool so link generation + the (possibly long) materialization wait
+        baked into the provider's fetch happen concurrently across files rather than one at a time.
+        """
+        plan = self._plan_item(item)
+        self._preallocate(item.destination, plan.total_size)
+        return plan
 
     # ---- IO helpers ----
 

--- a/nominal/core/dataset_file.py
+++ b/nominal/core/dataset_file.py
@@ -21,6 +21,7 @@ from nominal.core._utils.multipart import DEFAULT_CHUNK_SIZE
 from nominal.core._utils.multipart_downloader import (
     DownloadItem,
     MultipartFileDownloader,
+    PresignedURL,
     PresignedURLProvider,
 )
 from nominal.core.bounds import Bounds
@@ -123,18 +124,19 @@ class DatasetFile(RefreshableMixin[scout_catalog.DatasetFile]):
         return self
 
     def _presigned_url_provider(self, ttl_secs: float = 60.0, skew_secs: float = 15.0) -> PresignedURLProvider:
-        def fetch() -> str:
-            return self._clients.catalog.get_dataset_file_uri(self._clients.auth_header, self.dataset_rid, self.id).uri
+        def fetch() -> PresignedURL:
+            uri = self._clients.catalog.get_dataset_file_uri(self._clients.auth_header, self.dataset_rid, self.id).uri
+            return PresignedURL(url=uri)
 
         return PresignedURLProvider(fetch_fn=fetch, ttl_secs=ttl_secs, skew_secs=skew_secs)
 
     def _origin_presigned_url_provider(
         self, origin_path: str, ttl_secs: float = 60.0, skew_secs: float = 15.0
     ) -> PresignedURLProvider:
-        def fetch() -> str:
+        def fetch() -> PresignedURL:
             for uri in self._clients.catalog.get_origin_file_uris(self._clients.auth_header, self.dataset_rid, self.id):
                 if uri.path == origin_path:
-                    return uri.uri
+                    return PresignedURL(url=uri.uri)
 
             raise ValueError(f"No such origin path: {origin_path}")
 

--- a/nominal/thirdparty/polars/polars_export_handler.py
+++ b/nominal/thirdparty/polars/polars_export_handler.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 import pathlib
 import random
+import threading
 import time
 from typing import Iterator, Mapping, Sequence
 
@@ -19,6 +20,7 @@ from nominal.core._utils.multipart import DEFAULT_CHUNK_SIZE
 from nominal.core._utils.multipart_downloader import (
     DownloadItem,
     MultipartFileDownloader,
+    PresignedURL,
     PresignedURLProvider,
 )
 from nominal.core.channel import Channel, ChannelDataType, filter_channels_with_data
@@ -75,6 +77,12 @@ DEFAULT_URL_SKEW_SECS = 60.0
 # backoff that grows to ~30s -- patient enough to ride out shared-limit contention.
 DEFAULT_MAX_LINK_RETRIES = 8
 _MAX_LINK_RETRY_BACKOFF_SECS = 30.0
+
+# The downloader plans (generates links + waits for S3 materialization) for many files concurrently.
+# Since each link is a server-side compute query, bound how many generate at once -- independently of
+# `num_workers` -- to stay under the backend's concurrent-query limit. Byte downloads stay fully
+# parallel regardless; kept well below the download concurrency on purpose.
+DEFAULT_MAX_CONCURRENT_LINKS = 4
 
 # Large exports are materialized to S3 asynchronously: the link is returned with the final
 # `file_size_bytes` before the object is fully written, and its served size grows until complete. We
@@ -657,14 +665,29 @@ class PolarsExportHandler:
         points_per_dataframe: int = DEFAULT_POINTS_PER_DATAFRAME,
         channels_per_request: int = DEFAULT_CHANNELS_PER_REQUEST,
         num_workers: int = DEFAULT_NUM_WORKERS,
+        max_concurrent_links: int = DEFAULT_MAX_CONCURRENT_LINKS,
     ):
-        """Initialize export handler"""
+        """Initialize export handler.
+
+        Args:
+            client: Nominal client used for all API calls.
+            points_per_request: Target maximum number of points fetched in a single export request.
+            points_per_dataframe: Target maximum number of points per output DataFrame / file; drives
+                how the time range is subdivided into batches.
+            channels_per_request: Maximum number of channels packed into a single request.
+            num_workers: Number of parallel worker threads used for requests and downloads.
+            max_concurrent_links: Maximum presigned export links generated concurrently during the
+                (multi-threaded) planning phase of `export_to_files`. Each link is a server-side
+                compute query, so this is bounded below `num_workers` to stay under the backend's
+                concurrent-query limit; byte downloads remain fully parallel regardless.
+        """
         self._client = client
         self._points_per_request = points_per_request
         self._points_per_dataframe = points_per_dataframe
         self._channels_per_request = channels_per_request
 
         self._num_workers = num_workers
+        self._max_concurrent_links = max_concurrent_links
 
     def _compute_channel_rates(
         self,
@@ -1012,7 +1035,11 @@ class PolarsExportHandler:
         export_jobs = self._compute_export_jobs(
             supported_channels, _TimeRange(start, end), timestamp_type, tags or {}, buckets, resolution, batch_duration
         )
-        items = self._build_download_items(export_jobs, output_dir, file_prefix)
+        # One semaphore shared across all providers bounds how many presigned links (server-side
+        # compute queries) generate concurrently while the downloader plans files in parallel, keeping
+        # us under the backend's concurrent-query limit. Byte downloads stay fully parallel.
+        link_semaphore = threading.BoundedSemaphore(self._max_concurrent_links)
+        items = self._build_download_items(export_jobs, output_dir, file_prefix, link_semaphore)
         if not items:
             logger.warning("No export jobs computed-- returning")
             return []
@@ -1067,6 +1094,7 @@ class PolarsExportHandler:
         export_jobs: Mapping[_TimeRange, Sequence[_ExportJob]],
         output_dir: pathlib.Path,
         file_prefix: str,
+        link_semaphore: threading.BoundedSemaphore,
     ) -> list[DownloadItem]:
         """Build one :class:`DownloadItem` per export job -- a 1:1 file:job (and thus file:dataframe) map."""
         # Resolve each datasource once (cached) since many jobs share a datasource.
@@ -1077,7 +1105,7 @@ class PolarsExportHandler:
         for slice_idx, time_slice in enumerate(sorted(export_jobs.keys())):
             for job_idx, job in enumerate(export_jobs[time_slice]):
                 destination = output_dir / self._file_name(file_prefix, job, slice_idx, job_idx)
-                provider = self._presigned_url_provider(job, datasources[job.datasource_rid])
+                provider = self._presigned_url_provider(job, datasources[job.datasource_rid], link_semaphore)
                 items.append(DownloadItem(provider=provider, destination=destination, part_size=DEFAULT_CHUNK_SIZE))
         return items
 
@@ -1086,16 +1114,21 @@ class PolarsExportHandler:
         datasource_short = job.datasource_rid.split(".")[-1]
         return f"{file_prefix}_{datasource_short}_s{slice_idx:04d}_g{job_idx:03d}.csv.gz"
 
-    def _presigned_url_provider(self, job: _ExportJob, datasource: DataSource) -> PresignedURLProvider:
+    def _presigned_url_provider(
+        self, job: _ExportJob, datasource: DataSource, link_semaphore: threading.BoundedSemaphore
+    ) -> PresignedURLProvider:
         # Build the export request lazily on first fetch (it issues a get_channels call), then memoize
         # so re-signing on expiry doesn't rebuild it.
         cached_request: scout_dataexport_api.ExportDataRequest | None = None
 
-        def fetch() -> str:
+        def fetch() -> PresignedURL:
             nonlocal cached_request
             if cached_request is None:
                 cached_request = job.export_request(datasource)
-            response = self._generate_presigned_link(cached_request)
+            # Hold a slot across the (retrying) link generation so concurrent compute queries stay
+            # bounded; release it before the S3 readiness wait, which isn't a query.
+            with link_semaphore:
+                response = self._generate_presigned_link(cached_request)
             url = response.presigned_url.url
             logger.debug(
                 "Presigned export link ready (channels=%d, %.2f MB)",
@@ -1103,10 +1136,11 @@ class PolarsExportHandler:
                 response.file_size_bytes / 1e6,
             )
             # Large exports are written to S3 asynchronously; wait until the object is fully
-            # materialized so the downloader never captures a partial (header-only) file. The
-            # downloader re-measures the (now-complete) size itself via its ranged-GET probe.
-            self._wait_until_materialized(url, response.file_size_bytes)
-            return url
+            # materialized so the downloader never captures a partial (header-only) file. The same
+            # probe yields the size (authoritative from file_size_bytes) and ETag, which we pass to
+            # the downloader so it can skip its own size/ETag probe -- one fewer round-trip per file.
+            etag = self._wait_until_materialized(url, response.file_size_bytes)
+            return PresignedURL(url=url, total_size=response.file_size_bytes, etag=etag)
 
         return PresignedURLProvider(fetch_fn=fetch, ttl_secs=DEFAULT_URL_TTL_SECS, skew_secs=DEFAULT_URL_SKEW_SECS)
 
@@ -1142,12 +1176,15 @@ class PolarsExportHandler:
                 delay = min(delay * 2, _MAX_LINK_RETRY_BACKOFF_SECS)
         raise AssertionError("unreachable")  # loop either returns or raises
 
-    def _wait_until_materialized(self, url: str, expected_size: int) -> None:
-        """Block until the object served at ``url`` reaches ``expected_size`` bytes.
+    def _wait_until_materialized(self, url: str, expected_size: int) -> str | None:
+        """Block until the object served at ``url`` reaches ``expected_size`` bytes; return its ETag.
 
         The presigned export endpoint returns the authoritative final ``file_size_bytes`` before the
         S3 object is fully written; its served size grows until complete. Polling avoids downloading a
         partially-written file. Empty exports (tiny ``expected_size``) satisfy this immediately.
+
+        The same probe also yields the object's ETag, which is returned so the caller can hand it to
+        the downloader (no separate size/ETag probe needed).
 
         Raises:
             ExportNotReadyError: if the object never reaches ``expected_size`` before the readiness
@@ -1157,9 +1194,9 @@ class PolarsExportHandler:
         deadline = time.monotonic() + DEFAULT_READINESS_TIMEOUT_SECS
         delay = 0.5
         while True:
-            served = self._served_size(url)
+            served, etag = self._served_size(url)
             if served is not None and served >= expected_size:
-                return
+                return etag
             if time.monotonic() >= deadline:
                 raise ExportNotReadyError(
                     f"Export object not fully materialized after {DEFAULT_READINESS_TIMEOUT_SECS:.0f}s "
@@ -1169,23 +1206,24 @@ class PolarsExportHandler:
             delay = min(delay * 2, 5.0)
 
     @staticmethod
-    def _served_size(url: str) -> int | None:
-        """Return the full object size S3 currently reports for ``url`` via a ranged probe (``None`` if unknown).
+    def _served_size(url: str) -> tuple[int | None, str | None]:
+        """Return ``(served_size, etag)`` S3 currently reports for ``url`` via a ranged probe.
 
-        The probe streams (and closes) the 1-byte body so we never buffer a response body just to read
-        headers.
+        ``served_size`` is the full object size (``None`` if it couldn't be determined). The probe
+        streams (and closes) the 1-byte body so we never buffer a response body just to read headers.
         """
         try:
             resp = requests.get(url, headers={"Range": "bytes=0-0"}, timeout=30.0, stream=True)
         except requests.RequestException:
-            return None
+            return None, None
         try:
             if resp.status_code not in (200, 206):
-                return None
+                return None, None
+            etag = resp.headers.get("ETag")
             content_range = resp.headers.get("Content-Range")
             if content_range:
-                return int(content_range.split("/")[-1])
+                return int(content_range.split("/")[-1]), etag
             content_length = resp.headers.get("Content-Length")
-            return int(content_length) if content_length is not None else None
+            return (int(content_length) if content_length is not None else None), etag
         finally:
             resp.close()

--- a/nominal/thirdparty/polars/polars_export_handler.py
+++ b/nominal/thirdparty/polars/polars_export_handler.py
@@ -105,6 +105,60 @@ def _is_transient_error(exc: Exception) -> bool:
     return isinstance(exc, requests.RequestException)
 
 
+@dataclasses.dataclass
+class _PlanningProfile:
+    """Thread-safe accumulator for per-file planning timings, to diagnose where planning time goes.
+
+    The presigned planning phase has three distinct, serial-per-file costs that the parallel planner
+    runs concurrently across files: waiting for a link-generation slot (`semaphore`), the link
+    generation backend call itself (`link`), and polling S3 until the object is materialized
+    (`materialize`). Recording them separately lets `log_summary` attribute slow planning to the
+    right cause rather than lumping it into one number.
+    """
+
+    _lock: threading.Lock = dataclasses.field(default_factory=threading.Lock)
+    _semaphore: list[float] = dataclasses.field(default_factory=list)
+    _link: list[float] = dataclasses.field(default_factory=list)
+    _materialize: list[float] = dataclasses.field(default_factory=list)
+
+    def record(self, *, semaphore_s: float, link_s: float, materialize_s: float) -> None:
+        with self._lock:
+            self._semaphore.append(semaphore_s)
+            self._link.append(link_s)
+            self._materialize.append(materialize_s)
+
+    def log_summary(self) -> None:
+        """Log an INFO-level breakdown of total/avg/max time spent in each planning phase."""
+        with self._lock:
+            count = len(self._link)
+            if not count:
+                return
+
+            def stats(samples: list[float]) -> tuple[float, float, float]:
+                return sum(samples), sum(samples) / len(samples), max(samples)
+
+            sem_total, sem_avg, sem_max = stats(self._semaphore)
+            link_total, link_avg, link_max = stats(self._link)
+            mat_total, mat_avg, mat_max = stats(self._materialize)
+
+        logger.info(
+            "Planning profile over %d file(s) [wall-clock is lower due to parallelism]: "
+            "link-gen total=%.1fs avg=%.2fs max=%.2fs | "
+            "materialize-wait total=%.1fs avg=%.2fs max=%.2fs | "
+            "semaphore-wait total=%.1fs avg=%.2fs max=%.2fs",
+            count,
+            link_total,
+            link_avg,
+            link_max,
+            mat_total,
+            mat_avg,
+            mat_max,
+            sem_total,
+            sem_avg,
+            sem_max,
+        )
+
+
 def _extract_bucket_counts(
     response: scout_compute_api.ComputeNodeResponse,
 ) -> Sequence[tuple[IntegralNanosecondsUTC, int]]:
@@ -1039,7 +1093,10 @@ class PolarsExportHandler:
         # compute queries) generate concurrently while the downloader plans files in parallel, keeping
         # us under the backend's concurrent-query limit. Byte downloads stay fully parallel.
         link_semaphore = threading.BoundedSemaphore(self._max_concurrent_links)
-        items = self._build_download_items(export_jobs, output_dir, file_prefix, link_semaphore)
+        # Records per-file planning timings (semaphore wait / link gen / materialization) so we can
+        # report where the planning phase spends its time -- summarized at INFO once downloads finish.
+        profile = _PlanningProfile()
+        items = self._build_download_items(export_jobs, output_dir, file_prefix, link_semaphore, profile)
         if not items:
             logger.warning("No export jobs computed-- returning")
             return []
@@ -1055,6 +1112,7 @@ class PolarsExportHandler:
             ) as downloader,
         ):
             results = downloader.download_files(items)
+        profile.log_summary()
 
         if results.failed:
             for dest, ex in results.failed.items():
@@ -1095,6 +1153,7 @@ class PolarsExportHandler:
         output_dir: pathlib.Path,
         file_prefix: str,
         link_semaphore: threading.BoundedSemaphore,
+        profile: _PlanningProfile,
     ) -> list[DownloadItem]:
         """Build one :class:`DownloadItem` per export job -- a 1:1 file:job (and thus file:dataframe) map."""
         # Resolve each datasource once (cached) since many jobs share a datasource.
@@ -1105,7 +1164,7 @@ class PolarsExportHandler:
         for slice_idx, time_slice in enumerate(sorted(export_jobs.keys())):
             for job_idx, job in enumerate(export_jobs[time_slice]):
                 destination = output_dir / self._file_name(file_prefix, job, slice_idx, job_idx)
-                provider = self._presigned_url_provider(job, datasources[job.datasource_rid], link_semaphore)
+                provider = self._presigned_url_provider(job, datasources[job.datasource_rid], link_semaphore, profile)
                 items.append(DownloadItem(provider=provider, destination=destination, part_size=DEFAULT_CHUNK_SIZE))
         return items
 
@@ -1115,7 +1174,11 @@ class PolarsExportHandler:
         return f"{file_prefix}_{datasource_short}_s{slice_idx:04d}_g{job_idx:03d}.csv.gz"
 
     def _presigned_url_provider(
-        self, job: _ExportJob, datasource: DataSource, link_semaphore: threading.BoundedSemaphore
+        self,
+        job: _ExportJob,
+        datasource: DataSource,
+        link_semaphore: threading.BoundedSemaphore,
+        profile: _PlanningProfile,
     ) -> PresignedURLProvider:
         # Build the export request lazily on first fetch (it issues a get_channels call), then memoize
         # so re-signing on expiry doesn't rebuild it.
@@ -1126,20 +1189,32 @@ class PolarsExportHandler:
             if cached_request is None:
                 cached_request = job.export_request(datasource)
             # Hold a slot across the (retrying) link generation so concurrent compute queries stay
-            # bounded; release it before the S3 readiness wait, which isn't a query.
+            # bounded; release it before the S3 readiness wait, which isn't a query. Time each phase
+            # separately so slow planning can be attributed to queueing, link gen, or the S3 wait.
+            acquire_start = time.monotonic()
             with link_semaphore:
+                semaphore_s = time.monotonic() - acquire_start
+                link_start = time.monotonic()
                 response = self._generate_presigned_link(cached_request)
+                link_s = time.monotonic() - link_start
             url = response.presigned_url.url
-            logger.debug(
-                "Presigned export link ready (channels=%d, %.2f MB)",
-                len(job.channel_names),
-                response.file_size_bytes / 1e6,
-            )
             # Large exports are written to S3 asynchronously; wait until the object is fully
             # materialized so the downloader never captures a partial (header-only) file. The same
             # probe yields the size (authoritative from file_size_bytes) and ETag, which we pass to
             # the downloader so it can skip its own size/ETag probe -- one fewer round-trip per file.
+            materialize_start = time.monotonic()
             etag = self._wait_until_materialized(url, response.file_size_bytes)
+            materialize_s = time.monotonic() - materialize_start
+
+            profile.record(semaphore_s=semaphore_s, link_s=link_s, materialize_s=materialize_s)
+            logger.debug(
+                "Planned %d-channel %.2f MB export: link-gen %.2fs, materialize %.2fs, semaphore-wait %.2fs",
+                len(job.channel_names),
+                response.file_size_bytes / 1e6,
+                link_s,
+                materialize_s,
+                semaphore_s,
+            )
             return PresignedURL(url=url, total_size=response.file_size_bytes, etag=etag)
 
         return PresignedURLProvider(fetch_fn=fetch, ttl_secs=DEFAULT_URL_TTL_SECS, skew_secs=DEFAULT_URL_SKEW_SECS)

--- a/tests/core/test_multipart_downloader.py
+++ b/tests/core/test_multipart_downloader.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Sequence, cast
+from typing import Iterator, Sequence, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,25 +11,33 @@ import requests
 from nominal.core._utils.multipart_downloader import (
     DownloadItem,
     MultipartFileDownloader,
+    PresignedURL,
     PresignedURLProvider,
     _DataChunkBounds,
     _PlannedDownload,
 )
 
 
-def _provider() -> PresignedURLProvider:
-    return PresignedURLProvider(fetch_fn=lambda: "https://example.com/file", ttl_secs=60.0, skew_secs=0.0)
+def _provider(presigned: PresignedURL | None = None) -> PresignedURLProvider:
+    presigned = presigned or PresignedURL(url="https://example.com/file")
+    return PresignedURLProvider(fetch_fn=lambda: presigned, ttl_secs=60.0, skew_secs=0.0)
 
 
 @pytest.fixture
-def downloader() -> MultipartFileDownloader:
-    return MultipartFileDownloader(
-        max_workers=1,
-        timeout=30.0,
-        max_part_retries=3,
-        _session=MagicMock(spec=["head", "get", "close"]),
-        _pool=MagicMock(spec=["submit", "shutdown"]),
-    )
+def downloader() -> Iterator[MultipartFileDownloader]:
+    # A real pool is needed because download_files now plans (and pre-allocates) on the pool in
+    # parallel; the HTTP session stays mocked since these tests patch _plan_item / _run_downloads.
+    pool = ThreadPoolExecutor(max_workers=2)
+    try:
+        yield MultipartFileDownloader(
+            max_workers=2,
+            timeout=30.0,
+            max_part_retries=3,
+            _session=MagicMock(spec=["head", "get", "close"]),
+            _pool=pool,
+        )
+    finally:
+        pool.shutdown(wait=True)
 
 
 @pytest.fixture
@@ -41,10 +50,10 @@ def test_presigned_url_provider_caches_until_invalidated() -> None:
     """URL is reused across calls until invalidate() is called, then a fresh URL is fetched."""
     calls = 0
 
-    def fetch() -> str:
+    def fetch() -> PresignedURL:
         nonlocal calls
         calls += 1
-        return f"https://example.com/file/{calls}"
+        return PresignedURL(url=f"https://example.com/file/{calls}")
 
     provider = PresignedURLProvider(fetch_fn=fetch, ttl_secs=60.0, skew_secs=0.0)
 
@@ -158,6 +167,34 @@ def test_download_files_planning_failure_excluded_from_succeeded(
     assert list(results.succeeded) == []
     assert results.failed == {item.destination: error}
     assert not item.destination.exists()
+
+
+# ---- _plan_item PresignedURL passthrough tests ----
+
+
+def test_plan_item_skips_probe_when_size_known(tmp_path: Path, downloader: MultipartFileDownloader) -> None:
+    """When the provider already knows the object size, planning uses it and skips the HEAD/GET probe."""
+    provider = _provider(PresignedURL(url="https://example.com/f", total_size=123, etag="abc"))
+    item = DownloadItem(provider=provider, destination=tmp_path / "f.bin", part_size=4)
+
+    with patch.object(downloader, "_head_or_probe", side_effect=AssertionError("should not probe")) as probe:
+        plan = downloader._plan_item(item)
+
+    assert plan.total_size == 123
+    assert plan.etag == "abc"
+    probe.assert_not_called()
+
+
+def test_plan_item_probes_when_size_unknown(tmp_path: Path, downloader: MultipartFileDownloader) -> None:
+    """When the provider doesn't know the size, planning falls back to the HEAD/GET probe."""
+    item = DownloadItem(provider=_provider(), destination=tmp_path / "f.bin", part_size=4)
+
+    with patch.object(downloader, "_head_or_probe", return_value=(64, "etag")) as probe:
+        plan = downloader._plan_item(item)
+
+    assert plan.total_size == 64
+    assert plan.etag == "etag"
+    probe.assert_called_once()
 
 
 # ---- _write_part tests ----

--- a/tests/thirdparty/polars/test_polars_export_handler.py
+++ b/tests/thirdparty/polars/test_polars_export_handler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import datetime
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -625,14 +626,14 @@ def test_generate_presigned_link_raises_after_max_retries(mock_client, monkeypat
 # -- _wait_until_materialized / _served_size --
 
 
-def test_wait_until_materialized_returns_when_object_is_complete(mock_client, monkeypatch):
-    """Once the served size reaches the expected size, the wait returns without raising."""
+def test_wait_until_materialized_returns_etag_when_object_is_complete(mock_client, monkeypatch):
+    """Once the served size reaches the expected size, the wait returns the probed ETag."""
     resp = MagicMock(status_code=206)
-    resp.headers = {"Content-Range": "bytes 0-0/100"}
+    resp.headers = {"Content-Range": "bytes 0-0/100", "ETag": "abc123"}
     monkeypatch.setattr(peh.requests, "get", lambda *a, **k: resp)
 
     handler = PolarsExportHandler(client=mock_client)
-    handler._wait_until_materialized("https://s3/export", expected_size=100)  # does not raise
+    assert handler._wait_until_materialized("https://s3/export", expected_size=100) == "abc123"
 
 
 def test_wait_until_materialized_raises_on_timeout(mock_client, monkeypatch):
@@ -653,7 +654,56 @@ def test_served_size_returns_none_on_request_error(mock_client, monkeypatch):
         raise requests.ConnectionError("connection reset")
 
     monkeypatch.setattr(peh.requests, "get", _boom)
-    assert PolarsExportHandler._served_size("https://s3/export") is None
+    assert PolarsExportHandler._served_size("https://s3/export") == (None, None)
+
+
+def test_served_size_returns_size_and_etag(mock_client, monkeypatch):
+    """A successful ranged probe returns the full object size (from Content-Range) and the ETag."""
+    resp = MagicMock(status_code=206)
+    resp.headers = {"Content-Range": "bytes 0-0/4096", "ETag": "deadbeef"}
+    monkeypatch.setattr(peh.requests, "get", lambda *a, **k: resp)
+
+    assert PolarsExportHandler._served_size("https://s3/export") == (4096, "deadbeef")
+
+
+def test_presigned_url_provider_returns_metadata_and_bounds_link_concurrency(mock_client, monkeypatch):
+    """The provider's fetch returns a PresignedURL with size+etag, and the semaphore caps concurrent link gen."""
+    import concurrent.futures
+    import threading
+
+    handler = PolarsExportHandler(client=mock_client)
+    # The fetch builds an export request via job.export_request(datasource); an empty channel list
+    # keeps that construction trivial without a real datasource.
+    datasource = MagicMock()
+    datasource.get_channels.return_value = []
+    job = _job("ri.datasource.x.dsa", "a")
+
+    # Track how many link generations run concurrently; sleep so overlap is observable.
+    concurrency = {"cur": 0, "max": 0}
+    lock = threading.Lock()
+
+    def _fake_gen(_request):
+        with lock:
+            concurrency["cur"] += 1
+            concurrency["max"] = max(concurrency["max"], concurrency["cur"])
+        time.sleep(0.02)
+        with lock:
+            concurrency["cur"] -= 1
+        resp = MagicMock()
+        resp.presigned_url.url = "https://s3/export"
+        resp.file_size_bytes = 4096
+        return resp
+
+    monkeypatch.setattr(handler, "_generate_presigned_link", _fake_gen)
+    monkeypatch.setattr(handler, "_wait_until_materialized", lambda _url, _size: "etag-1")
+
+    semaphore = threading.BoundedSemaphore(2)
+    providers = [handler._presigned_url_provider(job, datasource, semaphore) for _ in range(8)]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda p: p.get(), providers))
+
+    assert all(r.total_size == 4096 and r.etag == "etag-1" and r.url == "https://s3/export" for r in results)
+    assert concurrency["max"] <= 2
 
 
 # -- export_to_files --

--- a/tests/thirdparty/polars/test_polars_export_handler.py
+++ b/tests/thirdparty/polars/test_polars_export_handler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import datetime
+import logging
 import time
 from unittest.mock import MagicMock
 
@@ -657,6 +658,27 @@ def test_served_size_returns_none_on_request_error(mock_client, monkeypatch):
     assert PolarsExportHandler._served_size("https://s3/export") == (None, None)
 
 
+def test_planning_profile_summary_logs_phase_breakdown(caplog):
+    """log_summary reports per-phase totals so slow planning can be attributed to a cause."""
+    profile = peh._PlanningProfile()
+    profile.record(semaphore_s=0.1, link_s=1.0, materialize_s=2.0)
+    profile.record(semaphore_s=0.2, link_s=3.0, materialize_s=0.5)
+
+    with caplog.at_level(logging.INFO, logger="nominal.thirdparty.polars.polars_export_handler"):
+        profile.log_summary()
+
+    assert "Planning profile over 2 file(s)" in caplog.text
+    assert "link-gen total=4.0s" in caplog.text  # 1.0 + 3.0
+    assert "materialize-wait total=2.5s" in caplog.text  # 2.0 + 0.5
+
+
+def test_planning_profile_summary_noop_when_empty(caplog):
+    """With no recorded files, log_summary emits nothing (avoids divide-by-zero / noise)."""
+    with caplog.at_level(logging.INFO, logger="nominal.thirdparty.polars.polars_export_handler"):
+        peh._PlanningProfile().log_summary()
+    assert caplog.text == ""
+
+
 def test_served_size_returns_size_and_etag(mock_client, monkeypatch):
     """A successful ranged probe returns the full object size (from Content-Range) and the ETag."""
     resp = MagicMock(status_code=206)
@@ -698,12 +720,15 @@ def test_presigned_url_provider_returns_metadata_and_bounds_link_concurrency(moc
     monkeypatch.setattr(handler, "_wait_until_materialized", lambda _url, _size: "etag-1")
 
     semaphore = threading.BoundedSemaphore(2)
-    providers = [handler._presigned_url_provider(job, datasource, semaphore) for _ in range(8)]
+    profile = peh._PlanningProfile()
+    providers = [handler._presigned_url_provider(job, datasource, semaphore, profile) for _ in range(8)]
     with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
         results = list(pool.map(lambda p: p.get(), providers))
 
     assert all(r.total_size == 4096 and r.etag == "etag-1" and r.url == "https://s3/export" for r in results)
     assert concurrency["max"] <= 2
+    # The profile recorded one timing sample per file (used for the planning summary).
+    assert len(profile._link) == 8
 
 
 # -- export_to_files --


### PR DESCRIPTION
## Summary

Stacked on #818. Parallelizes the planning/pre-allocation phase of `MultipartFileDownloader.download_files`: each file's presigned-link generation, S3-materialization wait, and pre-allocation now run **concurrently** on the shared pool (a barrier before byte downloads, so it can't deadlock against `_run_downloads`) instead of one file at a time. For exports of many files — each carrying a long, variable materialization wait — serial planning was the wall-clock bottleneck.

Also adds a `PresignedURL(url, total_size, etag)` so a provider that already knows the object size lets `_plan_item` skip its HEAD/ranged-GET probe (one fewer round-trip per file). `PresignedURLProvider.fetch_fn` now returns a `PresignedURL`; the two providers in `dataset_file.py` are updated to wrap their URL accordingly (behavior-preserving — they pass no size, so the downloader probes as before).

The export handler feeds the authoritative `file_size_bytes` + ETag through, and bounds concurrent link generation with a semaphore (`max_concurrent_links`, default 4) since each link is a server-side compute query. A planning-profile log (per-file DEBUG + INFO summary) attributes slow planning to semaphore-wait / link-gen / materialization.

## Test plan
- `uv run mypy` (clean), `ruff check` / `ruff format --check`
- `uv run pytest tests --ignore=tests/e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)