### PR TITLE
feat: improve containerized extractor image registration

### DIFF
--- a/examples/containerized-extractor-ci/README.md
+++ b/examples/containerized-extractor-ci/README.md
@@ -1,0 +1,66 @@
+# Containerized Extractor CI Examples
+
+These examples show a generic image create/update flow for Nominal containerized extractors.
+
+They are templates. Copy the workflow for your CI provider into your extractor repository, then set provider secrets and variables.
+
+## Required CI Values
+
+Store these as CI secrets or protected variables:
+
+| Name | Purpose |
+| --- | --- |
+| `NOMINAL_API_KEY` | Nominal API token |
+| `NOMINAL_API_URL` | Nominal API base URL |
+| `NOMINAL_WORKSPACE_RID` | Target workspace RID |
+
+Set `NOMINAL_SDK_REF` or the GitHub workflow input `nominal-sdk-ref` to the Nominal Python SDK branch, tag, or commit SHA you want to test.
+
+## Flow
+
+1. Build one Docker tarball per platform.
+2. Use immutable tags shaped like `<branch>-<short-sha>-<platform>`.
+3. Install the Nominal Python SDK from a Git ref.
+4. Upsert the extractor by exact name.
+5. Register each image tarball with `reuse_existing=True`.
+6. Wait until the image is `READY`.
+7. Activate the selected runtime platform.
+
+The examples do not push to any external registry. They upload Docker tarballs through the Nominal SDK.
+
+The GitLab template assumes a runner that permits privileged Docker commands for Docker-in-Docker and QEMU setup.
+
+## Current Registry Limits
+
+Nominal container image tags are immutable. Use a new tag for every source revision. The sample workflows generate
+tags from the Git branch, short commit SHA, and platform.
+
+Only one container image RID is active on a containerized extractor. The sample workflows register one image per
+platform, then activate the platform selected by `ACTIVE_PLATFORM`. Set it to the runtime platform for the target
+Nominal deployment, usually `linux/amd64`. When registering exactly one image, the helper activates that image by
+default.
+
+Some registry deployments can reject repeated uploads of a Docker layer that already exists in the workspace. Set
+`squash_before_registering` to `true` in the config, or pass `--squash-before-registering`, to make the SDK flatten
+the Docker archive before upload. This uses Docker load, container export, image import, and image save locally. It
+requires the Docker CLI and removes layer sharing/history from the uploaded archive.
+
+Use these sample workflows when setting up GitHub or GitLab repositories that publish Nominal registry container images
+and create or update containerized extractors.
+
+## Files
+
+| File | Use |
+| --- | --- |
+| `github-actions.yml` | Copy to `.github/workflows/deploy-containerized-extractor.yml` |
+| `gitlab-ci.yml` | Copy to `.gitlab-ci.yml` or include from an existing GitLab pipeline |
+| `deploy_containerized_extractor.py` | CI helper using SDK client primitives |
+| `extractor-config.example.json` | Generic extractor contract |
+
+## Notes
+
+- `output_format` defaults to `MANIFEST` in the example config.
+- Timestamp metadata uses absolute epoch microseconds.
+- File suffixes should omit leading dots.
+- Set `ACTIVE_PLATFORM` to the platform that should run in the target deployment.
+- Docker Buildx exports one Docker archive per platform because tarball upload workflows should not depend on an external container registry.

