### PR TITLE
chore(deps): bump nominal-api to 0.1282.0

### DIFF
--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -1240,6 +1240,7 @@ def _construct_new_ingest_options(
                 is_archive=file_type.is_parquet_archive(),
                 additional_file_tags={**tags} if tags else None,
                 exclude_columns=[],
+                channel_name_overrides={},
             )
         )
     else:
@@ -1255,6 +1256,7 @@ def _construct_new_ingest_options(
                 tag_columns=tag_columns,
                 additional_file_tags={**tags} if tags else None,
                 exclude_columns=[],
+                channel_name_overrides={},
             )
         )
 
@@ -1288,6 +1290,7 @@ def _construct_existing_ingest_options(
                 is_archive=file_type.is_parquet_archive(),
                 additional_file_tags={**tags} if tags else None,
                 exclude_columns=[],
+                channel_name_overrides={},
             )
         )
     else:
@@ -1302,5 +1305,6 @@ def _construct_existing_ingest_options(
                 tag_columns=tag_columns,
                 additional_file_tags={**tags} if tags else None,
                 exclude_columns=[],
+                channel_name_overrides={},
             )
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "conjure-python-client>=3.1.0,<4",
     "exceptiongroup>=1.3.0",
-    "nominal-api==0.1259.1",
+    "nominal-api==0.1282.0",
     "truststore>=0.10.4",
     "typing-extensions>=4,<5",
     "pandas>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -847,7 +847,7 @@ requires-dist = [
     { name = "conjure-python-client", specifier = ">=3.1.0,<4" },
     { name = "exceptiongroup", specifier = ">=1.3.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
-    { name = "nominal-api", specifier = "==0.1259.1" },
+    { name = "nominal-api", specifier = "==0.1282.0" },
     { name = "nominal-api-protos", marker = "extra == 'protos'", specifier = ">=0.1090.0" },
     { name = "nominal-streaming", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')", specifier = "==0.8.2" },
     { name = "nominal-tdms", marker = "extra == 'tdms'", editable = "packages/nominal-tdms" },
@@ -888,14 +888,14 @@ dev = [
 
 [[package]]
 name = "nominal-api"
-version = "0.1259.1"
+version = "0.1282.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "conjure-python-client" },
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/2e/a76eff9e1e50cb67fa77dd043e2797b3c4efb58dd6eec49601c345ef4957/nominal_api-0.1259.1-py3-none-any.whl", hash = "sha256:f300cbb9c2296350ff2bae77c162d7baf1992710b09bca9953d73f0771078932", size = 880460, upload-time = "2026-06-09T04:22:45.277Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/da/19694b96e54a3e9a2b52ed2eb524861b9e1740191e6d4a5178e3b4250a2a/nominal_api-0.1282.0-py3-none-any.whl", hash = "sha256:e3129d27b65575852ab01ec70365637c5a28e7ce22174e85aea7202c77154296", size = 890659, upload-time = "2026-06-22T15:25:14.687Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump `nominal-api` to `0.1282.0`.
- `nominal-api` 0.1282.0 makes `channel_name_overrides` a required argument on `ingest_api.ParquetOpts` and `ingest_api.CsvOpts`. Pass `channel_name_overrides={}` at the four call sites in `nominal/core/dataset.py` (in `_construct_new_ingest_options` / `_construct_existing_ingest_options`) so Parquet/CSV dataset ingest doesn't raise `TypeError` at runtime. An empty dict preserves prior behavior (no channel-name overrides).

Scoped to just the `nominal-api` bump and its requisite fix — separate from the gRPC / `nominal-api-protos` work in #835.

## Testing

- `uv run pytest tests/` → 217 passed, 10 skipped
- `uv run mypy -p nominal` → Success (0 errors, 142 files)
- `uv run ruff check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
