### PR TITLE
fix(migration): allow empty/absent source_asset_rids

### DIFF
--- a/nominal/experimental/migration/migration_cli.py
+++ b/nominal/experimental/migration/migration_cli.py
@@ -113,8 +113,12 @@ def _load_asset_resources(
         raise click.UsageError("Provide only one of 'migration.source_asset_rids' or 'migration.source_assets'.")
 
     if source_assets is None:
-        if not isinstance(asset_rids, list) or not asset_rids:
-            raise click.UsageError("'migration.source_asset_rids' must be a non-empty list.")
+        # An absent or empty source_asset_rids means no assets to migrate; skip straight to
+        # standalone_workbook_template_rids rather than failing.
+        if asset_rids is None or asset_rids == []:
+            return {}
+        if not isinstance(asset_rids, list):
+            raise click.UsageError("'migration.source_asset_rids' must be a list.")
         return _load_asset_resources_from_list(source_client, asset_rids)
 
     if not isinstance(source_assets, dict) or not source_assets:

--- a/tests/core/test_migration_source_assets.py
+++ b/tests/core/test_migration_source_assets.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock
+
+import pytest
+from click import UsageError
+
+from nominal.experimental.migration.migration_cli import _load_asset_resources
+
+
+def test_load_asset_resources_none_returns_empty() -> None:
+    """An absent source_asset_rids should yield no assets rather than erroring."""
+    assert _load_asset_resources(MagicMock(), None, None) == {}
+
+
+def test_load_asset_resources_empty_list_returns_empty() -> None:
+    """An explicitly empty source_asset_rids should yield no assets rather than erroring."""
+    assert _load_asset_resources(MagicMock(), [], None) == {}
+
+
+def test_load_asset_resources_non_list_rejected() -> None:
+    """A non-list, non-empty source_asset_rids is still a config error."""
+    with pytest.raises(UsageError, match="must be a list"):
+        _load_asset_resources(MagicMock(), "ri.asset", None)
+
+
+def test_load_asset_resources_rejects_both_provided() -> None:
+    """Providing both source_asset_rids and source_assets is ambiguous."""
+    with pytest.raises(UsageError, match="only one of"):
+        _load_asset_resources(MagicMock(), ["ri.asset"], {"ri.asset": {}})


### PR DESCRIPTION
## Problem

In the migration runner (`nominal/experimental/migration`), `_load_asset_resources` required `migration.source_asset_rids` to be a non-empty list. A config that omits it or sets it to an empty list raised a `UsageError`, even when the intent was to migrate only `standalone_workbook_template_rids`.

## Fix

Treat an absent or empty `source_asset_rids` as "no assets to migrate" — return an empty asset map so the migration skips assets and proceeds to `standalone_workbook_template_rids`. A non-list value (e.g. a bare string) is still rejected as a config error.

## Tests

Added `tests/core/test_migration_source_assets.py` covering: `None`, empty list, non-list rejection, and the both-provided error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)