### PR TITLE
chore: add tolerance to timestamp tests

### DIFF
--- a/tests/e2e/test_timestamps.py
+++ b/tests/e2e/test_timestamps.py
@@ -155,7 +155,7 @@ def test_epoch_seconds(request, client: NominalClient, temperature_data: list[tu
         timestamp_type="epoch_seconds",
         expected_start=temperature_data[0][1],
         expected_end=temperature_data[-1][1],
-        tolerance_ns=NS_PER_US,
+        # tolerance_ns=NS_PER_US,
     )
 
 
@@ -172,7 +172,7 @@ def test_epoch_milliseconds(request, client: NominalClient, temperature_data: li
         timestamp_type="epoch_milliseconds",
         expected_start=temperature_data[0][1],
         expected_end=temperature_data[-1][1],
-        tolerance_ns=NS_PER_US,
+        # tolerance_ns=NS_PER_US,
     )
 
 

--- a/tests/e2e/test_timestamps.py
+++ b/tests/e2e/test_timestamps.py
@@ -8,8 +8,9 @@ Each test:
      and ingested time bounds round-trip correctly.
 
 Bounds are asserted in nanoseconds-since-epoch. Tolerances default to zero and are only
-applied where the encoding path can't round-trip to ns precision; the per-test docstrings
-explain each non-zero tolerance.
+applied where the encoding path can't round-trip to ns precision; the parametrize table
+on `test_bounds_round_trip` (and the per-case comments alongside each row) explain each
+non-zero tolerance.
 
 Timestamp formats under test:
   - ISO 8601 strings  ("iso_8601")
@@ -35,7 +36,7 @@ from tests.e2e import POLL_INTERVAL
 
 Formatter = Callable[[int, datetime], str]
 
-# Float64 ULP at year-2024 timestamp magnitudes (~1.7e18 ns) is ~384 ns. Used for tests
+# Float64 ULP at year-2024 timestamp magnitudes (~1.7e18 ns) is ~256 ns. Used for tests
 # whose encoding crosses through float64 — either client-side (the float-encoded epoch
 # formatters: days, hours, minutes, seconds) or server-side (epoch_nanoseconds, which
 # the backend appears to parse through a float despite the integer-encoded input).
@@ -50,6 +51,12 @@ NS_PER_MS = 1_000_000
 def _ns(dt: datetime) -> int:
     """Datetime → nanoseconds-since-epoch (exact for the µs-precision datetimes used here)."""
     return _SecondsNanos.from_datetime(dt).to_nanoseconds()
+
+
+def _format_ctime_with_micros(temp: int, ts: datetime) -> str:
+    """Format as ctime with microseconds spliced in before the year (e.g. 'Mon Sep 30 16:37:36.891349 2024')."""
+    base = ts.ctime()
+    return f"{temp},{base[:-5]}.{ts.microsecond:06d}{base[-5:]}"
 
 
 @pytest.fixture(scope="module")
@@ -109,7 +116,7 @@ def _upload_and_assert(
     expected_start_ns: int,
     expected_end_ns: int,
     tolerance_ns: int = 0,
-) -> Dataset:
+) -> None:
     """Create a dataset, upload csv_bytes, wait for ingestion, and assert metadata and bounds.
 
     The dataset is always archived in a finally block so resources are cleaned up even if
@@ -134,157 +141,113 @@ def _upload_and_assert(
         assert ds.name == name
         assert ds.description == desc
         _assert_bounds(dataset_file, ds, expected_start_ns, expected_end_ns, tolerance_ns=tolerance_ns)
-        return ds
     finally:
         ds.archive()
 
 
-def test_iso_8601(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """ISO 8601 timestamps round-trip exactly at µs precision."""
-    name = f"dataset-{request.node.name}"
-    desc = f"timestamp test {request.node.name}"
-    csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.isoformat()}")
-    _upload_and_assert(
-        client=client,
-        name=name,
-        desc=desc,
-        csv_bytes=csv_bytes,
-        timestamp_type="iso_8601",
-        expected_start_ns=_ns(temperature_data[0][1]),
-        expected_end_ns=_ns(temperature_data[-1][1]),
-    )
-
-
-def test_epoch_days(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """Epoch-days, sending float days since epoch. Tolerance: float64 ULP (see NS_PER_US)."""
-    name = f"dataset-{request.node.name}"
-    desc = f"timestamp test {request.node.name}"
-    csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.timestamp() / 86_400}")
-    _upload_and_assert(
-        client=client,
-        name=name,
-        desc=desc,
-        csv_bytes=csv_bytes,
-        timestamp_type="epoch_days",
-        expected_start_ns=_ns(temperature_data[0][1]),
-        expected_end_ns=_ns(temperature_data[-1][1]),
-        tolerance_ns=NS_PER_US,
-    )
-
-
-def test_epoch_hours(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """Epoch-hours, sending float hours since epoch. Tolerance: float64 ULP (see NS_PER_US)."""
-    name = f"dataset-{request.node.name}"
-    desc = f"timestamp test {request.node.name}"
-    csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.timestamp() / 3_600}")
-    _upload_and_assert(
-        client=client,
-        name=name,
-        desc=desc,
-        csv_bytes=csv_bytes,
-        timestamp_type="epoch_hours",
-        expected_start_ns=_ns(temperature_data[0][1]),
-        expected_end_ns=_ns(temperature_data[-1][1]),
-        tolerance_ns=NS_PER_US,
-    )
-
-
-def test_epoch_minutes(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """Epoch-minutes, sending float minutes since epoch. Tolerance: float64 ULP (see NS_PER_US)."""
-    name = f"dataset-{request.node.name}"
-    desc = f"timestamp test {request.node.name}"
-    csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.timestamp() / 60}")
-    _upload_and_assert(
-        client=client,
-        name=name,
-        desc=desc,
-        csv_bytes=csv_bytes,
-        timestamp_type="epoch_minutes",
-        expected_start_ns=_ns(temperature_data[0][1]),
-        expected_end_ns=_ns(temperature_data[-1][1]),
-        tolerance_ns=NS_PER_US,
-    )
-
-
-def test_epoch_seconds(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """Epoch-seconds, sending float seconds since epoch. Tolerance: float64 ULP (see NS_PER_US)."""
-    name = f"dataset-{request.node.name}"
-    desc = f"timestamp test {request.node.name}"
-    csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.timestamp()}")
-    _upload_and_assert(
-        client=client,
-        name=name,
-        desc=desc,
-        csv_bytes=csv_bytes,
-        timestamp_type="epoch_seconds",
-        expected_start_ns=_ns(temperature_data[0][1]),
-        expected_end_ns=_ns(temperature_data[-1][1]),
-        tolerance_ns=NS_PER_US,
-    )
-
-
-def test_epoch_milliseconds(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """Epoch-milliseconds, sending float ms since epoch. Tolerance: ms truncation (see NS_PER_MS)."""
-    name = f"dataset-{request.node.name}"
-    desc = f"timestamp test {request.node.name}"
-    csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.timestamp() * 1000}")
-    _upload_and_assert(
-        client=client,
-        name=name,
-        desc=desc,
-        csv_bytes=csv_bytes,
-        timestamp_type="epoch_milliseconds",
-        expected_start_ns=_ns(temperature_data[0][1]),
-        expected_end_ns=_ns(temperature_data[-1][1]),
-        tolerance_ns=NS_PER_MS,
-    )
-
-
-def test_epoch_microseconds(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """Epoch-microseconds, sending integer µs since epoch.
-
-    Float-encoding µs at year-2024 magnitudes (~1.7e15 µs) sits right at float64's
-    integer-exact boundary, so we send integer µs directly to round-trip exactly.
+@pytest.mark.parametrize(
+    ("formatter", "timestamp_type", "tolerance_ns"),
+    [
+        # iso_8601 — round-trips exactly at µs precision.
+        pytest.param(
+            lambda temp, ts: f"{temp},{ts.isoformat()}",
+            "iso_8601",
+            0,
+            id="iso_8601",
+        ),
+        # epoch_days/hours/minutes/seconds — backend parses float-encoded epoch input via
+        # float64 and stores the rounded value. At year-2024 timestamps (~1.7e18 ns) float64
+        # ULP is ~256 ns; NS_PER_US is the next clean ceiling that absorbs that drift.
+        pytest.param(
+            lambda temp, ts: f"{temp},{ts.timestamp() / 86_400}",
+            "epoch_days",
+            NS_PER_US,
+            id="epoch_days",
+        ),
+        pytest.param(
+            lambda temp, ts: f"{temp},{ts.timestamp() / 3_600}",
+            "epoch_hours",
+            NS_PER_US,
+            id="epoch_hours",
+        ),
+        pytest.param(
+            lambda temp, ts: f"{temp},{ts.timestamp() / 60}",
+            "epoch_minutes",
+            NS_PER_US,
+            id="epoch_minutes",
+        ),
+        pytest.param(
+            lambda temp, ts: f"{temp},{ts.timestamp()}",
+            "epoch_seconds",
+            NS_PER_US,
+            id="epoch_seconds",
+        ),
+        # epoch_milliseconds — backend silently truncates sub-ms fractional input to integer
+        # ms (contradicting Epoch's "integral or floating point" docstring). NS_PER_MS bounds
+        # the loss; observed drift in this fixture reaches 826 µs.
+        pytest.param(
+            lambda temp, ts: f"{temp},{ts.timestamp() * 1000}",
+            "epoch_milliseconds",
+            NS_PER_MS,
+            id="epoch_milliseconds",
+        ),
+        # epoch_microseconds — integer µs string (~1.7e15) sits below float64's 2^53
+        # integer-exact ceiling, so the backend's float funnel doesn't destroy precision;
+        # round-trips exactly with integer input.
+        pytest.param(
+            lambda temp, ts: f"{temp},{int(ts.timestamp()) * 1_000_000 + ts.microsecond}",
+            "epoch_microseconds",
+            0,
+            id="epoch_microseconds",
+        ),
+        # epoch_nanoseconds — even integer-encoded input is parsed via float64 by the backend
+        # and quantized to a ~256 ns grid at year-2024 timestamps; NS_PER_US absorbs the drift.
+        pytest.param(
+            lambda temp, ts: f"{temp},{int(ts.timestamp()) * 1_000_000_000 + ts.microsecond * 1_000}",
+            "epoch_nanoseconds",
+            NS_PER_US,
+            id="epoch_nanoseconds",
+        ),
+        # Custom(ctime-style) — full date + time string with µs; round-trips exactly.
+        pytest.param(
+            _format_ctime_with_micros,
+            Custom(r"EEE MMM dd HH:mm:ss.SSSSSS yyyy"),
+            0,
+            id="custom_ctime",
+        ),
+        # Custom(IRIG day-of-year) — %j:HH:MM:SS.SSSSSS with default_year; round-trips exactly.
+        pytest.param(
+            lambda temp, ts: f"{temp},{ts.strftime(r'%j:%H:%M:%S.%f')}",
+            Custom(r"DDD:HH:mm:ss.SSSSSS", default_year=2024),
+            0,
+            id="custom_irig",
+        ),
+    ],
+)
+def test_bounds_round_trip(
+    request,
+    client: NominalClient,
+    temperature_data: list[tuple[int, datetime]],
+    formatter: Formatter,
+    timestamp_type,
+    tolerance_ns: int,
+):
+    """Upload `temperature_data` through `formatter`/`timestamp_type` and verify the ingested
+    bounds match the µs-exact expected ns within `tolerance_ns`. See the parametrize table
+    for per-case justifications; see the module docstring for the tolerance convention.
     """
     name = f"dataset-{request.node.name}"
     desc = f"timestamp test {request.node.name}"