--- a/examples/containerized-extractor-ci/deploy_containerized_extractor.py
+++ b/examples/containerized-extractor-ci/deploy_containerized_extractor.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+from dataclasses import dataclass
+from os import environ
+from pathlib import Path
+from typing import Any, Sequence
+
+from nominal import ts
+from nominal.core import (
+    FileExtractionInput,
+    FileExtractionParameter,
+    FileOutputFormat,
+    NominalClient,
+    TimestampMetadata,
+)
+
+logger = logging.getLogger(__name__)
+_TAG_COMPONENT_PATTERN = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+@dataclass(frozen=True)
+class ImageSpec:
+    platform: str
+    tarball: Path
+
+
+def _safe_platform(platform: str) -> str:
+    return platform.replace("/", "-")
+
+
+def _safe_tag_component(value: str) -> str:
+    sanitized = _TAG_COMPONENT_PATTERN.sub("-", value).strip(".-")
+    if not sanitized:
+        raise ValueError("image tag prefix must contain at least one Docker tag character")
+    return sanitized
+
+
+def _parse_image_spec(value: str) -> ImageSpec:
+    platform, separator, tarball = value.partition("=")
+    if separator == "" or not platform or not tarball:
+        raise argparse.ArgumentTypeError("image must use PLATFORM=TARBALL, for example linux/amd64=dist/image.tar")
+    return ImageSpec(platform=platform, tarball=Path(tarball))
+
+
+def _read_config(path: Path) -> dict[str, Any]:
+    config: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    return config
+
+
+def _parse_timestamp_type(value: str) -> ts.TypedTimestampType:
+    normalized = value.lower()
+    if normalized in {"iso8601", "iso_8601"}:
+        return ts.Iso8601()
+    if normalized.startswith("epoch_"):
+        return ts.Epoch(normalized.removeprefix("epoch_"))  # type: ignore[arg-type]
+    raise ValueError("timestamp.type must be iso_8601 or epoch_<unit>")
+
+
+def _parse_inputs(config: dict[str, Any]) -> Sequence[FileExtractionInput]:
+    inputs = []
+    for item in config.get("inputs", []):
+        inputs.append(
+            FileExtractionInput(
+                name=str(item["name"]),
+                environment_variable=str(item["environment_variable"]),
+                file_suffixes=tuple(str(suffix).lstrip(".") for suffix in item.get("file_suffixes", [])),
+                description=item.get("description"),
+                required=bool(item.get("required", False)),
+            )
+        )
+    return tuple(inputs)
+
+
+def _parse_parameters(config: dict[str, Any]) -> Sequence[FileExtractionParameter]:
+    parameters = []
+    for item in config.get("parameters", []):
+        parameters.append(
+            FileExtractionParameter(
+                name=str(item["name"]),
+                environment_variable=str(item["environment_variable"]),
+                description=item.get("description"),
+                required=bool(item.get("required", False)),
+            )
+        )
+    return tuple(parameters)
+
+
+def _parse_timestamp(config: dict[str, Any]) -> TimestampMetadata:
+    timestamp = config["timestamp"]
+    return TimestampMetadata(
+        series_name=str(timestamp["series_name"]),
+        timestamp_type=_parse_timestamp_type(str(timestamp["type"])),
+    )
+
+
+def _parse_output_format(config: dict[str, Any]) -> FileOutputFormat:
+    return FileOutputFormat[str(config.get("output_format", "MANIFEST")).upper()]
+
+
+def _validate_tarballs(images: Sequence[ImageSpec]) -> None:
+    missing = [str(image.tarball) for image in images if not image.tarball.is_file()]
+    if missing:
+        raise FileNotFoundError(f"Missing image tarballs: {', '.join(missing)}")
+
+
+def _read_api_key(api_key: str | None, api_key_env: str) -> str:
+    if api_key is not None:
+        return api_key
+    value = environ.get(api_key_env)
+    if not value:
+        raise ValueError(f"API key not provided; set {api_key_env} or pass --api-key")
+    return value
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Deploy Nominal containerized extractor images from Docker tarballs.")
+    parser.add_argument("--api-url", required=True)
+    parser.add_argument("--api-key")
+    parser.add_argument("--api-key-env", default="NOMINAL_API_KEY")
+    parser.add_argument("--workspace-rid", required=True)
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("--image", required=True, action="append", type=_parse_image_spec)
+    parser.add_argument("--image-tag-prefix", required=True)
+    parser.add_argument("--active-platform")
+    parser.add_argument("--squash-before-registering", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    config = _read_config(args.config)
+    images: Sequence[ImageSpec] = tuple(args.image)
+    _validate_tarballs(images)
+    image_tag_prefix = _safe_tag_component(args.image_tag_prefix)
+
+    active_platform = args.active_platform
+    image_platforms = {image.platform for image in images}
+    if active_platform is None:
+        if len(image_platforms) == 1:
+            active_platform = next(iter(image_platforms))
+        else:
+            raise ValueError("--active-platform is required when registering multiple platforms")
+    if active_platform is not None and active_platform not in image_platforms:
+        raise ValueError(f"active platform '{active_platform}' has no matching --image entry")
+    squash_before_registering = args.squash_before_registering or bool(config.get("squash_before_registering", False))
+
+    inputs = _parse_inputs(config)
+    parameters = _parse_parameters(config)
+    timestamp = _parse_timestamp(config)
+    output_format = _parse_output_format(config)
+
+    logger.info("deploying extractor name=%s workspace=%s", config["name"], args.workspace_rid)
+    logger.info("registering platforms=%s active_platform=%s", sorted(image_platforms), active_platform)
+    logger.info("squash_before_registering=%s", squash_before_registering)
+
+    if args.dry_run:
+        logger.info("dry run complete")
+        return
+
+    client = NominalClient.from_token(
+        _read_api_key(args.api_key, args.api_key_env), args.api_url, workspace_rid=args.workspace_rid
+    )
+    extractor = client.upsert_containerized_extractor(
+        str(config["name"]),
+        description=config.get("description"),
+        workspace=args.workspace_rid,
+    )
+    logger.info("using extractor rid=%s name=%s", extractor.rid, extractor.name)
+
+    for image in images:
+        image_tag = f"{image_tag_prefix}-{_safe_platform(image.platform)}"
+        activate = image.platform == active_platform
+        registered = extractor.register_image(
+            image.tarball,
+            tag=image_tag,
+            inputs=inputs,
+            parameters=parameters,
+            default_timestamp_column=timestamp.series_name,
+            default_timestamp_type=timestamp.timestamp_type,
+            output_format=output_format,
+            reuse_existing=True,
+            wait_until_ready=True,
+            activate=activate,
+            squash_before_registering=squash_before_registering,
+        )
+        logger.info(
+            "registered image rid=%s tag=%s status=%s activate=%s",
+            registered.rid,
+            registered.tag,
+            registered.status.name,
+            activate,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/containerized-extractor-ci/extractor-config.example.json
+++ b/examples/containerized-extractor-ci/extractor-config.example.json
@@ -1,0 +1,20 @@
+{
+  "name": "Example Containerized Extractor",
+  "description": "Generic manifest extractor example",
+  "output_format": "MANIFEST",
+  "squash_before_registering": false,
+  "timestamp": {
+    "series_name": "timestamp",
+    "type": "epoch_microseconds"
+  },
+  "inputs": [
+    {
+      "name": "Input file",
+      "environment_variable": "INPUT_FILE",
+      "file_suffixes": ["bin", "dat"],
+      "description": "Primary file consumed by the extractor",
+      "required": true
+    }
+  ],
+  "parameters": []
+}

--- a/examples/containerized-extractor-ci/github-actions.yml
+++ b/examples/containerized-extractor-ci/github-actions.yml
@@ -1,0 +1,82 @@
+name: Deploy Nominal containerized extractor
+
+on:
+  workflow_dispatch:
+    inputs:
+      nominal-sdk-ref:
+        description: "Nominal Python SDK branch, tag, or commit SHA"
+        required: true
+        default: "main"
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+env:
+  ACTIVE_PLATFORM: "linux/amd64"
+  EXTRACTOR_IMAGE_NAME: "example-containerized-extractor"
+  NOMINAL_SDK_REF: "main"
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.x"
+          enable-cache: false
+
+      - name: Select SDK package
+        run: |
+          sdk_ref="${{ inputs['nominal-sdk-ref'] }}"
+          if [ -z "$sdk_ref" ]; then
+            sdk_ref="$NOMINAL_SDK_REF"
+          fi
+          echo "NOMINAL_SDK_PACKAGE=nominal @ git+https://github.com/nominal-io/nominal-client.git@${sdk_ref}" >> "$GITHUB_ENV"
+
+      - name: Compute immutable image tag prefix
+        run: |
+          branch="$(printf '%s' "$GITHUB_REF_NAME" | tr -c 'A-Za-z0-9_.-' '-' | sed 's/^-*//; s/-*$//; s/--*/-/g')"
+          short_sha="${GITHUB_SHA::7}"
+          echo "IMAGE_TAG_PREFIX=${branch}-${short_sha}" >> "$GITHUB_ENV"
+
+      - name: Build Docker tarballs
+        run: |
+          mkdir -p dist
+          for platform in linux/amd64 linux/arm64; do
+            safe_platform="$(printf '%s' "$platform" | tr '/' '-')"
+            docker buildx build \
+              --platform "$platform" \
+              --tag "${EXTRACTOR_IMAGE_NAME}:${IMAGE_TAG_PREFIX}-${safe_platform}" \
+              --output "type=docker,dest=dist/${EXTRACTOR_IMAGE_NAME}-${safe_platform}.tar" \
+              .
+          done
+
+      - name: Register images and update extractor
+        env:
+          NOMINAL_API_KEY: ${{ secrets.NOMINAL_API_KEY }}
+        run: |
+          uv run --with "$NOMINAL_SDK_PACKAGE" \
+            python examples/containerized-extractor-ci/deploy_containerized_extractor.py \
+              --api-url "${{ vars.NOMINAL_API_URL }}" \
+              --api-key-env NOMINAL_API_KEY \
+              --workspace-rid "${{ vars.NOMINAL_WORKSPACE_RID }}" \
+              --config examples/containerized-extractor-ci/extractor-config.example.json \
+              --image-tag-prefix "$IMAGE_TAG_PREFIX" \
+              --active-platform "$ACTIVE_PLATFORM" \
+              --image "linux/amd64=dist/${EXTRACTOR_IMAGE_NAME}-linux-amd64.tar" \
+              --image "linux/arm64=dist/${EXTRACTOR_IMAGE_NAME}-linux-arm64.tar"

--- a/examples/containerized-extractor-ci/gitlab-ci.yml
+++ b/examples/containerized-extractor-ci/gitlab-ci.yml
@@ -1,0 +1,46 @@
+stages:
+  - deploy
+
+deploy_nominal_containerized_extractor:
+  stage: deploy
+  image: docker:27
+  services:
+    - name: docker:27-dind
+  variables:
+    ACTIVE_PLATFORM: "linux/amd64"
+    DOCKER_TLS_CERTDIR: "/certs"
+    EXTRACTOR_IMAGE_NAME: "example-containerized-extractor"
+    NOMINAL_SDK_REF: "main"
+  before_script:
+    - apk add --no-cache bash curl git python3
+    - curl -LsSf https://astral.sh/uv/install.sh | sh
+    - export PATH="$HOME/.local/bin:$PATH"
+    - docker buildx create --use
+    - docker run --privileged --rm tonistiigi/binfmt --install arm64
+  script:
+    - export IMAGE_TAG_PREFIX="${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}"
+    - export NOMINAL_SDK_PACKAGE="nominal @ git+https://github.com/nominal-io/nominal-client.git@${NOMINAL_SDK_REF}"
+    - mkdir -p dist
+    - |
+      for platform in linux/amd64 linux/arm64; do
+        safe_platform="$(printf '%s' "$platform" | tr '/' '-')"
+        docker buildx build \
+          --platform "$platform" \
+          --tag "${EXTRACTOR_IMAGE_NAME}:${IMAGE_TAG_PREFIX}-${safe_platform}" \
+          --output "type=docker,dest=dist/${EXTRACTOR_IMAGE_NAME}-${safe_platform}.tar" \
+          .
+      done
+    - |
+      uv run --with "$NOMINAL_SDK_PACKAGE" \
+        python examples/containerized-extractor-ci/deploy_containerized_extractor.py \
+          --api-url "$NOMINAL_API_URL" \
+          --api-key-env NOMINAL_API_KEY \
+          --workspace-rid "$NOMINAL_WORKSPACE_RID" \
+          --config examples/containerized-extractor-ci/extractor-config.example.json \
+          --image-tag-prefix "$IMAGE_TAG_PREFIX" \
+          --active-platform "$ACTIVE_PLATFORM" \
+          --image "linux/amd64=dist/${EXTRACTOR_IMAGE_NAME}-linux-amd64.tar" \
+          --image "linux/arm64=dist/${EXTRACTOR_IMAGE_NAME}-linux-arm64.tar"
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+    - if: '$CI_PIPELINE_SOURCE == "web"'

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import BinaryIO, Iterable, Mapping, Sequence, overload
 
 import certifi
+import grpc
 from conjure_python_client import ServiceConfiguration, SslConfiguration
 from nominal_api import (
     api,
@@ -127,6 +128,14 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_CONNECT_TIMEOUT = timedelta(seconds=30)
 MAX_ASSETS_SHOWN = 10
+
+
+def _is_grpc_already_exists_error(exc: Exception) -> bool:
+    return (
+        isinstance(exc, NominalError)
+        and isinstance(exc.__cause__, grpc.RpcError)
+        and (exc.__cause__.code() is grpc.StatusCode.ALREADY_EXISTS)
+    )
 
 
 class WorkspaceSearchType(enum.Enum):
@@ -1516,6 +1525,39 @@ class NominalClient:
         """
         return _create_containerized_extractor(self._clients, name, description=description)
 
+    def upsert_containerized_extractor(
+        self, name: str, *, description: str | None = None, workspace: str | Workspace | None = None
+    ) -> ContainerizedExtractor:
+        """Create or update a containerized extractor identified by exact name in one workspace."""
+
+        def exact_matches() -> list[ContainerizedExtractor]:
+            return [
+                extractor
+                for extractor in self.search_containerized_extractors(include_archived=True, workspace=workspace)
+                if extractor.name == name
+            ]
+
+        matches = exact_matches()
+        if len(matches) > 1:
+            raise ValueError(f"Multiple containerized extractors found with name '{name}'")
+        if not matches:
+            try:
+                return self.create_containerized_extractor(name, description=description)
+            except Exception as exc:
+                if not _is_grpc_already_exists_error(exc):
+                    raise
+                matches = exact_matches()
+                if len(matches) == 1:
+                    return matches[0]
+                raise
+
+        extractor = matches[0]
+        new_is_archived = False if extractor.is_archived else None
+        new_description = description if description is not None and extractor.description != description else None
+        if new_is_archived is not None or new_description is not None:
+            extractor.update(description=new_description, is_archived=new_is_archived)
+        return extractor
+
     def get_containerized_extractor(self, rid: str) -> ContainerizedExtractor:
         """Get a containerized extractor by its RID.
 
@@ -1566,6 +1608,7 @@ class NominalClient:
         *,
         tag: str | None = None,
         status: ContainerImageStatus | None = None,
+        extractor_rid: str | None = None,
         workspace: str | Workspace | None = None,
     ) -> Sequence[ContainerImage]:
         """Search for container images meeting the specified filters.
@@ -1575,13 +1618,17 @@ class NominalClient:
         Args:
             tag: If provided, only include images registered with this tag.
             status: If provided, only include images with this status.
+            extractor_rid: If provided, only include images registered against this extractor
+                (filtered client-side).
             workspace: Workspace to search within (the client's default workspace if not provided).
 
         Returns:
             All container images matching all of the provided filters.
         """
         workspace_rid = None if workspace is None else rid_from_instance_or_string(workspace)
-        return _search_container_images(self._clients, tag=tag, status=status, workspace_rid=workspace_rid)
+        return _search_container_images(
+            self._clients, tag=tag, status=status, extractor_rid=extractor_rid, workspace_rid=workspace_rid
+        )
 
     def get_workbook(self, rid: str) -> Workbook:
         """Gets the given workbook by rid."""

--- a/nominal/core/container_image.py
+++ b/nominal/core/container_image.py
@@ -315,6 +315,24 @@ class ContainerImage(HasRid, RefreshableMixin[registry_pb2.ContainerImage]):
                     assert_never(self.status)
             time.sleep(interval.total_seconds())
 
+    def wait_until_ready(self, *, timeout_seconds: float = 300, poll_interval_seconds: float = 2) -> Self:
+        """Poll this image until it reaches READY, or fail when it reaches FAILED."""
+        if timeout_seconds < 0:
+            raise ValueError("timeout_seconds must be non-negative")
+        if poll_interval_seconds <= 0:
+            raise ValueError("poll_interval_seconds must be positive")
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            if self.status is ContainerImageStatus.READY:
+                return self
+            if self.status is ContainerImageStatus.FAILED:
+                raise RuntimeError(f"Container image '{self.rid}' failed registration")
+            now = time.monotonic()
+            if now >= deadline:
+                raise TimeoutError(f"Timed out waiting for container image '{self.rid}' to become READY")
+            time.sleep(min(poll_interval_seconds, deadline - now))
+            self.refresh()
+
     @classmethod
     def _from_proto(cls, clients: _Clients, workspace_rid: str, msg: registry_pb2.ContainerImage) -> Self:
         return cls(
@@ -349,12 +367,15 @@ def _iter_search_container_images(
     *,
     tag: str | None = None,
     status: ContainerImageStatus | None = None,
+    extractor_rid: str | None = None,
     workspace_rid: str | None = None,
 ) -> Iterable[ContainerImage]:
     ws = clients.resolve_workspace(workspace_rid).rid
     search_filter = create_search_container_images_query(tag=tag, status=status)
     for img in search_container_images_paginated(clients.registry, ws, search_filter):
-        yield ContainerImage._from_proto(clients, ws, img)
+        image = ContainerImage._from_proto(clients, ws, img)
+        if extractor_rid is None or image.extractor_rid == extractor_rid:
+            yield image
 
 
 def _search_container_images(
@@ -362,6 +383,11 @@ def _search_container_images(
     *,
     tag: str | None = None,
     status: ContainerImageStatus | None = None,
+    extractor_rid: str | None = None,
     workspace_rid: str | None = None,
 ) -> Sequence[ContainerImage]:
-    return list(_iter_search_container_images(clients, tag=tag, status=status, workspace_rid=workspace_rid))
+    return list(
+        _iter_search_container_images(
+            clients, tag=tag, status=status, extractor_rid=extractor_rid, workspace_rid=workspace_rid
+        )
+    )

--- a/nominal/core/containerized_extractor.py
+++ b/nominal/core/containerized_extractor.py
@@ -8,10 +8,16 @@ exactly one of which is active.
 
 from __future__ import annotations
 
+import json
+import subprocess
+import tempfile
+import uuid
+from contextlib import ExitStack
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, Protocol, Sequence
 
+import grpc
 from nominal_api import upload_api
 from typing_extensions import Self
 
@@ -28,6 +34,7 @@ from nominal.core.container_image import (
     FileExtractionParameter,
     FileOutputFormat,
     TimestampMetadata,
+    _search_container_images,
 )
 from nominal.core.exceptions import NominalContainerImageError
 from nominal.protos.ingest.v2 import containerized_extractor_pb2, containerized_extractor_pb2_grpc
@@ -142,6 +149,25 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
 
         return self.update(active_container_image=image)
 
+    def search_images(
+        self, *, tag: str | None = None, status: ContainerImageStatus | None = None
+    ) -> Sequence[ContainerImage]:
+        """Search images registered against this extractor."""
+        return _search_container_images(
+            self._clients,
+            tag=tag,
+            status=status,
+            extractor_rid=self.rid,
+            workspace_rid=self._workspace_rid,
+        )
+
+    def get_image_by_tag(self, tag: str, *, status: ContainerImageStatus | None = None) -> ContainerImage | None:
+        """Fetch this extractor's image for an immutable tag, returning None when absent."""
+        matches = self.search_images(tag=tag, status=status)
+        if len(matches) > 1:
+            raise ValueError(f"Multiple container images found for extractor '{self.rid}' with tag '{tag}'")
+        return matches[0] if matches else None
+
     def register_image(
         self,
         tarball: Path | str,
@@ -152,12 +178,19 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
         default_timestamp_type: ts._AnyTimestampType,
         output_format: FileOutputFormat = FileOutputFormat.PARQUET,
         parameters: Sequence[FileExtractionParameter] = (),
+        reuse_existing: bool = True,
+        activate: bool = False,
+        wait_until_ready: bool = False,
+        wait_timeout_seconds: float = 300,
+        poll_interval_seconds: float = 2,
+        squash_before_registering: bool = False,
     ) -> ContainerImage:
         """Upload a `docker save` tarball and register it as a container image for this extractor.
 
-        Registering attaches the image to this extractor in Nominal's registry, but does not change
-        which image the extractor runs: the new image starts PENDING (being pushed server-side) and
-        must be activated with `set_active_image` once READY. This extractor instance is unmodified.
+        Tags are immutable. With `reuse_existing=True`, an existing image with the same tag and contract
+        is returned instead of re-uploading. Set `squash_before_registering=True` to flatten the archive
+        before upload (requires the Docker CLI). Registering does not change which image the extractor
+        runs unless `activate=True`.
 
         Args:
             tarball: Path to a `docker save` tarball of the extractor image.
@@ -175,14 +208,18 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
                 `REGISTERABLE_OUTPUT_FORMATS` — the backend cannot currently ingest the others, so
                 registering an image with one would produce an extractor whose ingests always fail.
             parameters: Scalar parameters passed to the extractor.
-
-        Returns:
-            The newly registered image, in `ContainerImageStatus.PENDING`. Wait for it with
-            `ContainerImage.poll_until_ready` (or `set_active_image(..., poll_until_ready=True)`),
-            then activate it before ingesting.
+            reuse_existing: If true, return the already-registered image for this tag (validating it
+                carries the same contract) instead of raising or re-uploading.
+            activate: If true, activate the image on this extractor once it is READY.
+            wait_until_ready: If true, block until the image reaches READY before returning.
+            wait_timeout_seconds: Deadline for `wait_until_ready`.
+            poll_interval_seconds: Poll cadence for `wait_until_ready`.
+            squash_before_registering: If true, flatten the Docker archive to a single layer with the
+                local Docker CLI before uploading.
 
         Raises:
-            ValueError: If `output_format` is not currently ingestible via containerized extraction.
+            ValueError: If `output_format` is not currently ingestible via containerized extraction,
+                or an existing image with this tag carries a different contract.
         """
         if output_format not in REGISTERABLE_OUTPUT_FORMATS:
             supported = ", ".join(sorted(fmt.name for fmt in REGISTERABLE_OUTPUT_FORMATS))
@@ -191,16 +228,31 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
                 f"extraction ingest; an image registered with it could never ingest data successfully. "
                 f"Supported formats: {supported}."
             )
-        s3_path = upload_multipart_file(
-            self._clients.auth_header,
-            self._workspace_rid,
-            Path(tarball),
-            self._clients.upload,
-            header_provider=self._clients.header_provider,
-        )
         timestamp_metadata = TimestampMetadata(
             series_name=default_timestamp_column, timestamp_type=default_timestamp_type
         )
+        if reuse_existing and (existing := self.get_image_by_tag(tag)) is not None:
+            _validate_image_contract(existing, inputs, parameters, output_format, timestamp_metadata)
+            if wait_until_ready:
+                existing.wait_until_ready(
+                    timeout_seconds=wait_timeout_seconds,
+                    poll_interval_seconds=poll_interval_seconds,
+                )
+            if activate:
+                self._activate_ready_image(existing)
+            return existing
+
+        with ExitStack() as stack:
+            tarball_path = Path(tarball)
+            if squash_before_registering:
+                tarball_path = _squash_image_tarball(tarball_path, stack)
+            s3_path = upload_multipart_file(
+                self._clients.auth_header,
+                self._workspace_rid,
+                tarball_path,
+                self._clients.upload,
+                header_provider=self._clients.header_provider,
+            )
         request = registry_pb2.CreateImageRequest(
             workspace_rid=self._workspace_rid,
             tag=tag,
@@ -211,9 +263,33 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
             file_output_format=output_format._to_proto(),
             default_timestamp_metadata=timestamp_metadata._to_proto(),
         )
-        with translate_grpc_errors():
-            response = self._clients.registry.CreateImage(request)
-        return ContainerImage._from_proto(self._clients, self._workspace_rid, response.image)
+        try:
+            with translate_grpc_errors():
+                response = self._clients.registry.CreateImage(request)
+        except Exception as exc:
+            existing = self.get_image_by_tag(tag) if reuse_existing and _is_reusable_create_image_error(exc) else None
+            if existing is None:
+                raise
+            _validate_image_contract(existing, inputs, parameters, output_format, timestamp_metadata)
+            if wait_until_ready:
+                existing.wait_until_ready(
+                    timeout_seconds=wait_timeout_seconds,
+                    poll_interval_seconds=poll_interval_seconds,
+                )
+            if activate:
+                self._activate_ready_image(existing)
+            return existing
+        image = ContainerImage._from_proto(self._clients, self._workspace_rid, response.image)
+        if wait_until_ready:
+            image.wait_until_ready(timeout_seconds=wait_timeout_seconds, poll_interval_seconds=poll_interval_seconds)
+        if activate:
+            self._activate_ready_image(image)
+        return image
+
+    def _activate_ready_image(self, image: ContainerImage) -> None:
+        if image.status is not ContainerImageStatus.READY:
+            raise ValueError(f"Cannot activate container image '{image.rid}' while status is {image.status.name}")
+        self.update(active_container_image=image)
 
     @classmethod
     def _from_proto(cls, clients: _Clients, msg: containerized_extractor_pb2.ContainerizedExtractor) -> Self:
@@ -284,3 +360,143 @@ def _search_containerized_extractors(
             clients, include_archived=include_archived, file_extension=file_extension, workspace_rid=workspace_rid
         )
     )
+
+def _is_reusable_create_image_error(exc: Exception) -> bool:
+    if not isinstance(exc.__cause__, grpc.RpcError):
+        return False
+    rpc_error = exc.__cause__
+    if rpc_error.code() is grpc.StatusCode.ALREADY_EXISTS:
+        return True
+    details = (rpc_error.details() or "").lower()
+    return (
+        rpc_error.code() is grpc.StatusCode.INTERNAL
+        and "failed to push image to registry" in details
+        and ("blobalreadyexists" in details or "already exists" in details)
+    )
+
+
+def _validate_image_contract(
+    image: ContainerImage,
+    inputs: Sequence[FileExtractionInput],
+    parameters: Sequence[FileExtractionParameter],
+    output_format: FileOutputFormat,
+    timestamp: TimestampMetadata,
+) -> None:
+    mismatches = []
+    if tuple(image.inputs) != tuple(inputs):
+        mismatches.append("inputs")
+    if tuple(image.parameters) != tuple(parameters):
+        mismatches.append("parameters")
+    if image.file_output_format is not output_format:
+        mismatches.append("output_format")
+    if (
+        image.default_timestamp_metadata is None
+        or image.default_timestamp_metadata._to_proto() != timestamp._to_proto()
+    ):
+        mismatches.append("timestamp")
+    if mismatches:
+        joined = ", ".join(mismatches)
+        raise ValueError(f"Existing container image '{image.rid}' has a different registration contract: {joined}")
+
+
+def _run_docker(args: Sequence[str]) -> str:
+    try:
+        completed = subprocess.run(
+            ["docker", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("Docker CLI is required to squash an image before registering it") from exc
+    except subprocess.CalledProcessError as exc:
+        output = "\n".join(part for part in [exc.stdout, exc.stderr] if part)
+        raise RuntimeError(f"Docker command failed: docker {' '.join(args)}\n{output}") from exc
+    return "\n".join(part for part in [completed.stdout, completed.stderr] if part)
+
+
+def _run_docker_best_effort(args: Sequence[str]) -> None:
+    try:
+        _run_docker(args)
+    except RuntimeError:
+        pass
+
+
+def _parse_docker_load_image_ref(output: str) -> str:
+    refs = []
+    for line in output.splitlines():
+        if line.startswith("Loaded image: "):
+            refs.append(line.removeprefix("Loaded image: ").strip())
+        elif line.startswith("Loaded image ID: "):
+            refs.append(line.removeprefix("Loaded image ID: ").strip())
+    refs = sorted(set(ref for ref in refs if ref))
+    if len(refs) != 1:
+        raise RuntimeError(f"Expected docker load to produce exactly one image reference; got {refs!r}")
+    return refs[0]
+
+
+def _image_platform(inspected: dict[str, object]) -> str | None:
+    os_name = inspected.get("Os")
+    architecture = inspected.get("Architecture")
+    if not isinstance(os_name, str) or not isinstance(architecture, str):
+        return None
+    platform = f"{os_name}/{architecture}"
+    variant = inspected.get("Variant")
+    if isinstance(variant, str) and variant:
+        platform = f"{platform}/{variant}"
+    return platform
+
+
+def _image_config_to_import_changes(config: dict[str, object]) -> Sequence[str]:
+    changes = []
+    if entrypoint := config.get("Entrypoint"):
+        changes.append(f"ENTRYPOINT {json.dumps(entrypoint, separators=(',', ':'))}")
+    if cmd := config.get("Cmd"):
+        changes.append(f"CMD {json.dumps(cmd, separators=(',', ':'))}")
+    if (env := config.get("Env")) and isinstance(env, list):
+        changes.extend(f"ENV {item}" for item in env if isinstance(item, str))
+    if (workdir := config.get("WorkingDir")) and isinstance(workdir, str):
+        changes.append(f"WORKDIR {workdir}")
+    if (user := config.get("User")) and isinstance(user, str):
+        changes.append(f"USER {user}")
+    if (stop_signal := config.get("StopSignal")) and isinstance(stop_signal, str):
+        changes.append(f"STOPSIGNAL {stop_signal}")
+    if (exposed_ports := config.get("ExposedPorts")) and isinstance(exposed_ports, dict):
+        changes.append(f"EXPOSE {' '.join(sorted(exposed_ports))}")
+    if (volumes := config.get("Volumes")) and isinstance(volumes, dict):
+        changes.append(f"VOLUME {json.dumps(sorted(volumes), separators=(',', ':'))}")
+    if (labels := config.get("Labels")) and isinstance(labels, dict):
+        for key, value in sorted(labels.items()):
+            changes.append(f"LABEL {key}={json.dumps(str(value), separators=(',', ':'))}")
+    if (on_build := config.get("OnBuild")) and isinstance(on_build, list):
+        changes.extend(f"ONBUILD {item}" for item in on_build if isinstance(item, str))
+    return tuple(changes)
+
+
+def _squash_image_tarball(tarball: Path, stack: ExitStack) -> Path:
+    """Flatten a Docker archive using load/export/import/save before uploading."""
+    temp_dir = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="nominal-image-squash-")))
+    loaded_ref = _parse_docker_load_image_ref(_run_docker(["image", "load", "--input", str(tarball)]))
+    inspected = json.loads(_run_docker(["image", "inspect", loaded_ref, "--format", "{{json .}}"]))
+    config = inspected.get("Config")
+    changes = _image_config_to_import_changes(config if isinstance(config, dict) else {})
+    platform = _image_platform(inspected)
+
+    container_id = _run_docker(["container", "create", loaded_ref]).strip()
+    stack.callback(_run_docker_best_effort, ["container", "rm", "-f", container_id])
+    rootfs = temp_dir / "rootfs.tar"
+    _run_docker(["container", "export", "--output", str(rootfs), container_id])
+
+    squashed_ref = f"nominal-sdk-squashed:{uuid.uuid4().hex}"
+    import_args = ["image", "import"]
+    if platform is not None:
+        import_args.append(f"--platform={platform}")
+    for change in changes:
+        import_args.extend(["--change", change])
+    import_args.extend([str(rootfs), squashed_ref])
+    _run_docker(import_args)
+    stack.callback(_run_docker_best_effort, ["image", "rm", "-f", squashed_ref])
+
+    squashed_tarball = temp_dir / "squashed-image.tar"
+    _run_docker(["image", "save", "--output", str(squashed_tarball), squashed_ref])
+    return squashed_tarball

--- a/tests/core/test_container_image.py
+++ b/tests/core/test_container_image.py
@@ -146,3 +146,20 @@ def test_enum_from_proto_falls_back_to_unspecified_on_unknown_value() -> None:
     """A value a newer server might return (unknown to this SDK) decodes to UNSPECIFIED, not a crash."""
     assert FileOutputFormat._from_proto(999) is FileOutputFormat.UNSPECIFIED
     assert ContainerImageStatus._from_proto(999) is ContainerImageStatus.UNSPECIFIED
+
+
+def test_search_images_can_filter_by_extractor_rid() -> None:
+    """Extractor scoping filters registry search results client-side."""
+    clients = _clients()
+    img_other = _img("i1")
+    img_other.extractor_rid = "ri.ext.1"
+    img_match = _img("i2")
+    img_match.extractor_rid = "ri.ext.2"
+    clients.registry.SearchImages.return_value = registry_pb2.SearchImagesResponse(
+        images=[img_other, img_match],
+        next_page_token="",
+    )
+
+    results = _search_container_images(clients, extractor_rid="ri.ext.2", workspace_rid=None)
+
+    assert [i.rid for i in results] == ["i2"]

--- a/tests/core/test_containerized_extractor.py
+++ b/tests/core/test_containerized_extractor.py
@@ -4,15 +4,19 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from nominal.core.container_image import FileOutputFormat
+from nominal import ts
+from nominal.core.client import NominalClient
+from nominal.core.container_image import ContainerImageStatus, FileOutputFormat
 from nominal.core.containerized_extractor import (
     ContainerizedExtractor,
     _create_containerized_extractor,
+    _parse_docker_load_image_ref,
     _search_containerized_extractors,
 )
 from nominal.core.exceptions import NominalContainerImageError
 from nominal.protos.ingest.v2 import containerized_extractor_pb2
 from nominal.protos.registry.v2 import registry_pb2
+from nominal.protos.types.time import timestamp_parsers_pb2
 
 
 def _clients() -> MagicMock:
@@ -29,8 +33,26 @@ def _ext(rid: str) -> containerized_extractor_pb2.ContainerizedExtractor:
     )
 
 
