### PR TITLE
chore(deps): bump nominal-api & nominal-api-protos to 0.1287.0

### DIFF
--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -174,10 +174,10 @@ class ClientsBunch:
     def _get_workspace_by_rid(self, workspace_rid: str) -> workspaces_pb2.Workspace:
         """Fetch a single workspace by its RID via the gRPC workspace service.
 
-        Centralizes the one place the untyped gRPC stub's response is narrowed to the proto `Workspace` type.
+        Centralizes the single call site for fetching a workspace by RID (the RPC plus gRPC error translation).
         """
         with translate_grpc_errors():
-            return self.workspace.GetWorkspace(  # type: ignore[no-any-return]
+            return self.workspace.GetWorkspace(
                 workspaces_pb2.GetWorkspaceRequest(workspace_rid=workspace_rid)
             ).workspace
 
@@ -195,7 +195,7 @@ class ClientsBunch:
         with translate_grpc_errors():
             response = self.workspace.GetDefaultWorkspace(workspaces_pb2.GetDefaultWorkspaceRequest())
         if response.HasField("workspace"):
-            return response.workspace  # type: ignore[no-any-return]
+            return response.workspace
 
         raise NominalConfigError(
             "Could not retrieve default workspace! "

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -33,7 +33,7 @@ from nominal_api import (
 from typing_extensions import Self
 
 from nominal._utils.dataclass_tools import LazyField
-from nominal.core._utils.grpc_tools import create_grpc_stub_factory, translate_grpc_errors
+from nominal.core._utils.grpc_tools import GRPCStub, create_grpc_channel, translate_grpc_errors
 from nominal.core._utils.networking import (
     HeaderProvider,
     create_conjure_client_factory,
@@ -47,6 +47,7 @@ from nominal.ts import IntegralNanosecondsUTC
 
 ON_BEHALF_OF_USER_RID_HEADER = "X-Nominal-On-Behalf-Of-User"
 TService = TypeVar("TService", bound=Service)
+TStub = TypeVar("TStub")
 
 
 @dataclass(frozen=True)
@@ -277,13 +278,16 @@ class ClientsBunch:
                 header_provider=header_provider,
             )(service_class)
 
-        grpc_factory = create_grpc_stub_factory(
+        grpc_channel = create_grpc_channel(
             api_base_url=base_url,
             service_config=cfg,
             user_agent=agent,
             auth_header=f"Bearer {token}",
             header_provider=header_provider,
         )
+
+        def grpc_factory(stub_class: GRPCStub[TStub]) -> TStub:
+            return stub_class(grpc_channel)
 
         return cls(
             auth_header=f"Bearer {token}",

--- a/nominal/core/_utils/grpc_tools.py
+++ b/nominal/core/_utils/grpc_tools.py
@@ -1,8 +1,8 @@
 """gRPC transport plumbing for the Nominal client.
 
-This module is the gRPC analogue of the conjure stub factory in `_utils.networking`: it builds a single,
-shared, fully-configured `grpc.Channel` and returns a `create_grpc_stub_factory(StubClass) -> stub`
-closure, so each backend gRPC service is exposed as a generated stub bound to that one channel.
+This module is the gRPC analogue of the conjure transport in `_utils.networking`: it builds a single,
+shared, fully-configured `grpc.Channel` (`create_grpc_channel`) that each backend gRPC service binds its
+generated stub to, so every stub shares that one channel.
 
 The channel is configured to track the conjure HTTP transport as closely as gRPC allows:
 
@@ -22,7 +22,7 @@ from collections import namedtuple
 from contextlib import contextmanager
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Callable, Iterator, TypeVar
+from typing import Any, Iterator, Protocol, TypeVar
 from urllib.parse import urlparse
 
 import grpc
@@ -37,7 +37,19 @@ from nominal.core.exceptions import (
     NominalPermissionDeniedError,
 )
 
-TStub = TypeVar("TStub")
+TStub_co = TypeVar("TStub_co", covariant=True)
+
+
+class GRPCStub(Protocol[TStub_co]):
+    """A generated gRPC stub class, viewed as a callable that binds itself to a channel.
+
+    Generated ``*_pb2_grpc`` stub classes are constructed as ``StubClass(channel)``. Annotating a stub
+    class as ``GRPCStub[StubClass]`` rather than ``type[StubClass]`` lets mypy see that channel-accepting
+    constructor, so callers can build stubs without a ``# type: ignore[call-arg]``.
+    """
+
+    def __call__(self, channel: grpc.Channel) -> TStub_co: ...
+
 
 # gRPC channel-arg ints are int32; 2**31 - 1 (~2 GiB) lifts the 4 MB default receive cap without overflowing.
 _MAX_MESSAGE_LENGTH = 2**31 - 1
@@ -267,34 +279,6 @@ def create_grpc_channel(
         _AuthMetadataInterceptor(auth_header, header_provider),
         _DefaultDeadlineInterceptor(service_config.read_timeout),
     )
-
-
-def create_grpc_stub_factory(
-    *,
-    api_base_url: str,
-    service_config: ServiceConfiguration,
-    user_agent: str,
-    auth_header: str,
-    header_provider: HeaderProvider | None,
-) -> Callable[[type[TStub]], TStub]:
-    """Build the shared channel once and return ``factory(StubClass) -> StubClass(channel)``.
-
-    The gRPC analogue of `create_conjure_client_factory`: one shared channel, many stubs. Callers
-    (`ClientsBunch`) bind each backend service's generated stub to the returned factory.
-    """
-    channel = create_grpc_channel(
-        api_base_url=api_base_url,
-        service_config=service_config,
-        user_agent=user_agent,
-        auth_header=auth_header,
-        header_provider=header_provider,
-    )
-
-    def factory(stub_class: type[TStub]) -> TStub:
-        # stub_class is a generic ``type[TStub]``; mypy can't see the channel-accepting stub constructor.
-        return stub_class(channel)  # type: ignore[call-arg]
-
-    return factory
 
 
 _GRPC_STATUS_TO_EXCEPTION: dict[grpc.StatusCode, type[NominalError]] = {

--- a/nominal/core/_utils/grpc_tools.py
+++ b/nominal/core/_utils/grpc_tools.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterator, TypeVar
 from urllib.parse import urlparse
 
-import grpc  # type: ignore[import-untyped]
+import grpc
 from conjure_python_client import ServiceConfiguration
 
 from nominal.core._utils.networking import HeaderProvider, raise_header_conflict
@@ -133,7 +133,7 @@ def _service_config_json(service_config: ServiceConfiguration) -> str:
 # immutable, attribute-compatible copy of the call details; grpc.ClientCallDetails itself is abstract.
 class _ClientCallDetails(
     namedtuple("_ClientCallDetails", ("method", "timeout", "metadata", "credentials", "wait_for_ready", "compression")),
-    grpc.ClientCallDetails,  # type: ignore[misc]  # grpc stubs type base classes as Any
+    grpc.ClientCallDetails,
 ):
     pass
 
@@ -156,10 +156,10 @@ def _replace_call_details(details: grpc.ClientCallDetails, **changes: Any) -> _C
 
 
 class _ClientCallDetailsInterceptor(
-    grpc.UnaryUnaryClientInterceptor,  # type: ignore[misc]  # grpc stubs type base classes as Any
-    grpc.UnaryStreamClientInterceptor,  # type: ignore[misc]
-    grpc.StreamUnaryClientInterceptor,  # type: ignore[misc]
-    grpc.StreamStreamClientInterceptor,  # type: ignore[misc]
+    grpc.UnaryUnaryClientInterceptor,
+    grpc.UnaryStreamClientInterceptor,
+    grpc.StreamUnaryClientInterceptor,
+    grpc.StreamStreamClientInterceptor,
 ):
     """Base for interceptors that rewrite the outgoing `ClientCallDetails`.
 
@@ -291,7 +291,8 @@ def create_grpc_stub_factory(
     )
 
     def factory(stub_class: type[TStub]) -> TStub:
-        return stub_class(channel)  # type: ignore[call-arg]  # grpc stub constructors are untyped
+        # stub_class is a generic ``type[TStub]``; mypy can't see the channel-accepting stub constructor.
+        return stub_class(channel)  # type: ignore[call-arg]
 
     return factory
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dev = [
     "pytest-cov>=5.0.0,<6",
     "pytest>=8.3.2,<9",
     "ruff==0.12.1",
-    "types-grpcio>=1.0",
+    "types-grpcio>=1.0.0.20260614,<2",
     "types-protobuf>=4.24.0.20240311,<5",
     "types-python-dateutil>=2.9.0.20250822",
     "types-pyyaml>=6.0.12.20240808,<7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "conjure-python-client>=3.1.0,<4",
     "exceptiongroup>=1.3.0",
-    "nominal-api==0.1282.0",
-    "nominal-api-protos==0.1282.0",
+    "nominal-api==0.1287.0",
+    "nominal-api-protos==0.1287.0",
     "truststore>=0.10.4",
     "typing-extensions>=4,<5",
     "pandas>=2.0.0",
@@ -74,6 +74,7 @@ dev = [
     "pytest-cov>=5.0.0,<6",
     "pytest>=8.3.2,<9",
     "ruff==0.12.1",
+    "types-grpcio>=1.0",
     "types-protobuf>=4.24.0.20240311,<5",
     "types-python-dateutil>=2.9.0.20250822",
     "types-pyyaml>=6.0.12.20240808,<7",

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -15,7 +15,10 @@ from nominal.core._clientsbunch import (
 from nominal.core.client import NominalClient
 from nominal.core.exceptions import NominalConfigError
 from nominal.experimental import as_user
-from nominal.protos.workspaces.v1 import workspaces_pb2
+from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
+from nominal.protos.comments.v1 import comments_pb2_grpc
+from nominal.protos.units.v1 import units_pb2_grpc
+from nominal.protos.workspaces.v1 import workspaces_pb2, workspaces_pb2_grpc
 
 
 def _make_clients_bunch(*, workspace_rid: str | None) -> ClientsBunch:
@@ -228,12 +231,14 @@ def test_resolve_workspace_reuses_the_cached_configured_default_workspace_object
     workspace_stub.GetDefaultWorkspace.assert_not_called()
 
 
-def test_from_config_wires_roles_via_the_grpc_factory(monkeypatch):
-    """from_config builds `roles`, `comments`, `units`, and `workspace` through the gRPC stub factory."""
+def test_from_config_wires_grpc_services_through_one_shared_channel(monkeypatch):
+    """from_config builds `units`, `comments`, `workspace`, and `roles` as generated gRPC stubs, each bound
+    to a single shared channel.
+    """
     monkeypatch.setattr("nominal.core._clientsbunch.create_conjure_client_factory", _fake_create_conjure_client_factory)
-    roles_stub = object()
-    grpc_factory = MagicMock(return_value=MagicMock(return_value=roles_stub))
-    monkeypatch.setattr("nominal.core._clientsbunch.create_grpc_stub_factory", grpc_factory)
+    channel = MagicMock(name="grpc-channel")
+    create_grpc_channel = MagicMock(return_value=channel)
+    monkeypatch.setattr("nominal.core._clientsbunch.create_grpc_channel", create_grpc_channel)
 
     clients = ClientsBunch.from_config(
         ServiceConfiguration(uris=["https://api.nominal.test"]),
@@ -243,20 +248,22 @@ def test_from_config_wires_roles_via_the_grpc_factory(monkeypatch):
         None,
     )
 
-    assert clients.roles is roles_stub
-    assert clients.comments is roles_stub
-    assert clients.units is roles_stub
-    assert clients.workspace is roles_stub
-    assert grpc_factory.call_args.kwargs["auth_header"] == "Bearer token"
-    assert grpc_factory.call_args.kwargs["api_base_url"] == "https://api.nominal.test"
-    assert grpc_factory.call_args.kwargs["header_provider"] is None
+    assert isinstance(clients.units, units_pb2_grpc.UnitsServiceStub)
+    assert isinstance(clients.comments, comments_pb2_grpc.CommentsServiceStub)
+    assert isinstance(clients.workspace, workspaces_pb2_grpc.WorkspaceServiceStub)
+    assert isinstance(clients.roles, roles_pb2_grpc.RoleServiceStub)
+    # Exactly one channel, built from the right transport params and shared by every gRPC stub.
+    create_grpc_channel.assert_called_once()
+    assert create_grpc_channel.call_args.kwargs["auth_header"] == "Bearer token"
+    assert create_grpc_channel.call_args.kwargs["api_base_url"] == "https://api.nominal.test"
+    assert create_grpc_channel.call_args.kwargs["header_provider"] is None
 
 
 def test_experimental_as_user_returns_derived_nominal_client(monkeypatch):
     """as_user returns a new client that injects the on-behalf-of header on both the HTTP and gRPC paths."""
     monkeypatch.setattr("nominal.core._clientsbunch.create_conjure_client_factory", _fake_create_conjure_client_factory)
-    grpc_factory = MagicMock(return_value=MagicMock(return_value=MagicMock(name="roles")))
-    monkeypatch.setattr("nominal.core._clientsbunch.create_grpc_stub_factory", grpc_factory)
+    create_grpc_channel = MagicMock(return_value=MagicMock(name="grpc-channel"))
+    monkeypatch.setattr("nominal.core._clientsbunch.create_grpc_channel", create_grpc_channel)
 
     client = NominalClient(
         _clients=ClientsBunch.from_config(
@@ -279,8 +286,8 @@ def test_experimental_as_user_returns_derived_nominal_client(monkeypatch):
     assert impersonated._clients.assets._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
         "ri.authn.dev.user.target"
     )
-    # The impersonation header_provider must also reach the gRPC stub factory; the most
-    # recent factory call is the impersonated client's.
-    header_provider = grpc_factory.call_args.kwargs["header_provider"]
+    # The impersonation header_provider must also reach the gRPC channel; the most
+    # recent channel build is the impersonated client's.
+    header_provider = create_grpc_channel.call_args.kwargs["header_provider"]
     assert header_provider is not None
     assert header_provider.headers()[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"

--- a/tests/core/test_grpc.py
+++ b/tests/core/test_grpc.py
@@ -16,7 +16,6 @@ from nominal.core._utils.grpc_tools import (
     _service_config_json,
     api_base_url_to_grpc_target,
     create_grpc_channel,
-    create_grpc_stub_factory,
     translate_grpc_errors,
 )
 from nominal.core._utils.networking import StaticHeaderProvider
@@ -187,26 +186,6 @@ def test_create_grpc_channel_wires_credentials_options_and_interceptors(monkeypa
     assert options["grpc.max_receive_message_length"] == 2**31 - 1
     assert intercept_channel.call_args.args[0] == "raw-channel"
     assert len(intercept_channel.call_args.args[1:]) == 2
-
-
-def test_create_grpc_stub_factory_binds_stubs_to_one_shared_channel(monkeypatch) -> None:
-    """create_grpc_stub_factory builds the channel once and binds every stub to that same channel."""
-    _patch_channel(monkeypatch)
-    stub_class = MagicMock()
-
-    factory = create_grpc_stub_factory(
-        api_base_url="https://api.gov.nominal.io/api",
-        service_config=_config(),
-        user_agent="test-agent",
-        auth_header="Bearer tok",
-        header_provider=None,
-    )
-    factory(stub_class)
-    factory(stub_class)
-
-    first_channel = stub_class.call_args_list[0].args[0]
-    assert first_channel == "intercepted-channel"
-    assert first_channel is stub_class.call_args_list[1].args[0]
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -890,7 +890,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.2,<9" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6" },
     { name = "ruff", specifier = "==0.12.1" },
-    { name = "types-grpcio", specifier = ">=1.0" },
+    { name = "types-grpcio", specifier = ">=1.0.0.20260614,<2" },
     { name = "types-protobuf", specifier = ">=4.24.0.20240311,<5" },
     { name = "types-python-dateutil", specifier = ">=2.9.0.20250822" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20240808,<7" },

--- a/uv.lock
+++ b/uv.lock
@@ -844,6 +844,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-grpcio" },
     { name = "types-protobuf" },
     { name = "types-python-dateutil" },
     { name = "types-pyyaml" },
@@ -857,8 +858,8 @@ requires-dist = [
     { name = "conjure-python-client", specifier = ">=3.1.0,<4" },
     { name = "exceptiongroup", specifier = ">=1.3.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
-    { name = "nominal-api", specifier = "==0.1282.0" },
-    { name = "nominal-api-protos", specifier = "==0.1282.0" },
+    { name = "nominal-api", specifier = "==0.1287.0" },
+    { name = "nominal-api-protos", specifier = "==0.1287.0" },
     { name = "nominal-streaming", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')", specifier = "==0.8.2" },
     { name = "nominal-tdms", marker = "extra == 'tdms'", editable = "packages/nominal-tdms" },
     { name = "nominal-video", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin' and extra == 'video') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'video') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'video') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32' and extra == 'video')", specifier = "==0.1.9" },
@@ -889,6 +890,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.2,<9" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6" },
     { name = "ruff", specifier = "==0.12.1" },
+    { name = "types-grpcio", specifier = ">=1.0" },
     { name = "types-protobuf", specifier = ">=4.24.0.20240311,<5" },
     { name = "types-python-dateutil", specifier = ">=2.9.0.20250822" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20240808,<7" },
@@ -898,19 +900,19 @@ dev = [
 
 [[package]]
 name = "nominal-api"
-version = "0.1282.0"
+version = "0.1287.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "conjure-python-client" },
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/da/19694b96e54a3e9a2b52ed2eb524861b9e1740191e6d4a5178e3b4250a2a/nominal_api-0.1282.0-py3-none-any.whl", hash = "sha256:e3129d27b65575852ab01ec70365637c5a28e7ce22174e85aea7202c77154296", size = 890659, upload-time = "2026-06-22T15:25:14.687Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d7/eb9f769494dfd8efc46bc7a312751aaa6a79417ed5f567cbd962c2c7d9c3/nominal_api-0.1287.0-py3-none-any.whl", hash = "sha256:91669a125dd06b36ada3d22eb2747dcad6e42166ac4125ef6c14f3f38efcc78b", size = 896466, upload-time = "2026-06-25T15:19:00.909Z" },
 ]
 
 [[package]]
 name = "nominal-api-protos"
-version = "0.1282.0"
+version = "0.1287.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -919,7 +921,7 @@ dependencies = [
     { name = "protobuf" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/09/d8accc32036bb5c8f97be2c441a2c60b443561fbbc7fee2ea1772ff53678/nominal_api_protos-0.1282.0-py3-none-any.whl", hash = "sha256:15f28364c0c5a6b74c0083d5cfdcb7e4877c4c3662e2e3f8a8d87172e5b5974d", size = 358502, upload-time = "2026-06-22T15:25:16.644Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/22/e9997fe6288ec2ca69d3e84e9ac7fa92f6cbc22c335884d17248df80eb44/nominal_api_protos-0.1287.0-py3-none-any.whl", hash = "sha256:cddd02c727f4f32699099e3e7629aed65b19304e034f176931744b6eef410870", size = 476743, upload-time = "2026-06-25T15:19:02.308Z" },
 ]
 
 [[package]]
@@ -1599,6 +1601,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "types-grpcio"
+version = "1.0.0.20260614"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/1c/e299150827a2224fe9ddb59e9f789f0eb8e72e0befc23fd47195024311fa/types_grpcio-1.0.0.20260614.tar.gz", hash = "sha256:e86d1aabb7e7eedae487c3ac10e010a13d5db1fd350e766562053af557366aab", size = 15063, upload-time = "2026-06-14T06:23:33.591Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/f5/a8b8ca4d891bc4e835ef758a8fb50c7539c7f45bc0e42fae2b847cbc59b7/types_grpcio-1.0.0.20260614-py3-none-any.whl", hash = "sha256:050472cb4ef329ae8fe20278c62bc0da5b961aad3dd889cc35f6e0c70d368dae", size = 15629, upload-time = "2026-06-14T06:23:32.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bumps `nominal-api` and `nominal-api-protos` from `0.1282.0` → `0.1287.0`, and cleans up gRPC `# type: ignore` comments that the new stubs make unnecessary.

## Why the type-ignore cleanup

`nominal-api-protos==0.1287.0` now ships `*_pb2_grpc.pyi` type stubs (and a `py.typed` marker) for the gRPC route stubs — e.g. `WorkspaceServiceStub.GetWorkspace` is typed as `grpc.UnaryUnaryMultiCallable[GetWorkspaceRequest, GetWorkspaceResponse]`.

On their own those stubs change nothing for mypy: they're typed in terms of `grpc.*`, and `grpc` was untyped here, so the subscripts collapsed to `Any`. Adding **`types-grpcio`** (dev dependency) makes `grpc` concrete, which lets the route-stub return types resolve and renders several ignores unused. mypy (`strict = true`, so `warn_unused_ignores` is on) then flagged exactly these:

| File | Removed |
|------|---------|
| `nominal/core/_clientsbunch.py` | `# type: ignore[no-any-return]` on the two `WorkspaceServiceStub` calls |
| `nominal/core/_utils/grpc_tools.py` | `# type: ignore[import-untyped]` on `import grpc` |
| `nominal/core/_utils/grpc_tools.py` | `# type: ignore[misc]` on 5 grpc base-class subclassings (`ClientCallDetails`, the 4 interceptor bases) |

Two now-inaccurate "untyped gRPC stub" comments were refreshed in the process.

### Intentionally kept

`grpc_tools.py` — the `[call-arg]` ignore on the stub factory stays. It's not about grpc typing: `stub_class` is a generic `type[TStub]` whose constructor mypy can't resolve. mypy confirms it's still needed.

## Verification

- `uv run mypy` — clean (`Success: no issues found in 143 source files`)
- `uv run pytest` — 251 passed, 10 skipped
- `uv run ruff format --check` / `uv run ruff check` — clean
- `uv lock --check` — passes
- Enum-safety spot check: `IngestStatusV2` in `0.1287.0` has 8 union members, all handled by `IngestStatus._from_conjure` (the spot fixed in #838) — no new unhandled members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