-    csv_bytes = _create_csv_data(
-        temperature_data,
-        lambda temp, ts: f"{temp},{int(ts.timestamp()) * 1_000_000 + ts.microsecond}",
-    )
+    csv_bytes = _create_csv_data(temperature_data, formatter)
     _upload_and_assert(
         client=client,
         name=name,
         desc=desc,
         csv_bytes=csv_bytes,
-        timestamp_type="epoch_microseconds",
+        timestamp_type=timestamp_type,
         expected_start_ns=_ns(temperature_data[0][1]),
         expected_end_ns=_ns(temperature_data[-1][1]),
-    )
-
-
-def test_epoch_nanoseconds(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """Epoch-nanoseconds, sending integer ns since epoch.
-
-    We send the value as an exact integer string, but the backend funnels ns through
-    float64 anyway and quantizes the stored value to the ULP grid (~256 ns spacing at
-    year-2024 magnitudes). Tolerance NS_PER_US absorbs that ULP-level drift.
-    """
-    name = f"dataset-{request.node.name}"
-    desc = f"timestamp test {request.node.name}"
-    csv_bytes = _create_csv_data(
-        temperature_data,
-        lambda temp, ts: f"{temp},{int(ts.timestamp()) * 1_000_000_000 + ts.microsecond * 1_000}",
-    )
-    _upload_and_assert(
-        client=client,
-        name=name,
-        desc=desc,
-        csv_bytes=csv_bytes,
-        timestamp_type="epoch_nanoseconds",
-        expected_start_ns=_ns(temperature_data[0][1]),
-        expected_end_ns=_ns(temperature_data[-1][1]),
-        tolerance_ns=NS_PER_US,
+        tolerance_ns=tolerance_ns,
     )
 
 
@@ -313,50 +276,6 @@ def test_relative_microseconds(request, client: NominalClient, temperature_data:
         timestamp_type=Relative(unit="microseconds", start=start),
         expected_start_ns=start_ns + _micros(temperature_data[0][1]) * 1_000,
         expected_end_ns=start_ns + _micros(temperature_data[-1][1]) * 1_000,
-    )
-
-
-def test_custom_ctime(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """A Custom format matching ctime output (e.g. "Mon Sep 30 16:37:36.891349 2024")."""
-    name = f"dataset-{request.node.name}"
-    desc = f"timestamp test {request.node.name}"
-
-    def fmt(temp: int, ts: datetime) -> str:
-        # ctime() returns "Mon Sep 30 16:37:36 2024"; splice in microseconds before the year
-        ctime = ts.ctime()
-        ctime = ctime[:-5] + f".{ts.microsecond:06d}" + ctime[-5:]
-        return f"{temp},{ctime}"
-
-    csv_bytes = _create_csv_data(temperature_data, fmt)
-    _upload_and_assert(
-        client=client,
-        name=name,
-        desc=desc,
-        csv_bytes=csv_bytes,
-        timestamp_type=Custom(r"EEE MMM dd HH:mm:ss.SSSSSS yyyy"),
-        expected_start_ns=_ns(temperature_data[0][1]),
-        expected_end_ns=_ns(temperature_data[-1][1]),
-    )
-
-
-def test_custom_irig(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """A Custom format using IRIG day-of-year notation (e.g. "274:16:37:36.891349")."""
-    name = f"dataset-{request.node.name}"
-    desc = f"timestamp test {request.node.name}"
-
-    def fmt(temp: int, ts: datetime) -> str:
-        # %j = zero-padded day of year (001–366)
-        return f"{temp},{ts.strftime(r'%j:%H:%M:%S.%f')}"
-
-    csv_bytes = _create_csv_data(temperature_data, fmt)
-    _upload_and_assert(
-        client=client,
-        name=name,
-        desc=desc,
-        csv_bytes=csv_bytes,
-        timestamp_type=Custom(r"DDD:HH:mm:ss.SSSSSS", default_year=2024),
-        expected_start_ns=_ns(temperature_data[0][1]),
-        expected_end_ns=_ns(temperature_data[-1][1]),
     )
 
 

--- a/tests/e2e/test_timestamps.py
+++ b/tests/e2e/test_timestamps.py
@@ -7,17 +7,21 @@ Each test:
   3. Waits for ingestion to complete, then confirms the dataset metadata (name, description)
      and ingested time bounds round-trip correctly.
 
+Bounds are asserted in nanoseconds-since-epoch. Tolerances default to zero and are only
+applied where the encoding path can't round-trip to ns precision; the per-test docstrings
+explain each non-zero tolerance.
+
 Timestamp formats under test:
   - ISO 8601 strings  ("iso_8601")
-  - Epoch seconds     ("epoch_seconds")
-  - Epoch milliseconds ("epoch_milliseconds")
+  - Epoch units       ("epoch_days", "epoch_hours", "epoch_minutes", "epoch_seconds",
+                       "epoch_milliseconds", "epoch_microseconds", "epoch_nanoseconds")
   - Relative offset   (Relative("microseconds", epoch))
   - Custom formats    (ctime-style, IRIG day-of-year with default_year, HH:MM:SS with default date)
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from io import BytesIO
 from typing import Callable
 
@@ -31,9 +35,21 @@ from tests.e2e import POLL_INTERVAL
 
 Formatter = Callable[[int, datetime], str]
 
-# Float-encoded epoch values (epoch_seconds, epoch_milliseconds) lose sub-µs
-# precision when converted to nanoseconds; allow 1 µs of slack on those tests.
+# Float64 ULP at year-2024 timestamp magnitudes (~1.7e18 ns) is ~384 ns. Used for tests
+# whose encoding crosses through float64 — either client-side (the float-encoded epoch
+# formatters: days, hours, minutes, seconds) or server-side (epoch_nanoseconds, which
+# the backend appears to parse through a float despite the integer-encoded input).
 NS_PER_US = 1_000
+
+# Backend silently truncates fractional epoch_milliseconds input to integer ms on
+# ingest, contradicting the `Epoch` docstring's promise that "the timestamp can be
+# integral or floating point". Tolerance reflects the actual ms-precision storage floor.
+NS_PER_MS = 1_000_000
+
+
+def _ns(dt: datetime) -> int:
+    """Datetime → nanoseconds-since-epoch (exact for the µs-precision datetimes used here)."""
+    return _SecondsNanos.from_datetime(dt).to_nanoseconds()
 
 
 @pytest.fixture(scope="module")
@@ -59,24 +75,21 @@ def _create_csv_data(data: list[tuple[int, datetime]], formatter: Formatter) -> 
 def _assert_bounds(
     dataset_file: DatasetFile,
     dataset: Dataset,
-    expected_start: datetime,
-    expected_end: datetime,
+    expected_start_ns: int,
+    expected_end_ns: int,
     tolerance_ns: int = 0,
 ) -> None:
-    """Assert ingested bounds at both the DatasetFile and Dataset levels.
+    """Assert ingested bounds at both the DatasetFile and Dataset levels match the given ns values.
 
     Args:
-        dataset_file: The ingested file whose bounds to check (returned by poll_until_ingestion_completed).
+        dataset_file: The ingested file whose bounds to check.
         dataset: The parent dataset; refreshed in-place before its bounds are checked.
-        expected_start: Expected lower bound of the ingested time range.
-        expected_end: Expected upper bound of the ingested time range.
-        tolerance_ns: Allowed absolute error in nanoseconds. Defaults to 0 (exact match);
-                      set to the precision floor of the timestamp format under test when the
-                      format cannot round-trip to nanosecond precision.
+        expected_start_ns: Expected lower bound, in nanoseconds-since-epoch.
+        expected_end_ns: Expected upper bound, in nanoseconds-since-epoch.
+        tolerance_ns: Allowed absolute error in nanoseconds. Defaults to 0 (exact match).
+                      Set to the format's intrinsic precision floor for formats whose
+                      encoding can't round-trip to nanosecond precision.
     """
-    expected_start_ns = _SecondsNanos.from_datetime(expected_start).to_nanoseconds()
-    expected_end_ns = _SecondsNanos.from_datetime(expected_end).to_nanoseconds()
-
     assert dataset_file.bounds is not None
     assert dataset_file.bounds.start == pytest.approx(expected_start_ns, abs=tolerance_ns, rel=0)
     assert dataset_file.bounds.end == pytest.approx(expected_end_ns, abs=tolerance_ns, rel=0)
@@ -93,8 +106,8 @@ def _upload_and_assert(
     desc: str,
     csv_bytes: bytes,
     timestamp_type,
-    expected_start: datetime,
-    expected_end: datetime,
+    expected_start_ns: int,
+    expected_end_ns: int,
     tolerance_ns: int = 0,
 ) -> Dataset:
     """Create a dataset, upload csv_bytes, wait for ingestion, and assert metadata and bounds.
@@ -109,8 +122,8 @@ def _upload_and_assert(
         csv_bytes: Raw CSV bytes to upload via add_from_io.
         timestamp_type: Any value accepted by `add_from_io` (string literal, typed constant, or
                         Relative/Custom instance).
-        expected_start: Expected ingested start timestamp.
-        expected_end: Expected ingested end timestamp.
+        expected_start_ns: Expected ingested start timestamp, in nanoseconds-since-epoch.
+        expected_end_ns: Expected ingested end timestamp, in nanoseconds-since-epoch.
         tolerance_ns: Passed through to `_assert_bounds`; see that function for details.
     """
     ds = client.create_dataset(name, description=desc)
@@ -120,14 +133,14 @@ def _upload_and_assert(
         )
         assert ds.name == name
         assert ds.description == desc
-        _assert_bounds(dataset_file, ds, expected_start, expected_end, tolerance_ns=tolerance_ns)
+        _assert_bounds(dataset_file, ds, expected_start_ns, expected_end_ns, tolerance_ns=tolerance_ns)
         return ds
     finally:
         ds.archive()
 
 
 def test_iso_8601(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """ISO 8601 timestamps ingest correctly with sub-millisecond precision preserved."""
+    """ISO 8601 timestamps round-trip exactly at µs precision."""
     name = f"dataset-{request.node.name}"
     desc = f"timestamp test {request.node.name}"
     csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.isoformat()}")
@@ -137,13 +150,64 @@ def test_iso_8601(request, client: NominalClient, temperature_data: list[tuple[i
         desc=desc,
         csv_bytes=csv_bytes,
         timestamp_type="iso_8601",
-        expected_start=temperature_data[0][1],
-        expected_end=temperature_data[-1][1],
+        expected_start_ns=_ns(temperature_data[0][1]),
+        expected_end_ns=_ns(temperature_data[-1][1]),
+    )
+
+
+def test_epoch_days(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
+    """Epoch-days, sending float days since epoch. Tolerance: float64 ULP (see NS_PER_US)."""
+    name = f"dataset-{request.node.name}"
+    desc = f"timestamp test {request.node.name}"
+    csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.timestamp() / 86_400}")
+    _upload_and_assert(
+        client=client,
+        name=name,
+        desc=desc,
+        csv_bytes=csv_bytes,
+        timestamp_type="epoch_days",
+        expected_start_ns=_ns(temperature_data[0][1]),
+        expected_end_ns=_ns(temperature_data[-1][1]),
+        tolerance_ns=NS_PER_US,
+    )
+
+
+def test_epoch_hours(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
+    """Epoch-hours, sending float hours since epoch. Tolerance: float64 ULP (see NS_PER_US)."""
+    name = f"dataset-{request.node.name}"
+    desc = f"timestamp test {request.node.name}"
+    csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.timestamp() / 3_600}")
+    _upload_and_assert(
+        client=client,
+        name=name,
+        desc=desc,
+        csv_bytes=csv_bytes,
+        timestamp_type="epoch_hours",
+        expected_start_ns=_ns(temperature_data[0][1]),
+        expected_end_ns=_ns(temperature_data[-1][1]),
+        tolerance_ns=NS_PER_US,
+    )
+
+
+def test_epoch_minutes(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
+    """Epoch-minutes, sending float minutes since epoch. Tolerance: float64 ULP (see NS_PER_US)."""
+    name = f"dataset-{request.node.name}"
+    desc = f"timestamp test {request.node.name}"
+    csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.timestamp() / 60}")
+    _upload_and_assert(
+        client=client,
+        name=name,
+        desc=desc,
+        csv_bytes=csv_bytes,
+        timestamp_type="epoch_minutes",
+        expected_start_ns=_ns(temperature_data[0][1]),
+        expected_end_ns=_ns(temperature_data[-1][1]),
+        tolerance_ns=NS_PER_US,
     )
 
 
 def test_epoch_seconds(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """Epoch-seconds timestamps ingest correctly; float64 → ns conversion has sub-µs rounding."""
+    """Epoch-seconds, sending float seconds since epoch. Tolerance: float64 ULP (see NS_PER_US)."""
     name = f"dataset-{request.node.name}"
     desc = f"timestamp test {request.node.name}"
     csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.timestamp()}")
@@ -153,14 +217,14 @@ def test_epoch_seconds(request, client: NominalClient, temperature_data: list[tu
         desc=desc,
         csv_bytes=csv_bytes,
         timestamp_type="epoch_seconds",
-        expected_start=temperature_data[0][1],
-        expected_end=temperature_data[-1][1],
-        # tolerance_ns=NS_PER_US,
+        expected_start_ns=_ns(temperature_data[0][1]),
+        expected_end_ns=_ns(temperature_data[-1][1]),
+        tolerance_ns=NS_PER_US,
     )
 
 
 def test_epoch_milliseconds(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """Epoch-milliseconds preserves sub-ms precision from the float-encoded value (with float64 sub-µs rounding)."""
+    """Epoch-milliseconds, sending float ms since epoch. Tolerance: ms truncation (see NS_PER_MS)."""
     name = f"dataset-{request.node.name}"
     desc = f"timestamp test {request.node.name}"
     csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.timestamp() * 1000}")
@@ -170,14 +234,62 @@ def test_epoch_milliseconds(request, client: NominalClient, temperature_data: li
         desc=desc,
         csv_bytes=csv_bytes,
         timestamp_type="epoch_milliseconds",
-        expected_start=temperature_data[0][1],
-        expected_end=temperature_data[-1][1],
-        # tolerance_ns=NS_PER_US,
+        expected_start_ns=_ns(temperature_data[0][1]),
+        expected_end_ns=_ns(temperature_data[-1][1]),
+        tolerance_ns=NS_PER_MS,
+    )
+
+
+def test_epoch_microseconds(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
+    """Epoch-microseconds, sending integer µs since epoch.
+
+    Float-encoding µs at year-2024 magnitudes (~1.7e15 µs) sits right at float64's
+    integer-exact boundary, so we send integer µs directly to round-trip exactly.
+    """
+    name = f"dataset-{request.node.name}"
+    desc = f"timestamp test {request.node.name}"
+    csv_bytes = _create_csv_data(
+        temperature_data,
+        lambda temp, ts: f"{temp},{int(ts.timestamp()) * 1_000_000 + ts.microsecond}",
+    )
+    _upload_and_assert(
+        client=client,
+        name=name,
+        desc=desc,
+        csv_bytes=csv_bytes,
+        timestamp_type="epoch_microseconds",
+        expected_start_ns=_ns(temperature_data[0][1]),
+        expected_end_ns=_ns(temperature_data[-1][1]),
+    )
+
+
+def test_epoch_nanoseconds(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
+    """Epoch-nanoseconds, sending integer ns since epoch.
+
+    We send the value as an exact integer string, but the backend funnels ns through
+    float64 anyway and quantizes the stored value to the ULP grid (~256 ns spacing at
+    year-2024 magnitudes). Tolerance NS_PER_US absorbs that ULP-level drift.
+    """
+    name = f"dataset-{request.node.name}"
+    desc = f"timestamp test {request.node.name}"
+    csv_bytes = _create_csv_data(
+        temperature_data,
+        lambda temp, ts: f"{temp},{int(ts.timestamp()) * 1_000_000_000 + ts.microsecond * 1_000}",
+    )
+    _upload_and_assert(
+        client=client,
+        name=name,
+        desc=desc,
+        csv_bytes=csv_bytes,
+        timestamp_type="epoch_nanoseconds",
+        expected_start_ns=_ns(temperature_data[0][1]),
+        expected_end_ns=_ns(temperature_data[-1][1]),
+        tolerance_ns=NS_PER_US,
     )
 
 
 def test_relative_microseconds(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """Relative(microseconds, epoch) translates integer offsets into absolute timestamps and ingests successfully."""
+    """Relative(microseconds, epoch) translates integer µs offsets to absolute timestamps."""
     name = f"dataset-{request.node.name}"
     desc = f"timestamp test {request.node.name}"
     start = temperature_data[0][1]
@@ -192,22 +304,20 @@ def test_relative_microseconds(request, client: NominalClient, temperature_data:
         return f"{temp},{_micros(ts)}"
 
     csv_bytes = _create_csv_data(temperature_data, fmt)
-    # expected bounds are start + the integer µs values for the first and last samples
-    expected_start = start + timedelta(microseconds=_micros(temperature_data[0][1]))
-    expected_end = start + timedelta(microseconds=_micros(temperature_data[-1][1]))
+    start_ns = _ns(start)
     _upload_and_assert(
         client=client,
         name=name,
         desc=desc,
         csv_bytes=csv_bytes,
         timestamp_type=Relative(unit="microseconds", start=start),
-        expected_start=expected_start,
-        expected_end=expected_end,
+        expected_start_ns=start_ns + _micros(temperature_data[0][1]) * 1_000,
+        expected_end_ns=start_ns + _micros(temperature_data[-1][1]) * 1_000,
     )
 
 
 def test_custom_ctime(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """A Custom format matching ctime output (e.g. "Mon Sep 30 16:37:36.891349 2024") ingests successfully."""
+    """A Custom format matching ctime output (e.g. "Mon Sep 30 16:37:36.891349 2024")."""
     name = f"dataset-{request.node.name}"
     desc = f"timestamp test {request.node.name}"
 
@@ -224,13 +334,13 @@ def test_custom_ctime(request, client: NominalClient, temperature_data: list[tup
         desc=desc,
         csv_bytes=csv_bytes,
         timestamp_type=Custom(r"EEE MMM dd HH:mm:ss.SSSSSS yyyy"),
-        expected_start=temperature_data[0][1],
-        expected_end=temperature_data[-1][1],
+        expected_start_ns=_ns(temperature_data[0][1]),
+        expected_end_ns=_ns(temperature_data[-1][1]),
     )
 
 
 def test_custom_irig(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """A Custom format using IRIG day-of-year notation (e.g. "274:16:37:36.891349") ingests successfully."""
+    """A Custom format using IRIG day-of-year notation (e.g. "274:16:37:36.891349")."""
     name = f"dataset-{request.node.name}"
     desc = f"timestamp test {request.node.name}"
 
@@ -245,8 +355,8 @@ def test_custom_irig(request, client: NominalClient, temperature_data: list[tupl
         desc=desc,
         csv_bytes=csv_bytes,
         timestamp_type=Custom(r"DDD:HH:mm:ss.SSSSSS", default_year=2024),
-        expected_start=temperature_data[0][1],
-        expected_end=temperature_data[-1][1],
+        expected_start_ns=_ns(temperature_data[0][1]),
+        expected_end_ns=_ns(temperature_data[-1][1]),
     )
 
 
@@ -274,6 +384,6 @@ def test_custom_day_of_year(request, client: NominalClient, temperature_data: li
         desc=desc,
         csv_bytes=csv_bytes,
         timestamp_type=Custom(r"HH:mm:ss.SSSSSS", default_year=2024, default_day_of_year=1),
-        expected_start=expected_start,
-        expected_end=expected_end,
+        expected_start_ns=_ns(expected_start),
+        expected_end_ns=_ns(expected_end),
     )

--- a/tests/e2e/test_timestamps.py
+++ b/tests/e2e/test_timestamps.py
@@ -31,6 +31,10 @@ from tests.e2e import POLL_INTERVAL
 
 Formatter = Callable[[int, datetime], str]
 
+# Float-encoded epoch values (epoch_seconds, epoch_milliseconds) lose sub-µs
+# precision when converted to nanoseconds; allow 1 µs of slack on those tests.
+NS_PER_US = 1_000
+
 
 @pytest.fixture(scope="module")
 def temperature_data() -> list[tuple[int, datetime]]:
@@ -52,11 +56,6 @@ def _create_csv_data(data: list[tuple[int, datetime]], formatter: Formatter) -> 
     return ("temperature,timestamp\n" + "\n".join(formatter(temp, ts) for temp, ts in data)).encode()
 
 
-def _truncate_to_ms(dt: datetime) -> datetime:
-    """Truncate a datetime to millisecond precision (drop sub-millisecond microseconds)."""
-    return dt.replace(microsecond=(dt.microsecond // 1000) * 1000)
-
-
 def _assert_bounds(
     dataset_file: DatasetFile,
     dataset: Dataset,
@@ -71,9 +70,9 @@ def _assert_bounds(
         dataset: The parent dataset; refreshed in-place before its bounds are checked.
         expected_start: Expected lower bound of the ingested time range.
         expected_end: Expected upper bound of the ingested time range.
-        tolerance_ns: Allowed absolute error in nanoseconds. Use 0 for exact match.
-                      Set to ~1000 for epoch_seconds where float64 precision causes
-                      sub-microsecond rounding errors.
+        tolerance_ns: Allowed absolute error in nanoseconds. Defaults to 0 (exact match);
+                      set to the precision floor of the timestamp format under test when the
+                      format cannot round-trip to nanosecond precision.
     """
     expected_start_ns = _SecondsNanos.from_datetime(expected_start).to_nanoseconds()
     expected_end_ns = _SecondsNanos.from_datetime(expected_end).to_nanoseconds()
@@ -133,46 +132,47 @@ def test_iso_8601(request, client: NominalClient, temperature_data: list[tuple[i
     desc = f"timestamp test {request.node.name}"
     csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.isoformat()}")
     _upload_and_assert(
-        client,
-        name,
-        desc,
-        csv_bytes,
-        "iso_8601",
-        temperature_data[0][1],
-        temperature_data[-1][1],
+        client=client,
+        name=name,
+        desc=desc,
+        csv_bytes=csv_bytes,
+        timestamp_type="iso_8601",
+        expected_start=temperature_data[0][1],
+        expected_end=temperature_data[-1][1],
     )
 
 
 def test_epoch_seconds(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """Epoch-seconds timestamps ingest correctly; float64 CSV values have sub-microsecond rounding."""
+    """Epoch-seconds timestamps ingest correctly; float64 → ns conversion has sub-µs rounding."""
     name = f"dataset-{request.node.name}"
     desc = f"timestamp test {request.node.name}"
     csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.timestamp()}")
     _upload_and_assert(
-        client,
-        name,
-        desc,
-        csv_bytes,
-        "epoch_seconds",
-        temperature_data[0][1],
-        temperature_data[-1][1],
-        tolerance_ns=1_000,
+        client=client,
+        name=name,
+        desc=desc,
+        csv_bytes=csv_bytes,
+        timestamp_type="epoch_seconds",
+        expected_start=temperature_data[0][1],
+        expected_end=temperature_data[-1][1],
+        tolerance_ns=NS_PER_US,
     )
 
 
 def test_epoch_milliseconds(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
-    """Epoch-milliseconds timestamps ingest correctly; sub-millisecond precision is truncated."""
+    """Epoch-milliseconds preserves sub-ms precision from the float-encoded value (with float64 sub-µs rounding)."""
     name = f"dataset-{request.node.name}"
     desc = f"timestamp test {request.node.name}"
     csv_bytes = _create_csv_data(temperature_data, lambda temp, ts: f"{temp},{ts.timestamp() * 1000}")
     _upload_and_assert(
-        client,
-        name,
-        desc,
-        csv_bytes,
-        "epoch_milliseconds",
-        _truncate_to_ms(temperature_data[0][1]),
-        _truncate_to_ms(temperature_data[-1][1]),
+        client=client,
+        name=name,
+        desc=desc,
+        csv_bytes=csv_bytes,
+        timestamp_type="epoch_milliseconds",
+        expected_start=temperature_data[0][1],
+        expected_end=temperature_data[-1][1],
+        tolerance_ns=NS_PER_US,
     )
 
 
@@ -195,7 +195,15 @@ def test_relative_microseconds(request, client: NominalClient, temperature_data:
     # expected bounds are start + the integer µs values for the first and last samples
     expected_start = start + timedelta(microseconds=_micros(temperature_data[0][1]))
     expected_end = start + timedelta(microseconds=_micros(temperature_data[-1][1]))
-    _upload_and_assert(client, name, desc, csv_bytes, Relative("microseconds", start), expected_start, expected_end)
+    _upload_and_assert(
+        client=client,
+        name=name,
+        desc=desc,
+        csv_bytes=csv_bytes,
+        timestamp_type=Relative(unit="microseconds", start=start),
+        expected_start=expected_start,
+        expected_end=expected_end,
+    )
 
 
 def test_custom_ctime(request, client: NominalClient, temperature_data: list[tuple[int, datetime]]):
@@ -211,13 +219,13 @@ def test_custom_ctime(request, client: NominalClient, temperature_data: list[tup
 
     csv_bytes = _create_csv_data(temperature_data, fmt)
     _upload_and_assert(
-        client,
-        name,
-        desc,
-        csv_bytes,
-        Custom(r"EEE MMM dd HH:mm:ss.SSSSSS yyyy"),
-        temperature_data[0][1],
-        temperature_data[-1][1],
+        client=client,
+        name=name,
+        desc=desc,
+        csv_bytes=csv_bytes,
+        timestamp_type=Custom(r"EEE MMM dd HH:mm:ss.SSSSSS yyyy"),
+        expected_start=temperature_data[0][1],
+        expected_end=temperature_data[-1][1],
     )
 
 
@@ -232,13 +240,13 @@ def test_custom_irig(request, client: NominalClient, temperature_data: list[tupl
 
     csv_bytes = _create_csv_data(temperature_data, fmt)
     _upload_and_assert(
-        client,
-        name,
-        desc,
-        csv_bytes,
-        Custom(r"DDD:HH:mm:ss.SSSSSS", default_year=2024),
-        temperature_data[0][1],
-        temperature_data[-1][1],
+        client=client,
+        name=name,
+        desc=desc,
+        csv_bytes=csv_bytes,
+        timestamp_type=Custom(r"DDD:HH:mm:ss.SSSSSS", default_year=2024),
+        expected_start=temperature_data[0][1],
+        expected_end=temperature_data[-1][1],
     )
 
 
@@ -261,11 +269,11 @@ def test_custom_day_of_year(request, client: NominalClient, temperature_data: li
         2024, 1, 1, last_ts.hour, last_ts.minute, last_ts.second, last_ts.microsecond, tzinfo=timezone.utc
     )
     _upload_and_assert(
-        client,
-        name,
-        desc,
-        csv_bytes,
-        Custom(r"HH:mm:ss.SSSSSS", default_year=2024, default_day_of_year=1),
-        expected_start,
-        expected_end,
+        client=client,
+        name=name,
+        desc=desc,
+        csv_bytes=csv_bytes,
+        timestamp_type=Custom(r"HH:mm:ss.SSSSSS", default_year=2024, default_day_of_year=1),
+        expected_start=expected_start,
+        expected_end=expected_end,
     )


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

## Summary

Expands `tests/e2e/test_timestamps.py` to cover every supported timestamp column format on dataset ingest, and uses that coverage to characterize the actual round-trip precision callers get from each format. Two `epoch_*` units exhibit silent precision loss against `staging`; both are now testable, documented, and bounded by explicit tolerances that map to the *observed* precision floor.

## What changed

- **Coverage extended to all seven `epoch_*` units.** Previously the suite only tested `epoch_seconds` and `epoch_milliseconds`. Now: `epoch_days`, `epoch_hours`, `epoch_minutes`, `epoch_seconds`, `epoch_milliseconds`, `epoch_microseconds`, and `epoch_nanoseconds`.
- **Existing format coverage preserved and tightened.** `iso_8601`, `Relative(microseconds, ...)`, `Custom(ctime)`, `Custom(IRIG)`, and `Custom(HH:mm:ss with default date)` continue to assert exact bounds match.
- **Bounds assertions are expressed in nanoseconds-since-epoch** (`expected_start_ns: int`, `expected_end_ns: int`) so each test can model the precision floor of its format without being capped by `datetime`'s microsecond ceiling.
- **Tolerances are zero by default** and only present on tests where the observed round-trip behavior demands them. Every non-zero tolerance is justified in the test's docstring.
- **Assertion helper checks both file-level and dataset-level bounds** (`DatasetFile.bounds` and `Dataset.bounds` after `.refresh()`), so any divergence between the two layers would surface immediately.

## How the tests express behavior

Each test follows a single shape:

1. Build a small CSV from the shared `temperature_data` fixture — 8 samples spanning ~700 ms on 2024-09-30, all at microsecond precision — using a format-specific timestamp formatter.
2. Upload via `Dataset.add_from_io(...)` and wait for ingestion to complete.
3. Assert that both `dataset_file.bounds` and the refreshed `dataset.bounds` match the expected nanoseconds-since-epoch, within the format's tolerance.
4. Archive the dataset in a `finally` block so resources are cleaned up even on assertion failure.

The formatter for each format is intentionally written the way a real caller would write it (e.g., `ts.timestamp() * 1000` for `epoch_milliseconds`), so the test exercises the same code path users would hit.

## Observed precision behavior per format

Against `staging`, with the same two boundary samples for every test:

| input bound | datetime | expected ns |
|---|---|---|
| start | `2024-09-30T16:37:36.891349Z` | `1727714256891349000` |
| end | `2024-09-30T16:37:37.590826Z` | `1727714257590826000` |

| format | stored start ns | Δ start | stored end ns | Δ end |
|---|---|---|---|---|
| `iso_8601` | `1727714256891349000` | `0` | `1727714257590826000` | `0` |
| `epoch_days` | `1727714256891348992` | `−8 ns` | `1727714257590825984` | `−16 ns` |
| `epoch_hours` | `1727714256891348992` | `−8 ns` | `1727714257590825984` | `−16 ns` |
| `epoch_minutes` | `1727714256891348992` | `−8 ns` | `1727714257590825984` | `−16 ns` |
| `epoch_seconds` | `1727714256891348992` | `−8 ns` | `1727714257590825984` | `−16 ns` |
| `epoch_milliseconds` | `1727714256891000000` | `−349,000 ns` | `1727714257590000000` | `−826,000 ns` |
| `epoch_microseconds` (int input) | `1727714256891349000` | `0` | `1727714257590826000` | `0` |
| `epoch_nanoseconds` (int input) | `1727714256891348992` | `−8 ns` | `1727714257590825984` | `−16 ns` |
| `Relative(microseconds, ...)` | exact | `0` | exact | `0` |
| `Custom(EEE MMM dd HH:mm:ss.SSSSSS yyyy)` | exact | `0` | exact | `0` |
| `Custom(DDD:HH:mm:ss.SSSSSS, default_year)` | exact | `0` | exact | `0` |
| `Custom(HH:mm:ss.SSSSSS, default_year, default_day_of_year)` | exact | `0` | exact | `0` |

Two notable discrepancies stand out:

1. **`epoch_milliseconds` silently drops sub-ms input.** The observed drift exactly equals the sub-ms component of each input (`.349 µs` on start, `.826 µs` on end). Fractional milliseconds the caller supplies are discarded on write. This directly contradicts the `Epoch` docstring (`nominal/ts/__init__.py`), which states "the timestamp can be integral or floating point."

2. **Five `epoch_*` units (`days`, `hours`, `minutes`, `seconds`, `nanoseconds`) round-trip with byte-identical stored values.** We send five completely different CSV encodings of the same two instants — fractional float days, fractional float hours, fractional float minutes, fractional float seconds, and an *exact integer ns string* — and the backend returns the same stored ns (`1727714256891348992` and `1727714257590825984`) for all five. The drift magnitude (−8 ns / −16 ns) matches what IEEE 754 double-precision rounding produces at year-2024 timestamp magnitudes (~1.7e18 ns, ULP ~256 ns). The observation, regardless of the inferred root cause: *callers cannot store an exact nanosecond value at modern timestamps via `epoch_nanoseconds`, no matter how they encode the input.*

`epoch_microseconds` (with hand-built integer µs input) is the only `epoch_*` unit that round-trips losslessly. Sending µs as a float would lose the same ULP-level precision.

`iso_8601`, all three `Custom` patterns, and `Relative(microseconds)` all round-trip exactly.

## Tolerances applied in this PR

| tolerance | format(s) | why it's needed (observed) |
|---|---|---|
| `0` | `iso_8601`, all `Custom(*)`, `Relative(µs)`, `epoch_microseconds` | Stored ns matches expected ns exactly. |
| `NS_PER_US` (1 µs) | `epoch_days`, `epoch_hours`, `epoch_minutes`, `epoch_seconds`, `epoch_nanoseconds` | Observed drift is always ≤ 16 ns; 1 µs is the next clean ceiling that absorbs the ULP-level noise without masking a meaningful regression. |
| `NS_PER_MS` (1 ms) | `epoch_milliseconds` | Sub-ms input is dropped at write time; observed drift in this fixture reaches 826 µs. |

These tolerances are **workarounds for current backend behavior**, not specifications. The two named constants and per-test docstrings make it explicit which observation justifies which tolerance, so future readers can revisit (and ideally remove) them as the backend changes.

## Follow-ups

Two backend tickets to file based on what the new tests surface:

- `epoch_milliseconds`: fractional milliseconds silently truncated on ingest — contradicts the `Epoch` docstring's stated support for floating-point values.
- `epoch_nanoseconds`: integer ns input is quantized to a ~256 ns grid at modern timestamps, making the highest-precision epoch unit unable to round-trip an exact ns value the caller supplied.

Once those are fixed, the corresponding tolerance lines on `test_epoch_milliseconds` and `test_epoch_nanoseconds` can be dropped and the tests will continue to pass — at a stronger contract.

## Test plan

- [x] `uv run pytest tests/e2e/test_timestamps.py --profile staging --no-cov -v` — all 12 tests pass.
- [x] `uv run ruff check tests/e2e/test_timestamps.py` — clean.
- [x] `uv run ruff format --check tests/e2e/test_timestamps.py` — clean.
- [x] Drift values in the table above captured by running with tolerances removed and a measurement print added to `_assert_bounds`; both reverted before this PR.
