### PR TITLE
fix: allow registering JSON_L-output containerized extractors

### DIFF
--- a/nominal/core/container_image.py
+++ b/nominal/core/container_image.py
@@ -35,9 +35,8 @@ class FileOutputFormat(Enum):
     CSV = "CSV"
     AVRO_STREAM = "AVRO_STREAM"
     PARQUET_TAR = "PARQUET_TAR"
-    """Not currently ingestible via containerized extraction; `register_image` rejects it."""
+    """Being retired with the migration to v2 containerized ingest; `register_image` rejects it."""
     JSON_L = "JSON_L"
-    """Not currently ingestible via containerized extraction; `register_image` rejects it."""
     UNSPECIFIED = "UNSPECIFIED"
     """Unset, or a format a newer server sent that this SDK doesn't know. Not registerable."""
 
@@ -87,14 +86,16 @@ REGISTERABLE_OUTPUT_FORMATS = frozenset(
         FileOutputFormat.PARQUET,
         FileOutputFormat.CSV,
         FileOutputFormat.AVRO_STREAM,
+        FileOutputFormat.JSON_L,
         FileOutputFormat.MANIFEST,
     }
 )
-"""Output formats the backend can currently ingest via containerized extraction.
+"""Output formats `register_image` accepts.
 
-Registration accepts other formats server-side, but their ingest jobs would always fail
-(the containerized transform path has no reader for them), so `register_image` rejects them
-up-front. Update when the backend gains readers for the remaining formats.
+PARQUET_TAR is excluded deliberately: it is being retired with the migration to the v2 containerized
+ingest path (which has no reader for it), so rather than allow new extractors that would stop working
+mid-migration, registration rejects it up-front. UNSPECIFIED is not a real format. Remove this guard
+if the retirement plan changes.
 """
 
 

--- a/nominal/core/containerized_extractor.py
+++ b/nominal/core/containerized_extractor.py
@@ -172,8 +172,8 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
                 registration even when every ingest overrides it. See
                 `ContainerImage.default_timestamp_metadata` for the full resolution order.
             output_format: File format the extractor writes. Must be one of
-                `REGISTERABLE_OUTPUT_FORMATS` — the backend cannot currently ingest the others, so
-                registering an image with one would produce an extractor whose ingests always fail.
+                `REGISTERABLE_OUTPUT_FORMATS` — PARQUET_TAR is being retired with the migration to
+                v2 containerized ingest, so new registrations with it are rejected.
             parameters: Scalar parameters passed to the extractor.
 
         Returns:
@@ -187,9 +187,8 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
         if output_format not in REGISTERABLE_OUTPUT_FORMATS:
             supported = ", ".join(sorted(fmt.name for fmt in REGISTERABLE_OUTPUT_FORMATS))
             raise ValueError(
-                f"Output format {output_format.name} is not currently supported for containerized "
-                f"extraction ingest; an image registered with it could never ingest data successfully. "
-                f"Supported formats: {supported}."
+                f"Output format {output_format.name} is not registerable: it is being retired with "
+                f"the migration to v2 containerized ingest. Supported formats: {supported}."
             )
         s3_path = upload_multipart_file(
             self._clients.auth_header,

--- a/tests/core/test_containerized_extractor.py
+++ b/tests/core/test_containerized_extractor.py
@@ -98,11 +98,11 @@ def test_set_active_image_raises_when_image_not_ready() -> None:
     clients.containerized_extractor.UpdateContainerizedExtractor.assert_not_called()
 
 
-@pytest.mark.parametrize("output_format", [FileOutputFormat.JSON_L, FileOutputFormat.PARQUET_TAR])
-def test_register_image_rejects_non_ingestible_output_formats_before_uploading(
+@pytest.mark.parametrize("output_format", [FileOutputFormat.PARQUET_TAR, FileOutputFormat.UNSPECIFIED])
+def test_register_image_rejects_retired_output_formats_before_uploading(
     output_format: FileOutputFormat,
 ) -> None:
-    """Formats the backend can't ingest fail up-front, before the tarball upload starts."""
+    """Formats being retired (or unset) fail up-front, before the tarball upload starts."""
     clients = _clients()
     extractor = ContainerizedExtractor._from_proto(clients, _ext("ri.ext"))
 


### PR DESCRIPTION
## Summary

- Add `JSON_L` to `REGISTERABLE_OUTPUT_FORMATS`: the guard's premise ("the backend can never ingest it") was wrong. JSON_L extractor output is ingested end to end on current deployments (via log ingest), so registration must allow it.
- Keep `PARQUET_TAR` rejected, with the corrected rationale documented on the constant and in the error message: it is being **retired** with an upcoming ingest-pipeline migration, so new registrations would create extractors that stop working mid-migration — not "the backend can't ingest it today."

## Verification

- `uv run pytest tests/` — 291 passed (guard test reparametrized to PARQUET_TAR + UNSPECIFIED)
- `uv run mypy -p nominal` / `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
