### PR TITLE
feat(core): add IngestionJob resource for tracking ingest jobs

### DIFF
--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -26,6 +26,7 @@ from nominal.core.dataset_file import DatasetFile, IngestWaitType, as_files_inge
 from nominal.core.datasource import DataSource
 from nominal.core.event import Event
 from nominal.core.filetype import FileType, FileTypes
+from nominal.core.ingestion_job import IngestionJob, IngestionJobStatus, IngestType
 from nominal.core.log import LogPoint
 from nominal.core.run import Run
 from nominal.core.secret import Secret
@@ -64,6 +65,9 @@ __all__ = [
     "FileType",
     "FileTypes",
     "HeaderProvider",
+    "IngestionJob",
+    "IngestionJobStatus",
+    "IngestType",
     "IngestWaitType",
     "LinkDict",
     "LogPoint",

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -149,6 +149,7 @@ class ClientsBunch:
     dataexport: scout_dataexport_api.DataExportService
     datasource: scout_datasource.DataSourceService
     ingest: ingest_api.IngestService
+    ingest_jobs: ingest_api.IngestJobService
     run: scout.RunService
     units: units_pb2_grpc.UnitsServiceStub
     upload: upload_api.UploadService
@@ -307,6 +308,7 @@ class ClientsBunch:
             dataexport=client_factory(scout_dataexport_api.DataExportService),
             datasource=client_factory(scout_datasource.DataSourceService),
             ingest=client_factory(ingest_api.IngestService),
+            ingest_jobs=client_factory(ingest_api.IngestJobService),
             run=client_factory(scout.RunService),
             units=grpc_factory(units_pb2_grpc.UnitsServiceStub),
             upload=client_factory(upload_api.UploadService),

--- a/nominal/core/_utils/pagination_tools.py
+++ b/nominal/core/_utils/pagination_tools.py
@@ -5,6 +5,7 @@ from typing import Any, Iterable, Protocol, Sequence, TypeVar, overload
 from nominal_api import (
     authentication_api,
     event,
+    ingest_api,
     scout,
     scout_asset_api,
     scout_assets,
@@ -113,6 +114,26 @@ def search_assets_paginated(
 
     for response in paginate_rpc(client.search_assets, auth_header, request_factory=factory):
         yield from response.results
+
+
+def search_ingest_jobs_paginated(
+    client: ingest_api.IngestJobService,
+    auth_header: str,
+    filter: ingest_api.IngestJobSearchFilter,
+) -> Iterable[ingest_api.IngestJob]:
+    def factory(page_token: str | None) -> ingest_api.SearchIngestJobsRequest:
+        return ingest_api.SearchIngestJobsRequest(
+            page_size=DEFAULT_PAGE_SIZE,
+            filter=filter,
+            sort=ingest_api.IngestJobSortOptions(
+                is_descending=True,
+                sort_key=ingest_api.IngestJobSortKey.CREATED_AT,
+            ),
+            next_page_token=page_token,
+        )
+
+    for response in paginate_rpc(client.search_ingest_jobs, auth_header, request_factory=factory):
+        yield from response.ingest_jobs
 
 
 def search_data_reviews_paginated(

--- a/nominal/core/_utils/query_tools.py
+++ b/nominal/core/_utils/query_tools.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Iterable, Mapping, Sequence, cast
+from typing import TYPE_CHECKING, Iterable, Mapping, Sequence, cast
 
 from nominal_api import (
     api,
@@ -21,7 +21,13 @@ from nominal_api import (
 )
 
 from nominal._utils.deprecation_tools import _NotProvided
+from nominal.core._utils.api_tools import rid_from_instance_or_string
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
+
+if TYPE_CHECKING:
+    from nominal.core.dataset import Dataset
+    from nominal.core.ingestion_job import IngestionJobStatus
+    from nominal.core.user import User
 
 
 class AssetMatch(Enum):
@@ -262,6 +268,51 @@ def create_search_assets_query(
         queries.append(scout_asset_api.SearchAssetsQuery(workspace=workspace_rid))
 
     return scout_asset_api.SearchAssetsQuery(and_=queries)
+
+
+def create_search_ingest_jobs_query(
+    *,
+    datasets: Sequence[Dataset | str] | None = None,
+    created_by: Sequence[User | str] | None = None,
+    statuses: Sequence[IngestionJobStatus] | None = None,
+    search_text: str | None = None,
+    start_time_after: str | datetime | IntegralNanosecondsUTC | None = None,
+    start_time_before: str | datetime | IntegralNanosecondsUTC | None = None,
+    workspace_rid: str | None = None,
+) -> ingest_api.IngestJobSearchFilter:
+    queries: list[ingest_api.IngestJobSearchFilter] = []
+    if datasets:
+        queries.append(
+            ingest_api.IngestJobSearchFilter(dataset_rids=[rid_from_instance_or_string(d) for d in datasets])
+        )
+    if created_by:
+        queries.append(
+            ingest_api.IngestJobSearchFilter(
+                created_by_rids=[rid_from_instance_or_string(actor) for actor in created_by]
+            )
+        )
+    if statuses:
+        queries.append(ingest_api.IngestJobSearchFilter(statuses=[status._to_conjure() for status in statuses]))
+    if search_text is not None:
+        queries.append(ingest_api.IngestJobSearchFilter(search_text=search_text))
+    if start_time_after is not None or start_time_before is not None:
+        queries.append(
+            ingest_api.IngestJobSearchFilter(
+                start_time_range=ingest_api.IngestJobStartTimeRange(
+                    start_time_after=(
+                        None if start_time_after is None else _SecondsNanos.from_flexible(start_time_after).to_iso8601()
+                    ),
+                    start_time_before=(
+                        None
+                        if start_time_before is None
+                        else _SecondsNanos.from_flexible(start_time_before).to_iso8601()
+                    ),
+                )
+            )
+        )
+    if workspace_rid is not None:
+        queries.append(ingest_api.IngestJobSearchFilter(workspace=workspace_rid))
+    return ingest_api.IngestJobSearchFilter(and_=queries)
 
 
 def create_search_checklists_query(

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -51,6 +51,7 @@ from nominal.core._utils.pagination_tools import (
     search_assets_paginated,
     search_checklists_paginated,
     search_datasets_paginated,
+    search_ingest_jobs_paginated,
     search_runs_by_asset_paginated,
     search_runs_paginated,
     search_secrets_paginated,
@@ -64,6 +65,7 @@ from nominal.core._utils.query_tools import (
     create_search_checklists_query,
     create_search_containerized_extractors_query,
     create_search_datasets_query,
+    create_search_ingest_jobs_query,
     create_search_runs_query,
     create_search_secrets_query,
     create_search_users_query,
@@ -101,6 +103,7 @@ from nominal.core.exceptions import (
     NominalNotFoundError,
 )
 from nominal.core.filetype import FileType, FileTypes
+from nominal.core.ingestion_job import IngestionJob, IngestionJobStatus
 from nominal.core.run import Run, _create_run
 from nominal.core.secret import Secret
 from nominal.core.streaming_checklist import _iter_list_streaming_checklists
@@ -1298,6 +1301,60 @@ class NominalClient:
             workspace_rid=self._workspace_rid_for_search(workspace or WorkspaceSearchType.ALL),
         )
         return list(self._iter_search_assets(query, archive_status))
+
+    def get_ingestion_job(self, rid: str) -> IngestionJob:
+        """Retrieve an ingest job by its RID."""
+        job = self._clients.ingest_jobs.get_ingest_job(self._clients.auth_header, rid)
+        return IngestionJob._from_conjure(self._clients, job)
+
+    def _iter_search_ingestion_jobs(self, filter: ingest_api.IngestJobSearchFilter) -> Iterable[IngestionJob]:
+        for job in search_ingest_jobs_paginated(self._clients.ingest_jobs, self._clients.auth_header, filter):
+            yield IngestionJob._from_conjure(self._clients, job)
+
+    def search_ingestion_jobs(
+        self,
+        *,
+        datasets: Sequence[Dataset | str] | None = None,
+        created_by: Sequence[User | str] | None = None,
+        statuses: Sequence[IngestionJobStatus] | None = None,
+        search_text: str | None = None,
+        start_time_after: str | datetime | IntegralNanosecondsUTC | None = None,
+        start_time_before: str | datetime | IntegralNanosecondsUTC | None = None,
+        workspace: WorkspaceSearchT | None = WorkspaceSearchType.ALL,
+    ) -> Sequence[IngestionJob]:
+        """Search ingest jobs. Filters are ANDed together.
+
+        Results are limited to datasets the caller can read; jobs without a persisted dataset are
+        never returned by search.
+
+        Args:
+            datasets: Only jobs targeting any of these datasets (or their RIDs).
+            created_by: Only jobs created by any of these users or user RIDs.
+            statuses: Only jobs in any of these statuses.
+            search_text: Case-insensitive substring match against origin file paths.
+            start_time_after: Only jobs that started at or after this time (inclusive).
+            start_time_before: Only jobs that started before this time (exclusive).
+            workspace: Filters search to given workspace.
+
+        NOTE: If WorkspaceSearchType.ALL is given for `workspace` (default), the workspace filter is omitted and the
+            search spans all workspaces the user can access. If WorkspaceSearchType.DEFAULT, the client prefers its
+            configured `workspace_rid` (for example from `config.yml`) and otherwise falls back to a client-side
+            default-workspace lookup; if neither succeeds, a NominalConfigError is raised. If a Workspace or workspace
+            RID is given, that value is used directly.
+
+        Returns:
+            All ingest jobs matching all of the provided conditions, most recent first.
+        """
+        filter = create_search_ingest_jobs_query(
+            datasets=datasets,
+            created_by=created_by,
+            statuses=statuses,
+            search_text=search_text,
+            start_time_after=start_time_after,
+            start_time_before=start_time_before,
+            workspace_rid=self._workspace_rid_for_search(workspace or WorkspaceSearchType.ALL),
+        )
+        return list(self._iter_search_ingestion_jobs(filter))
 
     def list_streaming_checklists(self, asset: Asset | str | None = None) -> Sequence[str]:
         """List all Streaming Checklists.

--- a/nominal/core/ingestion_job.py
+++ b/nominal/core/ingestion_job.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable, Protocol, Sequence
+
+from nominal_api import ingest_api
+from typing_extensions import Self
+
+from nominal.core._utils.api_tools import HasRid, RefreshableMixin
+from nominal.core.dataset_file import DatasetFile
+from nominal.core.dataset_file import as_files_ingested as _as_files_ingested
+from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
+
+
+class IngestionJobStatus(Enum):
+    """Lifecycle status of an ingest job."""
+
+    SUBMITTED = "SUBMITTED"
+    QUEUED = "QUEUED"
+    IN_PROGRESS = "IN_PROGRESS"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
+    UNKNOWN = "UNKNOWN"
+    """Unknown or unrecognized status returned by a newer server."""
+
+    @classmethod
+    def _from_conjure(cls, status: ingest_api.IngestJobStatus) -> IngestionJobStatus:
+        match status.name:
+            case "SUBMITTED":
+                result = cls.SUBMITTED
+            case "QUEUED":
+                result = cls.QUEUED
+            case "IN_PROGRESS":
+                result = cls.IN_PROGRESS
+            case "COMPLETED":
+                result = cls.COMPLETED
+            case "FAILED":
+                result = cls.FAILED
+            case "CANCELLED":
+                result = cls.CANCELLED
+            case _:
+                result = cls.UNKNOWN
+        return result
+
+    def _to_conjure(self) -> ingest_api.IngestJobStatus:
+        match self.name:
+            case "SUBMITTED":
+                result = ingest_api.IngestJobStatus.SUBMITTED
+            case "QUEUED":
+                result = ingest_api.IngestJobStatus.QUEUED
+            case "IN_PROGRESS":
+                result = ingest_api.IngestJobStatus.IN_PROGRESS
+            case "COMPLETED":
+                result = ingest_api.IngestJobStatus.COMPLETED
+            case "FAILED":
+                result = ingest_api.IngestJobStatus.FAILED
+            case "CANCELLED":
+                result = ingest_api.IngestJobStatus.CANCELLED
+            case _:
+                result = ingest_api.IngestJobStatus.UNKNOWN
+        return result
+
+
+class IngestType(Enum):
+    """The kind of data an ingest job ingests."""
+
+    TABULAR = "TABULAR"
+    MCAP = "MCAP"
+    DATAFLASH = "DATAFLASH"
+    JOURNAL_JSON = "JOURNAL_JSON"
+    CONTAINERIZED = "CONTAINERIZED"
+    VIDEO = "VIDEO"
+    AVRO_STREAM = "AVRO_STREAM"
+    POINT_CLOUD = "POINT_CLOUD"
+    MULTI = "MULTI"
+    UNKNOWN = "UNKNOWN"
+    """Unknown or unrecognized ingest type returned by a newer server."""
+
+    @classmethod
+    def _from_conjure(cls, ingest_type: ingest_api.IngestType) -> IngestType:
+        match ingest_type.name:
+            case "TABULAR":
+                result = cls.TABULAR
+            case "MCAP":
+                result = cls.MCAP
+            case "DATAFLASH":
+                result = cls.DATAFLASH
+            case "JOURNAL_JSON":
+                result = cls.JOURNAL_JSON
+            case "CONTAINERIZED":
+                result = cls.CONTAINERIZED
+            case "VIDEO":
+                result = cls.VIDEO
+            case "AVRO_STREAM":
+                result = cls.AVRO_STREAM
+            case "POINT_CLOUD":
+                result = cls.POINT_CLOUD
+            case "MULTI":
+                result = cls.MULTI
+            case _:
+                result = cls.UNKNOWN
+        return result
+
+
+def _optional_iso_to_nanos(value: str | None) -> IntegralNanosecondsUTC | None:
+    if value is None:
+        return None
+    return _SecondsNanos.from_flexible(value).to_nanoseconds()
+
+
+@dataclass(frozen=True)
+class IngestionJob(HasRid, RefreshableMixin[ingest_api.IngestJob]):
+    """A trackable record of one ingestion request moving through the async pipeline."""
+
+    rid: str
+    status: IngestionJobStatus
+    ingest_type: IngestType
+    dataset_rid: str | None
+    origin_files: Sequence[str]
+    produced_file_count: int | None
+    created_by_rid: str | None
+    created_at: IntegralNanosecondsUTC | None
+    start_time: IntegralNanosecondsUTC | None
+    end_time: IntegralNanosecondsUTC | None
+    _clients: _Clients = field(repr=False)
+
+    class _Clients(DatasetFile._Clients, Protocol):
+        @property
+        def ingest_jobs(self) -> ingest_api.IngestJobService: ...
+
+    @property
+    def nominal_url(self) -> str:
+        """Returns a link to the page for this ingest job in the Nominal app."""
+        return f"{self._clients.app_base_url}/ingestion/{self.rid}"
+
+    @classmethod
+    def _from_conjure(cls, clients: _Clients, job: ingest_api.IngestJob) -> Self:
+        return cls(
+            rid=job.ingest_job_rid,
+            status=IngestionJobStatus._from_conjure(job.status),
+            ingest_type=IngestType._from_conjure(job.ingest_type),
+            dataset_rid=job.dataset_rid,
+            origin_files=tuple(job.origin_files or ()),
+            produced_file_count=job.produced_file_count,
+            created_by_rid=job.created_by_rid,
+            created_at=_optional_iso_to_nanos(job.created_at),
+            start_time=_optional_iso_to_nanos(job.start_time),
+            end_time=_optional_iso_to_nanos(job.end_time),
+            _clients=clients,
+        )
+
+    def _get_latest_api(self) -> ingest_api.IngestJob:
+        return self._clients.ingest_jobs.get_ingest_job(self._clients.auth_header, self.rid)
+
+    def cancel(self) -> Self:
+        """Cancel this ingest job.
+
+        SUBMITTED/QUEUED jobs transition directly to CANCELLED; IN_PROGRESS jobs have their
+        underlying workflow cancelled. Cancelling a job already in a terminal state raises a
+        conjure IngestJobNotCancellable (CONFLICT) error from the server.
+        """
+        job = self._clients.ingest_jobs.cancel_ingest_job(self._clients.auth_header, self.rid)
+        return self._refresh_from_api(job)
+
+    def _iter_dataset_files(self) -> Iterable[DatasetFile]:
+        next_page_token = None
+        while True:
+            page = self._clients.catalog.get_dataset_files_for_job(self._clients.auth_header, self.rid, next_page_token)
+            for dataset_file in page.files:
+                yield DatasetFile._from_conjure(self._clients, dataset_file)
+            if page.next_page is None:
+                break
+            next_page_token = page.next_page
+
+    def dataset_files(self) -> Sequence[DatasetFile]:
+        """Return the dataset files produced by this ingest job."""
+        return list(self._iter_dataset_files())
+
+    def as_files_ingested(
+        self, *, poll_interval: datetime.timedelta = datetime.timedelta(seconds=1)
+    ) -> Iterable[DatasetFile]:
+        """Yield this job's dataset files as each completes ingestion.
+
+        Polls the files produced by this job (as of the call) until each finishes ingesting, mirroring
+        `nominal.core.as_files_ingested`. `list(job.as_files_ingested())` blocks until all are ingested.
+        For timeout / return-when control, use `nominal.core.wait_for_files_to_ingest(job.dataset_files(), ...)`.
+        """
+        yield from _as_files_ingested(self.dataset_files(), poll_interval=poll_interval)

--- a/tests/core/test_client_search.py
+++ b/tests/core/test_client_search.py
@@ -1,7 +1,10 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from nominal.core._utils.query_tools import ArchiveStatusFilter
+from nominal.core._utils.query_tools import ArchiveStatusFilter, create_search_ingest_jobs_query
 from nominal.core.client import NominalClient
+from nominal.core.ingestion_job import IngestionJobStatus
+from nominal.ts import _SecondsNanos
 
 
 def test_search_data_reviews_passes_archive_status():
@@ -14,3 +17,70 @@ def test_search_data_reviews_passes_archive_status():
     assert result == []
     mock_reviews.assert_called_once()
     assert mock_reviews.call_args.kwargs["archive_status"] == ArchiveStatusFilter.ANY
+
+
+def test_create_search_ingest_jobs_query_empty_returns_empty_and():
+    """With no filters, the query is an empty AND (match-all)."""
+    result = create_search_ingest_jobs_query()
+    assert result.and_ == []
+
+
+def test_create_search_ingest_jobs_query_single_leaf_wrapped_in_and():
+    """A single filter is wrapped in a one-element AND."""
+    result = create_search_ingest_jobs_query(datasets=["ri.catalog.test.dataset.a"])
+    assert len(result.and_) == 1
+    assert result.and_[0].dataset_rids == ["ri.catalog.test.dataset.a"]
+
+
+def test_create_search_ingest_jobs_query_multiple_leaves_are_anded():
+    """Multiple filters are AND-composed, with statuses converted to wire enums."""
+    result = create_search_ingest_jobs_query(
+        datasets=["ri.catalog.test.dataset.a"],
+        statuses=[IngestionJobStatus.COMPLETED],
+    )
+    assert len(result.and_) == 2
+    assert result.and_[0].dataset_rids == ["ri.catalog.test.dataset.a"]
+    assert [s.name for s in result.and_[1].statuses] == ["COMPLETED"]
+
+
+def test_create_search_ingest_jobs_query_start_time_after_sets_range():
+    """A start-time bound becomes a single start_time_range leaf with an ISO-8601 timestamp."""
+    result = create_search_ingest_jobs_query(start_time_after="2026-06-25T00:00:00Z")
+    expected = _SecondsNanos.from_flexible("2026-06-25T00:00:00Z").to_iso8601()
+    assert len(result.and_) == 1
+    assert result.and_[0].start_time_range is not None
+    assert result.and_[0].start_time_range.start_time_after == expected
+    assert result.and_[0].start_time_range.start_time_before is None
+
+
+def test_create_search_ingest_jobs_query_workspace_rid_sets_workspace():
+    """A workspace RID becomes a single workspace filter leaf."""
+    result = create_search_ingest_jobs_query(workspace_rid="ri.workspace.test.w")
+    assert len(result.and_) == 1
+    assert result.and_[0].workspace == "ri.workspace.test.w"
+
+
+def test_search_ingestion_jobs_resolves_and_applies_workspace_filter():
+    """search_ingestion_jobs resolves the workspace selector and forwards it as a workspace filter."""
+    client = NominalClient(_clients=MagicMock())
+    client._clients.resolve_workspace.return_value.rid = "ri.workspace.resolved"
+    client._clients.ingest_jobs.search_ingest_jobs.return_value = SimpleNamespace(ingest_jobs=[], next_page_token=None)
+
+    client.search_ingestion_jobs(workspace="ri.workspace.input")
+
+    client._clients.resolve_workspace.assert_called_once_with("ri.workspace.input")
+    request = client._clients.ingest_jobs.search_ingest_jobs.call_args.args[1]
+    assert len(request.filter.and_) == 1
+    assert request.filter.and_[0].workspace == "ri.workspace.resolved"
+
+
+def test_search_ingestion_jobs_forwards_filter_to_the_search_endpoint():
+    """search_ingestion_jobs builds an AND filter from its kwargs and forwards it to the search endpoint."""
+    client = NominalClient(_clients=MagicMock())
+    client._clients.ingest_jobs.search_ingest_jobs.return_value = SimpleNamespace(ingest_jobs=[], next_page_token=None)
+
+    result = client.search_ingestion_jobs(statuses=[IngestionJobStatus.FAILED])
+
+    assert result == []
+    request = client._clients.ingest_jobs.search_ingest_jobs.call_args.args[1]
+    assert [s.name for s in request.filter.and_[0].statuses] == ["FAILED"]

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -291,3 +291,9 @@ def test_experimental_as_user_returns_derived_nominal_client(monkeypatch):
     header_provider = create_grpc_channel.call_args.kwargs["header_provider"]
     assert header_provider is not None
     assert header_provider.headers()[ON_BEHALF_OF_USER_RID_HEADER] == "ri.authn.dev.user.target"
+
+
+def test_clients_bunch_exposes_ingest_jobs_service():
+    """ClientsBunch declares an `ingest_jobs` field so resources can reach the job-query API."""
+    names = {field.name for field in fields(ClientsBunch)}
+    assert "ingest_jobs" in names

--- a/tests/core/test_ingestion_job.py
+++ b/tests/core/test_ingestion_job.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from nominal_api import ingest_api
+
+from nominal.core.ingestion_job import IngestionJob, IngestionJobStatus
+
+
+def _job_bean(**overrides: object) -> ingest_api.IngestJob:
+    """Build a conjure IngestJob bean with sensible defaults for tests."""
+    kwargs: dict[str, object] = dict(
+        ingest_job_rid="ri.ingest.test.ingest-job.0000",
+        status=ingest_api.IngestJobStatus.IN_PROGRESS,
+        ingest_type=ingest_api.IngestType.TABULAR,
+        created_by="11111111-1111-1111-1111-111111111111",
+        org_uuid="22222222-2222-2222-2222-222222222222",
+        created_by_rid="ri.authn.test.user.abc",
+        dataset_rid="ri.catalog.test.dataset.def",
+        origin_files=None,
+        produced_file_count=None,
+        created_at=None,
+        start_time=None,
+        end_time=None,
+    )
+    kwargs.update(overrides)
+    return ingest_api.IngestJob(**kwargs)
+
+
+def test_from_conjure_unknown_status_falls_back_to_unknown() -> None:
+    """An unrecognized wire status name maps to UNKNOWN for forward-compatibility."""
+    future = SimpleNamespace(name="SOME_FUTURE_STATUS")
+    assert IngestionJobStatus._from_conjure(future) is IngestionJobStatus.UNKNOWN
+
+
+def test_cancel_calls_service_and_refreshes(mock_clients: MagicMock) -> None:
+    """cancel() calls the cancel endpoint and refreshes the job in place from the response."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
+    mock_clients.ingest_jobs.cancel_ingest_job.return_value = _job_bean(status=ingest_api.IngestJobStatus.CANCELLED)
+
+    result = job.cancel()
+
+    mock_clients.ingest_jobs.cancel_ingest_job.assert_called_once_with(mock_clients.auth_header, job.rid)
+    assert result is job
+    assert job.status is IngestionJobStatus.CANCELLED
+
+
+def test_dataset_files_paginates_and_maps(mock_clients: MagicMock) -> None:
+    """dataset_files() pages through the per-job files endpoint, threading the page token."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean())
+
+    raw_file_1 = object()
+    raw_file_2 = object()
+    raw_file_3 = object()
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = [
+        SimpleNamespace(files=[raw_file_1, raw_file_2], next_page="t2"),
+        SimpleNamespace(files=[raw_file_3], next_page=None),
+    ]
+
+    sentinels = {raw_file_1: "f1", raw_file_2: "f2", raw_file_3: "f3"}
+    with patch(
+        "nominal.core.ingestion_job.DatasetFile._from_conjure",
+        side_effect=lambda _clients, raw_file: sentinels[raw_file],
+    ):
+        result = job.dataset_files()
+
+    assert result == ["f1", "f2", "f3"]
+    assert mock_clients.catalog.get_dataset_files_for_job.call_count == 2
+    first_call = mock_clients.catalog.get_dataset_files_for_job.call_args_list[0]
+    assert first_call.args == (mock_clients.auth_header, job.rid, None)
+    second_call = mock_clients.catalog.get_dataset_files_for_job.call_args_list[1]
+    assert second_call.args[2] == "t2"

--- a/tests/core/test_pagination_tools.py
+++ b/tests/core/test_pagination_tools.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from nominal_api import ingest_api
+
+from nominal.core._utils.pagination_tools import DEFAULT_PAGE_SIZE, search_ingest_jobs_paginated
+
+
+def test_search_ingest_jobs_paginated_walks_all_pages():
+    """Walks every page, threading the token and building requests with the page size and descending CREATED_AT sort."""
+    client = MagicMock()
+    page_one = MagicMock(ingest_jobs=["job-a"], next_page_token="token-2")
+    page_two = MagicMock(ingest_jobs=["job-b"], next_page_token=None)
+    client.search_ingest_jobs.side_effect = [page_one, page_two]
+
+    sentinel_filter = MagicMock()
+    results = list(search_ingest_jobs_paginated(client, "Bearer token", filter=sentinel_filter))
+
+    assert results == ["job-a", "job-b"]
+    assert client.search_ingest_jobs.call_count == 2
+    # First request carries the page size, filter, and descending CREATED_AT sort.
+    first_request = client.search_ingest_jobs.call_args_list[0].args[1]
+    assert first_request.page_size == DEFAULT_PAGE_SIZE == 100
+    assert first_request.filter is sentinel_filter
+    assert first_request.sort.is_descending is True
+    assert first_request.sort.sort_key is ingest_api.IngestJobSortKey.CREATED_AT
+    # Second request carries the token returned by the first page.
+    second_request = client.search_ingest_jobs.call_args_list[1].args[1]
+    assert second_request.next_page_token == "token-2"


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

## Summary

Adds a conjure-backed `IngestionJob` resource dataclass so users can **retrieve, track, search, and cancel existing ingest jobs**, following the existing resource conventions (`Asset`/`Run`/`Dataset`): a frozen dataclass with an inner `_Clients` protocol, `HasRid` + `RefreshableMixin`, a `_from_conjure` builder, and native enums.

The public ingest-job query API (`getIngestJob` / `searchIngestJobs` / `cancelIngestJob`) is conjure-only on the backend — there is no gRPC equivalent (verified against scout: no such service on `main`, any branch, or history). So this intentionally uses the conjure `IngestJobService`, which was not previously wired into `ClientsBunch`.

## What's included

- **`IngestionJob`** (`nominal/core/ingestion_job.py`): fields (`rid`, `status`, `ingest_type`, `dataset_rid`, `origin_files`, `produced_file_count`, `created_by_rid`, `created_at`/`start_time`/`end_time`), plus `nominal_url`, `refresh()`, and `cancel()`.
- **Dataset-file access on a job**: `dataset_files()` returns the files produced by the job, and `as_files_ingested()` yields them as each finishes ingesting (delegating to the existing `nominal.core.as_files_ingested` poller). For timeout / return-when control, callers use `nominal.core.wait_for_files_to_ingest(job.dataset_files(), ...)`.
- **Enums** `IngestionJobStatus` and `IngestType`, with `UNKNOWN`-fallback conversion (mirrors the `EventType` convention).
- **`NominalClient.get_ingestion_job(rid)`** and **`search_ingestion_jobs(...)`** with friendly, AND-composed filter kwargs (datasets / created_by / statuses / search_text / start-time range).
- Wired `IngestJobService` into `ClientsBunch`; added `search_ingest_jobs_paginated` (in `pagination_tools`) and `create_search_ingest_jobs_query` (in the canonical `query_tools` layer).
- Exports `IngestionJob`, `IngestionJobStatus`, `IngestType` from `nominal.core`.

## Out of scope (by design)

- Triggering/creating ingest jobs (v1 conjure or v2 gRPC `Ingest`) — the existing upload/dataset paths already create jobs.
- A job-level `wait_until_complete()` poller — superseded by the file-level pollers above (`as_files_ingested()` / `wait_for_files_to_ingest`), which avoid the "unknown terminal status polls forever" failure mode by keying completion off per-file ingest state rather than the job status enum.
- Exposing the job's `org_uuid` — no sibling resource (`Asset`/`Run`/`Event`) surfaces org info, and the wire value is a bare UUID rather than a RID, so it was dropped rather than exposed under a misleading `org_rid` name.
- The internal `InternalIngestJobService`, and the recursive `and`/`or`/`not`/`workspace` search-filter variants (YAGNI).

## Testing

- New behavior tests for the dataclass (`_from_conjure` mapping, enum `UNKNOWN` fallback, `cancel()` refresh, `dataset_files()` token-threaded pagination), the pagination helper, the filter builder (composition), and the client get/search methods.
- `tests/core`: green · `mypy -p nominal`: clean (142 files) · `ruff check`/`format`: clean · verified against `nominal-api` 0.1287.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
