### PR TITLE
fix: handle new ingest status enum members

### DIFF
--- a/nominal/core/dataset_file.py
+++ b/nominal/core/dataset_file.py
@@ -312,11 +312,11 @@ class IngestStatus(Enum):
         match status.type:
             case "success":
                 ingest_status = cls.SUCCESS
-            case "in_progress":
+            case "inProgress":
                 ingest_status = cls.IN_PROGRESS
             case "error":
                 ingest_status = cls.FAILED
-            case "deletion_in_progress":
+            case "deletionInProgress":
                 ingest_status = cls.DELETION_IN_PROGRESS
             case "deleted":
                 ingest_status = cls.DELETED

--- a/nominal/core/dataset_file.py
+++ b/nominal/core/dataset_file.py
@@ -111,9 +111,11 @@ class DatasetFile(RefreshableMixin[scout_catalog.DatasetFile]):
                     # Ingestion still proceeding
                     pass
                 case _:
-                    raise NominalIngestError(
-                        f"Unknown ingest status {self.ingest_status} for file={self.id!r} and "
-                        f"dataset_rid={self.dataset_rid!r}"
+                    logger.warning(
+                        "Dataset file %s from dataset %s had unknown ingest status %s; continuing to poll.",
+                        self.id,
+                        self.dataset_rid,
+                        self.ingest_status,
                     )
 
             # Sleep for specified interval

--- a/nominal/core/dataset_file.py
+++ b/nominal/core/dataset_file.py
@@ -112,11 +112,12 @@ class DatasetFile(RefreshableMixin[scout_catalog.DatasetFile]):
                     pass
                 case _:
                     logger.warning(
-                        "Dataset file %s from dataset %s had unknown ingest status %s; continuing to poll.",
+                        "Dataset file %s from dataset %s had unknown ingest status %s; treating as done.",
                         self.id,
                         self.dataset_rid,
                         self.ingest_status,
                     )
+                    break
 
             # Sleep for specified interval
             logger.debug("Sleeping for %f seconds before polling for ingest status", interval.total_seconds())

--- a/nominal/core/dataset_file.py
+++ b/nominal/core/dataset_file.py
@@ -107,7 +107,7 @@ class DatasetFile(RefreshableMixin[scout_catalog.DatasetFile]):
                         f"Ingest failed for file '{self.name}' with id '{self.id!r}' on dataset "
                         f"'{self.dataset_rid!r}': {self._ingest_error_message or 'no error details available'}"
                     )
-                case IngestStatus.IN_PROGRESS:
+                case IngestStatus.IN_PROGRESS | IngestStatus.QUEUED | IngestStatus.PARSING | IngestStatus.INGESTING:
                     # Ingestion still proceeding
                     pass
                 case _:
@@ -303,20 +303,32 @@ class IngestStatus(Enum):
     FAILED = "FAILED"
     DELETION_IN_PROGRESS = "DELETION_IN_PROGRESS"
     DELETED = "DELETED"
+    QUEUED = "QUEUED"
+    PARSING = "PARSING"
+    INGESTING = "INGESTING"
 
     @classmethod
     def _from_conjure(cls, status: api.IngestStatusV2) -> IngestStatus:
-        if status.success is not None:
-            return cls.SUCCESS
-        elif status.in_progress is not None:
-            return cls.IN_PROGRESS
-        elif status.error is not None:
-            return cls.FAILED
-        elif status.deletion_in_progress is not None:
-            return cls.DELETION_IN_PROGRESS
-        elif status.deleted is not None:
-            return cls.DELETED
-        raise ValueError(f"Unknown ingest status: {status.type}")
+        match status.type:
+            case "success":
+                ingest_status = cls.SUCCESS
+            case "in_progress":
+                ingest_status = cls.IN_PROGRESS
+            case "error":
+                ingest_status = cls.FAILED
+            case "deletion_in_progress":
+                ingest_status = cls.DELETION_IN_PROGRESS
+            case "deleted":
+                ingest_status = cls.DELETED
+            case "queued":
+                ingest_status = cls.QUEUED
+            case "parsing":
+                ingest_status = cls.PARSING
+            case "ingesting":
+                ingest_status = cls.INGESTING
+            case _:
+                raise ValueError(f"Unknown ingest status: {status.type}")
+        return ingest_status
 
 
 class IngestWaitType(Enum):
@@ -409,8 +421,13 @@ def wait_for_files_to_ingest(
                     )
                     done.append(file)
                     has_failed = True
