### PR TITLE
feat(cli): containerized extractor and container registry commands

### DIFF
--- a/nominal/cli/__init__.py
+++ b/nominal/cli/__init__.py
@@ -3,7 +3,15 @@ import sys
 
 import click
 
-from nominal.cli import attachment, config, dataset, download, mis, run
+from nominal.cli import (
+    attachment,
+    config,
+    container,
+    dataset,
+    download,
+    mis,
+    run,
+)
 
 
 @click.group(context_settings={"show_default": True, "help_option_names": ("-h", "--help")})
@@ -14,6 +22,7 @@ def nom() -> None:
 
 nom.add_command(attachment.attachment_cmd)
 nom.add_command(config.config_cmd)
+nom.add_command(container.container_cmd)
 nom.add_command(dataset.dataset_cmd)
 nom.add_command(download.download_cmd)
 nom.add_command(mis.mis_cmd)

--- a/nominal/cli/container.py
+++ b/nominal/cli/container.py
@@ -1,0 +1,513 @@
+from __future__ import annotations
+
+import collections
+import json
+import pathlib
+from typing import Any, Mapping, NamedTuple, Protocol, Sequence, TypeVar, cast, get_args
+
+import click
+
+from nominal import ts
+from nominal.cli.util.format import emit_table, table_data_to_string
+from nominal.cli.util.global_decorators import client_options, global_options
+from nominal.core.client import NominalClient
+from nominal.core.container_image import (
+    REGISTERABLE_OUTPUT_FORMATS,
+    ContainerImage,
+    ContainerImageStatus,
+    FileExtractionInput,
+    FileExtractionParameter,
+    FileOutputFormat,
+)
+from nominal.core.containerized_extractor import ContainerizedExtractor
+from nominal.ts import _SecondsNanos
+
+
+@click.group(name="container")
+def container_cmd() -> None:
+    """Work with containerized extractors and the container images they run.
+
+    An extractor carries identity; its execution contract (inputs, parameters, output format,
+    timestamp defaults) lives on the container images registered against it, exactly one of
+    which is active.
+    """
+
+
+@container_cmd.group(name="extractor")
+def extractor_cmd() -> None:
+    """Create and manage containerized extractors and their image lifecycle"""
+
+
+@container_cmd.group(name="image")
+def image_cmd() -> None:
+    """Inspect and manage container images in Nominal's registry"""
+
+
+# --------------------------------------------------------------------------------------
+# nom container extractor ...
+# --------------------------------------------------------------------------------------
+
+
+@extractor_cmd.command()
+@click.option("-n", "--name", required=True)
+@click.option("-d", "--description", help="description of the extractor")
+@client_options
+@global_options
+def create(name: str, description: str | None, client: NominalClient) -> None:
+    """Create a containerized extractor.
+
+    A newly created extractor has no container image: register one with `register-image` and
+    activate it with `set-active-image` before ingesting.
+    """
+    extractor = client.create_containerized_extractor(name, description=description)
+    click.echo(extractor)
+
+
+@extractor_cmd.command("get")
+@click.option("-r", "--rid", required=True)
+@client_options
+@global_options
+def get_extractor(rid: str, client: NominalClient) -> None:
+    """Get a containerized extractor by its RID"""
+    extractor = client.get_containerized_extractor(rid)
+    click.echo(extractor)
+
+
+@extractor_cmd.command("search")
+@click.option("--include-archived", is_flag=True, help="include archived extractors in the results")
+@click.option(
+    "--file-extension",
+    help='only include extractors whose active image accepts files with this suffix (e.g. "csv" -- no leading dot)',
+)
+@click.option("--workspace", "workspace_rid", help="workspace RID to search  [default: the profile's workspace]")
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(dir_okay=False, resolve_path=True, path_type=pathlib.Path),
+    help="If provided, a path to write the output to as a file",
+)
+@click.option(
+    "-f",
+    "--format",
+    type=click.Choice(["csv", "table"], case_sensitive=True),
+    default="table",
+    show_default=True,
+    help="Output data format to represent the data as",
+)
+@client_options
+@global_options
+def search_extractors(
+    include_archived: bool,
+    file_extension: str | None,
+    workspace_rid: str | None,
+    output: pathlib.Path | None,
+    format: str,
+    client: NominalClient,
+) -> None:
+    """Search for containerized extractors (filters are ANDed together)"""
+    extractors = client.search_containerized_extractors(
+        include_archived=include_archived,
+        file_extension=file_extension,
+        workspace=workspace_rid,
+    )
+    emit_table(_extractors_to_string(extractors, format), output, "containerized extractor(s)")
+
+
+@extractor_cmd.command()
+@click.option("-r", "--rid", required=True)
+@click.option("-n", "--name", help="replace the extractor's name")
+@click.option("-d", "--description", help="replace the extractor's description")
+@client_options
+@global_options
+def update(rid: str, name: str | None, description: str | None, client: NominalClient) -> None:
+    """Update mutable fields of a containerized extractor (only the flags you pass are sent)"""
+    extractor = client.get_containerized_extractor(rid)
+    extractor.update(name=name, description=description)
+    click.echo(extractor)
+
+
+@extractor_cmd.command()
+@click.option("-r", "--rid", required=True)
+@client_options
+@global_options
+def archive(rid: str, client: NominalClient) -> None:
+    """Archive a containerized extractor"""
+    client.get_containerized_extractor(rid).archive()
+    click.secho(f"Archived containerized extractor {rid}", fg="green")
+
+
+@extractor_cmd.command()
+@click.option("-r", "--rid", required=True)
+@client_options
+@global_options
+def unarchive(rid: str, client: NominalClient) -> None:
+    """Unarchive a containerized extractor"""
+    client.get_containerized_extractor(rid).unarchive()
+    click.secho(f"Unarchived containerized extractor {rid}", fg="green")
+
+
+_TIMESTAMP_TYPE_CHOICES = get_args(ts._LiteralAbsolute)
+_OUTPUT_FORMAT_CHOICES = tuple(sorted(fmt.name.lower() for fmt in REGISTERABLE_OUTPUT_FORMATS))
+
+
+@extractor_cmd.command("register-image")
+@click.option("-r", "--rid", required=True, help="RID of the extractor to register the image against")
+@click.option(
+    "-f",
+    "--file",
+    "tarball",
+    type=click.Path(exists=True, dir_okay=False, readable=True, resolve_path=True, path_type=pathlib.Path),
+    required=True,
+    help="path to the uncompressed `docker save` tarball to upload",
+)
+@click.option("-t", "--tag", help="tag to register the image under, typically a git short SHA")
+@click.option(
+    "-c",
+    "--config",
+    "config_file",
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True, path_type=pathlib.Path),
+    help=(
+        "path to a JSON file describing the image's execution contract: `inputs` and `parameters` "
+        "(lists of objects with snake_case FileExtractionInput / FileExtractionParameter fields), "
+        "and optionally `tag`, `default_timestamp_column`, `default_timestamp_type`, and "
+        "`output_format`. Typically a per-package config checked into the repo. Values supplied "
+        "via flags override fields in the JSON."
+    ),
+)
+@click.option("--timestamp-column", help="the column containing timestamp data in the extractor's output files")
+@click.option(
+    "--timestamp-type",
+    type=click.Choice(_TIMESTAMP_TYPE_CHOICES, case_sensitive=False),
+    help="interpretation of the timestamp column in the extractor's output files",
+)
+@click.option(
+    "--output-format",
+    type=click.Choice(_OUTPUT_FORMAT_CHOICES, case_sensitive=False),
+    help="file format the extractor writes  [default: parquet]",
+)
+@click.option("--wait/--no-wait", default=True, show_default=True, help="wait until the image is READY")
+@client_options
+@global_options
+def register_image(
+    rid: str,
+    tarball: pathlib.Path,
+    tag: str | None,
+    config_file: pathlib.Path | None,
+    timestamp_column: str | None,
+    timestamp_type: str | None,
+    output_format: str | None,
+    wait: bool,
+    client: NominalClient,
+) -> None:
+    r"""Upload a `docker save` tarball and register it as a container image for an extractor.
+
+    Prints the resulting container image RID on stdout (status messages go to stderr), suitable
+    for capturing in CI:
+
+        IMAGE_RID=$(nom container extractor register-image -r "$EXTRACTOR_RID" \
+            -f image.tar -t $(git rev-parse --short HEAD) -c extractor-config.json)
+        nom container extractor set-active-image -r "$EXTRACTOR_RID" -i "$IMAGE_RID"
+
+    The registered image starts PENDING and must be activated with `set-active-image` once READY.
+    """
+    parsed = _parse_config(_load_config(config_file))
+    tag = tag if tag is not None else parsed.tag
+    if tag is None:
+        raise click.BadParameter("a tag is required: pass --tag or set `tag` in the config JSON.")
+    timestamp_column = timestamp_column if timestamp_column is not None else parsed.timestamp_column
+    timestamp_type = timestamp_type if timestamp_type is not None else parsed.timestamp_type
+    if timestamp_column is None or timestamp_type is None:
+        raise click.BadParameter(
+            "default timestamp metadata is required: pass --timestamp-column and --timestamp-type, "
+            "or set `default_timestamp_column` and `default_timestamp_type` in the config JSON."
+        )
+    format_enum = _parse_output_format(output_format) if output_format is not None else parsed.output_format
+
+    extractor = client.get_containerized_extractor(rid)
+    click.secho(f"Uploading {tarball.name} and registering it against {extractor.name}...", fg="cyan", err=True)
+    image = extractor.register_image(
+        tarball,
+        tag=tag,
+        inputs=parsed.inputs,
+        parameters=parsed.parameters,
+        default_timestamp_column=timestamp_column,
+        default_timestamp_type=cast(ts._AnyTimestampType, timestamp_type),
+        output_format=format_enum if format_enum is not None else FileOutputFormat.PARQUET,
+    )
+    if wait:
+        click.secho(f"Waiting for image {image.rid} ({image.tag}) to become READY...", fg="cyan", err=True)
+        image.poll_until_ready()
+    click.echo(image.rid)
+
+
+@extractor_cmd.command("validate-config")
+@click.argument(
+    "config_path",
+    type=click.Path(exists=True, dir_okay=False, readable=True, resolve_path=True, path_type=pathlib.Path),
+)
+@global_options
+def validate_config(config_path: pathlib.Path) -> None:
+    """Validate a register-image config JSON without contacting Nominal.
+
+    Runs the exact validation `register-image` performs before uploading, so it can lint a
+    checked-in config in CI without credentials. Values that must be supplied via flags at
+    register time (e.g. a missing `tag`) are reported as notes, not errors.
+    """
+    parsed = _parse_config(_load_config(config_path))
+    click.secho(f"{config_path.name} is a valid register-image config", fg="green")
+    click.echo(f"  inputs: {len(parsed.inputs)}, parameters: {len(parsed.parameters)}")
+    if parsed.tag is None:
+        click.echo("  note: no `tag` -- pass --tag at register time")
+    if parsed.timestamp_column is None or parsed.timestamp_type is None:
+        click.echo(
+            "  note: incomplete default timestamp metadata -- pass --timestamp-column and "
+            "--timestamp-type at register time"
+        )
+    if parsed.output_format is None:
+        click.echo("  note: no `output_format` -- parquet will be used unless --output-format is passed")
+
+
+@extractor_cmd.command("set-active-image")
+@click.option("-r", "--rid", required=True, help="RID of the extractor")
+@click.option("-i", "--image-rid", required=True, help="RID of the registered image to activate")
+@click.option(
+    "--wait/--no-wait",
+    default=True,
+    show_default=True,
+    help="wait until the image is READY before activating (with --no-wait, a non-READY image errors)",
+)
+@client_options
+@global_options
+def set_active_image(rid: str, image_rid: str, wait: bool, client: NominalClient) -> None:
+    """Select the container image an extractor runs when ingesting"""
+    extractor = client.get_containerized_extractor(rid)
+    extractor.set_active_image(image_rid, poll_until_ready=wait)
+    click.echo(extractor)
+
+
+# --------------------------------------------------------------------------------------
+# nom container image ...
+# --------------------------------------------------------------------------------------
+
+
+@image_cmd.command("get")
+@click.option("-r", "--rid", required=True)
+@client_options
+@global_options
+def get_image(rid: str, client: NominalClient) -> None:
+    """Get a container image by its RID"""
+    image = client.get_container_image(rid)
+    click.echo(image)
+
+
+_STATUS_CHOICES = tuple(s.name.lower() for s in ContainerImageStatus if s is not ContainerImageStatus.UNSPECIFIED)
+
+
+@image_cmd.command("search")
+@click.option("-t", "--tag", help="filter to images with this exact tag")
+@click.option(
+    "--status",
+    type=click.Choice(_STATUS_CHOICES, case_sensitive=False),
+    help="filter to images with this lifecycle status",
+)
+@click.option("-e", "--extractor", "extractor_rid", help="filter to images registered against this extractor RID")
+@click.option("--workspace", "workspace_rid", help="workspace RID to search  [default: the profile's workspace]")
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(dir_okay=False, resolve_path=True, path_type=pathlib.Path),
+    help="If provided, a path to write the output to as a file",
+)
+@click.option(
+    "-f",
+    "--format",
+    type=click.Choice(["csv", "table"], case_sensitive=True),
+    default="table",
+    show_default=True,
+    help="Output data format to represent the data as",
+)
+@client_options
+@global_options
+def search_images(
+    tag: str | None,
+    status: str | None,
+    extractor_rid: str | None,
+    workspace_rid: str | None,
+    output: pathlib.Path | None,
+    format: str,
+    client: NominalClient,
+) -> None:
+    """Search for container images, filtering by tag, status, and/or extractor (filters are ANDed together)"""
+    status_enum = ContainerImageStatus[status.upper()] if status is not None else None
+    images = client.search_container_images(
+        tag=tag, status=status_enum, extractor=extractor_rid, workspace=workspace_rid
+    )
+    emit_table(_images_to_string(images, format), output, "container image(s)")
+
+
+@image_cmd.command()
+@click.option("-r", "--rid", required=True)
+@click.option("--yes", is_flag=True, help="skip the confirmation prompt")
+@client_options
+@global_options
+def delete(rid: str, yes: bool, client: NominalClient) -> None:
+    """Delete a container image (fails if an extractor still has it as its active image)"""
+    if not yes:
+        click.confirm(f"Delete container image {rid}?", abort=True)
+    client.get_container_image(rid).delete()
+    click.secho(f"Deleted container image {rid}", fg="green")
+
+
+# --------------------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------------------
+
+
+class _RegisterImageConfig(NamedTuple):
+    """A parsed and validated register-image config JSON; None fields must come from CLI flags."""
+
+    inputs: list[FileExtractionInput]
+    parameters: list[FileExtractionParameter]
+    tag: str | None
+    timestamp_column: str | None
+    timestamp_type: str | None
+    output_format: FileOutputFormat | None
+
+
+_KNOWN_CONFIG_KEYS = frozenset(
+    {"inputs", "parameters", "tag", "default_timestamp_column", "default_timestamp_type", "output_format"}
+)
+
+
+def _load_config(config_file: pathlib.Path | None) -> dict[str, Any]:
+    """Load the register-image config JSON, defaulting to empty when no file is given."""
+    if config_file is None:
+        return {}
+    try:
+        raw = config_file.read_text()
+    except (OSError, UnicodeDecodeError) as ex:
+        raise click.BadParameter(f"failed to read config: {ex}") from ex
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as ex:
+        raise click.BadParameter(f"invalid config JSON: {ex.msg}") from ex
+    if not isinstance(payload, dict):
+        raise click.BadParameter("top-level config JSON must be an object")
+    return payload
+
+
+def _parse_config(config: dict[str, Any]) -> _RegisterImageConfig:
+    """Validate a register-image config JSON and parse it into SDK types.
+
+    This is the shared pre-upload validation behind both `register-image` and `validate-config`:
+    unknown keys (typos) are rejected rather than silently ignored, contract entries must parse
+    into their SDK dataclasses with non-empty names and unique environment variables, and
+    timestamp type / output format values must be known.
+    """
+    unknown_keys = set(config) - _KNOWN_CONFIG_KEYS
+    if unknown_keys:
+        raise click.BadParameter(
+            f"unknown config keys {sorted(unknown_keys)}; expected a subset of {sorted(_KNOWN_CONFIG_KEYS)}"
+        )
+    inputs = _parse_contract_items(config.get("inputs", []), FileExtractionInput, "inputs")
+    parameters = _parse_contract_items(config.get("parameters", []), FileExtractionParameter, "parameters")
+
+    contract_items: list[FileExtractionInput | FileExtractionParameter] = [*inputs, *parameters]
+    env_var_counts = collections.Counter(item.environment_variable for item in contract_items)
+    duplicates = sorted(env_var for env_var, count in env_var_counts.items() if count > 1)
+    if duplicates:
+        raise click.BadParameter(
+            f"duplicate environment variables across inputs and parameters: {duplicates}; "
+            "each input and parameter must use a distinct environment variable."
+        )
+
+    timestamp_type = _non_empty_string_or_none(config, "default_timestamp_type")
+    if timestamp_type is not None:
+        # Match the --timestamp-type flag's case-insensitive click.Choice.
+        timestamp_type = timestamp_type.lower()
+    if timestamp_type is not None and timestamp_type not in _TIMESTAMP_TYPE_CHOICES:
+        raise click.BadParameter(
+            f"unknown `default_timestamp_type` {timestamp_type!r}; expected one of {_TIMESTAMP_TYPE_CHOICES}."
+        )
+    output_format = _non_empty_string_or_none(config, "output_format")
+    return _RegisterImageConfig(
+        inputs=inputs,
+        parameters=parameters,
+        tag=_non_empty_string_or_none(config, "tag"),
+        timestamp_column=_non_empty_string_or_none(config, "default_timestamp_column"),
+        timestamp_type=timestamp_type,
+        output_format=None if output_format is None else _parse_output_format(output_format),
+    )
+
+
+def _non_empty_string_or_none(config: Mapping[str, Any], key: str) -> str | None:
+    """Read an optional config value that must be a non-empty string when present."""
+    value = config.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise click.BadParameter(f"`{key}` in the config JSON must be a non-empty string, got {value!r}")
+    return value
+
+
+class _ContractItem(Protocol):
+    @property
+    def name(self) -> str: ...
+    @property
+    def environment_variable(self) -> str: ...
+
+
+_ContractItemT = TypeVar("_ContractItemT", bound=_ContractItem)
+
+
+def _parse_contract_items(raw: Any, item_type: type[_ContractItemT], field_name: str) -> list[_ContractItemT]:
+    """Build FileExtractionInput / FileExtractionParameter entries from config JSON objects."""
+    if not isinstance(raw, list) or not all(isinstance(item, dict) for item in raw):
+        raise click.BadParameter(f"`{field_name}` in the config JSON must be a list of objects")
+    items = []
+    for item in raw:
+        try:
+            parsed = item_type(**item)
+        except TypeError as ex:
+            raise click.BadParameter(f"invalid `{field_name}` entry {item!r}: {ex}") from ex
+        if not parsed.name or not parsed.environment_variable:
+            raise click.BadParameter(
+                f"invalid `{field_name}` entry {item!r}: `name` and `environment_variable` must be non-empty."
+            )
+        items.append(parsed)
+    return items
+
+
+def _parse_output_format(value: str) -> FileOutputFormat:
+    try:
+        output_format = FileOutputFormat[value.upper()]
+    except KeyError:
+        raise click.BadParameter(f"unknown `output_format` {value!r}; expected one of {_OUTPUT_FORMAT_CHOICES}.")
+    if output_format not in REGISTERABLE_OUTPUT_FORMATS:
+        raise click.BadParameter(f"`output_format` {value!r} is not registerable; use one of {_OUTPUT_FORMAT_CHOICES}.")
+    return output_format
+
+
+def _extractors_to_string(extractors: Sequence[ContainerizedExtractor], format: str) -> str:
+    data = collections.defaultdict(list)
+    for extractor in extractors:
+        image = extractor.active_image
+        data["rid"].append(extractor.rid)
+        data["name"].append(extractor.name)
+        data["description"].append(extractor.description or "")
+        data["archived"].append("yes" if extractor.is_archived else "no")
+        data["active image"].append("" if image is None else f"{image.tag} ({image.status.value})")
+        data["created"].append(_SecondsNanos.from_nanoseconds(extractor.created_at).to_iso8601())
+    return table_data_to_string(data, format)
+
+
+def _images_to_string(images: Sequence[ContainerImage], format: str) -> str:
+    data = collections.defaultdict(list)
+    for image in images:
+        data["rid"].append(image.rid)
+        data["tag"].append(image.tag)
+        data["status"].append(image.status.value)
+        data["extractor rid"].append(image.extractor_rid)
+        data["size (bytes)"].append(str(image.size_bytes))
+        data["created"].append(_SecondsNanos.from_nanoseconds(image.created_at).to_iso8601())
+    return table_data_to_string(data, format)

