### PR TITLE
chore: bump nominal-api and nominal-api-protos to 0.1292.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "conjure-python-client>=3.1.0,<4",
     "exceptiongroup>=1.3.0",
-    "nominal-api==0.1287.0",
-    "nominal-api-protos==0.1287.0",
+    "nominal-api==0.1292.1",
+    "nominal-api-protos==0.1292.1",
     "truststore>=0.10.4",
     "typing-extensions>=4,<5",
     "pandas>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -858,8 +858,8 @@ requires-dist = [
     { name = "conjure-python-client", specifier = ">=3.1.0,<4" },
     { name = "exceptiongroup", specifier = ">=1.3.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
-    { name = "nominal-api", specifier = "==0.1287.0" },
-    { name = "nominal-api-protos", specifier = "==0.1287.0" },
+    { name = "nominal-api", specifier = "==0.1292.1" },
+    { name = "nominal-api-protos", specifier = "==0.1292.1" },
     { name = "nominal-streaming", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')", specifier = "==0.8.2" },
     { name = "nominal-tdms", marker = "extra == 'tdms'", editable = "packages/nominal-tdms" },
     { name = "nominal-video", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin' and extra == 'video') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'video') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'video') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32' and extra == 'video')", specifier = "==0.1.9" },
@@ -900,19 +900,19 @@ dev = [
 
 [[package]]
 name = "nominal-api"
-version = "0.1287.0"
+version = "0.1292.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "conjure-python-client" },
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/d7/eb9f769494dfd8efc46bc7a312751aaa6a79417ed5f567cbd962c2c7d9c3/nominal_api-0.1287.0-py3-none-any.whl", hash = "sha256:91669a125dd06b36ada3d22eb2747dcad6e42166ac4125ef6c14f3f38efcc78b", size = 896466, upload-time = "2026-06-25T15:19:00.909Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/a5/19ac0c95abc4bdc88b76b78cfb0754434843c91c50d7b56357f5fd8a9afa/nominal_api-0.1292.1-py3-none-any.whl", hash = "sha256:e1b3b1024b3ec03c36f1fca8d9b42414da52ea24641bf12913f6a91be13f3f30", size = 901847, upload-time = "2026-06-27T01:06:00.902Z" },
 ]
 
 [[package]]
 name = "nominal-api-protos"
-version = "0.1287.0"
+version = "0.1292.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -921,7 +921,7 @@ dependencies = [
     { name = "protobuf" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/22/e9997fe6288ec2ca69d3e84e9ac7fa92f6cbc22c335884d17248df80eb44/nominal_api_protos-0.1287.0-py3-none-any.whl", hash = "sha256:cddd02c727f4f32699099e3e7629aed65b19304e034f176931744b6eef410870", size = 476743, upload-time = "2026-06-25T15:19:02.308Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/7d/c7da3f8f6b7615ac18968eeae2d053f20c4396d0470827e1123cffa5182a/nominal_api_protos-0.1292.1-py3-none-any.whl", hash = "sha256:84a40d9c1f31ddd18a90045b0df4f974aaabe7030f0372ea5fcd6786c359b24b", size = 486211, upload-time = "2026-06-27T01:06:02.689Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `nominal-api` and `nominal-api-protos` from 0.1287.0 to 0.1292.1 in `pyproject.toml` and `uv.lock`.

Diff manually reviewed by @drake-nominal. The conjure (`nominal-api`) changes are additive/behavioral with no breaking client references. The proto bump's only flagged breaking change (`file_store.v1.File` removed) was confirmed safe on manual review.

Changes are limited to the two version pins and their lockfile entries.