### PR TITLE
feat(migration): support migrating standalone checklists

### DIFF
--- a/nominal/experimental/migration/README.md
+++ b/nominal/experimental/migration/README.md
@@ -75,6 +75,8 @@ migration:
     - asset_rid: ri.scout.main.asset.<uuid>
   standalone_workbook_template_rids:
     - ri.scout.main.template.<uuid>
+  standalone_checklist_rids:     # optional: clone checklist definitions, no asset/run required
+    - ri.scout.main.checklist.<uuid>
   impersonation:                 # optional: create resources as mapped destination users
     enabled: true
     unmapped_source_user_behavior: service_user
@@ -85,6 +87,7 @@ migration:
 How it works:
 1. For each source asset RID in `source_asset_rids`, the script will copy the asset and all linked resources — runs, workbooks, datasets, events, videos, and checklists — into the destination tenant.
 2. For each workbook template RID in `standalone_workbook_template_rids`, the script will copy the workbook template into the destination tenant.
+3. For each checklist RID in `standalone_checklist_rids`, the script will clone the checklist definition into the destination tenant. No run or execution is involved — the checklist's channel references resolve at execution time against whatever run it is later run against (the run must expose matching data-source ref names and channel names, plus tags if any).
 
 Misc. configs:
 1. `include_dataset_files` — if `true`, copies all dataset files attached to a dataset into the destination. Typically `true` for demo hydration and `false` for tenant migration (which relies on a separate Clickhouse backup).

--- a/nominal/experimental/migration/config/migration_resources.py
+++ b/nominal/experimental/migration/config/migration_resources.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Mapping, Sequence
 
 from nominal.core.asset import Asset
+from nominal.core.checklist import Checklist
 from nominal.core.workbook_template import WorkbookTemplate
 
 
@@ -18,3 +19,4 @@ class AssetResources:
 class MigrationResources:
     source_assets: Mapping[str, AssetResources]
     source_standalone_templates: Sequence[WorkbookTemplate]
+    source_standalone_checklists: Sequence[Checklist] = ()

--- a/nominal/experimental/migration/migration_cli.py
+++ b/nominal/experimental/migration/migration_cli.py
@@ -11,7 +11,7 @@ import yaml
 from nominal_api.scout_sandbox_api import SetDemoWorkbooksRequest
 
 from nominal.cli.util.global_decorators import client_options, global_options
-from nominal.core import ArchiveStatusFilter, Asset, NominalClient, Workbook
+from nominal.core import ArchiveStatusFilter, Asset, Checklist, NominalClient, Workbook
 from nominal.experimental import as_user
 from nominal.experimental.migration.config.migration_data_config import AssetInclusionConfig, MigrationDatasetConfig
 from nominal.experimental.migration.config.migration_resources import AssetResources, MigrationResources
@@ -171,7 +171,7 @@ def _load_standalone_templates(source_client: NominalClient, template_rids: Any)
     return templates
 
 
-def _load_standalone_checklists(source_client: NominalClient, checklist_rids: Any) -> list[Any]:
+def _load_standalone_checklists(source_client: NominalClient, checklist_rids: Any) -> list[Checklist]:
     if checklist_rids is None:
         return []
 