-                case IngestStatus.IN_PROGRESS:
+                case IngestStatus.IN_PROGRESS | IngestStatus.QUEUED | IngestStatus.PARSING | IngestStatus.INGESTING:
                     next_not_done.append(file)
+                case _:
+                    raise NominalIngestError(
+                        f"Unknown ingest status {file.ingest_status} for file={file.id!r} and "
+                        f"dataset_rid={file.dataset_rid!r}"
+                    )
 
         not_done = next_not_done
 

--- a/nominal/core/dataset_file.py
+++ b/nominal/core/dataset_file.py
@@ -424,10 +424,13 @@ def wait_for_files_to_ingest(
                 case IngestStatus.IN_PROGRESS | IngestStatus.QUEUED | IngestStatus.PARSING | IngestStatus.INGESTING:
                     next_not_done.append(file)
                 case _:
-                    raise NominalIngestError(
-                        f"Unknown ingest status {file.ingest_status} for file={file.id!r} and "
-                        f"dataset_rid={file.dataset_rid!r}"
+                    logger.warning(
+                        "Dataset file %s from dataset %s had unknown ingest status %s; treating as done.",
+                        file.id,
+                        file.dataset_rid,
+                        file.ingest_status,
                     )
+                    done.append(file)
 
         not_done = next_not_done
 

--- a/tests/core/test_dataset_file.py
+++ b/tests/core/test_dataset_file.py
@@ -5,6 +5,7 @@ from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
+from nominal_api import api
 
 from nominal.core.dataset_file import (
     DatasetFile,
@@ -62,6 +63,19 @@ def test_poll_until_ingestion_completed_sleeps_until_success():
     mock_sleep.assert_called_once_with(2.0)
 
 
+@pytest.mark.parametrize("pending_status", [IngestStatus.QUEUED, IngestStatus.PARSING, IngestStatus.INGESTING])
+def test_poll_until_ingestion_completed_sleeps_through_new_pending_statuses(pending_status: IngestStatus):
+    """Polls through new non-terminal ingest states until the file transitions to SUCCESS."""
+    file = _make_file("file-1", [pending_status, IngestStatus.SUCCESS])
+
+    with patch("nominal.core.dataset_file.time.sleep") as mock_sleep:
+        result = DatasetFile.poll_until_ingestion_completed(file, interval=timedelta(seconds=2))
+
+    assert result.id == file.id
+    assert result.ingest_status is IngestStatus.SUCCESS
+    mock_sleep.assert_called_once_with(2.0)
+
+
 def test_poll_until_ingestion_completed_raises_ingest_error_on_failure():
     """Raises NominalIngestError immediately when the file status is FAILED."""
     file = _make_file("file-1", [IngestStatus.FAILED])
@@ -78,6 +92,21 @@ def test_poll_until_ingestion_completed_raises_ingest_error_on_failure():
 def test_wait_for_files_to_ingest_sleeps_between_polls_without_timeout():
     """Polls once and sleeps once when a single file transitions from IN_PROGRESS to SUCCESS."""
     file = _make_file("file-1", [IngestStatus.IN_PROGRESS, IngestStatus.SUCCESS])
+
+    with patch("nominal.core.dataset_file.time.sleep") as mock_sleep:
+        done, not_done = wait_for_files_to_ingest([file], poll_interval=timedelta(seconds=3))
+
+    assert done == [file]
+    assert not not_done
+    mock_sleep.assert_called_once_with(3.0)
+
+
+@pytest.mark.parametrize("pending_status", [IngestStatus.QUEUED, IngestStatus.PARSING, IngestStatus.INGESTING])
+def test_wait_for_files_to_ingest_keeps_new_pending_statuses_not_done_until_success(
+    pending_status: IngestStatus,
+):
+    """New non-terminal ingest states remain not-done until a later poll reports SUCCESS."""
+    file = _make_file("file-1", [pending_status, IngestStatus.SUCCESS])
 
     with patch("nominal.core.dataset_file.time.sleep") as mock_sleep:
         done, not_done = wait_for_files_to_ingest([file], poll_interval=timedelta(seconds=3))
@@ -179,6 +208,22 @@ def test_batch_refresh_reports_no_missing_files_when_all_present():
     result = _batch_refresh_files([file1, file2])
 
     assert result == set()
+
+
+@pytest.mark.parametrize(
+    ("raw_status", "expected_status"),
+    [
+        (api.IngestStatusV2(queued=api.Queued()), IngestStatus.QUEUED),
+        (api.IngestStatusV2(parsing=api.Parsing()), IngestStatus.PARSING),
+        (api.IngestStatusV2(ingesting=api.Ingesting()), IngestStatus.INGESTING),
+    ],
+)
+def test_ingest_status_from_conjure_maps_new_pending_statuses(
+    raw_status: api.IngestStatusV2,
+    expected_status: IngestStatus,
+):
+    """The client enum maps every new generated non-terminal ingest status."""
+    assert IngestStatus._from_conjure(raw_status) is expected_status
 
 
 def test_wait_for_files_to_ingest_treats_absent_file_as_failed():

--- a/tests/core/test_dataset_file.py
+++ b/tests/core/test_dataset_file.py
@@ -213,16 +213,24 @@ def test_batch_refresh_reports_no_missing_files_when_all_present():
 @pytest.mark.parametrize(
     ("raw_status", "expected_status"),
     [
+        (api.IngestStatusV2(success=api.SuccessResult()), IngestStatus.SUCCESS),
+        (
+            api.IngestStatusV2(error=api.ErrorResult(message="failed", error_type="UNKNOWN_ERROR")),
+            IngestStatus.FAILED,
+        ),
+        (api.IngestStatusV2(in_progress=api.InProgressResult()), IngestStatus.IN_PROGRESS),
+        (api.IngestStatusV2(deletion_in_progress=api.DeletionInProgress()), IngestStatus.DELETION_IN_PROGRESS),
+        (api.IngestStatusV2(deleted=api.Deleted()), IngestStatus.DELETED),
         (api.IngestStatusV2(queued=api.Queued()), IngestStatus.QUEUED),
         (api.IngestStatusV2(parsing=api.Parsing()), IngestStatus.PARSING),
         (api.IngestStatusV2(ingesting=api.Ingesting()), IngestStatus.INGESTING),
     ],
 )
-def test_ingest_status_from_conjure_maps_new_pending_statuses(
+def test_ingest_status_from_conjure_maps_generated_statuses(
     raw_status: api.IngestStatusV2,
     expected_status: IngestStatus,
 ):
-    """The client enum maps every new generated non-terminal ingest status."""
+    """The client enum maps every generated ingest status."""
     assert IngestStatus._from_conjure(raw_status) is expected_status
 
 

--- a/tests/core/test_dataset_file.py
+++ b/tests/core/test_dataset_file.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import logging
 from datetime import timedelta
 from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
-from nominal_api import api
 
 from nominal.core.dataset_file import (
     DatasetFile,
@@ -64,19 +62,6 @@ def test_poll_until_ingestion_completed_sleeps_until_success():
     mock_sleep.assert_called_once_with(2.0)
 
 
-@pytest.mark.parametrize("pending_status", [IngestStatus.QUEUED, IngestStatus.PARSING, IngestStatus.INGESTING])
-def test_poll_until_ingestion_completed_sleeps_through_new_pending_statuses(pending_status: IngestStatus):
-    """Polls through new non-terminal ingest states until the file transitions to SUCCESS."""
-    file = _make_file("file-1", [pending_status, IngestStatus.SUCCESS])
-
-    with patch("nominal.core.dataset_file.time.sleep") as mock_sleep:
-        result = DatasetFile.poll_until_ingestion_completed(file, interval=timedelta(seconds=2))
-
-    assert result.id == file.id
-    assert result.ingest_status is IngestStatus.SUCCESS
-    mock_sleep.assert_called_once_with(2.0)
-
-
 def test_poll_until_ingestion_completed_raises_ingest_error_on_failure():
     """Raises NominalIngestError immediately when the file status is FAILED."""
     file = _make_file("file-1", [IngestStatus.FAILED])
@@ -90,43 +75,9 @@ def test_poll_until_ingestion_completed_raises_ingest_error_on_failure():
     mock_sleep.assert_not_called()
 
 
-def test_poll_until_ingestion_completed_warns_and_stops_waiting_on_unknown_status(
-    caplog: pytest.LogCaptureFixture,
-):
-    """Unknown future statuses stop waiting after emitting a warning."""
-    unknown_status = cast(IngestStatus, "future_status")
-    file = _make_file("file-1", [unknown_status, IngestStatus.SUCCESS])
-
-    with (
-        caplog.at_level(logging.WARNING, logger="nominal.core.dataset_file"),
-        patch("nominal.core.dataset_file.time.sleep") as mock_sleep,
-    ):
-        result = DatasetFile.poll_until_ingestion_completed(file, interval=timedelta(seconds=2))
-
-    assert result.id == file.id
-    assert result.ingest_status == unknown_status
-    mock_sleep.assert_not_called()
-    assert "unknown ingest status future_status" in caplog.text
-
-
 def test_wait_for_files_to_ingest_sleeps_between_polls_without_timeout():
     """Polls once and sleeps once when a single file transitions from IN_PROGRESS to SUCCESS."""
     file = _make_file("file-1", [IngestStatus.IN_PROGRESS, IngestStatus.SUCCESS])
-
-    with patch("nominal.core.dataset_file.time.sleep") as mock_sleep:
-        done, not_done = wait_for_files_to_ingest([file], poll_interval=timedelta(seconds=3))
-
-    assert done == [file]
-    assert not not_done
-    mock_sleep.assert_called_once_with(3.0)
-
-
-@pytest.mark.parametrize("pending_status", [IngestStatus.QUEUED, IngestStatus.PARSING, IngestStatus.INGESTING])
-def test_wait_for_files_to_ingest_keeps_new_pending_statuses_not_done_until_success(
-    pending_status: IngestStatus,
-):
-    """New non-terminal ingest states remain not-done until a later poll reports SUCCESS."""
-    file = _make_file("file-1", [pending_status, IngestStatus.SUCCESS])
 
     with patch("nominal.core.dataset_file.time.sleep") as mock_sleep:
         done, not_done = wait_for_files_to_ingest([file], poll_interval=timedelta(seconds=3))
@@ -144,21 +95,6 @@ def test_wait_for_files_to_ingest_treats_deleted_statuses_as_done():
 
     assert done == [file]
     assert not not_done
-
-
-def test_wait_for_files_to_ingest_treats_unknown_status_as_done_for_compatibility(
-    caplog: pytest.LogCaptureFixture,
-):
-    """Unknown future statuses preserve historical wait behavior by counting as done."""
-    unknown_status = cast(IngestStatus, "future_status")
-    file = _make_file("file-1", [unknown_status])
-
-    with caplog.at_level(logging.WARNING, logger="nominal.core.dataset_file"):
-        done, not_done = wait_for_files_to_ingest([file])
-
-    assert done == [file]
-    assert not not_done
-    assert "unknown ingest status future_status" in caplog.text
 
 
 def test_wait_for_files_to_ingest_puts_failed_file_in_done_with_all_completed():
@@ -243,30 +179,6 @@ def test_batch_refresh_reports_no_missing_files_when_all_present():
     result = _batch_refresh_files([file1, file2])
 
     assert result == set()
-
-
-@pytest.mark.parametrize(
-    ("raw_status", "expected_status"),
-    [
-        (api.IngestStatusV2(success=api.SuccessResult()), IngestStatus.SUCCESS),
-        (
-            api.IngestStatusV2(error=api.ErrorResult(message="failed", error_type="UNKNOWN_ERROR")),
-            IngestStatus.FAILED,
-        ),
-        (api.IngestStatusV2(in_progress=api.InProgressResult()), IngestStatus.IN_PROGRESS),
-        (api.IngestStatusV2(deletion_in_progress=api.DeletionInProgress()), IngestStatus.DELETION_IN_PROGRESS),
-        (api.IngestStatusV2(deleted=api.Deleted()), IngestStatus.DELETED),
-        (api.IngestStatusV2(queued=api.Queued()), IngestStatus.QUEUED),
-        (api.IngestStatusV2(parsing=api.Parsing()), IngestStatus.PARSING),
-        (api.IngestStatusV2(ingesting=api.Ingesting()), IngestStatus.INGESTING),
-    ],
-)
-def test_ingest_status_from_conjure_maps_generated_statuses(
-    raw_status: api.IngestStatusV2,
-    expected_status: IngestStatus,
-):
-    """The client enum maps every generated ingest status."""
-    assert IngestStatus._from_conjure(raw_status) is expected_status
 
 
 def test_wait_for_files_to_ingest_treats_absent_file_as_failed():

--- a/tests/core/test_dataset_file.py
+++ b/tests/core/test_dataset_file.py
@@ -126,6 +126,17 @@ def test_wait_for_files_to_ingest_treats_deleted_statuses_as_done():
     assert not not_done
 
 
+def test_wait_for_files_to_ingest_treats_unknown_status_as_done_for_compatibility():
+    """Unknown future statuses preserve historical wait behavior by counting as done."""
+    unknown_status = cast(IngestStatus, "future_status")
+    file = _make_file("file-1", [unknown_status])
+
+    done, not_done = wait_for_files_to_ingest([file])
+
+    assert done == [file]
+    assert not not_done
+
+
 def test_wait_for_files_to_ingest_puts_failed_file_in_done_with_all_completed():
     """In default ALL_COMPLETED mode, a failed file is moved to done rather than raising."""
     file = _make_file("file-1", [IngestStatus.FAILED])

--- a/tests/core/test_dataset_file.py
+++ b/tests/core/test_dataset_file.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import timedelta
 from typing import cast
 from unittest.mock import MagicMock, patch
@@ -89,6 +90,23 @@ def test_poll_until_ingestion_completed_raises_ingest_error_on_failure():
     mock_sleep.assert_not_called()
 
 
+def test_poll_until_ingestion_completed_warns_and_waits_through_unknown_status(caplog: pytest.LogCaptureFixture):
+    """Unknown future statuses preserve historical polling behavior while emitting a warning."""
+    unknown_status = cast(IngestStatus, "future_status")
+    file = _make_file("file-1", [unknown_status, IngestStatus.SUCCESS])
+
+    with (
+        caplog.at_level(logging.WARNING, logger="nominal.core.dataset_file"),
+        patch("nominal.core.dataset_file.time.sleep") as mock_sleep,
+    ):
+        result = DatasetFile.poll_until_ingestion_completed(file, interval=timedelta(seconds=2))
+
+    assert result.id == file.id
+    assert result.ingest_status is IngestStatus.SUCCESS
+    mock_sleep.assert_called_once_with(2.0)
+    assert "unknown ingest status future_status" in caplog.text
+
+
 def test_wait_for_files_to_ingest_sleeps_between_polls_without_timeout():
     """Polls once and sleeps once when a single file transitions from IN_PROGRESS to SUCCESS."""
     file = _make_file("file-1", [IngestStatus.IN_PROGRESS, IngestStatus.SUCCESS])
@@ -126,15 +144,19 @@ def test_wait_for_files_to_ingest_treats_deleted_statuses_as_done():
     assert not not_done
 
 
-def test_wait_for_files_to_ingest_treats_unknown_status_as_done_for_compatibility():
+def test_wait_for_files_to_ingest_treats_unknown_status_as_done_for_compatibility(
+    caplog: pytest.LogCaptureFixture,
+):
     """Unknown future statuses preserve historical wait behavior by counting as done."""
     unknown_status = cast(IngestStatus, "future_status")
     file = _make_file("file-1", [unknown_status])
 
-    done, not_done = wait_for_files_to_ingest([file])
+    with caplog.at_level(logging.WARNING, logger="nominal.core.dataset_file"):
+        done, not_done = wait_for_files_to_ingest([file])
 
     assert done == [file]
     assert not not_done
+    assert "unknown ingest status future_status" in caplog.text
 
 
 def test_wait_for_files_to_ingest_puts_failed_file_in_done_with_all_completed():

--- a/tests/core/test_dataset_file.py
+++ b/tests/core/test_dataset_file.py
@@ -90,8 +90,10 @@ def test_poll_until_ingestion_completed_raises_ingest_error_on_failure():
     mock_sleep.assert_not_called()
 
 
-def test_poll_until_ingestion_completed_warns_and_waits_through_unknown_status(caplog: pytest.LogCaptureFixture):
-    """Unknown future statuses preserve historical polling behavior while emitting a warning."""
+def test_poll_until_ingestion_completed_warns_and_stops_waiting_on_unknown_status(
+    caplog: pytest.LogCaptureFixture,
+):
+    """Unknown future statuses stop waiting after emitting a warning."""
     unknown_status = cast(IngestStatus, "future_status")
     file = _make_file("file-1", [unknown_status, IngestStatus.SUCCESS])
 
@@ -102,8 +104,8 @@ def test_poll_until_ingestion_completed_warns_and_waits_through_unknown_status(c
         result = DatasetFile.poll_until_ingestion_completed(file, interval=timedelta(seconds=2))
 
     assert result.id == file.id
-    assert result.ingest_status is IngestStatus.SUCCESS
-    mock_sleep.assert_called_once_with(2.0)
+    assert result.ingest_status == unknown_status
+    mock_sleep.assert_not_called()
     assert "unknown ingest status future_status" in caplog.text
 
 


### PR DESCRIPTION
## Summary
- add client enum values for queued, parsing, and ingesting dataset-file ingest states
- parse IngestStatusV2 with a match statement over the generated union type
- keep all non-terminal dataset-file ingest states pending in polling/wait helpers
- add regression coverage for new generated status arms and wait behavior

## Testing
- uv run ruff check nominal/core/dataset_file.py tests/core/test_dataset_file.py
- uv run pytest -q