### PR TITLE
feat: pipeline export downloads with link generation + progress bar

### DIFF
--- a/nominal/core/_utils/multipart_downloader.py
+++ b/nominal/core/_utils/multipart_downloader.py
@@ -7,10 +7,10 @@ import multiprocessing
 import pathlib
 import threading
 import time
-from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, as_completed, wait
 from dataclasses import dataclass, field
 from types import TracebackType
-from typing import Callable, Iterable, Mapping, Sequence, Type
+from typing import Any, Callable, Iterable, Mapping, Sequence, Type
 
 import requests
 from typing_extensions import Self
@@ -127,6 +127,9 @@ class MultipartFileDownloader:
     _session: requests.Session = field(repr=False)
     _pool: ThreadPoolExecutor = field(repr=False)
     _closed: bool = field(default=False, repr=False)
+    # Retained so download_files_pipelined can build a *separate* session for its planning pool,
+    # keeping planning probes off the download session's connection pool.
+    _header_provider: HeaderProvider | None = field(default=None, repr=False)
 
     @classmethod
     def create(
@@ -156,7 +159,15 @@ class MultipartFileDownloader:
 
         session = create_multipart_request_session(pool_size=max_workers, header_provider=header_provider)
         pool = ThreadPoolExecutor(max_workers=max_workers)
-        return cls(max_workers, timeout, max_part_retries, _session=session, _pool=pool, _closed=False)
+        return cls(
+            max_workers,
+            timeout,
+            max_part_retries,
+            _session=session,
+            _pool=pool,
+            _closed=False,
+            _header_provider=header_provider,
+        )
 
     # ---- lifecycle ----
 
@@ -249,6 +260,161 @@ class MultipartFileDownloader:
 
         return DownloadResults(all_successes, all_failures)
 
+    def download_files_pipelined(
+        self,
+        items: Sequence[DownloadItem],
+        *,
+        on_file_planned: Callable[[pathlib.Path], None] | None = None,
+        on_file_complete: Callable[[pathlib.Path], None] | None = None,
+    ) -> DownloadResults:
+        """Download many files, pipelining link-generation with downloads.
+
+        Unlike :meth:`download_files` (which plans every file before any download starts), this starts
+        a file's byte downloads as soon as its own link is fetched, size is probed, and the file is
+        preallocated. Planning runs on a *dedicated* pool with its *own* HTTP session while part
+        downloads run on the shared download pool/session, so the two never contend -- a file begins
+        downloading immediately while other links are still being generated, and per-part parallelism
+        is preserved. (Providers that already know the object size skip the planning probe entirely,
+        so the planning session is only exercised when a size must be discovered.)
+
+        Args:
+            items: The files to download.
+            on_file_planned: Optional callback invoked with each destination once its presigned link
+                is fetched, size probed, and the file preallocated (i.e. ready to download).
+            on_file_complete: Optional callback invoked with each destination as soon as that file
+                finishes downloading successfully. Both callbacks run on the calling thread (not a
+                worker), so they are serialized and safe to drive a progress display.
+
+        Returns:
+            A :class:`DownloadResults` partitioning destinations into succeeded and failed. Files that
+            fail (destination validation, link/size planning, or any part download) are recorded in
+            ``failed`` and their partial artifacts deleted, mirroring :meth:`download_files`.
+        """
+        failures: dict[pathlib.Path, Exception] = {}
+
+        # A dedicated planning pool keeps the slow, server-side link-generation + preallocation off
+        # the download pool's FIFO queue, so part downloads are never stuck behind pending plans. It
+        # also gets its *own* HTTP session so planning probes don't share (and oversubscribe) the
+        # download session's connection pool. Futures are tracked as Future[Any] because planning and
+        # part-download futures share one pending set and are dispatched by membership in plan_futs.
+        plan_session = create_multipart_request_session(
+            pool_size=self.max_workers, header_provider=self._header_provider
+        )
+        with (
+            plan_session,
+            ThreadPoolExecutor(max_workers=self.max_workers, thread_name_prefix="presign-plan") as plan_pool,
+        ):
+            plan_futs: dict[Future[Any], DownloadItem] = {}
+            for it in items:
+                try:
+                    self._check_destination(it.destination)
+                except Exception as ex:
+                    failures[it.destination] = ex
+                    logger.error("Invalid destination %s", it.destination, exc_info=ex)
+                    continue
+                plan_futs[plan_pool.submit(self._plan_and_preallocate, it, plan_session)] = it
+
+            # Reactively drive a growing set of futures: planning futures resolve into per-file part
+            # futures (submitted to the download pool), which we add back into the pending set.
+            part_futs: dict[Future[Any], tuple[pathlib.Path, int]] = {}
+            remaining_parts: dict[pathlib.Path, int] = {}
+            succeeded: list[pathlib.Path] = []
+            pending: set[Future[Any]] = set(plan_futs)
+
+            while pending:
+                done, pending = wait(pending, return_when=FIRST_COMPLETED)
+                for fut in done:
+                    if fut in plan_futs:
+                        self._handle_plan_complete(
+                            fut, plan_futs, part_futs, remaining_parts, failures, pending, on_file_planned
+                        )
+                    else:
+                        self._handle_part_complete(
+                            fut, part_futs, remaining_parts, failures, succeeded, on_file_complete
+                        )
+
+        logger.info("Successfully downloaded %d files (%d total, %d failed)", len(succeeded), len(items), len(failures))
+        self._cleanup_failed_artifacts(failures)
+        return DownloadResults(succeeded, failures)
+
+    def _handle_plan_complete(
+        self,
+        fut: Future[Any],
+        plan_futs: dict[Future[Any], DownloadItem],
+        part_futs: dict[Future[Any], tuple[pathlib.Path, int]],
+        remaining_parts: dict[pathlib.Path, int],
+        failures: dict[pathlib.Path, Exception],
+        pending: set[Future[Any]],
+        on_file_planned: Callable[[pathlib.Path], None] | None,
+    ) -> None:
+        """Resolve a completed planning future and submit the file's part-download futures."""
+        item = plan_futs.pop(fut)
+        try:
+            plan = fut.result()  # link + size probe + preallocation already done on the planning pool
+        except Exception as ex:
+            failures[item.destination] = ex
+            logger.error("Planning failed for %s", item.destination, exc_info=ex)
+            return
+
+        if on_file_planned is not None:
+            on_file_planned(item.destination)
+
+        chunk_bounds = list(plan.ranges())
+        remaining_parts[item.destination] = len(chunk_bounds)
+        for data_chunk in chunk_bounds:
+            part_fut = self._pool.submit(
+                self._fetch_range_bytes,
+                plan.item.provider,
+                data_chunk.start_bytes,
+                data_chunk.end_bytes,
+                plan.etag,
+                item.destination,
+            )
+            part_futs[part_fut] = (item.destination, data_chunk.start_bytes)
+            pending.add(part_fut)
+
+    def _handle_part_complete(
+        self,
+        fut: Future[Any],
+        part_futs: dict[Future[Any], tuple[pathlib.Path, int]],
+        remaining_parts: dict[pathlib.Path, int],
+        failures: dict[pathlib.Path, Exception],
+        succeeded: list[pathlib.Path],
+        on_file_complete: Callable[[pathlib.Path], None] | None,
+    ) -> None:
+        """Resolve a completed part-download future, firing on_file_complete on the last part."""
+        dest, start = part_futs.pop(fut)
+        # A prior part for this destination already failed (and cancelled the rest); ignore.
+        if dest in failures:
+            return
+        try:
+            fut.result()
+        except Exception as ex:
+            logger.error("Failed part for %s @%d", dest, start, exc_info=ex)
+            failures[dest] = ex
+            # Cancel any not-yet-started parts for this destination to avoid wasted work.
+            for part_fut, (other_dest, _) in part_futs.items():
+                if other_dest == dest:
+                    part_fut.cancel()
+            return
+
+        remaining_parts[dest] -= 1
+        if remaining_parts[dest] == 0:
+            succeeded.append(dest)
+            logger.debug("Completed download for %s", dest)
+            if on_file_complete is not None:
+                on_file_complete(dest)
+
+    def _cleanup_failed_artifacts(self, failures: Mapping[pathlib.Path, Exception]) -> None:
+        """Delete partially-written files for any failed downloads."""
+        if not failures:
+            return
+        logger.warning("Clearing out artifacts from %d failed file downloads", len(failures))
+        for file in failures:
+            if file.exists():
+                logger.info("Removing failed artifact %s", file)
+                file.unlink()
+
     def _run_downloads(
         self, plans: Sequence[_PlannedDownload], *, collect_errors: bool
     ) -> dict[pathlib.Path, Exception]:
@@ -295,22 +461,28 @@ class MultipartFileDownloader:
 
     # ---- planning helpers ----
 
-    def _head_or_probe(self, provider: PresignedURLProvider) -> tuple[int, str | None]:
+    def _head_or_probe(
+        self, provider: PresignedURLProvider, session: requests.Session | None = None
+    ) -> tuple[int, str | None]:
         """Discover (total_size, etag). Refresh once if the current URL is stale.
 
         Within platforms that support ETag (notably, AWS), this will typically be some hash or metadata
         that can be used as a trivial check that the file being downloaded has not changed substantially.
         This ETag may not be present on all platforms, in which case, None will be provided and any subsequent
         checks will assume the file is not changing during downloads.
+
+        ``session`` lets the pipelined planning pool probe on its own session rather than the shared
+        download session; defaults to the download session.
         """
+        session = session or self._session
         for attempt in range(3):
             url = provider.get_url(force=(attempt > 0))
 
-            r = self._session.head(url, timeout=self.timeout)
+            r = session.head(url, timeout=self.timeout)
             if r.ok and "Content-Length" in r.headers:
                 return int(r.headers["Content-Length"]), r.headers.get("ETag")
 
-            r = self._session.get(url, headers={"Range": "bytes=0-0"}, timeout=self.timeout)
+            r = session.get(url, headers={"Range": "bytes=0-0"}, timeout=self.timeout)
             if r.ok:
                 total = (
                     int(r.headers["Content-Range"].split("/")[-1])
@@ -327,26 +499,28 @@ class MultipartFileDownloader:
 
         raise RuntimeError("Could not determine object size/ETag (presigned URL kept failing)")
 
-    def _plan_item(self, item: DownloadItem) -> _PlannedDownload:
+    def _plan_item(self, item: DownloadItem, session: requests.Session | None = None) -> _PlannedDownload:
         # If the provider already knows the object size (e.g. an export service returned it), skip
         # the size/ETag probe entirely -- one fewer round-trip per file, which adds up over many files.
         presigned = item.provider.get()
         if presigned.total_size is not None:
             return _PlannedDownload(item=item, total_size=presigned.total_size, etag=presigned.etag)
-        total_size, etag = self._head_or_probe(item.provider)
+        total_size, etag = self._head_or_probe(item.provider, session)
         return _PlannedDownload(
             item=item,
             total_size=total_size,
             etag=etag,
         )
 
-    def _plan_and_preallocate(self, item: DownloadItem) -> _PlannedDownload:
+    def _plan_and_preallocate(self, item: DownloadItem, session: requests.Session | None = None) -> _PlannedDownload:
         """Fetch the presigned link, probe size/etag if needed, and preallocate the destination file.
 
-        Runs on the download pool so link generation + the (possibly long) materialization wait
-        baked into the provider's fetch happen concurrently across files rather than one at a time.
+        Runs on a worker thread so link generation + the (possibly long) materialization wait baked
+        into the provider's fetch happen concurrently across files rather than one at a time. ``session``
+        is the session used for any size probe (the pipelined path passes its dedicated planning
+        session; otherwise the shared download session is used).
         """
-        plan = self._plan_item(item)
+        plan = self._plan_item(item, session)
         self._preallocate(item.destination, plan.total_size)
         return plan
 

--- a/nominal/thirdparty/polars/polars_export_handler.py
+++ b/nominal/thirdparty/polars/polars_export_handler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import concurrent.futures
 import dataclasses
@@ -7,11 +9,15 @@ import pathlib
 import random
 import threading
 import time
-from typing import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Callable, Iterator, Mapping, Sequence
 
 import requests
 from nominal_api import api, scout_compute_api, scout_dataexport_api
 from typing_extensions import Self
+
+if TYPE_CHECKING:
+    from rich.console import Console
 
 import polars as pl
 from nominal._utils import LogTiming
@@ -157,6 +163,45 @@ class _PlanningProfile:
             sem_avg,
             sem_max,
         )
+
+
+@contextmanager
+def _progress_bars(
+    total: int, show: bool, console: Console | None = None
+) -> Iterator[tuple[Callable[[], None], Callable[[], None]]]:
+    """Yield ``(advance_prepare, advance_download)`` callables for the pipelined export.
+
+    When ``show`` is set, both advance tasks on a single Rich progress display: one tracks files
+    whose presigned link is ready (planning/pre-allocation) and one tracks completed downloads, each
+    with an elapsed timer and an estimated time remaining. When not shown, both are no-ops. Pass the
+    ``console`` shared with a Rich logging handler so log lines render cleanly above the live bars;
+    otherwise route logs to a file so they don't corrupt the display.
+    """
+    if not show:
+        noop: Callable[[], None] = lambda: None  # noqa: E731 - trivial no-op
+        yield noop, noop
+        return
+
+    from rich.progress import (
+        BarColumn,
+        MofNCompleteColumn,
+        Progress,
+        TextColumn,
+        TimeElapsedColumn,
+        TimeRemainingColumn,
+    )
+
+    with Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TimeElapsedColumn(),
+        TimeRemainingColumn(),  # estimated time remaining
+        console=console,
+    ) as progress:
+        prepare = progress.add_task("Preparing links", total=total)
+        download = progress.add_task("Downloading", total=total)
+        yield (lambda: progress.advance(prepare, 1), lambda: progress.advance(download, 1))
 
 
 def _extract_bucket_counts(
@@ -1029,6 +1074,8 @@ class PolarsExportHandler:
         buckets: int | None = None,
         resolution: IntegralNanosecondsDuration | None = None,
         file_prefix: str = "export",
+        show_progress: bool = False,
+        console: Console | None = None,
     ) -> list[pathlib.Path]:
         """Export the given channels to gzipped CSV files in ``output_dir`` and return the written paths.
 
@@ -1037,6 +1084,12 @@ class PolarsExportHandler:
         (``generate_export_channel_data_presigned_link``) and downloads each file **straight to disk**
         using parallel ranged GETs. This lifts the API-proxy size ceiling and is much faster for large
         exports.
+
+        Link generation (server-side compute + S3 materialization) is **pipelined** with downloads via
+        a single :class:`MultipartFileDownloader`: each file starts downloading the instant its own link
+        is ready, while other links are still being generated, and all byte downloads share one pool so
+        the number of download threads stays constant. Concurrent link generation is bounded by
+        ``max_concurrent_links`` to stay under the backend's concurrent-query limit.
 
         It reuses the exact same planning phase as :meth:`export`: each planned export request maps to
         one file, so an export of more than ``channels_per_request`` channels (or across multiple
@@ -1060,6 +1113,11 @@ class PolarsExportHandler:
             resolution: Decimate each channel to samples at this interval (nanoseconds). Mutually
                 exclusive with ``buckets``.
             file_prefix: Prefix for written file names.
+            show_progress: When True, render a Rich progress display with two bars -- files whose
+                presigned link is ready, and completed downloads -- each with elapsed time and an
+                estimated time remaining. Route logs to a file (not stdout) so they don't corrupt the
+                live display; pass ``console`` to share a console with a Rich logging handler instead.
+            console: Optional Rich console to render the progress display on.
 
         Returns:
             The list of written file paths, sorted.
@@ -1105,13 +1163,21 @@ class PolarsExportHandler:
         logger.info("Exporting %d channels into %d file(s) under %s", len(supported_channels), len(items), output_dir)
         with (
             LogTiming(f"Downloaded {len(items)} export file(s)"),
+            _progress_bars(len(items), show_progress, console) as (advance_prepare, advance_download),
+            # A single downloader for the whole export: byte downloads share one pool (constant
+            # download-thread count) while link generation is pipelined on the downloader's separate
+            # planning pool, so files download as soon as their link is ready.
             MultipartFileDownloader.create(
                 max_workers=self._num_workers,
                 # No header_provider: the links are genuinely pre-signed (auth is in the URL), so the
                 # readiness probe and the downloads are both header-less and consistent.
             ) as downloader,
         ):
-            results = downloader.download_files(items)
+            results = downloader.download_files_pipelined(
+                items,
+                on_file_planned=lambda _path: advance_prepare(),
+                on_file_complete=lambda _path: advance_download(),
+            )
         profile.log_summary()
 
         if results.failed:

--- a/tests/core/test_multipart_downloader.py
+++ b/tests/core/test_multipart_downloader.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Iterator, Sequence, cast
+from typing import Callable, Iterator, Sequence, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -100,7 +100,9 @@ def test_download_file_returns_path_on_success(tmp_path: Path, downloader: Multi
     item = DownloadItem(provider=_provider(), destination=tmp_path / "ok.bin", part_size=4)
 
     with (
-        patch.object(downloader, "_plan_item", lambda item: _PlannedDownload(item=item, total_size=4, etag=None)),
+        patch.object(
+            downloader, "_plan_item", lambda item, session=None: _PlannedDownload(item=item, total_size=4, etag=None)
+        ),
         patch.object(downloader, "_run_downloads", lambda plans, *, collect_errors: {}),
     ):
         result = downloader.download_file(item)
@@ -115,7 +117,9 @@ def test_download_file_raises_on_execution_failure(tmp_path: Path, downloader: M
     error = RuntimeError("download failed")
 
     with (
-        patch.object(downloader, "_plan_item", lambda item: _PlannedDownload(item=item, total_size=4, etag=None)),
+        patch.object(
+            downloader, "_plan_item", lambda item, session=None: _PlannedDownload(item=item, total_size=4, etag=None)
+        ),
         patch.object(downloader, "_run_downloads", lambda plans, *, collect_errors: {item.destination: error}),
         pytest.raises(RuntimeError, match="download failed"),
     ):
@@ -131,7 +135,7 @@ def test_download_files_execution_failure_excluded_from_succeeded(
     failed_item = DownloadItem(provider=_provider(), destination=tmp_path / "failed.bin", part_size=4)
     error = RuntimeError("download failed")
 
-    def _make_plan(item: DownloadItem) -> _PlannedDownload:
+    def _make_plan(item: DownloadItem, session: object = None) -> _PlannedDownload:
         return _PlannedDownload(item=item, total_size=4, etag=None)
 
     def _exec_downloads(plans: Sequence[_PlannedDownload], *, collect_errors: bool) -> dict[Path, Exception]:
@@ -158,11 +162,80 @@ def test_download_files_planning_failure_excluded_from_succeeded(
     item = DownloadItem(provider=_provider(), destination=tmp_path / "file.bin", part_size=4)
     error = RuntimeError("head request failed")
 
-    def _failing_plan(_: DownloadItem) -> _PlannedDownload:
+    def _failing_plan(_item: DownloadItem, _session: object = None) -> _PlannedDownload:
         raise error
 
     with patch.object(downloader, "_plan_item", _failing_plan):
         results = downloader.download_files([item])
+
+    assert list(results.succeeded) == []
+    assert results.failed == {item.destination: error}
+    assert not item.destination.exists()
+
+
+# ---- download_files_pipelined tests ----
+
+
+def _plan_returning(total_size: int) -> Callable[..., _PlannedDownload]:
+    """A _plan_item stand-in that returns a fixed-size plan (ignoring the link/probe)."""
+
+    def _plan(item: DownloadItem, session: object = None) -> _PlannedDownload:
+        return _PlannedDownload(item=item, total_size=total_size, etag=None)
+
+    return _plan
+
+
+def test_pipelined_fires_callbacks_once_per_file(tmp_path: Path, downloader: MultipartFileDownloader) -> None:
+    """Each file is reported planned once and complete once; all files succeed."""
+    items = [DownloadItem(provider=_provider(), destination=tmp_path / f"f{i}.bin", part_size=4) for i in range(3)]
+    planned: list[Path] = []
+    completed: list[Path] = []
+
+    with (
+        patch.object(downloader, "_plan_item", _plan_returning(8)),  # 8 bytes / 4 = 2 parts each
+        patch.object(downloader, "_fetch_range_bytes", lambda *a, **k: None),
+    ):
+        results = downloader.download_files_pipelined(
+            items, on_file_planned=planned.append, on_file_complete=completed.append
+        )
+
+    assert sorted(results.succeeded) == sorted(it.destination for it in items)
+    assert results.failed == {}
+    assert sorted(planned) == sorted(it.destination for it in items)
+    assert sorted(completed) == sorted(it.destination for it in items)
+
+
+def test_pipelined_part_failure_recorded_and_cleaned_up(tmp_path: Path, downloader: MultipartFileDownloader) -> None:
+    """A part failure fails only its file (recorded + artifact deleted); other files still succeed."""
+    ok = DownloadItem(provider=_provider(), destination=tmp_path / "ok.bin", part_size=4)
+    bad = DownloadItem(provider=_provider(), destination=tmp_path / "bad.bin", part_size=4)
+
+    def _fetch(provider: object, start: int, end: int, etag: str | None, destination: Path) -> None:
+        if destination == bad.destination:
+            raise RuntimeError("boom")
+
+    with (
+        patch.object(downloader, "_plan_item", _plan_returning(8)),
+        patch.object(downloader, "_fetch_range_bytes", _fetch),
+    ):
+        results = downloader.download_files_pipelined([ok, bad])
+
+    assert list(results.succeeded) == [ok.destination]
+    assert bad.destination in results.failed
+    assert ok.destination.exists()
+    assert not bad.destination.exists()
+
+
+def test_pipelined_planning_failure_recorded(tmp_path: Path, downloader: MultipartFileDownloader) -> None:
+    """A planning failure is recorded in failed and the file never downloads."""
+    item = DownloadItem(provider=_provider(), destination=tmp_path / "f.bin", part_size=4)
+    error = RuntimeError("link generation failed")
+
+    def _failing_plan(_item: DownloadItem, _session: object = None) -> _PlannedDownload:
+        raise error
+
+    with patch.object(downloader, "_plan_item", _failing_plan):
+        results = downloader.download_files_pipelined([item])
 
     assert list(results.succeeded) == []
     assert results.failed == {item.destination: error}

--- a/tests/thirdparty/polars/test_polars_export_handler.py
+++ b/tests/thirdparty/polars/test_polars_export_handler.py
@@ -750,10 +750,15 @@ class _FakeDownloader:
     def __exit__(self, *_args):
         return False
 
-    def download_files(self, items):
+    def download_files_pipelined(self, items, *, on_file_planned=None, on_file_complete=None):
         type(self).last_items = list(items)
         if type(self).fail:
             return DownloadResults(succeeded=[], failed={items[0].destination: RuntimeError("boom")})
+        for it in items:
+            if on_file_planned is not None:
+                on_file_planned(it.destination)
+            if on_file_complete is not None:
+                on_file_complete(it.destination)
         return DownloadResults(succeeded=[it.destination for it in items], failed={})
 
 


### PR DESCRIPTION
## Summary

Stacked on #819. Adds `MultipartFileDownloader.download_files_pipelined`: instead of planning every file before any download starts, each file begins downloading the instant **its own** presigned link is generated, S3 object materialized, and destination pre-allocated — while other files are still planning. A fast file finishes downloading before a slow file's link is even ready, hiding the long, variable materialization waits.

- Link generation + size probes run on a **dedicated planning pool with its own HTTP session**; byte downloads run on the **single shared download pool/session**, so the two never contend and the download-thread count stays constant.
- A reactive future-set loop dispatches planning vs part-download completions, with `on_file_planned` / `on_file_complete` callbacks (invoked on the calling thread, safe to drive a progress display). Failures are isolated per file and partial artifacts cleaned up.

`export_to_files` switches to the pipelined path on one downloader and gains an optional Rich **progress bar** (`show_progress` / `console`): two bars (links prepared + files downloaded) with elapsed time and **estimated time remaining**. Route logs to a file when enabling it so they don't corrupt the live display.

## Test plan
- `uv run mypy` (clean), `ruff check` / `ruff format --check`
- `uv run pytest tests --ignore=tests/e2e` (324 passed)
- Manual: verified a fast file completes downloading before a slow file's link is ready (true pipelining), and the progress bar renders both bars with an ETA column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)