### PR TITLE
fix(video): adaptive, safe frame-rate normalization in normalize_video

### DIFF
--- a/check_normalize_video.py
+++ b/check_normalize_video.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Diagnostic for normalize_video.
+
+Runs nominal's `normalize_video` on one or more source videos and reports whether each ran
+safely and correctly: it probes the source and the normalized output and checks the guarantees
+the normalizer is supposed to provide.
+
+  * Output is h264/hevc, yuv420p, with no B-frames.
+  * No real frames are dropped (output frame count >= source frame count).
+  * Output duration stays aligned to the source.
+  * The muxed avg_frame_rate reads correctly (constant-rate output reports its true rate).
+
+A source that the normalizer *rejects* with a clear error (e.g. timestamp discontinuity, no video
+stream) is reported as SAFE-REJECTED -- that is correct behavior, not a failure.
+
+Requires ffmpeg/ffprobe on PATH (this actually re-encodes the file). Note: counting frames decodes
+the whole file, so this is slow on large inputs.
+
+Usage:
+    python check_normalize_video.py VIDEO [VIDEO ...]
+        [-o OUTPUT_DIR] [--codec {h264,h264_nvenc,hevc,hevc_nvenc}]
+        [--mode {auto,cfr,passthrough}] [--keep] [--no-color]
+
+Exit code: 0 if every input passed (or was safely rejected); 1 if any input produced output that
+failed a check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+from fractions import Fraction
+from pathlib import Path
+
+import ffmpeg
+
+from nominal.experimental.video_processing.video_conversion import (
+    NormalizationError,
+    frame_count,
+    normalize_video,
+)
+
+# Tolerances for the correctness checks.
+_RATE_REL_TOL = 0.01  # avg_frame_rate is "correct" if within 1% of r_frame_rate
+_DURATION_WARN_S = 0.5  # duration drift above this fails; a couple of frames passes
+
+
+class _C:
+    """ANSI colors, disabled when output isn't a TTY or --no-color is passed."""
+
+    enabled = sys.stdout.isatty()
+
+    @classmethod
+    def wrap(cls, code: str, text: str) -> str:
+        return f"\033[{code}m{text}\033[0m" if cls.enabled else text
+
+
+def _status(kind: str, label: str, detail: str = "") -> bool:
+    """Print one PASS/FAIL/WARN/INFO line; return True if it counts as a failure."""
+    mark, code = {"PASS": ("PASS", "32"), "FAIL": ("FAIL", "31"), "WARN": ("WARN", "33"), "INFO": ("INFO", "2")}[kind]
+    line = f"  {_C.wrap(code, mark):<4}  {label}"
+    if detail:
+        line += f"   {_C.wrap('2', detail)}"
+    print(line)
+    return kind == "FAIL"
+
+
+def _probe(path: Path) -> dict | None:
+    """Probe the first video stream; return parsed fields, or None if there is no video stream."""
+    try:
+        info = ffmpeg.probe(
+            str(path),
+            v="error",
+            select_streams="v:0",
+            show_entries="stream=codec_name,pix_fmt,has_b_frames,r_frame_rate,avg_frame_rate:format=duration",
+        )
+    except ffmpeg.Error as exc:
+        stderr = exc.stderr.decode("utf-8", "replace") if exc.stderr else ""
+        raise RuntimeError(f"ffprobe failed for {path}: {stderr.strip()}") from exc
+
+    streams = info.get("streams", [])
+    if not streams:
+        return None
+    s = streams[0]
+
+    def _frac(value: str | None) -> Fraction | None:
+        try:
+            f = Fraction(value)  # type: ignore[arg-type]
+            return f if f > 0 else None
+        except (ValueError, ZeroDivisionError, TypeError):
+            return None
+
+    def _float(value: object) -> float | None:
+        try:
+            return float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return None
+
+    return {
+        "codec": s.get("codec_name"),
+        "pix_fmt": s.get("pix_fmt"),
+        "has_b_frames": s.get("has_b_frames"),
+        "r": _frac(s.get("r_frame_rate")),
+        "avg": _frac(s.get("avg_frame_rate")),
+        "duration": _float(info.get("format", {}).get("duration")),
+    }
+
+
+def _fmt_rate(r: Fraction | None) -> str:
+    return f"{float(r):.4f} ({r.numerator}/{r.denominator})" if r else "unknown"
+
+
+def _run_output_checks(src_info: dict | None, src_frames: int, out_info: dict, out_frames: int) -> bool:  # noqa: PLR0912 -- a flat list of independent checks
+    """Run the correctness checks comparing source and normalized output. Return True if all passed."""
+    failed = False
+
+    # Codec.
+    failed |= _status(
+        "PASS" if out_info["codec"] in ("h264", "hevc") else "FAIL",
+        "codec is h264/hevc",
+        f"got {out_info['codec']}",
+    )
+
+    # Pixel format.
+    failed |= _status(
+        "PASS" if out_info["pix_fmt"] == "yuv420p" else "FAIL",
+        "pixel format is yuv420p",
+        f"got {out_info['pix_fmt']}",
+    )
+
+    # No B-frames.
+    try:
+        bframes = int(out_info["has_b_frames"])
+    except (TypeError, ValueError):
+        bframes = -1
+    failed |= _status("PASS" if bframes == 0 else "FAIL", "no B-frames", f"has_b_frames={out_info['has_b_frames']}")
+
+    # No real frames dropped.
+    if out_frames >= src_frames:
+        added = out_frames - src_frames
+        detail = f"{out_frames} >= {src_frames}" + (f" (+{added} duplicate fill)" if added else " (preserved)")
+        _status("PASS", "no frames dropped", detail)
+    else:
+        failed |= _status("FAIL", "no frames dropped", f"output {out_frames} < source {src_frames} -- LOST FRAMES")
+
+    # Duration aligned to source.
+    if src_info and src_info["duration"] is not None and out_info["duration"] is not None and out_info["r"]:
+        delta = abs(out_info["duration"] - src_info["duration"])
+        ok_tol = max(0.05, 2.0 / float(out_info["r"]))
+        detail = f"|{out_info['duration']:.3f} - {src_info['duration']:.3f}| = {delta:.3f}s"
+        if delta <= ok_tol:
+            _status("PASS", "duration aligned", detail)
+        elif delta <= _DURATION_WARN_S:
+            _status("WARN", "duration off by a few frames", detail)
+        else:
+            failed |= _status("FAIL", "duration drifted", detail)
+    else:
+        _status("WARN", "duration not verifiable", "missing source/output duration or rate")
+
+    # avg_frame_rate reports correctly (the original symptom).
+    if out_info["r"] and out_info["avg"]:
+        if abs(float(out_info["avg"]) - float(out_info["r"])) <= _RATE_REL_TOL * float(out_info["r"]):
+            _status("PASS", "avg_frame_rate matches true rate", f"avg={_fmt_rate(out_info['avg'])}")
+        else:
+            _status(
+                "WARN",
+                "avg_frame_rate below r_frame_rate",
+                "output is variable/passthrough; avg reflects the true average, not a defect",
+            )
+    else:
+        _status("WARN", "avg_frame_rate not verifiable")
+
+    if failed:
+        print("  " + _C.wrap("31", "RESULT: FAILED a check"))
+    else:
+        print("  " + _C.wrap("32", "RESULT: ran safely and correctly"))
+    return not failed
+
+
+def check_one(src: Path, out: Path, codec: str, mode: str) -> bool:
+    """Normalize `src` -> `out` and print diagnostics. Return True if it passed (or was safely rejected)."""
+    print(_C.wrap("1", f"\n=== {src} ==="))
+
+    src_info = _probe(src)
+    if src_info is None:
+        _status("INFO", "source has no video stream")
+    else:
+        _status(
+            "INFO",
+            "source",
+            f"{src_info['codec']} {src_info['pix_fmt']} "
+            f"r={_fmt_rate(src_info['r'])} avg={_fmt_rate(src_info['avg'])} dur={src_info['duration']}",
+        )
+
+    print(_C.wrap("2", "  counting source frames (decodes the file)..."))
+    src_frames = frame_count(src)
+    _status("INFO", "source decoded frames", str(src_frames))
+
+    # Run the normalizer. A NormalizationError is a correct, safe refusal -- not a failure.
+    try:
+        normalize_video(src, out, video_codec=codec, frame_rate_mode=mode)  # type: ignore[arg-type]
+    except NormalizationError as exc:
+        _status("INFO", "SAFE-REJECTED", str(exc))
+        print(_C.wrap("33", "  -> normalizer correctly refused to produce output for this source."))
+        return True
+
+    out_info = _probe(out)
+    if out_info is None:
+        _status("FAIL", "output has no video stream")
+        return False
+    out_frames = frame_count(out)
+    _status(
+        "INFO",
+        "output",
+        f"{out_info['codec']} {out_info['pix_fmt']} "
+        f"r={_fmt_rate(out_info['r'])} avg={_fmt_rate(out_info['avg'])} dur={out_info['duration']} "
+        f"frames={out_frames}",
+    )
+
+    return _run_output_checks(src_info, src_frames, out_info, out_frames)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Diagnose normalize_video on video files.")
+    parser.add_argument("videos", nargs="+", type=Path, help="source video file(s)")
+    parser.add_argument("-o", "--output-dir", type=Path, help="where to write normalized output (default: temp dir)")
+    parser.add_argument("--codec", default="h264", choices=["h264", "h264_nvenc", "hevc", "hevc_nvenc"])
+    parser.add_argument("--mode", default="auto", choices=["auto", "cfr", "passthrough"])
+    parser.add_argument("--keep", action="store_true", help="keep the normalized output files")
+    parser.add_argument("--no-color", action="store_true", help="disable colored output")
+    args = parser.parse_args()
+
+    if args.no_color:
+        _C.enabled = False
+
+    tmp = None
+    out_dir = args.output_dir
+    if out_dir is None:
+        tmp = tempfile.TemporaryDirectory()
+        out_dir = Path(tmp.name)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    all_ok = True
+    try:
+        for video in args.videos:
+            if not video.exists():
+                _status("FAIL", f"{video}", "file does not exist")
+                all_ok = False
+                continue
+            out = out_dir / f"{video.stem}.normalized.mp4"
+            try:
+                all_ok &= check_one(video, out, args.codec, args.mode)
+            except Exception as exc:  # ffprobe failure, unexpected error -> report, don't crash the batch
+                _status("FAIL", f"{video}", f"unexpected error: {exc}")
+                all_ok = False
+            if args.keep and out.exists():
+                _status("INFO", "kept output", str(out))
+    finally:
+        if tmp is not None and not args.keep:
+            tmp.cleanup()
+
+    print()
+    print(_C.wrap("32" if all_ok else "31", "ALL PASSED" if all_ok else "SOME CHECKS FAILED"))
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nominal/experimental/video_processing/__init__.py
+++ b/nominal/experimental/video_processing/__init__.py
@@ -9,9 +9,15 @@ from nominal.experimental.video_processing.resolution import (
     VideoResolution,
     scale_factor_from_resolution,
 )