--- a/nominal/cli/dataset.py
+++ b/nominal/cli/dataset.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import collections
 import logging
 import pathlib
-from typing import Mapping, Sequence
+from typing import Sequence
 
 import click
-import tabulate
 
+from nominal.cli.util.format import emit_table, table_data_to_string
 from nominal.cli.util.global_decorators import client_options, global_options
 from nominal.core.client import NominalClient
 from nominal.ts import _LiteralAbsolute
@@ -132,22 +132,4 @@ def summarize(
             if show_rids:
                 data["dataset rid"].append(dataset.rid)
 
-    output_str = _dataset_data_to_string(data, format)
-
-    if output is None:
-        click.echo(output_str)
-    else:
-        click.secho(f"Writing dataset(s) metadata to {output}", fg="cyan")
-        output.parent.mkdir(parents=True, exist_ok=True)
-        output.write_text(output_str)
-
-
-def _dataset_data_to_string(table_data: Mapping[str, list[str]], format: str) -> str:
-    import pandas as pd
-
-    if format == "csv":
-        return pd.DataFrame(table_data).to_csv(index=False)
-    elif format == "table":
-        return tabulate.tabulate(table_data, headers=list(table_data.keys()))
-    else:
-        raise ValueError(f"Expected format to be one of csv or table, received {format}")
+    emit_table(table_data_to_string(data, format), output, "dataset(s)")

--- a/nominal/cli/mis.py
+++ b/nominal/cli/mis.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 import click
 import pandas as pd
-import tabulate
 
+from nominal.cli.util.format import table_data_to_string
 from nominal.cli.util.global_decorators import client_options, global_options
 from nominal.core import NominalClient
 
@@ -232,11 +232,11 @@ def list_units(output: Path | None, format: str, client: NominalClient) -> None:
     units = client.get_all_units()
     sorted_units = sorted(units, key=lambda u: u.symbol)
 
-    # Convert Unit objects to DataFrame
-    units_data = [{"UCUM": unit.symbol, "Unit Name": unit.name} for unit in sorted_units]
-    df = pd.DataFrame(units_data)
-
-    output_str = _data_to_string(df, format)
+    units_data = {
+        "UCUM": [unit.symbol for unit in sorted_units],
+        "Unit Name": [unit.name for unit in sorted_units],
+    }
+    output_str = table_data_to_string(units_data, format)
 
     if output:
         output.parent.mkdir(parents=True, exist_ok=True)
@@ -244,12 +244,3 @@ def list_units(output: Path | None, format: str, client: NominalClient) -> None:
         click.secho(f"Unit list successfully written to {output}", fg="cyan")
     else:
         click.echo(output_str)
-
-
-def _data_to_string(data: pd.DataFrame, format: str) -> str:
-    if format == "csv":
-        return data.to_csv(index=False)
-    elif format == "table":
-        return tabulate.tabulate(data.values.tolist(), headers=data.columns.tolist())
-    else:
-        raise ValueError(f"Expected format to be one of csv, table, received {format}")

--- a/nominal/cli/util/format.py
+++ b/nominal/cli/util/format.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pathlib
+from typing import Mapping
+
+import click
+import tabulate
+
+
+def table_data_to_string(table_data: Mapping[str, list[str]], format: str) -> str:
+    """Render columnar data (column name -> values) as `csv` or a human-readable `table`."""
+    import pandas as pd
+
+    if format == "csv":
+        return pd.DataFrame(table_data).to_csv(index=False)
+    elif format == "table":
+        return tabulate.tabulate(table_data, headers=list(table_data.keys()))
+    else:
+        raise ValueError(f"Expected format to be one of csv or table, received {format}")
+
+
+def emit_table(output_str: str, output: pathlib.Path | None, what: str) -> None:
+    """Echo tabular output, or write it to a file when `-o/--output` is given."""
+    if output is None:
+        click.echo(output_str)
+    else:
+        click.secho(f"Writing {what} metadata to {output}", fg="cyan")
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(output_str)

--- a/nominal/core/filetype.py
+++ b/nominal/core/filetype.py
@@ -138,6 +138,7 @@ class FileTypes:
     PARQUET_TAR_GZ: FileType = FileType(".parquet.tar.gz", "application/x-tar")
     PARQUET_TAR: FileType = FileType(".parquet.tar", "application/x-tar")
     PARQUET_ZIP: FileType = FileType(".parquet.zip", "application/zip")
+    TAR: FileType = FileType(".tar", "application/x-tar")
     TS: FileType = FileType(".ts", "video/mp2t")
     JOURNAL_JSONL: FileType = FileType(".jsonl", "application/jsonl")
     JOURNAL_JSONL_GZ: FileType = FileType(".jsonl.gz", "application/jsonl")

--- a/tests/cli/test_container_config.py
+++ b/tests/cli/test_container_config.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Any
+
+import click
+import pytest
+
+from nominal.cli.container import _parse_config
+from nominal.core.container_image import FileExtractionInput, FileExtractionParameter, FileOutputFormat
+
+
+def test_valid_config_parses_into_sdk_types() -> None:
+    """A full config parses into SDK dataclasses and enums, ready to pass to register_image."""
+    parsed = _parse_config(
+        {
+            "tag": "abc123",
+            "default_timestamp_column": "timestamp",
+            "default_timestamp_type": "iso_8601",
+            "output_format": "parquet",
+            "inputs": [{"name": "Input", "environment_variable": "INPUT_FILE", "required": True}],
+            "parameters": [{"name": "Rate", "environment_variable": "SAMPLE_RATE"}],
+        }
+    )
+
+    assert parsed.inputs == [FileExtractionInput(name="Input", environment_variable="INPUT_FILE", required=True)]
+    assert parsed.parameters == [FileExtractionParameter(name="Rate", environment_variable="SAMPLE_RATE")]
+    assert parsed.tag == "abc123"
+    assert parsed.timestamp_column == "timestamp"
+    assert parsed.timestamp_type == "iso_8601"
+    assert parsed.output_format is FileOutputFormat.PARQUET
+
+
+def test_empty_config_is_valid_with_everything_deferred_to_flags() -> None:
+    """An empty config is legal: every value may instead be supplied via register-image flags."""
+    parsed = _parse_config({})
+
+    assert parsed.inputs == []
+    assert parsed.parameters == []
+    assert parsed.tag is None
+    assert parsed.timestamp_column is None
+    assert parsed.timestamp_type is None
+    assert parsed.output_format is None
+
+
+def test_unknown_top_level_keys_are_rejected_not_ignored() -> None:
+    """A typo'd config key fails loudly instead of being silently dropped at register time."""
+    with pytest.raises(click.BadParameter, match="default_timestamp_colum"):
+        _parse_config({"default_timestamp_colum": "timestamp"})
+
+
+def test_unknown_entry_fields_are_rejected() -> None:
+    """A typo'd field inside an input entry fails loudly instead of being silently dropped."""
+    with pytest.raises(click.BadParameter, match="inputs"):
+        _parse_config({"inputs": [{"name": "A", "environment_variable": "X", "requird": True}]})
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"name": "", "environment_variable": "X"},
+        {"name": "A", "environment_variable": ""},
+    ],
+)
+def test_entries_require_nonempty_name_and_environment_variable(entry: dict[str, Any]) -> None:
+    """Inputs and parameters must carry a non-empty name and environment variable."""
+    with pytest.raises(click.BadParameter, match="non-empty"):
+        _parse_config({"inputs": [entry]})
+
+
+def test_duplicate_environment_variables_across_inputs_and_parameters_are_rejected() -> None:
+    """An environment variable can only carry one value, so reuse across inputs and parameters fails."""
+    with pytest.raises(click.BadParameter, match="duplicate environment variables"):
+        _parse_config(
+            {
+                "inputs": [{"name": "A", "environment_variable": "X"}],
+                "parameters": [{"name": "B", "environment_variable": "X"}],
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"tag": 123},
+        {"tag": ""},
+        {"default_timestamp_column": ["timestamp"]},
+        {"output_format": 123},
+    ],
+)
+def test_scalar_values_must_be_nonempty_strings(config: dict[str, Any]) -> None:
+    """Wrong-typed or empty scalar values fail validation instead of failing after the tarball upload."""
+    with pytest.raises(click.BadParameter, match="non-empty string"):
+        _parse_config(config)
+
+
+def test_timestamp_type_is_case_insensitive_like_the_flag() -> None:
+    """Config-supplied timestamp types accept any casing, matching the --timestamp-type flag."""
+    assert _parse_config({"default_timestamp_type": "ISO_8601"}).timestamp_type == "iso_8601"
+
+
+def test_unknown_timestamp_type_is_rejected() -> None:
+    """A timestamp type the SDK doesn't recognize fails rather than passing through to the backend."""
+    with pytest.raises(click.BadParameter, match="weeks"):
+        _parse_config({"default_timestamp_type": "weeks"})
+
+
+def test_non_registerable_output_format_is_rejected() -> None:
+    """Formats the backend cannot ingest via containerized extraction are rejected up-front."""
+    with pytest.raises(click.BadParameter, match="not registerable"):
+        _parse_config({"output_format": "json_l"})