@@ -180,9 +180,10 @@ def _load_standalone_checklists(source_client: NominalClient, checklist_rids: An
 
     checklists = []
     for c in checklist_rids:
-        checklist_resource = source_client.get_checklist(c)
-        if not checklist_resource:
-            raise click.UsageError(f"Checklist with RID '{c}' not found in source client.")
+        try:
+            checklist_resource = source_client.get_checklist(c)
+        except Exception as exc:
+            raise click.UsageError(f"Checklist with RID '{c}' not found in source client.") from exc
         checklists.append(checklist_resource)
     return checklists
 

--- a/nominal/experimental/migration/migration_cli.py
+++ b/nominal/experimental/migration/migration_cli.py
@@ -171,6 +171,22 @@ def _load_standalone_templates(source_client: NominalClient, template_rids: Any)
     return templates
 
 
+def _load_standalone_checklists(source_client: NominalClient, checklist_rids: Any) -> list[Any]:
+    if checklist_rids is None:
+        return []
+
+    if not isinstance(checklist_rids, list) or not all(isinstance(c, str) and c.strip() for c in checklist_rids):
+        raise click.UsageError("'migration.standalone_checklist_rids' must be a list of strings.")
+
+    checklists = []
+    for c in checklist_rids:
+        checklist_resource = source_client.get_checklist(c)
+        if not checklist_resource:
+            raise click.UsageError(f"Checklist with RID '{c}' not found in source client.")
+        checklists.append(checklist_resource)
+    return checklists
+
+
 def load_impersonation_config(raw: Any) -> ImpersonationConfig | None:
     if raw is None:
         return None
@@ -369,6 +385,10 @@ def _load_migration_config(
         source_client,
         m.get("standalone_workbook_template_rids"),
     )
+    standalone_checklists = _load_standalone_checklists(
+        source_client,
+        m.get("standalone_checklist_rids"),
+    )
     impersonation_config = load_impersonation_config(m.get("impersonation"))
 
     dataset_config = MigrationDatasetConfig(
@@ -381,6 +401,7 @@ def _load_migration_config(
         MigrationResources(
             source_assets=asset_resources_by_rid,
             source_standalone_templates=standalone_workbook_templates,
+            source_standalone_checklists=standalone_checklists,
         ),
         dataset_config,
         asset_inclusion_config,
@@ -514,10 +535,12 @@ def copy(
             return
 
     logger.info(
-        "Processing migration config: %s (source_assets=%d, source_standalone_templates=%d)",
+        "Processing migration config: %s (source_assets=%d, source_standalone_templates=%d, "
+        "source_standalone_checklists=%d)",
         name,
         len(migration_resources.source_assets),
         len(migration_resources.source_standalone_templates),
+        len(migration_resources.source_standalone_checklists),
     )
     destination_client_resolver = build_destination_client_resolver(target_client, impersonation_config)
     if destination_client_resolver is not None:
@@ -643,6 +666,7 @@ def prep(client: NominalClient, migration_name: str, output_path: Path) -> None:
             "set_to_demo_workbook": False,
             "source_asset_rids": [{"asset_rid": rid} for rid in sorted(all_assets)],
             "standalone_workbook_template_rids": [t.rid for t in workbook_templates],
+            "standalone_checklist_rids": [],
         }
     }
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/nominal/experimental/migration/migration_runner.py
+++ b/nominal/experimental/migration/migration_runner.py
@@ -11,6 +11,7 @@ from nominal.experimental.migration.config.migration_data_config import AssetInc
 from nominal.experimental.migration.config.migration_resources import MigrationResources
 from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.migrator.asset_migrator import AssetCopyOptions, AssetMigrator
+from nominal.experimental.migration.migrator.checklist_migrator import ChecklistCopyOptions, ChecklistMigrator
 from nominal.experimental.migration.migrator.context import DestinationClientResolver, MigrationContext
 from nominal.experimental.migration.migrator.workbook_migrator import WorkbookMigrator
 from nominal.experimental.migration.migrator.workbook_template_migrator import WorkbookTemplateMigrator
@@ -99,6 +100,7 @@ class MigrationRunner:
             )
             asset_migrator = AssetMigrator(migration_context)
             template_migrator = WorkbookTemplateMigrator(migration_context)
+            checklist_migrator = ChecklistMigrator(migration_context)
             for asset_resources in self.migration_resources.source_assets.values():
                 source_asset = asset_resources.asset
                 asset_migrator.copy_from(
@@ -117,6 +119,12 @@ class MigrationRunner:
 
             for source_template in self.migration_resources.source_standalone_templates:
                 template_migrator.clone(source_template)
+
+            for source_checklist in self.migration_resources.source_standalone_checklists:
+                # ChecklistMigrator.clone() raises NotImplementedError; use copy_from() to clone the
+                # checklist definition. No run/execution is involved — series resolve at execution time
+                # against whatever run the checklist is later run against.
+                checklist_migrator.copy_from(source_checklist, ChecklistCopyOptions())
 
             source_clients_by_asset_rid: dict[str, ClientsBunch] = {
                 asset_rid: cast(ClientsBunch, asset_resources.asset._clients)

--- a/nominal/experimental/migration/parallel_migration_runner.py
+++ b/nominal/experimental/migration/parallel_migration_runner.py
@@ -6,9 +6,11 @@ import concurrent.futures
 import logging
 from typing import Callable
 
+from nominal.core.checklist import Checklist
 from nominal.experimental.migration.config.migration_resources import AssetResources
 from nominal.experimental.migration.migration_runner import MigrationRunner
 from nominal.experimental.migration.migrator.asset_migrator import AssetCopyOptions, AssetMigrator
+from nominal.experimental.migration.migrator.checklist_migrator import ChecklistCopyOptions, ChecklistMigrator
 from nominal.experimental.migration.migrator.context import MigrationContext
 from nominal.experimental.migration.migrator.workbook_template_migrator import WorkbookTemplateMigrator
 from nominal.experimental.migration.parallel_migration_executor import (
@@ -37,6 +39,14 @@ def _make_template_fn(template: object, template_migrator: WorkbookTemplateMigra
     return fn
 
 
+def _make_checklist_fn(checklist: Checklist, checklist_migrator: ChecklistMigrator) -> Callable[[], None]:
+    def fn() -> None:
+        # ChecklistMigrator.clone() raises NotImplementedError; use copy_from() to clone the definition.
+        checklist_migrator.copy_from(checklist, ChecklistCopyOptions())
+
+    return fn
+
+
 def run_parallel_migration(runner: MigrationRunner, max_workers: int) -> None:
     """Run resource migration with a shared thread pool."""
     max_workers = validate_max_workers(max_workers)
@@ -52,6 +62,7 @@ def run_parallel_migration(runner: MigrationRunner, max_workers: int) -> None:
         setattr(ctx, "destination_client_resolver", runner.destination_client_resolver)
     asset_migrator = AssetMigrator(ctx)
     template_migrator = WorkbookTemplateMigrator(ctx)
+    checklist_migrator = ChecklistMigrator(ctx)
     asset_tasks = [
         MigrationTask(
             rid=rid,
@@ -81,13 +92,22 @@ def run_parallel_migration(runner: MigrationRunner, max_workers: int) -> None:
         )
         for template in runner.migration_resources.source_standalone_templates
     ]
-    tasks = asset_tasks + template_tasks
+    checklist_tasks = [
+        MigrationTask(
+            rid=checklist.rid,
+            label="checklist",
+            fn=_make_checklist_fn(checklist, checklist_migrator),
+        )
+        for checklist in runner.migration_resources.source_standalone_checklists
+    ]
+    tasks = asset_tasks + template_tasks + checklist_tasks
 
     logger.info(
-        "Running migration with %d worker(s) across %d asset(s) and %d template(s)",
+        "Running migration with %d worker(s) across %d asset(s), %d template(s), and %d checklist(s)",
         max_workers,
         len(asset_tasks),
         len(template_tasks),
+        len(checklist_tasks),
     )
     try:
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/nominal/experimental/migration/sample_migration_config.yml
+++ b/nominal/experimental/migration/sample_migration_config.yml
@@ -63,6 +63,17 @@ migration:
   #   - "ri.scout.gov-staging.notebook-template.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 
   # -------------------------------------------------------------------------
+  # Standalone checklists (optional)
+  # Checklists listed here are cloned to the destination independently of any
+  # asset or run — only the checklist definition is copied (no execution).
+  # Their channel references resolve at execution time against whatever run
+  # they are later run against, so the run must expose matching data-source
+  # ref names and channel names (and tags, if any) for checks to resolve.
+  # -------------------------------------------------------------------------
+  # standalone_checklist_rids:
+  #   - "ri.scout.gov-staging.checklist.bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+  # -------------------------------------------------------------------------
   # Impersonation (optional)
   # When enabled, resources are created on the destination under the mapped
   # destination user rather than the service account running the migration.

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -681,6 +681,33 @@ def test_migrate_standalone_template(
     assert dest_template.properties == source_template.properties
 
 
+def test_migrate_standalone_checklist(
+    source_client: NominalClient,
+    dest_client: NominalClient,
+    register_cleanup: RegisterCleanup,
+    tmp_path: Path,
+):
+    """Standalone checklists are cloned to the destination client without any run or execution."""
+    source_checklist = _create_checklist_with_content(
+        source_client, title=f"migration-e2e-standalone-checklist-{uuid4()}", is_published=True
+    )
+    register_cleanup(source_checklist.archive)
+
+    resources = MigrationResources(
+        source_assets={},
+        source_standalone_templates=[],
+        source_standalone_checklists=[source_checklist],
+    )
+    runner = _make_runner(resources, _no_files_config(), dest_client, tmp_path / "state.json")
+    runner.run_migration()
+
+    dest_checklist_rid = runner.migration_state.get_mapped_rid(ResourceType.CHECKLIST, source_checklist.rid)
+    assert dest_checklist_rid is not None
+    dest_checklist = dest_client.get_checklist(dest_checklist_rid)
+    register_cleanup(dest_checklist.archive)
+    assert dest_checklist.name == source_checklist.name
+
+
 def test_migration_idempotency(
     source_client: NominalClient,
     dest_client: NominalClient,

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -689,7 +689,12 @@ def test_migrate_standalone_checklist(
 ):
     """Standalone checklists are cloned to the destination client without any run or execution."""
     source_checklist = _create_checklist_with_content(
-        source_client, title=f"migration-e2e-standalone-checklist-{uuid4()}", is_published=True
+        source_client,
+        title=f"migration-e2e-standalone-checklist-{uuid4()}",
+        description="standalone checklist description",
+        labels=["migration-e2e"],
+        properties={"checklist-prop": "checklist-val"},
+        is_published=True,
     )
     register_cleanup(source_checklist.archive)
 
@@ -706,6 +711,9 @@ def test_migrate_standalone_checklist(
     dest_checklist = dest_client.get_checklist(dest_checklist_rid)
     register_cleanup(dest_checklist.archive)
     assert dest_checklist.name == source_checklist.name
+    assert dest_checklist.description == source_checklist.description
+    assert set(dest_checklist.labels) == set(source_checklist.labels)
+    assert dest_checklist.properties == source_checklist.properties
 
 
 def test_migration_idempotency(


### PR DESCRIPTION
## Summary
Adds the ability to migrate **standalone checklists** (not tied to assets) given a list of checklist RIDs, mirroring the existing `standalone_workbook_template_rids` flow.

Only the checklist *definition* is cloned (via `ChecklistMigrator.copy_from` — `clone()` is unsupported for checklists). No run or execution is involved. Channel references resolve at execution time against whatever run the checklist is later run against, provided that run exposes matching data-source **ref names** and **channel names** (and tags, if any). This is the same portability mechanism checklists already rely on, so no new constraint is introduced.

## Changes
- `config/migration_resources.py` — add `source_standalone_checklists`
- `migration_cli.py` — parse `standalone_checklist_rids`; surface the key in the generated `prep` config; include count in log
- `parallel_migration_runner.py` (the path the CLI uses) and `migration_runner.py` (sequential, for parity with e2e tests) — clone via `copy_from(checklist, ChecklistCopyOptions())`
- `sample_migration_config.yml` + `README.md` — document the new key and the resolution caveat
- `tests/e2e/migration/test_migration.py` — `test_migrate_standalone_checklist`

## Usage
```yaml
migration:
  standalone_checklist_rids:
    - ri.scout.main.checklist.<uuid>
```

## Verification
- `just check-format`, `just check-imports`, `just check-types` (mypy strict, py3.10–3.14) — pass
- `just test` (unit) — 348 passed
- Migration e2e runs in CI (needs staging credentials)
- Ran a manual test checklist clone to verify checklist cloning without data still resolves an execution once data is available, via a test from demo-sandbox to staging-sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)