-def _img(rid: str, status: registry_pb2.ContainerImageStatus.ValueType) -> registry_pb2.ContainerImage:
-    return registry_pb2.ContainerImage(rid=rid, tag="v1", extractor_rid="ri.ext", status=status)
+def _img(
+    rid: str,
+    status: registry_pb2.ContainerImageStatus.ValueType,
+    *,
+    tag: str = "v1",
+    extractor_rid: str = "ri.ext",
+) -> registry_pb2.ContainerImage:
+    return registry_pb2.ContainerImage(
+        rid=rid,
+        tag=tag,
+        extractor_rid=extractor_rid,
+        status=status,
+        file_output_format=registry_pb2.FILE_OUTPUT_FORMAT_PARQUET,
+        default_timestamp_metadata=registry_pb2.TimestampMetadata(
+            series_name="ts",
+            timestamp_type=timestamp_parsers_pb2.TimestampType(
+                absolute=timestamp_parsers_pb2.AbsoluteTimestamp(iso8601=timestamp_parsers_pb2.Iso8601Timestamp())
+            ),
+        ),
+    )
 
 
 def test_search_extractors_follows_pagination_cursors() -> None:
@@ -137,3 +159,138 @@ def test_set_active_image_polls_then_activates() -> None:
     assert clients.registry.GetImage.call_args_list[0].args[0].workspace_rid == "ri.workspace.default"
     update_request = clients.containerized_extractor.UpdateContainerizedExtractor.call_args.args[0]
     assert update_request.active_container_image_rid == "ri.img.1"