### PR DESCRIPTION
Resurrects the CLI surface from #778 (thanks @awatwe!), ported onto the v2 containerized-extractor model that shipped in #842. #778 was written against the since-removed v1 conjure API (external-registry `DockerImageSource`, name-keyed images, labels/properties), so the command modules are rewritten rather than cherry-picked.

Builds on #861's extractor-scoped image search (`nom container image search -e <extractor-rid>`).

## Design

Everything lives under a single **`nom container`** root with `extractor` and `image` subgroups (nested groups like `nom config profile`) — one product feature, one entrypoint, rather than leaking the backend's `ingest.v2` / `registry.v2` service split into the command topology.

The commands follow the conventions of the existing CLI entrypoints:

- single resources echo their repr, like `attachment`/`run`/`dataset get`
- searches render via tabulate with `-f table|csv` and optional `-o` file output, like `dataset summarize` / `mis list-units`
- mutations confirm via `click.secho(..., fg="green")`, like `config profile add`
- blocking flags are `--wait/--no-wait` (default wait), like `dataset upload-csv`

(#778's rich-table + `--format json` rendering layer was deliberately not ported — it was a new dialect with no precedent in the CLI; `csv` covers the scripting story the way the rest of the CLI does.)

Also adds `FileTypes.TAR` (`.tar` → `application/x-tar`) so `docker save` tarballs upload with the right mimetype.

---

# Usage guide

## The model

A **containerized extractor** turns proprietary data formats into Nominal datasets by running your container. The extractor itself carries only identity (name, description, archived state). Its **execution contract** — what input files it consumes, what parameters it takes, what format it writes, and how its output timestamps are encoded — lives on the **container images** registered against it. Exactly one registered image is *active*: that's what runs when data is ingested through the extractor. Registering a new image never changes what runs until you activate it, which is what makes safe rollout (and rollback) possible.

All commands take `--profile <name>` to select a configured Nominal profile (see `nom config profile add`), plus `-h` for full flag listings.

## 1. Create an extractor

```console
$ nom container extractor create -n my-parser -d "Parses .bin telemetry into parquet"
ContainerizedExtractor(rid='ri.containerized-extractor...', name='my-parser', ...)
```

A new extractor has no image and can't ingest anything yet.

## 2. Describe the execution contract

Check a config JSON into your extractor's repo (next to its Dockerfile):

```json
{
  "default_timestamp_column": "timestamp",
  "default_timestamp_type": "iso_8601",
  "output_format": "parquet",
  "inputs": [
    {
      "name": "Telemetry file",
      "environment_variable": "INPUT_FILE",
      "file_suffixes": ["bin"],
      "required": true,
      "description": "Raw telemetry capture to parse"
    }
  ],
  "parameters": [
    {"name": "Sample rate", "environment_variable": "SAMPLE_RATE"}
  ]
}
```

- `inputs` / `parameters`: what your container reads from its environment — each input's env var receives a file path, each parameter's env var receives a value.
- `default_timestamp_column` + `default_timestamp_type`: how timestamps in your container's *output* are encoded. This is the fallback; individual ingests (and, for manifest extractors, individual manifest outputs) can override it.
- `output_format`: one of `parquet` (default), `csv`, `avro_stream`, `manifest`.
- `tag` may also be set here, though it's usually passed per-build via `--tag`.

Flags override config values, so one checked-in config serves every build.

Lint the config without contacting Nominal (no credentials needed -- e.g. as a CI check or
pre-commit step):

```console
$ nom container extractor validate-config extractor-config.json
extractor-config.json is a valid register-image config
  inputs: 1, parameters: 1
  note: no `tag` -- pass --tag at register time
```

It runs the exact validation `register-image` performs before uploading: unknown keys (typos)
are rejected rather than silently ignored, contract entries must have non-empty names and unique
environment variables, and timestamp type / output format values must be known.

## 3. Register an image

```console
$ docker build -t my-parser .
$ docker save my-parser -o image.tar
$ nom container extractor register-image \
      -r "$EXTRACTOR_RID" \
      -f image.tar \
      -t "$(git rev-parse --short HEAD)" \
      -c extractor-config.json
Uploading image.tar and registering it against my-parser...
Waiting for image ri.container-image... (abc1234) to become READY...
ri.container-image...
```

Everything validates **before** the upload starts (missing tag/timestamps, unknown timestamp type, or an output format the backend can't ingest all fail immediately). By default the command waits for the server-side push to complete — the image goes `PENDING → READY` (or errors loudly on `FAILED`); pass `--no-wait` to return immediately and check on it later with `nom container image get`.

**Only the image RID goes to stdout** — the progress messages go to stderr — so command substitution is CI-safe:

```console
IMAGE_RID=$(nom container extractor register-image -r "$EXTRACTOR_RID" -f image.tar -t "$SHA" -c extractor-config.json)
```

## 4. Activate it

```console
$ nom container extractor set-active-image -r "$EXTRACTOR_RID" -i "$IMAGE_RID"
ContainerizedExtractor(rid=..., active_image=ContainerImage(tag='abc1234', status=READY, ...), ...)
```

Waits for the image to be READY by default (`--no-wait` errors immediately on a non-READY image instead). From this point, ingests through the extractor run the new image.

**Rollback** is the same command pointed at a previous image:

```console
$ nom container image search -e "$EXTRACTOR_RID" --status ready   # list rollback candidates
$ nom container extractor set-active-image -r "$EXTRACTOR_RID" -i "$PREVIOUS_IMAGE_RID"
```

## 5. Putting it together in CI

```bash
#!/usr/bin/env bash
set -euo pipefail
SHA=$(git rev-parse --short HEAD)

docker build -t my-parser .
docker save my-parser -o image.tar

IMAGE_RID=$(nom container extractor register-image \
    -r "$EXTRACTOR_RID" -f image.tar -t "$SHA" -c extractor-config.json)
nom container extractor set-active-image -r "$EXTRACTOR_RID" -i "$IMAGE_RID"
```

## Command reference

<details>
<summary><b><code>nom container extractor</code></b> — create and manage extractors and their image lifecycle</summary>

| Command | Flags | Behavior |
|---|---|---|
| `create` | `-n/--name` (required), `-d/--description` | Creates an extractor in the profile's workspace; prints it |
| `get` | `-r/--rid` | Prints the extractor, including its active image's full contract |
| `search` | `--include-archived`, `--file-extension EXT`, `--workspace RID`, `-f table\|csv`, `-o FILE` | Lists extractors; `--file-extension csv` finds extractors whose active READY image accepts `.csv` inputs |
| `update` | `-r/--rid`, `-n/--name`, `-d/--description` | Partial update; only passed flags are sent |
| `archive` / `unarchive` | `-r/--rid` | Archived extractors are hidden from search and reject new ingests |
| `register-image` | `-r/--rid`, `-f/--file TARBALL`, `-t/--tag`, `-c/--config JSON`, `--timestamp-column`, `--timestamp-type`, `--output-format`, `--wait/--no-wait` | Uploads and registers an image (see guide above); prints the image RID on stdout |
| `validate-config CONFIG_PATH` | (none -- no client needed) | Lints a register-image config JSON offline; flag-supplied values (e.g. a missing `tag`) are notes, not errors |
| `set-active-image` | `-r/--rid`, `-i/--image-rid`, `--wait/--no-wait` | Selects the image the extractor runs; prints the refreshed extractor |

</details>

<details>
<summary><b><code>nom container image</code></b> — inspect and manage container images in Nominal's registry</summary>

| Command | Flags | Behavior |
|---|---|---|
| `get` | `-r/--rid` | Prints the image (status, tag, owning extractor, size, contract) — useful for checking on a PENDING push |
| `search` | `-t/--tag`, `--status pending\|ready\|failed`, `-e/--extractor RID`, `--workspace RID`, `-f table\|csv`, `-o FILE` | Lists images; filters AND together; `-e` scopes to one extractor's registered images (via #861) |
| `delete` | `-r/--rid`, `--yes` | Deletes an image after a confirmation prompt; the server refuses if it's still an extractor's active image |

</details>

## Not covered by the CLI (by design, today)

- **Triggering an ingest** — `Dataset.add_containerized(extractor, sources)` is SDK-only; a `nom` command for it could follow.
- `Relative` / `Custom` timestamp types — the CLI accepts the string literals (`iso_8601`, `epoch_seconds`, …); richer types need the SDK.
- Deleting an extractor — no such API; `archive` is the retirement path.

## Deliberately not ported from #778

- **CLI tests** — this repo doesn't test CLI surfaces.
- The rich/`emit_records` rendering utilities and `download.py` refactor (see Design above).
- The e2e docker fixture + registry e2e test — written against the v1 flow; can follow separately.
- #778's `pyproject.toml` protos pin and core-layer changes — superseded by #842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


