### PR TITLE
fix: prevent .zip files from being uploaded as .pyz files

### DIFF
--- a/nominal/core/filetype.py
+++ b/nominal/core/filetype.py
@@ -22,7 +22,11 @@ class FileType(NamedTuple):
         #       and lowercase to handle files with mixed capitalization on extensions
         ext_str = "".join(path.suffixes).lower()
 
-        # Attempt to match the file's extension(s) with those already explicitly listed under FileTypes
+        # Attempt to match the file's extension(s) with those already explicitly listed under FileTypes.
+        # When multiple registered extensions match (e.g. both ".zip" and ".parquet.zip" match
+        # "foo.parquet.zip"), prefer the longest/most-specific match so classification does not
+        # depend on the declaration order of FileTypes members.
+        best_match: FileType | None = None
         for file_type in FileTypes.__dict__.values():
             if not isinstance(file_type, cls):
                 # Skip any member variables which are not actually FileTypes
@@ -33,9 +37,13 @@ class FileType(NamedTuple):
                 continue
 
             # If the file ends with the given file extension, regardless of other suffixes it may have
-            # preceeding, then return the file type.
+            # preceeding, then it's a candidate; keep the longest matching extension.
             if ext_str.endswith(file_type.extension):
-                return file_type
+                if best_match is None or len(file_type.extension) > len(best_match.extension):
+                    best_match = file_type
+
+        if best_match is not None:
+            return best_match
 
         # Infer mimetype from filepath
         mimetype, _encoding = mimetypes.guess_type(path)

--- a/nominal/core/filetype.py
+++ b/nominal/core/filetype.py
@@ -132,6 +132,7 @@ class FileTypes:
     TS: FileType = FileType(".ts", "video/mp2t")
     JOURNAL_JSONL: FileType = FileType(".jsonl", "application/jsonl")
     JOURNAL_JSONL_GZ: FileType = FileType(".jsonl.gz", "application/jsonl")
+    ZIP: FileType = FileType(".zip", "application/zip")
 
     _CSV_TYPES = (CSV, CSV_GZ)
     _PARQUET_FILE_TYPES = (PARQUET_GZ, PARQUET)

--- a/tests/core/test_filetype.py
+++ b/tests/core/test_filetype.py
@@ -1,0 +1,35 @@
+"""Tests for nominal.core.filetype.FileType extension inference."""
+
+from __future__ import annotations
+
+import pytest
+
+from nominal.core.filetype import FileType, FileTypes
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        # Single-suffix types
+        ("x.zip", FileTypes.ZIP),
+        ("x.csv", FileTypes.CSV),
+        ("x.parquet", FileTypes.PARQUET),
+        ("x.jsonl", FileTypes.JOURNAL_JSONL),
+        ("x.mp4", FileTypes.MP4),
+        # Multi-suffix types must beat their shorter counterparts regardless of
+        # the declaration order of FileTypes members (longest match wins).
+        ("x.parquet.zip", FileTypes.PARQUET_ZIP),
+        ("x.parquet.gz", FileTypes.PARQUET_GZ),
+        ("x.parquet.tar", FileTypes.PARQUET_TAR),
+        ("x.parquet.tar.gz", FileTypes.PARQUET_TAR_GZ),
+        ("x.csv.gz", FileTypes.CSV_GZ),
+        ("x.jsonl.gz", FileTypes.JOURNAL_JSONL_GZ),
+        # Extension matching is case-insensitive.
+        ("X.ZIP", FileTypes.ZIP),
+        ("X.PARQUET.ZIP", FileTypes.PARQUET_ZIP),
+        # A leading directory path does not affect suffix matching.
+        ("some/dir/x.parquet.zip", FileTypes.PARQUET_ZIP),
+    ],
+)
+def test_from_path_infers_registered_type(path: str, expected: FileType) -> None:
+    assert FileType.from_path(path) == expected


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

`mimetypes.guess_type` was returning `.pyz` for `.zip` files for whatever reason-- fixed by pinning .zip as a valid type