+
+
+def test_client_upsert_containerized_extractor_updates_existing_match() -> None:
+    """CI can update an existing extractor by exact name without knowing its RID."""
+    clients = _clients()
+    existing = containerized_extractor_pb2.ContainerizedExtractor(
+        rid="ri.ext",
+        workspace_rid="ri.workspace.default",
+        name="parser",
+        description="old",
+        is_archived=True,
+    )
+    updated = containerized_extractor_pb2.ContainerizedExtractor(
+        rid="ri.ext",
+        workspace_rid="ri.workspace.default",
+        name="parser",
+        description="new",
+        is_archived=False,
+    )
+    clients.containerized_extractor.SearchContainerizedExtractors.return_value = (
+        containerized_extractor_pb2.SearchContainerizedExtractorsResponse(extractors=[existing])
+    )
+    clients.containerized_extractor.UpdateContainerizedExtractor.return_value = (
+        containerized_extractor_pb2.UpdateContainerizedExtractorResponse(extractor=updated)
+    )
+    client = NominalClient(_clients=clients)
+
+    extractor = client.upsert_containerized_extractor("parser", description="new", workspace="ri.workspace.default")
+
+    assert extractor.description == "new"
+    assert extractor.is_archived is False
+    request = clients.containerized_extractor.UpdateContainerizedExtractor.call_args.args[0]
+    assert request.description == "new"
+    assert request.is_archived is False
+
+
+def test_extractor_get_image_by_tag_scopes_to_own_images() -> None:
+    """Tag lookup ignores images with the same tag registered to other extractors."""
+    clients = _clients()
+    clients.registry.SearchImages.return_value = registry_pb2.SearchImagesResponse(
+        images=[
+            _img("i1", registry_pb2.CONTAINER_IMAGE_STATUS_READY, tag="same", extractor_rid="ri.other"),
+            _img("i2", registry_pb2.CONTAINER_IMAGE_STATUS_READY, tag="same", extractor_rid="ri.ext"),
+        ],
+        next_page_token="",
+    )
+    extractor = ContainerizedExtractor._from_proto(clients, _ext("ri.ext"))
+
+    image = extractor.get_image_by_tag("same")
+
+    assert image is not None
+    assert image.rid == "i2"
+
+
+def test_register_image_reuses_existing_matching_contract_and_activates() -> None:
+    """CI can rerun safely when an immutable image tag already exists."""
+    clients = _clients()
+    existing = _img("ri.img.1", registry_pb2.CONTAINER_IMAGE_STATUS_READY, tag="v1", extractor_rid="ri.ext")
+    clients.registry.SearchImages.return_value = registry_pb2.SearchImagesResponse(
+        images=[existing], next_page_token=""
+    )
+    updated = _ext("ri.ext")
+    updated.active_container_image.CopyFrom(existing)
+    clients.containerized_extractor.UpdateContainerizedExtractor.return_value = (
+        containerized_extractor_pb2.UpdateContainerizedExtractorResponse(extractor=updated)
+    )
+    extractor = ContainerizedExtractor._from_proto(clients, _ext("ri.ext"))
+
+    image = extractor.register_image(
+        "unused.tar",
+        tag="v1",
+        inputs=(),
+        default_timestamp_column="ts",
+        default_timestamp_type=ts.Iso8601(),
+        reuse_existing=True,
+        activate=True,
+        wait_until_ready=True,
+    )
+
+    assert image.rid == "ri.img.1"
+    clients.registry.CreateImage.assert_not_called()
+    request = clients.containerized_extractor.UpdateContainerizedExtractor.call_args.args[0]
+    assert request.active_container_image_rid == "ri.img.1"
+
+
+def test_register_image_uploads_waits_and_activates_new_image(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """New image registration uploads the tarball, waits for READY, and activates the image."""
+    from nominal.core import containerized_extractor as module
+
+    tarball = tmp_path / "image.tar"
+    tarball.write_bytes(b"tar")
+    uploaded_paths = []
+
+    def fake_upload(*args, **kwargs) -> str:
+        uploaded_paths.append(args[2])
+        return "s3://bucket/image.tar"
+
+    monkeypatch.setattr(module, "upload_multipart_file", fake_upload)
+    clients = _clients()
+    created = _img("ri.img.1", registry_pb2.CONTAINER_IMAGE_STATUS_PENDING, tag="v1", extractor_rid="ri.ext")
+    ready = _img("ri.img.1", registry_pb2.CONTAINER_IMAGE_STATUS_READY, tag="v1", extractor_rid="ri.ext")
+    clients.registry.SearchImages.return_value = registry_pb2.SearchImagesResponse(images=[], next_page_token="")
+    clients.registry.CreateImage.return_value = registry_pb2.CreateImageResponse(image=created)
+    clients.registry.GetImage.return_value = registry_pb2.GetImageResponse(image=ready)
+    updated = _ext("ri.ext")
+    updated.active_container_image.CopyFrom(ready)
+    clients.containerized_extractor.UpdateContainerizedExtractor.return_value = (
+        containerized_extractor_pb2.UpdateContainerizedExtractorResponse(extractor=updated)
+    )
+    extractor = ContainerizedExtractor._from_proto(clients, _ext("ri.ext"))
+
+    image = extractor.register_image(
+        tarball,
+        tag="v1",
+        inputs=(),
+        default_timestamp_column="ts",
+        default_timestamp_type=ts.Iso8601(),
+        wait_until_ready=True,
+        poll_interval_seconds=0.001,
+        activate=True,
+    )
+
+    assert image.status is ContainerImageStatus.READY
+    assert uploaded_paths == [tarball]
+    create_request = clients.registry.CreateImage.call_args.args[0]
+    assert create_request.object_path == "s3://bucket/image.tar"
+    assert clients.containerized_extractor.UpdateContainerizedExtractor.called
+
+
+def test_parse_docker_load_image_ref_requires_one_loaded_ref() -> None:
+    """Squash helper accepts Docker's image-ref and image-id load output variants."""
+    assert _parse_docker_load_image_ref("Loaded image: repo/image:tag\n") == "repo/image:tag"
+    assert _parse_docker_load_image_ref("Loaded image ID: sha256:abc\n") == "sha256:abc"
+    with pytest.raises(RuntimeError, match="exactly one image reference"):
+        _parse_docker_load_image_ref("Loaded image: a\nLoaded image: b\n")


### PR DESCRIPTION
## Summary

- Add reusable image registration helpers for containerized extractors, including exact-name extractor upsert, image lookup by tag, ready polling, activation, and optional Docker archive squashing before registry upload.
- Update dataset containerized ingest preflight to validate the selected active or tagged image before upload.
- Add sanitized GitHub and GitLab CI examples for building Docker tarballs and registering containerized extractor images without an external registry.

## Notes

- `squash_before_registering` is opt-in and uses local Docker load/export/import/save before upload.
- The example workflows use immutable branch/short-SHA/platform image tags and activate a selected runtime platform.
- Example docs describe current registry constraints and avoid deployment-specific identifiers.

## Verification

- `uv run ruff check nominal/core/client.py nominal/core/containerized_extractor.py nominal/core/dataset.py tests/core/test_containerized_extractor.py tests/core/test_dataset_add_containerized.py examples/containerized-extractor-ci/deploy_containerized_extractor.py`
- `uv run mypy -m nominal.core.containerized_extractor -m nominal.core.client -m nominal.core.dataset`
- `uv run pytest tests/core/test_containerized_extractor.py tests/core/test_dataset_add_containerized.py`
- Example JSON/YAML parse and helper dry-runs