### PR TITLE
feat: raise NominalAlreadyExistsError for ALREADY_EXISTS gRPC failures

### DIFF
--- a/nominal/core/_utils/grpc_tools.py
+++ b/nominal/core/_utils/grpc_tools.py
@@ -30,6 +30,7 @@ from conjure_python_client import ServiceConfiguration
 
 from nominal.core._utils.networking import HeaderProvider, raise_header_conflict
 from nominal.core.exceptions import (
+    NominalAlreadyExistsError,
     NominalAuthenticationError,
     NominalError,
     NominalInvalidArgumentError,
@@ -285,6 +286,7 @@ _GRPC_STATUS_TO_EXCEPTION: dict[grpc.StatusCode, type[NominalError]] = {
     grpc.StatusCode.PERMISSION_DENIED: NominalPermissionDeniedError,
     grpc.StatusCode.UNAUTHENTICATED: NominalAuthenticationError,
     grpc.StatusCode.NOT_FOUND: NominalNotFoundError,
+    grpc.StatusCode.ALREADY_EXISTS: NominalAlreadyExistsError,
     grpc.StatusCode.INVALID_ARGUMENT: NominalInvalidArgumentError,
 }
 

--- a/nominal/core/containerized_extractor.py
+++ b/nominal/core/containerized_extractor.py
@@ -157,8 +157,9 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
         """Upload a `docker save` tarball and register it as a container image for this extractor.
 
         Registering attaches the image to this extractor in Nominal's registry, but does not change
-        which image the extractor runs: the new image starts PENDING (being pushed server-side) and
-        must be activated with `set_active_image` once READY. This extractor instance is unmodified.
+        which image the extractor runs: the new image must be activated with `set_active_image`.
+        This extractor instance is unmodified. Tags are immutable — registering an already-registered
+        tag raises `NominalAlreadyExistsError`.
 
         Args:
             tarball: Path to a `docker save` tarball of the extractor image.
@@ -178,12 +179,15 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
             parameters: Scalar parameters passed to the extractor.
 
         Returns:
-            The newly registered image, in `ContainerImageStatus.PENDING`. Wait for it with
-            `ContainerImage.poll_until_ready` (or `set_active_image(..., poll_until_ready=True)`),
-            then activate it before ingesting.
+            The newly registered image. Current backends push the image to the registry within this
+            call and return it READY; if a backend processes asynchronously (a non-READY image),
+            `set_active_image` polls it to readiness before activating (or use
+            `ContainerImage.poll_until_ready` directly).
 
         Raises:
             ValueError: If `output_format` is not currently ingestible via containerized extraction.
+            NominalAlreadyExistsError: If an image with this tag is already registered for this
+                extractor.
         """
         if output_format not in REGISTERABLE_OUTPUT_FORMATS:
             supported = ", ".join(sorted(fmt.name for fmt in REGISTERABLE_OUTPUT_FORMATS))

--- a/nominal/core/exceptions.py
+++ b/nominal/core/exceptions.py
@@ -58,6 +58,10 @@ class NominalNotFoundError(NominalError):
     """The requested resource does not exist."""
 
 
+class NominalAlreadyExistsError(NominalError):
+    """The resource being created already exists (e.g. a container image tag already registered)."""
+
+
 class NominalInvalidArgumentError(NominalError):
     """The server rejected the request as malformed or invalid."""
 

--- a/tests/core/test_grpc.py
+++ b/tests/core/test_grpc.py
@@ -21,6 +21,7 @@ from nominal.core._utils.grpc_tools import (
 from nominal.core._utils.networking import StaticHeaderProvider
 from nominal.core.exceptions import (
     HeaderConflictError,
+    NominalAlreadyExistsError,
     NominalAuthenticationError,
     NominalError,
     NominalInvalidArgumentError,
@@ -194,6 +195,7 @@ def test_create_grpc_channel_wires_credentials_options_and_interceptors(monkeypa
         (grpc.StatusCode.PERMISSION_DENIED, NominalPermissionDeniedError),
         (grpc.StatusCode.UNAUTHENTICATED, NominalAuthenticationError),
         (grpc.StatusCode.NOT_FOUND, NominalNotFoundError),
+        (grpc.StatusCode.ALREADY_EXISTS, NominalAlreadyExistsError),
         (grpc.StatusCode.INVALID_ARGUMENT, NominalInvalidArgumentError),
     ],
 )


### PR DESCRIPTION
Chunked out of #859 so the CI registration example can land separately from the library changes it depends on.

## What's here

- **`NominalAlreadyExistsError`** (`nominal/core/exceptions.py`): new `NominalError` subclass for creating a resource that already exists — e.g. registering a container image tag that's already registered for an extractor (tags are immutable).
- **gRPC translation** (`grpc_tools.py`): `grpc.StatusCode.ALREADY_EXISTS` now maps to it in `translate_grpc_errors`, alongside the existing NOT_FOUND / PERMISSION_DENIED / UNAUTHENTICATED / INVALID_ARGUMENT mappings; covered by the existing parametrized status-mapping test.
- **`register_image` docstring corrections** (`containerized_extractor.py`):
  - documents tag immutability and the new `NominalAlreadyExistsError` in `Raises:`
  - fixes the `Returns:` claim that images come back PENDING — current backends push the image within the call and return it READY; the async-PENDING path is still handled (`set_active_image` polls by default) but no longer described as the normal case.

#859 will rebase down to just the `examples/containerized-extractor-ci/` flow once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)