-from nominal.experimental.video_processing.video_conversion import frame_count, has_audio_track, normalize_video
+from nominal.experimental.video_processing.video_conversion import (
+    NormalizationError,
+    frame_count,
+    has_audio_track,
+    normalize_video,
+)
 
 __all__ = [
+    "NormalizationError",
     "frame_count",
     "has_audio_track",
     "normalize_video",

--- a/nominal/experimental/video_processing/video_conversion.py
+++ b/nominal/experimental/video_processing/video_conversion.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import logging
 import pathlib
 import shlex
+from collections.abc import Callable  # noqa: F401
+from enum import Enum, auto
+from fractions import Fraction
+from typing import Any, Literal
 
 import ffmpeg
 
@@ -14,7 +18,318 @@ from nominal.experimental.video_processing.resolution import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_VIDEO_CODEC = "h264"
+
+class NormalizationError(Exception):
+    """Raised when a video cannot be cleanly normalized without violating frame/duration invariants."""
+
+
+class TimingStrategy(Enum):
+    """How the output's frame timing is produced."""
+
+    CFR_HEAL = auto()  # re-grid at the true rate; duplicate-fill dropped frames; clamp duration
+    PASSTHROUGH = auto()  # preserve the source's own frame timing exactly
+
+
+FrameRateMode = Literal["auto", "cfr", "passthrough"]
+
+# Tier-1: |avg-r|/r at or below this is treated as a clean constant-rate source (skip timestamp analysis).
+_CLEAN_RATE_TOLERANCE = 0.005
+# Tier-2: a PTS delta counts as "on-grid" if delta/(1/r) is within this of a positive integer.
+_GRID_DELTA_TOLERANCE = 0.25
+# Tier-2: at/above this fraction of on-grid deltas the source is a (possibly holey) constant-rate grid.
+_GRID_MATCH_MIN_FRACTION = 0.98
+# Verification: allowed output-vs-source duration drift, in seconds, before it is an error (CFR) or warning.
+_DURATION_TOLERANCE_SECONDS = 0.25
+
+
+def _parse_rate(rate: str | None) -> Fraction | None:
+    """Parse an ffprobe rate string ('num/den' or 'num') into a positive Fraction, or None.
+
+    Returns None for missing, zero ('0/0'), non-numeric, or non-positive values so callers can treat
+    'no usable rate' uniformly.
+    """
+    if not rate:
+        return None
+    try:
+        value = Fraction(rate)
+    except (ValueError, ZeroDivisionError):
+        return None
+    return value if value > 0 else None
+
+
+def _parse_timing_probe(
+    probe: dict[str, Any], video_path: pathlib.Path
+) -> tuple[Fraction | None, Fraction | None, float | None]:
+    """Parse (r_frame_rate, avg_frame_rate, container_duration_seconds) from an ffprobe result dict.
+
+    Pure (no I/O) so it can be unit-tested with canned probe dicts. Raises NormalizationError when the
+    result has no video stream. ``video_path`` is used only for the error message.
+    """
+    streams = probe.get("streams", [])
+    if not streams:
+        raise NormalizationError(f"Cannot normalize '{video_path}': no video stream found")
+
+    stream = streams[0]
+    r = _parse_rate(stream.get("r_frame_rate"))
+    avg = _parse_rate(stream.get("avg_frame_rate"))
+
+    duration_raw = probe.get("format", {}).get("duration")
+    try:
+        duration: float | None = float(duration_raw)
+    except (TypeError, ValueError):
+        duration = None
+
+    return r, avg, duration
+
+
+def _parse_packet_pts(probe: dict[str, Any]) -> list[float]:
+    """Extract packet presentation timestamps (seconds, file order) from an ffprobe result dict.
+
+    Pure (no I/O) so it can be unit-tested with canned probe dicts. Skips unparseable entries; file
+    order is preserved so the discontinuity check can see backward jumps.
+    """
+    times: list[float] = []
+    for packet in probe.get("packets", []):
+        try:
+            times.append(float(packet.get("pts_time")))
+        except (TypeError, ValueError):
+            continue
+    return times
+
+
+def _classify_tier1(
+    r: Fraction | None,
+    avg: Fraction | None,
+    tolerance: float = _CLEAN_RATE_TOLERANCE,
+) -> TimingStrategy | None:
+    """Cheap first-pass classification from r_frame_rate vs avg_frame_rate.
+
+    Returns PASSTHROUGH when the rate is indeterminate (preserve timing), CFR_HEAL when avg≈r
+    (clean constant-rate grid), or None when the gap is large in either direction -- which is
+    ambiguous (dropped frames, true VFR, or misdetected r) and must be resolved by Tier 2.
+    """
+    if r is None:
+        return TimingStrategy.PASSTHROUGH
+    if avg is None:
+        return None
+    if abs(float(avg) - float(r)) <= tolerance * float(r):
+        return TimingStrategy.CFR_HEAL
+    return None
+
+
+def _has_timestamp_discontinuity(pts: list[float], r: Fraction) -> bool:
+    """Return True if the timestamps (in file order) contain a large backward jump.
+
+    A PTS reset or 33-bit wrap shows up as a big backward step; small backward steps from normal
+    B-frame reordering are ignored. CFR cannot be safely imposed across a discontinuity, so callers
+    treat True as a hard error.
+    """
+    base = 1.0 / float(r)
+    threshold = max(1.0, 10.0 * base)
+    for prev, cur in zip(pts, pts[1:]):
+        if cur - prev < -threshold:
+            return True
+    return False
+
+
+def _deltas_match_grid(
+    pts: list[float],
+    r: Fraction,
+    tolerance: float = _GRID_DELTA_TOLERANCE,
+    min_fraction: float = _GRID_MATCH_MIN_FRACTION,
+) -> bool:
+    """Return True if the inter-frame deltas look like a constant-rate grid (possibly with holes).
+
+    Sorts the timestamps into presentation order, then checks what fraction of consecutive deltas are
+    positive-integer multiples of the base interval 1/r. A high fraction means a clean grid or a grid
+    with dropped frames (heal with CFR); a low fraction means genuine variable frame rate (pass through).
+    """
+    ordered = sorted(pts)
+    base = 1.0 / float(r)
+    deltas = [cur - prev for prev, cur in zip(ordered, ordered[1:])]
+    if not deltas:
+        return False
+    on_grid = 0
+    for delta in deltas:
+        if delta <= 0:
+            continue
+        multiple = delta / base
+        if multiple >= 0.5 and abs(multiple - round(multiple)) <= tolerance:
+            on_grid += 1
+    return on_grid / len(deltas) >= min_fraction
+
+
+def _select_strategy(
+    frame_rate_mode: FrameRateMode,
+    r: Fraction | None,
+    avg: Fraction | None,
+    sample_pts: Callable[[], list[float]],
+    video_path: pathlib.Path,
+) -> tuple[TimingStrategy, float | None]:
+    """Pick the timing strategy and the max observed PTS (used for the CFR clamp guard).
+
+    `sample_pts` is invoked lazily, only when Tier 1 is ambiguous, so clean and forced sources never pay
+    the timestamp-probe cost. Raises NormalizationError on a timestamp discontinuity, or when CFR is
+    forced on a source whose frame rate is indeterminate.
+    """
+    if frame_rate_mode == "passthrough":
+        return TimingStrategy.PASSTHROUGH, None
+    if frame_rate_mode == "cfr":
+        if r is None:
+            raise NormalizationError(f"Cannot force CFR on '{video_path}': frame rate is indeterminate")
+        return TimingStrategy.CFR_HEAL, None
+
+    tier1 = _classify_tier1(r, avg)
+    if tier1 is not None:
+        return tier1, None
+
+    if r is None:  # _classify_tier1 only returns None when r is known; defense-in-depth
+        raise NormalizationError(f"Cannot classify '{video_path}': frame rate is indeterminate")
+    pts = sample_pts()
+    if not pts:
+        logger.warning("Could not sample timestamps for '%s'; preserving original timing", video_path)
+        return TimingStrategy.PASSTHROUGH, None
+    if _has_timestamp_discontinuity(pts, r):
+        raise NormalizationError(
+            f"Cannot normalize '{video_path}': timestamp discontinuity/reset detected; "
+            "the source timeline is incoherent and cannot be cleanly normalized"
+        )
+    if _deltas_match_grid(pts, r):
+        return TimingStrategy.CFR_HEAL, max(pts)
+    logger.warning("Source '%s' is variable-frame-rate; preserving original timing", video_path)
+    return TimingStrategy.PASSTHROUGH, max(pts)
+
+
+def _timing_output_kwargs(
+    strategy: TimingStrategy,
+    r: Fraction | None,
+    duration: float | None,
+    max_observed_pts: float | None,
+) -> dict[str, str]:
+    """Build the timing-related ffmpeg output kwargs for the chosen strategy.
+
+    PASSTHROUGH preserves the source's own frame timing. CFR_HEAL stamps a constant grid at the true
+    rate (numerator timescale keeps per-frame timestamps exact for any rate) and clamps the duration so
+    gap-fill can't overshoot. The clamp is skipped when the duration is unknown or is contradicted by a
+    later sampled timestamp (which would mean -t truncates real frames).
+    """
+    if strategy is TimingStrategy.PASSTHROUGH:
+        return {"fps_mode": "passthrough"}
+
+    if r is None:
+        raise NormalizationError("CFR-heal requires a known frame rate")
+
+    kwargs = {
+        "r": f"{r.numerator}/{r.denominator}",
+        "fps_mode": "cfr",
+        "video_track_timescale": str(r.numerator),
+    }
+    if duration is not None and duration > 0 and (max_observed_pts is None or duration >= max_observed_pts):
+        kwargs["t"] = f"{duration:.6f}"
+    return kwargs
+
+
+def _clean_encode_kwargs(video_codec: VideoCodec) -> dict[str, str]:
+    """Codec/colorspace kwargs applied to every source: selected codec, AAC audio, yuv420p, no B-frames.
+
+    `-bf 0` disables B-frames for both the libx264/libx265 CPU encoders and the NVENC encoders.
+    """
+    return {
+        "vcodec": video_codec,
+        "acodec": DEFAULT_AUDIO_CODEC,
+        "pix_fmt": DEFAULT_PIXEL_FORMAT,
+        "bf": "0",
+    }
+
+
+def _build_output_kwargs(
+    strategy: TimingStrategy,
+    r: Fraction | None,
+    source_duration: float | None,
+    max_observed_pts: float | None,
+    video_codec: VideoCodec,
+    key_frame_interval: int | None,
+    resolution: AnyResolutionType | None,
+) -> dict[str, str | None]:
+    """Assemble the full ffmpeg output kwargs: clean-encode + timing strategy + keyframes + optional scale.
+
+    Pure (no I/O) so the exact ffmpeg arguments can be asserted directly in tests.
+    """
+    kwargs: dict[str, str | None] = {
+        **_clean_encode_kwargs(video_codec),
+        **_timing_output_kwargs(strategy, r, source_duration, max_observed_pts),
+    }
+    if key_frame_interval is None:
+        kwargs["force_key_frames"] = "source"
+    else:
+        kwargs["force_key_frames"] = f"expr:gte(t,n_forced*{key_frame_interval})"
+    if resolution is not None:
+        kwargs["vf"] = scale_factor_from_resolution(resolution)
+    return kwargs
+
+
+def _verify_invariants(
+    strategy: TimingStrategy,
+    r: Fraction | None,
+    source_duration: float | None,
+    source_frames: int | None,
+    output_frames: int,
+    output_duration: float | None,
+    video_path: pathlib.Path,
+) -> None:
+    """Enforce the normalization invariants on the produced output; raise NormalizationError if violated.
+
+    CFR_HEAL: the output frame count must match the source's intended count (duration x rate) within one
+    frame, and the duration must match the source within tolerance. PASSTHROUGH: the output must keep at
+    least as many frames as the source decoded; duration shortfalls only warn (trailing source drops are
+    a faithfully-reproduced source property).
+    """
+    if output_frames <= 0:
+        raise NormalizationError(f"Normalization of '{video_path}' produced no frames")
+
+    if strategy is TimingStrategy.CFR_HEAL:
+        if r is not None and source_duration is not None and source_duration > 0:
+            expected = round(source_duration * float(r))
+            if abs(output_frames - expected) > 1:
+                raise NormalizationError(
+                    f"Normalization of '{video_path}' is invalid: expected ~{expected} frames "
+                    f"({source_duration:.3f}s x {float(r):.5f} fps), got {output_frames}"
+                )
+            if output_duration is not None and abs(output_duration - source_duration) > _DURATION_TOLERANCE_SECONDS:
+                raise NormalizationError(
+                    f"Normalization of '{video_path}' is invalid: output duration {output_duration:.3f}s "
+                    f"differs from source {source_duration:.3f}s by more than {_DURATION_TOLERANCE_SECONDS}s"
+                )
+        else:
+            logger.warning("Could not verify CFR-heal invariants for '%s' (rate/duration unknown)", video_path)
+    else:  # PASSTHROUGH
+        if source_frames is not None and output_frames < source_frames:
+            raise NormalizationError(
+                f"Normalization of '{video_path}' dropped frames: source {source_frames}, output {output_frames}"
+            )
+        if (
+            source_duration is not None
+            and output_duration is not None
+            and abs(output_duration - source_duration) > _DURATION_TOLERANCE_SECONDS
+        ):
+            logger.warning(
+                "Passthrough output for '%s' duration %.3fs differs from source %.3fs (likely trailing source drops)",
+                video_path,
+                output_duration,
+                source_duration,
+            )
+
+
+# The video codec options exposed to callers. These names are passed directly to ffmpeg as the
+# -c:v value and ffmpeg resolves each to its default encoder for that codec:
+#   - "h264":        H.264 (CPU, resolves to libx264). Portable, no GPU required, slower.
+#   - "h264_nvenc":  GPU-accelerated H.264 via NVIDIA NVENC. Requires an NVIDIA GPU; much faster.
+#   - "hevc":        H.265/HEVC (CPU, resolves to libx265). Better compression, slower, less universally played.
+#   - "hevc_nvenc":  GPU-accelerated H.265/HEVC via NVIDIA NVENC. Requires an NVIDIA GPU; better
+#                    compression than h264_nvenc at similar speed.
+VideoCodec = Literal["h264", "h264_nvenc", "hevc", "hevc_nvenc"]
+
+DEFAULT_VIDEO_CODEC: VideoCodec = "h264"
 DEFAULT_AUDIO_CODEC = "aac"
 DEFAULT_PIXEL_FORMAT = "yuv420p"
 DEFAULT_KEY_FRAME_INTERVAL_SEC = 2
@@ -27,94 +342,111 @@ def normalize_video(
     force: bool = True,
     resolution: AnyResolutionType | None = None,
     num_threads: int | None = None,
+    video_codec: VideoCodec = DEFAULT_VIDEO_CODEC,
+    frame_rate_mode: FrameRateMode = "auto",
 ) -> None:
-    """Convert video file to an h264 encoded video file using ffmpeg.
+    """Re-encode ("normalize") a video into a clean form best supported by Nominal.
 
-    This function will also perform several other processing tasks to ensure that video is
-    properly encoded in a way that is best supported by nominal.
-    This includes:
-        * Ensuring that there are key-frames (I-frames) present approximately every 2s of video content
-        * Video is encoded with H264
-        * Audio is encoded with AAC
-        * Video has YUV4:2:0 planar color space
+    Always produces the selected codec, yuv420p, no B-frames, and keyframes at the requested interval.
+    The frame timing is chosen adaptively so the output never drops real frames and its duration stays
+    aligned to the source:
 
-    While this package includes bindings to use ffmpeg installed on your local system, it does not
-    include ffmpeg as a dependency due to the GPLv3 licensing present in the standard H264 processing library
-    contained within, thus, you must have ffmpeg installed locally to use this.
+      * Clean constant-rate sources are re-stamped at their true rate (identity for frame count).
+      * Constant-rate sources with dropped frames are healed: re-gridded at the true rate with the
+        previous frame duplicated to fill each gap, and the duration clamped so the fill can't overshoot.
+      * Variable-frame-rate (and indeterminate-rate) sources are passed through, preserving their exact
+        timing and frame count.
+      * Sources with a timestamp discontinuity/reset, no video stream, or that fail to probe/encode raise
+        NormalizationError. A post-encode check re-verifies the invariants and raises rather than emit a
+        file that lost frames or drifted in duration.
+
+    ffmpeg (>=5.1, built for the selected codec) must be installed locally.
 
     Args:
-        input_path: Path to video file on local filesystem.
-        output_path: Path to write converted video file to.
-            NOTE: it is expected that the output file is either an mkv or a mp4 file.
-        key_frame_interval: Number of seconds between keyframes allowed in the output video.
-            NOTE: While this field is technically optional, setting the right value here
-                  can be essential to allowing fluid playback on the frontend, in particular,
-                  in network constrained environments. Setting this value too low or too high
-                  can impact performance negatively-- typically, a value at or around 2s is considered
-                  "best of both worlds" as a reasonable default value.
-        force: If true, forcibly delete existing output path if already exists.
-        resolution: If provided, re-scale the video to the provided resolution
-        num_threads: If provided, the number of CPU cores to tell ffmpeg to use.
-            NOTE: If not provided, ffmpeg will choose. Typically, this amounts to the number of cores present
-                  on the machine
-
-    NOTE: this requires that you have installed ffmpeg on your system with support for H264.
+        input_path: Path to the source video.
+        output_path: Path to write the output (.mkv or .mp4).
+        key_frame_interval: Seconds between forced keyframes; None keeps source keyframes.
+        force: If True, overwrite an existing output path.
+        resolution: If provided, rescale to this resolution.
+        num_threads: If provided, the number of CPU cores ffmpeg may use.
+        video_codec: Encoder, one of h264 / h264_nvenc / hevc / hevc_nvenc (default h264).
+        frame_rate_mode: "auto" (default) classifies the source and picks a strategy; "cfr" forces
+            constant-rate healing; "passthrough" forces timing preservation.
     """
     input_path = pathlib.Path(input_path)
     output_path = pathlib.Path(output_path)
-    assert input_path.exists(), "Input path must exist"
-    assert output_path.suffix.lower() in (".mkv", ".mp4")
-
+    if not input_path.exists():
+        raise NormalizationError(f"Input path does not exist: {input_path}")
+    if output_path.suffix.lower() not in (".mkv", ".mp4"):
+        raise NormalizationError(f"Output must be .mkv or .mp4, got: {output_path}")
     if output_path.exists():
         if force:
-            logger.info(f"Output file {output_path} already exists! Deleting...")
+            logger.info("Output file %s already exists! Deleting...", output_path)
             output_path.unlink()
         else:
-            raise FileExistsError(f"Cannot convert {input_path} to {output_path}: output path already exists!")
+            raise NormalizationError(f"Output path already exists: {output_path}")
 
-    # Determine if input video has an audio track. If it doesn't, add in an empty audio track
-    # to allow for seamless play of this video content alongside content with audio tracks.
-    # While the backend will do this for you automatically, it dramatically faster to do it here
-    # than in the backend since we are already re-encoding video.
-    output_kwargs: dict[str, str | None] = dict(
-        acodec=DEFAULT_AUDIO_CODEC,
-        vcodec=DEFAULT_VIDEO_CODEC,
-        force_key_frames="source",
-        pix_fmt=DEFAULT_PIXEL_FORMAT,
+    r, avg, source_duration = _probe_timing(input_path)
+    strategy, max_observed_pts = _select_strategy(
+        frame_rate_mode, r, avg, lambda: _sample_frame_pts(input_path), input_path
+    )
+    output_kwargs = _build_output_kwargs(
+        strategy, r, source_duration, max_observed_pts, video_codec, key_frame_interval, resolution
     )
 
-    # If user has opted out of forcing key-frames, keep key frames at the same timestamps as
-    # present in the initial video.
-    if key_frame_interval is None:
-        output_kwargs["force_key_frames"] = "source"
-    else:
-        output_kwargs["force_key_frames"] = f"expr:gte(t,n_forced*{key_frame_interval})"
-
-    # If user specified an output resolution, add respective video filters
-    if resolution is not None:
-        output_kwargs["vf"] = scale_factor_from_resolution(resolution)
-
-    input_kwargs = {}
+    input_kwargs: dict[str, str] = {}
     if num_threads is not None:
         input_kwargs["threads"] = str(num_threads)
 
-    # Run ffmpeg in subprocess
     video_in = ffmpeg.input(str(input_path), **input_kwargs)
     video_out = video_in.output(str(output_path), **output_kwargs)
-    logger.info(f"Running command: '{shlex.join(video_out.compile())}'")
-    video_out.run()
+    logger.info("Running command: '%s'", shlex.join(video_out.compile()))
+    try:
+        video_out.run(capture_stderr=True)
+    except ffmpeg.Error as exc:
+        stderr = exc.stderr.decode("utf-8", "replace") if exc.stderr else ""
+        raise NormalizationError(f"ffmpeg failed to normalize '{input_path}'. {stderr.strip()}") from exc
 
-    # Warn the user if the number of frames changes as a result of re-encoding the video
-    frames_before = frame_count(input_path)
-    frames_after = frame_count(output_path)
-    if frames_before != frames_after:
-        logger.warning(
-            "H264 re-encoded video '%s' has differing frames from original '%s' (%d vs. %d)",
-            output_path,
-            input_path,
-            frames_after,
-            frames_before,
+    output_frames = frame_count(output_path)
+    _, _, output_duration = _probe_timing(output_path)
+    source_frames = frame_count(input_path) if strategy is TimingStrategy.PASSTHROUGH else None
+    _verify_invariants(strategy, r, source_duration, source_frames, output_frames, output_duration, input_path)
+
+
+def _probe_timing(video_path: pathlib.Path) -> tuple[Fraction | None, Fraction | None, float | None]:
+    """Probe (r_frame_rate, avg_frame_rate, container_duration_seconds) for the first video stream.
+
+    Raises NormalizationError if the file can't be probed or has no video stream.
+    """
+    try:
+        probe: dict[str, Any] = ffmpeg.probe(
+            video_path,
+            v="error",
+            select_streams="v:0",
+            show_entries="stream=r_frame_rate,avg_frame_rate:format=duration",
         )
+    except ffmpeg.Error as exc:
+        stderr = exc.stderr.decode("utf-8", "replace") if exc.stderr else ""
+        raise NormalizationError(f"Cannot normalize '{video_path}': ffprobe failed. {stderr.strip()}") from exc
+    return _parse_timing_probe(probe, video_path)
+
+
+def _sample_frame_pts(video_path: pathlib.Path) -> list[float]:
+    """Return the video stream's packet presentation timestamps (seconds), in file order, no decode.
+
+    File order is preserved so the discontinuity check can see backward jumps; the grid check sorts
+    internally. Returns [] if no parseable timestamps are present.
+    """
+    try:
+        probe: dict[str, Any] = ffmpeg.probe(
+            video_path, v="error", select_streams="v:0", show_entries="packet=pts_time"
+        )
+    except ffmpeg.Error as exc:
+        stderr = exc.stderr.decode("utf-8", "replace") if exc.stderr else ""
+        raise NormalizationError(
+            f"Cannot sample timestamps for '{video_path}': ffprobe failed. {stderr.strip()}"
+        ) from exc
+    return _parse_packet_pts(probe)
 
 
 def frame_count(video_path: pathlib.Path) -> int:
@@ -124,15 +456,18 @@ def frame_count(video_path: pathlib.Path) -> int:
           of the first video stream.
     """
     assert video_path.exists()
+    # Count decoded frames (nb_read_frames), not packets. A packet is not always one frame, so
+    # counting packets can both over- and under-report the true frame count, which would make the
+    # "differing frames" warning below unreliable -- exactly the integrity check we care about here.
     probe_resp = ffmpeg.probe(
-        video_path, v="error", select_streams="v:0", count_packets=None, show_entries="stream=nb_read_packets"
+        video_path, v="error", select_streams="v:0", count_frames=None, show_entries="stream=nb_read_frames"
     )
 
     # No video streams present
     if len(probe_resp["streams"]) == 0:
         return 0
 
-    return int(probe_resp["streams"][0]["nb_read_packets"])
+    return int(probe_resp["streams"][0]["nb_read_frames"])
 
 
 def has_audio_track(video_path: pathlib.Path) -> bool:

--- a/tests/experimental/test_video_conversion.py
+++ b/tests/experimental/test_video_conversion.py
@@ -1,0 +1,328 @@
+"""Unit tests for adaptive video normalization. All logic is tested with pure inputs; no real ffmpeg runs."""
+
+from __future__ import annotations
+
+import pathlib
+from fractions import Fraction
+
+import pytest
+
+from nominal.experimental.video_processing.video_conversion import (
+    NormalizationError,
+    TimingStrategy,
+    _build_output_kwargs,
+    _classify_tier1,
+    _clean_encode_kwargs,
+    _deltas_match_grid,
+    _has_timestamp_discontinuity,
+    _parse_packet_pts,
+    _parse_rate,
+    _parse_timing_probe,
+    _select_strategy,
+    _timing_output_kwargs,
+    _verify_invariants,
+    normalize_video,
+)
+
+
+class TestParseRate:
+    def test_fractional_rate(self) -> None:
+        assert _parse_rate("30000/1001") == Fraction(30000, 1001)
+
+    def test_integer_rate(self) -> None:
+        assert _parse_rate("25") == Fraction(25, 1)
+
+    def test_none(self) -> None:
+        assert _parse_rate(None) is None
+
+    def test_empty(self) -> None:
+        assert _parse_rate("") is None
+
+    @pytest.mark.parametrize("bad", ["0/0", "0/30", "30/0", "abc", "-5/1", "/"])
+    def test_invalid_or_nonpositive_is_none(self, bad: str) -> None:
+        assert _parse_rate(bad) is None
+
+
+class TestClassifyTier1:
+    def test_clean_cfr_when_avg_equals_r(self) -> None:
+        r = Fraction(30000, 1001)
+        assert _classify_tier1(r, r) is TimingStrategy.CFR_HEAL
+
+    def test_clean_cfr_within_tolerance(self) -> None:
+        # 2997/100 (29.97) vs 30000/1001 (29.97003) -> well within tolerance
+        assert _classify_tier1(Fraction(30000, 1001), Fraction(2997, 100)) is TimingStrategy.CFR_HEAL
+
+    def test_indeterminate_rate_is_passthrough(self) -> None:
+        assert _classify_tier1(None, Fraction(30, 1)) is TimingStrategy.PASSTHROUGH
+
+    def test_missing_avg_is_ambiguous(self) -> None:
+        assert _classify_tier1(Fraction(30, 1), None) is None
+
+    def test_large_gap_below_r_is_ambiguous(self) -> None:
+        assert _classify_tier1(Fraction(30, 1), Fraction(25, 1)) is None
+
+    def test_avg_greater_than_r_is_ambiguous(self) -> None:
+        # avg > r signals misdetected r; must NOT shortcut to CFR (would drop frames)
+        assert _classify_tier1(Fraction(25, 1), Fraction(50, 1)) is None
+
+
+_R30 = Fraction(30, 1)  # base interval 1/30 s
+
+
+class TestDiscontinuity:
+    def test_monotonic_is_clean(self) -> None:
+        pts = [i / 30 for i in range(20)]
+        assert _has_timestamp_discontinuity(pts, _R30) is False
+
+    def test_small_reordering_ignored(self) -> None:
+        # B-frame style local reorder (a few frames) is not a discontinuity
+        pts = [0.0, 2 / 30, 1 / 30, 3 / 30, 5 / 30, 4 / 30]
+        assert _has_timestamp_discontinuity(pts, _R30) is False
+
+    def test_large_backward_jump_is_discontinuity(self) -> None:
+        pts = [0.0, 1 / 30, 2 / 30, 95443.0, 95443.0 + 1 / 30, 0.5]
+        assert _has_timestamp_discontinuity(pts, _R30) is True
+
+
+class TestGridMatch:
+    def test_perfect_grid(self) -> None:
+        pts = [i / 30 for i in range(50)]
+        assert _deltas_match_grid(pts, _R30) is True
+
+    def test_grid_with_holes(self) -> None:
+        # drop frames 3 and 7 -> gaps of 2*base, still on-grid
+        idx = [0, 1, 2, 4, 5, 6, 8, 9, 10]
+        pts = [i / 30 for i in idx]
+        assert _deltas_match_grid(pts, _R30) is True
+
+    def test_variable_frame_rate_is_not_grid(self) -> None:
+        pts = [0.0, 0.02, 0.05, 0.07, 0.13, 0.18, 0.20, 0.27]
+        assert _deltas_match_grid(pts, _R30) is False
+
+    def test_unsorted_grid_still_matches(self) -> None:
+        pts = [3 / 30, 0.0, 2 / 30, 1 / 30, 4 / 30]
+        assert _deltas_match_grid(pts, _R30) is True
+
+
+class TestTimingOutputKwargs:
+    def test_passthrough(self) -> None:
+        assert _timing_output_kwargs(TimingStrategy.PASSTHROUGH, None, None, None) == {"fps_mode": "passthrough"}
+
+    def test_cfr_heal_with_clamp(self) -> None:
+        kwargs = _timing_output_kwargs(TimingStrategy.CFR_HEAL, Fraction(30000, 1001), 1110.346, 1109.0)
+        assert kwargs["r"] == "30000/1001"
+        assert kwargs["fps_mode"] == "cfr"
+        assert kwargs["video_track_timescale"] == "30000"
+        assert kwargs["t"] == "1110.346000"
+
+    def test_cfr_heal_numerator_timescale_for_5994(self) -> None:
+        kwargs = _timing_output_kwargs(TimingStrategy.CFR_HEAL, Fraction(60000, 1001), 10.0, 9.0)
+        assert kwargs["video_track_timescale"] == "60000"
+
+    def test_cfr_heal_skips_clamp_when_pts_exceeds_duration(self) -> None:
+        # duration under-reports (a sampled frame is later than it) -> do not clamp, would cut frames
+        kwargs = _timing_output_kwargs(TimingStrategy.CFR_HEAL, Fraction(30, 1), 10.0, 12.0)
+        assert "t" not in kwargs
+
+    def test_cfr_heal_skips_clamp_when_duration_unknown(self) -> None:
+        kwargs = _timing_output_kwargs(TimingStrategy.CFR_HEAL, Fraction(30, 1), None, None)
+        assert "t" not in kwargs
+
+    def test_cfr_heal_requires_rate(self) -> None:
+        with pytest.raises(NormalizationError):
+            _timing_output_kwargs(TimingStrategy.CFR_HEAL, None, 10.0, None)
+
+
+class TestCleanEncodeKwargs:
+    def test_h264_defaults(self) -> None:
+        assert _clean_encode_kwargs("h264") == {
+            "vcodec": "h264",
+            "acodec": "aac",
+            "pix_fmt": "yuv420p",
+            "bf": "0",
+        }
+
+    def test_passes_codec_through(self) -> None:
+        assert _clean_encode_kwargs("hevc_nvenc")["vcodec"] == "hevc_nvenc"
+
+    def test_disables_b_frames(self) -> None:
+        assert _clean_encode_kwargs("hevc")["bf"] == "0"
+
+
+_P = pathlib.Path("dummy.mp4")
+
+
+class TestVerifyInvariants:
+    def test_cfr_heal_ok(self) -> None:
+        # 1110.346s * 29.97003 fps = ~33276 frames
+        _verify_invariants(TimingStrategy.CFR_HEAL, Fraction(30000, 1001), 1110.346, None, 33276, 1110.349, _P)
+
+    def test_cfr_heal_frame_shortfall_raises(self) -> None:
+        with pytest.raises(NormalizationError, match="expected"):
+            _verify_invariants(TimingStrategy.CFR_HEAL, Fraction(30000, 1001), 1110.346, None, 33000, 1110.0, _P)
+
+    def test_cfr_heal_duration_drift_raises(self) -> None:
+        with pytest.raises(NormalizationError, match="duration"):
+            _verify_invariants(TimingStrategy.CFR_HEAL, Fraction(30000, 1001), 1110.346, None, 33276, 1108.0, _P)
+
+    def test_passthrough_ok(self) -> None:
+        _verify_invariants(TimingStrategy.PASSTHROUGH, None, 10.0, 300, 300, 10.0, _P)
+
+    def test_passthrough_dropped_frames_raises(self) -> None:
+        with pytest.raises(NormalizationError, match="dropped"):
+            _verify_invariants(TimingStrategy.PASSTHROUGH, None, 10.0, 300, 298, 10.0, _P)
+
+    def test_zero_frames_raises(self) -> None:
+        with pytest.raises(NormalizationError, match="no frames"):
+            _verify_invariants(TimingStrategy.PASSTHROUGH, None, 10.0, 0, 0, 0.0, _P)
+
+
+class TestParseTimingProbe:
+    def test_parses_rates_and_duration(self) -> None:
+        probe = {
+            "streams": [{"r_frame_rate": "30000/1001", "avg_frame_rate": "2997/100"}],
+            "format": {"duration": "3.003"},
+        }
+        r, avg, dur = _parse_timing_probe(probe, _P)
+        assert r == Fraction(30000, 1001)
+        assert avg == Fraction(2997, 100)
+        assert dur == pytest.approx(3.003)
+
+    def test_no_video_stream_raises(self) -> None:
+        with pytest.raises(NormalizationError, match="no video stream"):
+            _parse_timing_probe({"streams": [], "format": {}}, _P)
+
+    def test_missing_duration_is_none(self) -> None:
+        probe = {"streams": [{"r_frame_rate": "25/1", "avg_frame_rate": "25/1"}], "format": {}}
+        _, _, dur = _parse_timing_probe(probe, _P)
+        assert dur is None
+
+    def test_indeterminate_rates_are_none(self) -> None:
+        probe = {"streams": [{"r_frame_rate": "0/0", "avg_frame_rate": "0/0"}], "format": {"duration": "5.0"}}
+        r, avg, dur = _parse_timing_probe(probe, _P)
+        assert r is None
+        assert avg is None
+        assert dur == pytest.approx(5.0)
+
+
+class TestParsePacketPts:
+    def test_returns_pts_in_file_order_skipping_unparseable(self) -> None:
+        probe = {
+            "packets": [
+                {"pts_time": "0.0"},
+                {"pts_time": "0.033"},
+                {"pts_time": "bad"},
+                {"pts_time": "0.066"},
+            ]
+        }
+        assert _parse_packet_pts(probe) == [0.0, 0.033, 0.066]
+
+    def test_no_packets_is_empty(self) -> None:
+        assert _parse_packet_pts({}) == []
+
+
+_VPATH = pathlib.Path("v.mp4")
+
+
+def _never() -> list[float]:
+    raise AssertionError("sample_pts should not be called for this case")
+
+
+class TestSelectStrategy:
+    def test_forced_passthrough(self) -> None:
+        assert _select_strategy("passthrough", Fraction(30, 1), Fraction(30, 1), _never, _VPATH) == (
+            TimingStrategy.PASSTHROUGH,
+            None,
+        )
+
+    def test_forced_cfr(self) -> None:
+        assert _select_strategy("cfr", Fraction(30, 1), None, _never, _VPATH) == (
+            TimingStrategy.CFR_HEAL,
+            None,
+        )
+
+    def test_forced_cfr_without_rate_raises(self) -> None:
+        with pytest.raises(NormalizationError, match="indeterminate"):
+            _select_strategy("cfr", None, None, _never, _VPATH)
+
+    def test_auto_clean_cfr_skips_sampling(self) -> None:
+        r = Fraction(30000, 1001)
+        assert _select_strategy("auto", r, r, _never, _VPATH) == (TimingStrategy.CFR_HEAL, None)
+
+    def test_auto_indeterminate_passthrough_skips_sampling(self) -> None:
+        assert _select_strategy("auto", None, Fraction(30, 1), _never, _VPATH) == (
+            TimingStrategy.PASSTHROUGH,
+            None,
+        )
+
+    def test_auto_empty_pts_is_passthrough(self) -> None:
+        assert _select_strategy("auto", Fraction(30, 1), Fraction(20, 1), lambda: [], _VPATH) == (
+            TimingStrategy.PASSTHROUGH,
+            None,
+        )
+
+    def test_auto_grid_with_holes_is_cfr_heal(self) -> None:
+        pts = [i / 30 for i in [0, 1, 2, 4, 5, 6, 8, 9, 10]]
+        strategy, max_pts = _select_strategy("auto", Fraction(30, 1), Fraction(25, 1), lambda: pts, _VPATH)
+        assert strategy is TimingStrategy.CFR_HEAL
+        assert max_pts == max(pts)
+
+    def test_auto_vfr_is_passthrough(self) -> None:
+        pts = [0.0, 0.02, 0.05, 0.07, 0.13, 0.18, 0.20, 0.27]
+        strategy, max_pts = _select_strategy("auto", Fraction(30, 1), Fraction(20, 1), lambda: pts, _VPATH)
+        assert strategy is TimingStrategy.PASSTHROUGH
+        assert max_pts == max(pts)
+
+    def test_auto_discontinuity_raises(self) -> None:
+        pts = [0.0, 1 / 30, 2 / 30, 95443.0, 95443.0 + 1 / 30, 0.5]
+        with pytest.raises(NormalizationError, match="discontinuity"):
+            _select_strategy("auto", Fraction(30, 1), Fraction(20, 1), lambda: pts, _VPATH)
+
+
+class TestNormalizeVideoValidation:
+    """Input-validation errors that need no ffmpeg (the checks run before any probe)."""
+
+    def test_bad_output_suffix_raises(self, tmp_path: pathlib.Path) -> None:
+        src = tmp_path / "in.mp4"
+        src.write_bytes(b"not really a video")
+        with pytest.raises(NormalizationError, match="mkv or .mp4"):
+            normalize_video(src, tmp_path / "out.avi")
+
+    def test_missing_input_raises(self, tmp_path: pathlib.Path) -> None:
+        with pytest.raises(NormalizationError, match="does not exist"):
+            normalize_video(tmp_path / "nope.mp4", tmp_path / "out.mp4")
+
+    def test_force_false_existing_output_raises(self, tmp_path: pathlib.Path) -> None:
+        src = tmp_path / "in.mp4"
+        src.write_bytes(b"x")
+        out = tmp_path / "out.mp4"
+        out.write_bytes(b"existing")
+        with pytest.raises(NormalizationError, match="already exists"):
+            normalize_video(src, out, force=False)
+
+
+class TestBuildOutputKwargs:
+    def test_cfr_heal_includes_clean_encode_and_timing(self) -> None:
+        kwargs = _build_output_kwargs(TimingStrategy.CFR_HEAL, Fraction(30000, 1001), 10.0, None, "h264", 2, None)
+        # clean-encode layer
+        assert kwargs["vcodec"] == "h264"
+        assert kwargs["pix_fmt"] == "yuv420p"
+        assert kwargs["bf"] == "0"
+        # timing layer
+        assert kwargs["fps_mode"] == "cfr"
+        assert kwargs["r"] == "30000/1001"
+        assert kwargs["video_track_timescale"] == "30000"
+        # keyframes
+        assert kwargs["force_key_frames"] == "expr:gte(t,n_forced*2)"
+        assert "vf" not in kwargs
+
+    def test_passthrough_uses_passthrough_fps_mode(self) -> None:
+        kwargs = _build_output_kwargs(TimingStrategy.PASSTHROUGH, None, 10.0, None, "hevc", 2, None)
+        assert kwargs["fps_mode"] == "passthrough"
+        assert kwargs["vcodec"] == "hevc"
+        assert kwargs["bf"] == "0"
+        assert "r" not in kwargs
+
+    def test_key_frame_interval_none_uses_source(self) -> None:
+        kwargs = _build_output_kwargs(TimingStrategy.PASSTHROUGH, None, None, None, "h264", None, None)
+        assert kwargs["force_key_frames"] == "source"


### PR DESCRIPTION
## Summary

`normalize_video` re-encoded video without controlling output frame timing. For sources whose container duration is inflated relative to their true frame count, the muxed `avg_frame_rate` (= frames / duration) came out low, so downstream consumers that read `avg_frame_rate` saw the wrong rate; concatenated outputs also accumulated timing drift. This reworks `normalize_video` into a safe, general-purpose adaptive normalizer.

## Approach

**Clean-encode layer (every source):** selected codec (`h264` / `h264_nvenc` / `hevc` / `hevc_nvenc`), `yuv420p`, no B-frames (`-bf 0`), keyframe interval.

**Adaptive timing** — chosen per source by a tiered classifier (cheap `r_frame_rate` vs `avg_frame_rate`; per-frame timestamps sampled only when ambiguous):

- **CFR-heal** — re-grid at the source's true rate with a **numerator-derived timescale** (exact for 23.976 / 29.97 / 59.94, not just ~30 fps), duplicating the previous frame to fill gaps left by dropped/corrupt frames, with a guarded duration clamp so gap-fill can't overshoot.
- **passthrough** — preserve timing for genuine variable-frame-rate or indeterminate-rate sources (never re-grids → never drops real frames).
- **hard `NormalizationError`** for timestamp discontinuities/wraps, a missing video stream, or probe/encode failure.

**Post-encode invariant check** re-probes the output and raises rather than emit a file that lost frames or drifted in duration — no silent corruption.

## API / behavior

- New `frame_rate_mode: "auto" | "cfr" | "passthrough"` (default `auto`).
- `NormalizationError` raised on every unrecoverable case; re-exported from the package.
- `frame_count` now counts decoded frames (`nb_read_frames`) rather than packets.
- Requires ffmpeg ≥ 5.1 at runtime (for `-fps_mode`).

## Testing

Pure unit tests cover the decision logic — rate parsing, tiered classification, timing/encode kwarg assembly, and the post-encode invariant checks — by feeding canned inputs to small pure functions. **The suite invokes no real ffmpeg/ffprobe**, so it runs anywhere; end-to-end behavior was verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)