### PR TITLE
feat(experimental): runtime decorators for authoring containerized extractors

### DIFF
--- a/nominal/experimental/__init__.py
+++ b/nominal/experimental/__init__.py
@@ -1,1 +1,5 @@
-from nominal.experimental.impersonation import as_user as as_user
+from nominal.experimental.impersonation import as_user
+
+__all__ = [
+    "as_user",
+]

--- a/nominal/experimental/extractor/__init__.py
+++ b/nominal/experimental/extractor/__init__.py
@@ -1,0 +1,23 @@
+from nominal.core.container_image import TimestampMetadata
+from nominal.experimental.extractor._extractor import (
+    Extractor,
+    ExtractorContext,
+    ExtractorError,
+    IngestType,
+    ManifestExtractorContext,
+    SingleFileExtractorContext,
+    manifest_extractor,
+    single_file_extractor,
+)
+
+__all__ = [
+    "Extractor",
+    "ExtractorContext",
+    "ExtractorError",
+    "IngestType",
+    "ManifestExtractorContext",
+    "SingleFileExtractorContext",
+    "TimestampMetadata",
+    "manifest_extractor",
+    "single_file_extractor",
+]

--- a/nominal/experimental/extractor/_extractor.py
+++ b/nominal/experimental/extractor/_extractor.py
@@ -1,0 +1,693 @@
+"""Runtime helpers for authoring Nominal Hosted containerized extractors.
+
+A containerized extractor is a Docker image Nominal runs during ingest: it mounts the
+uploaded input file(s), runs your code, and ingests whatever your code writes to the
+output directory. The contract is environment-driven:
+
+- each input file is placed in the input mount (``/input``), and its path is also exposed
+  in the environment variable declared for that input at registration time;
+- output goes to the directory named by ``$OUTPUT_DIR``;
+- declared parameters arrive as environment variables (values are always strings).
+
+The image's registered output format fixes which of two output contracts the ingest
+pipeline applies, and this module provides one decorator per contract:
+
+- :func:`single_file_extractor` -- the pipeline ingests exactly one output file, parsed
+  according to the registered format (``PARQUET``, ``CSV``, ...). Your function declares
+  that file with :meth:`SingleFileExtractorContext.set_output`.
+- :func:`manifest_extractor` -- for images registered with the ``MANIFEST`` output format.
+  The pipeline reads a ``manifest.json`` describing every output file; your function
+  declares each file (with per-file ingest type, tag columns, channel prefix, and optional
+  epoch timestamp metadata) with :meth:`ManifestExtractorContext.add_output`, and
+  :meth:`Extractor.run` writes the manifest automatically.
+
+Both decorators turn ``def fn(ctx) -> None`` into a container entrypoint: ``ctx`` resolves
+inputs and parameters from the environment, and :meth:`Extractor.run` finalizes the outputs
+and turns any failure into a non-zero exit so the ingest job fails cleanly. Nominal describes
+the extractor's registered contract to the container through ``_NOMINAL_*`` environment
+variables -- the registered output format (``_NOMINAL_OUTPUT_FORMAT``), the mounted inputs
+(``_NOMINAL_INPUTS``), and the declared parameters (``_NOMINAL_PARAMETERS``). When the
+registered output format is injected and disagrees with the decorator you used, the run fails
+at startup with a clear error rather than emitting output the pipeline will reject; when it
+is absent (a local run) the decorator's word is law.
+
+Newer ingest pipelines additionally inject system metadata -- the ingest job and dataset RIDs,
+the resolved job-level timestamp metadata, and the ingest request's tags -- exposed through
+:attr:`ExtractorContext.ingest_job_rid`, :attr:`ExtractorContext.dataset_rid`,
+:attr:`ExtractorContext.job_timestamp_metadata`, and :attr:`ExtractorContext.additional_tags`.
+All are optional: None/empty when not injected (e.g. local runs).
+
+The manifest document is emitted through the generated ``nominal_api.ingest_manifest`` types, so
+its schema tracks the platform contract instead of being hand-mirrored here. Format I/O (pyarrow,
+etc.) remains the author's own dependency. Registering the built image with Nominal is a separate
+step (see the Nominal Hosted extractor APIs); this module is only the in-container runtime.
+"""
+
+from __future__ import annotations
+
+import enum
+import functools
+import json
+import logging
+import os
+import sys
+import traceback
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Generic, Mapping, TypeVar, overload
+
+from conjure_python_client import ConjureDecoder, ConjureEncoder
+from nominal_api import ingest_manifest, scout_catalog
+from typing_extensions import assert_never
+
+from nominal import ts
+from nominal.core.container_image import FileOutputFormat, TimestampMetadata
+from nominal.core.exceptions import NominalError
+
+# Mirrors the mount/env contract the Nominal ingest pipeline establishes for the customer
+# container.
+_DEFAULT_INPUT_DIR = "/input"
+_OUTPUT_DIR_ENV = "OUTPUT_DIR"
+_MANIFEST_FILENAME = "manifest.json"  # the well-known name the ingest pipeline reads from the output directory
+# Lets tests (and non-default mounts) point input discovery somewhere other than /input.
+_INPUT_DIR_ENV = "NOMINAL_EXTRACTOR_INPUT_DIR"
+# Contract metadata Nominal injects describing the registered extractor. All optional: absent on
+# local runs.
+_OUTPUT_FORMAT_ENV = "_NOMINAL_OUTPUT_FORMAT"  # registered FileOutputFormat name, e.g. "MANIFEST", "PARQUET"
+_INPUTS_ENV = "_NOMINAL_INPUTS"  # JSON: [{"name","environmentVariable","path","required"}]
+_PARAMETERS_ENV = "_NOMINAL_PARAMETERS"  # JSON: [{"name","environmentVariable","required"}]
+# System metadata newer ingest pipelines additionally inject alongside the extractor's own
+# arguments. All optional: absent when not injected (e.g. local runs).
+_INGEST_JOB_RID_ENV = "_NOMINAL_INGEST_JOB_RID"
+_DATASET_RID_ENV = "_NOMINAL_DATASET_RID"
+_JOB_TIMESTAMP_METADATA_ENV = "_NOMINAL_TIMESTAMP_METADATA"  # JSON: the resolved job-level timestamp metadata
+_ADDITIONAL_TAGS_ENV = "_NOMINAL_ADDITIONAL_TAGS"  # JSON: {"tag": "value"} applied to all ingested data
+
+logger = logging.getLogger(__name__)
+
+
+class ExtractorError(NominalError):
+    """Raised when the extractor contract is violated (missing input, wrong output count, ...)."""
+
+
+class IngestType(enum.Enum):
+    """How a manifest output file should be ingested."""
+
+    TABULAR = "TABULAR"
+    AVRO_STREAM = "AVRO_STREAM"
+    JSON_L = "JSON_L"
+
+    def _to_conjure(self) -> ingest_manifest.ManifestIngestType:
+        match self:
+            case IngestType.TABULAR:
+                result = ingest_manifest.ManifestIngestType.TABULAR
+            case IngestType.AVRO_STREAM:
+                result = ingest_manifest.ManifestIngestType.AVRO_STREAM
+            case IngestType.JSON_L:
+                result = ingest_manifest.ManifestIngestType.JSON_L
+            case _:
+                assert_never(self)
+        return result
+
+
+def _json_env(env: Mapping[str, str], var: str) -> Any:
+    """Parse a JSON-valued environment variable, or None when it is absent/empty."""
+    raw = env.get(var)
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as ex:
+        raise ExtractorError(f"{var} is not valid JSON: {raw!r}") from ex
+
+
+_MANIFEST_EPOCH_UNITS: dict[str, ingest_manifest.ManifestEpochTimeUnit] = {
+    "seconds": ingest_manifest.ManifestEpochTimeUnit.SECONDS,
+    "milliseconds": ingest_manifest.ManifestEpochTimeUnit.MILLISECONDS,
+    "microseconds": ingest_manifest.ManifestEpochTimeUnit.MICROSECONDS,
+    "nanoseconds": ingest_manifest.ManifestEpochTimeUnit.NANOSECONDS,
+}
+
+
+def _manifest_epoch_time_unit(timestamp_type: ts._AnyTimestampType) -> ingest_manifest.ManifestEpochTimeUnit:
+    """Validate a per-output timestamp type against the manifest contract and convert it.
+
+    Manifest outputs can only express numeric epoch timestamps in seconds through nanoseconds;
+    outputs needing richer types (ISO 8601, custom formats, relative offsets) must omit per-output
+    metadata and rely on the job-level timestamp metadata, which supports the full range.
+    """
+    typed = ts._to_typed_timestamp_type(timestamp_type)
+    if not isinstance(typed, ts.Epoch):
+        raise ExtractorError(
+            f"per-output timestamp metadata only supports numeric epoch timestamps, not {typed!r}; "
+            "omit it and rely on the job-level timestamp metadata for richer timestamp types"
+        )
+    unit = _MANIFEST_EPOCH_UNITS.get(typed.unit)
+    if unit is None:
+        raise ExtractorError(
+            f"per-output timestamp metadata does not support epoch unit {typed.unit!r}; "
+            f"supported units are {', '.join(_MANIFEST_EPOCH_UNITS)}"
+        )
+    return unit
+
+
+@dataclass(frozen=True)
+class _InputSpec:
+    """One entry of the registered input metadata (``_NOMINAL_INPUTS``).
+
+    ``path`` is where the file is mounted; it is also exposed directly under
+    ``environment_variable``.
+    """
+
+    environment_variable: str
+    name: str
+    path: str
+
+
+@dataclass(frozen=True)
+class _ParamSpec:
+    """One entry of the registered parameter metadata (``_NOMINAL_PARAMETERS``).
+
+    The value itself is exposed separately under ``environment_variable``.
+    """
+
+    environment_variable: str
+    name: str
+    required: bool
+
+
+_SpecT = TypeVar("_SpecT", _InputSpec, _ParamSpec)
+
+
+def _parse_input_specs(env: Mapping[str, str]) -> list[_InputSpec] | None:
+    """Parse ``_NOMINAL_INPUTS`` into specs, or ``None`` when not injected."""
+    entries = _json_env(env, _INPUTS_ENV)
+    if entries is None:
+        return None
+    try:
+        return [
+            _InputSpec(
+                environment_variable=entry["environmentVariable"],
+                name=entry.get("name", entry["environmentVariable"]),
+                path=entry["path"],
+            )
+            for entry in entries
+        ]
+    except (KeyError, TypeError, AttributeError) as ex:
+        raise ExtractorError(f"{_INPUTS_ENV} is not valid extractor contract metadata: {entries!r}") from ex
+
+
+def _parse_param_specs(env: Mapping[str, str]) -> list[_ParamSpec] | None:
+    """Parse ``_NOMINAL_PARAMETERS`` into specs, or ``None`` when not injected."""
+    entries = _json_env(env, _PARAMETERS_ENV)
+    if entries is None:
+        return None
+    try:
+        return [
+            _ParamSpec(
+                environment_variable=entry["environmentVariable"],
+                name=entry.get("name", entry["environmentVariable"]),
+                required=bool(entry["required"]),
+            )
+            for entry in entries
+        ]
+    except (KeyError, TypeError, AttributeError) as ex:
+        raise ExtractorError(f"{_PARAMETERS_ENV} is not valid extractor contract metadata: {entries!r}") from ex
+
+
+def _find_spec(specs: list[_SpecT] | None, name: str) -> _SpecT | None:
+    """Find a spec by its registered display name or environment variable."""
+    for spec in specs or []:
+        if name in (spec.environment_variable, spec.name):
+            return spec
+    return None
+
+
+def _spec_names(specs: list[_InputSpec] | list[_ParamSpec]) -> str:
+    """Render specs as 'ENV_VAR' or 'ENV_VAR (display name)' for error messages."""
+    return ", ".join(
+        spec.environment_variable
+        if spec.name == spec.environment_variable
+        else f"{spec.environment_variable} ({spec.name!r})"
+        for spec in specs
+    )
+
+
+@dataclass
+class ExtractorContext:
+    """The execution context handed to an extractor function.
+
+    Resolves inputs and parameters from the environment, and collects the output files the
+    function writes. Authors do not construct this directly; :meth:`Extractor.run` builds a
+    :class:`SingleFileExtractorContext` or :class:`ManifestExtractorContext`.
+    """
+
+    output_dir: Path
+    _env: Mapping[str, str] = field(repr=False)
+    _input_dir: Path = field(repr=False)
+    _input_specs: list[_InputSpec] | None = field(default=None, repr=False)
+    _param_specs: list[_ParamSpec] | None = field(default=None, repr=False)
+
+    @property
+    def inputs(self) -> list[Path]:
+        """All input files Nominal mounted for this run.
+
+        Taken from the registered ``_NOMINAL_INPUTS`` metadata when present, in the order Nominal
+        serializes them; otherwise discovered by listing the input mount, sorted by name.
+        """
+        if self._input_specs is not None:
+            return [Path(spec.path) for spec in self._input_specs]
+        if not self._input_dir.is_dir():
+            return []
+        return sorted(path for path in self._input_dir.iterdir() if path.is_file())
+
+    def input(self, name: str | None = None) -> Path:
+        """Resolve an input file.
+
+        With ``name`` -- the input's registered display name or its environment variable -- returns
+        that input's path. Without it, returns the sole mounted input file, raising if there is not
+        exactly one.
+        """
+        if name is not None:
+            spec = _find_spec(self._input_specs, name)
+            if spec is not None:
+                return Path(spec.path)
+            if self._input_specs is None:
+                value = self._env.get(name)
+                if value:
+                    return Path(value)
+                raise ExtractorError(f"input {name!r} is not set; no matching environment variable")
+            raise ExtractorError(
+                f"input {name!r} is not among this run's inputs: {_spec_names(self._input_specs) or '(none)'}; "
+                "an optional input not provided by the ingest request is not listed"
+            )
+        files = self.inputs
+        if len(files) != 1:
+            raise ExtractorError(
+                f"expected exactly one input file, found {len(files)}; pass an input name to input() to select one"
+            )
+        return files[0]
+
+    def _param_env_var(self, name: str) -> str:
+        """Resolve a parameter name to its environment variable.
+
+        With registered contract metadata, the contract is authoritative: a name with no entry is
+        an authoring error. Without it (a local run), ``name`` is treated as the environment
+        variable directly.
+        """
+        spec = _find_spec(self._param_specs, name)
+        if spec is not None:
+            return spec.environment_variable
+        if self._param_specs is None:
+            return name
+        raise ExtractorError(
+            f"unknown parameter {name!r}; registered parameters are: {_spec_names(self._param_specs) or '(none)'}"
+        )
+
+    def param(self, name: str) -> str:
+        """Read a required parameter from the environment.
+
+        ``name`` -- the parameter's registered display name or its environment variable -- is
+        resolved against ``_NOMINAL_PARAMETERS`` when Nominal injected it; otherwise it is treated
+        directly as the environment variable. Raises :class:`ExtractorError` when the parameter is
+        not set. Parameter values are strings; coerce them yourself: ``int(ctx.param("PARTS"))``.
+        With registered contract metadata present, an unregistered ``name`` raises
+        :class:`ExtractorError`.
+        """
+        raw = self._env.get(self._param_env_var(name))
+        if raw is None:
+            raise ExtractorError(f"required parameter {name!r} is not set")
+        return raw
+
+    @overload
+    def get_param(self, name: str, default: None = None) -> str | None: ...
+
+    @overload
+    def get_param(self, name: str, default: str) -> str: ...
+
+    def get_param(self, name: str, default: str | None = None) -> str | None:
+        """Read an optional parameter from the environment, or ``default`` when unset.
+
+        Name resolution matches :meth:`param`. Parameter values are strings; coerce them
+        yourself: ``int(ctx.get_param("PARTS", "2"))``. With registered contract metadata present,
+        an unregistered ``name`` raises :class:`ExtractorError`.
+        """
+        raw = self._env.get(self._param_env_var(name))
+        return default if raw is None else raw
+
+    @property
+    def ingest_job_rid(self) -> str | None:
+        """RID of the ingest job running this extractor, or None when Nominal didn't inject it."""
+        return self._env.get(_INGEST_JOB_RID_ENV) or None
+
+    @property
+    def dataset_rid(self) -> str | None:
+        """RID of the dataset this run ingests into, or None when Nominal didn't inject it."""
+        return self._env.get(_DATASET_RID_ENV) or None
+
+    @property
+    def additional_tags(self) -> dict[str, str]:
+        """Tags the ingest request applies to all data from this run; empty when Nominal didn't inject them."""
+        tags = _json_env(self._env, _ADDITIONAL_TAGS_ENV)
+        if tags is None:
+            return {}
+        if not isinstance(tags, dict):
+            raise ExtractorError(f"{_ADDITIONAL_TAGS_ENV} is not a JSON object: {tags!r}")
+        result: dict[str, str] = {}
+        for key, value in tags.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                raise ExtractorError(f"{_ADDITIONAL_TAGS_ENV} must map string tag names to string values: {tags!r}")
+            result[key] = value
+        return result
+
+    @property
+    def job_timestamp_metadata(self) -> TimestampMetadata | None:
+        """The job-level timestamp metadata this run's outputs default to.
+
+        This is the metadata the pipeline resolved for the whole job (the ingest request's override
+        when given, else the image's registered default) -- the value a manifest output falls back
+        to when it declares no per-output timestamp metadata of its own. None when Nominal didn't
+        inject it.
+        """
+        document = _json_env(self._env, _JOB_TIMESTAMP_METADATA_ENV)
+        if document is None:
+            return None
+        try:
+            decoded = ConjureDecoder().decode(document, scout_catalog.TimestampMetadata)
+        except Exception as ex:
+            raise ExtractorError(f"{_JOB_TIMESTAMP_METADATA_ENV} is not valid timestamp metadata: {document!r}") from ex
+        return TimestampMetadata(
+            series_name=decoded.series_name,
+            timestamp_type=ts._catalog_timestamp_type_to_typed_timestamp_type(decoded.timestamp_type),
+        )
+
+    def _relative_output_path(self, path: str | os.PathLike[str]) -> tuple[Path, str]:
+        """Validate an output file exists under ``output_dir``; return it with its relative path.
+
+        The relative path always uses forward slashes (``as_posix()``), matching the platform's
+        wire contract regardless of the host OS.
+        """
+        given = Path(path)
+        if not given.is_file():
+            raise ExtractorError(f"output file does not exist: {given}")
+        try:
+            relative = given.resolve().relative_to(self.output_dir.resolve())
+        except ValueError as ex:
+            raise ExtractorError(f"output file {given} is not inside the output directory {self.output_dir}") from ex
+        return given, relative.as_posix()
+
+    def _finalize(self) -> int:
+        """Enforce the mode's output contract; returns the number of finalized outputs."""
+        raise NotImplementedError
+
+
+def _check_for_undeclared_output_files(output_dir: Path, declared: set[str], declare_method: str) -> None:
+    """Reject files sitting in ``output_dir`` that were never declared as outputs.
+
+    Counting only declared outputs isn't enough to catch a stray file: an author who writes two
+    files but only declares one would pass a count check while still leaving two files on disk,
+    reproducing the downstream multiple-files failure this module exists to catch earlier.
+    """
+    actual = {path.relative_to(output_dir).as_posix() for path in output_dir.rglob("*") if path.is_file()}
+    undeclared = sorted(actual - declared)
+    if undeclared:
+        raise ExtractorError(
+            f"output directory contains file(s) not passed to {declare_method}: {undeclared}; declare "
+            "every file you want ingested, or remove stray files from the output directory"
+        )
+
+
+@dataclass
+class SingleFileExtractorContext(ExtractorContext):
+    """Context for :func:`single_file_extractor` functions: declare the one output via :meth:`set_output`."""
+
+    _output_relative: str | None = field(default=None, repr=False)
+
+    def set_output(self, path: str | os.PathLike[str]) -> Path:
+        """Declare the single file you wrote to the output directory.
+
+        Records the file (it must already exist under ``output_dir``); it does not write anything
+        itself. A single-file extractor produces exactly one output, so a second call raises. Use
+        :func:`manifest_extractor` (with the image registered under the ``MANIFEST`` output format)
+        to emit multiple files.
+        """
+        if self._output_relative is not None:
+            raise ExtractorError(
+                f"set_output() was already called with {self._output_relative!r}; a single-file extractor "
+                "produces exactly one output file. Register the image with the MANIFEST output format and "
+                "use @manifest_extractor to emit multiple files"
+            )
+        resolved, relative = self._relative_output_path(path)
+        logger.debug("declared output %s", relative)
+        self._output_relative = relative
+        return resolved
+
+    def _finalize(self) -> int:
+        if self._output_relative is None:
+            raise ExtractorError(
+                "single-file extractor produced no output; call ctx.set_output() with the file you wrote"
+            )
+        _check_for_undeclared_output_files(self.output_dir, {self._output_relative}, "ctx.set_output()")
+        return 1
+
+
+@dataclass
+class ManifestExtractorContext(ExtractorContext):
+    """Context for :func:`manifest_extractor` functions: declare each output via :meth:`add_output`."""
+
+    _outputs: list[ingest_manifest.ManifestOutput] = field(default_factory=list, repr=False)
+
+    def add_output(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        ingest_type: IngestType = IngestType.TABULAR,
+        tag_columns: Mapping[str, str] | None = None,
+        channel_prefix: str | None = None,
+        timestamp_column: str | None = None,
+        timestamp_type: ts._AnyTimestampType | None = None,
+    ) -> Path:
+        """Declare a file you wrote to the output directory; it becomes one manifest entry.
+
+        Records the file (it must already exist under ``output_dir``); it does not write anything
+        itself. ``timestamp_column``/``timestamp_type`` (provided together) override the job-level
+        timestamp metadata for this output, so each file can carry its own timestamp field. Only
+        numeric epoch timestamp types (seconds through nanoseconds) are supported here; outputs
+        needing richer types should omit the pair and rely on the job-level metadata. For
+        ``JSON_L`` outputs each line must still contain a ``MESSAGE`` field; that path is log
+        ingest.
+        """
+        if (timestamp_column is None) != (timestamp_type is None):
+            raise ExtractorError("timestamp_column and timestamp_type must be provided together")
+        resolved, relative = self._relative_output_path(path)
+        if relative == _MANIFEST_FILENAME:
+            raise ExtractorError(
+                f"{_MANIFEST_FILENAME} is written automatically by the runtime; write your data to a "
+                "different file name and declare that one with add_output() instead"
+            )
+        timestamp_metadata = None
+        if timestamp_column is not None and timestamp_type is not None:
+            timestamp_metadata = ingest_manifest.ManifestTimestampMetadata(
+                series_name=timestamp_column,
+                epoch_time_unit=_manifest_epoch_time_unit(timestamp_type),
+            )
+        logger.debug("declared output %s (%s)", relative, ingest_type.value)
+        self._outputs.append(
+            ingest_manifest.ManifestOutput(
+                ingest_type=ingest_type._to_conjure(),
+                relative_path=relative,
+                tag_columns=dict(tag_columns or {}),
+                channel_prefix=channel_prefix,
+                timestamp_metadata=timestamp_metadata,
+            )
+        )
+        return resolved
+
+    def build_manifest(self) -> dict[str, Any]:
+        """Build the manifest document from the declared outputs, exactly as it is written to disk."""
+        document: dict[str, Any] = ConjureEncoder.do_encode(
+            ingest_manifest.ExtractorManifest(outputs=list(self._outputs))
+        )
+        return document
+
+    def _finalize(self) -> int:
+        if not self._outputs:
+            raise ExtractorError("manifest extractor produced no outputs; call ctx.add_output() for each file")
+        _check_for_undeclared_output_files(
+            self.output_dir, {output.relative_path for output in self._outputs}, "ctx.add_output()"
+        )
+        manifest_path = self.output_dir / _MANIFEST_FILENAME
+        manifest_path.write_text(json.dumps(self.build_manifest()))
+        logger.info("wrote %s describing %d output(s)", manifest_path, len(self._outputs))
+        return len(self._outputs)
+
+
+_CtxT = TypeVar("_CtxT", bound=ExtractorContext)
+
+
+@dataclass
+class Extractor(Generic[_CtxT]):
+    """A containerized-extractor entrypoint produced by :func:`single_file_extractor` or :func:`manifest_extractor`.
+
+    Call :meth:`run` as the container's entrypoint to drive it from the environment. In tests,
+    drive it with :meth:`run` (``env=...``, ``exit=False``) rather than constructing a context by
+    hand. Carries the wrapped function's metadata (``__name__``, ``__doc__``, ...) like any well-behaved
+    decorator.
+    """
+
+    _fn: Callable[[_CtxT], None]
+    _context_cls: type[_CtxT]
+
+    def __post_init__(self) -> None:
+        functools.update_wrapper(self, self._fn)
+
+    def __call__(self, ctx: _CtxT) -> None:
+        self._fn(ctx)
+
+    @property
+    def _is_manifest(self) -> bool:
+        return issubclass(self._context_cls, ManifestExtractorContext)
+
+    def run(self, *, env: Mapping[str, str] | None = None, exit: bool = True) -> _CtxT:
+        """Run the extractor against the environment and finalize its outputs.
+
+        Intended as the container entrypoint (``if __name__ == "__main__": my_extractor.run()``).
+        On success returns the context; on failure prints a traceback and, when ``exit`` is
+        True (the default), exits with a non-zero status so the ingest job fails. Pass
+        ``exit=False`` to re-raise instead -- useful in tests.
+        """
+        environ = os.environ if env is None else env
+        if env is None:
+            # As the container entrypoint, make the runtime's log lines visible in the job's
+            # captured output; a no-op when the author already configured logging.
+            logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+        try:
+            self._check_registered_format(environ)
+            ctx = self._build_context(environ)
+            logger.info(
+                "running %s extractor %s with %d input(s)",
+                "manifest" if self._is_manifest else "single-file",
+                self._fn.__name__,
+                len(ctx.inputs),
+            )
+            self._validate_registered_contract(ctx)
+            self._fn(ctx)
+            count = ctx._finalize()
+            logger.info("extractor %s completed with %d output(s)", self._fn.__name__, count)
+            return ctx
+        except BaseException:  # deliberately broad: any failure (incl. SystemExit/KeyboardInterrupt
+            # from user code) must fail the ingest job cleanly, not just Exception subclasses.
+            if exit:
+                traceback.print_exc()
+                sys.exit(1)
+            raise
+
+    def _validate_registered_contract(self, ctx: _CtxT) -> None:
+        """Check the registered contract against the environment once, at startup.
+
+        Advisory only: a registered-required parameter left unset, or a registered input whose
+        mounted path is missing, earns a warning at the top of the job log -- but the run
+        proceeds, since only code that actually reads the affected name is impacted.
+        """
+        for param_spec in ctx._param_specs or []:
+            if param_spec.required and ctx._env.get(param_spec.environment_variable) is None:
+                logger.warning(
+                    "required parameter %s (%r) has no value set; ctx.param will fail if it is read",
+                    param_spec.environment_variable,
+                    param_spec.name,
+                )
+        for input_spec in ctx._input_specs or []:
+            if not Path(input_spec.path).is_file():
+                logger.warning(
+                    "input %s (%r) is not present at %s",
+                    input_spec.environment_variable,
+                    input_spec.name,
+                    input_spec.path,
+                )
+
+    def _check_registered_format(self, env: Mapping[str, str]) -> None:
+        """Assert the decorator's contract against the injected registered output format.
+
+        When ``_NOMINAL_OUTPUT_FORMAT`` is absent (a local run) the decorator's word is law.
+        """
+        registered = env.get(_OUTPUT_FORMAT_ENV)
+        if not registered:
+            return
+        registered_manifest = registered == FileOutputFormat.MANIFEST.value
+        if registered_manifest == self._is_manifest:
+            return
+        declared, alternative = (
+            ("@manifest_extractor", "@single_file_extractor")
+            if self._is_manifest
+            else ("@single_file_extractor", "@manifest_extractor")
+        )
+        raise ExtractorError(
+            f"{declared} disagrees with the image's registered output format {registered!r} "
+            f"(_NOMINAL_OUTPUT_FORMAT); re-register the image or switch to {alternative} so the "
+            "code and the registration agree"
+        )
+
+    def _build_context(self, env: Mapping[str, str]) -> _CtxT:
+        output_dir = env.get(_OUTPUT_DIR_ENV)
+        if not output_dir:
+            raise ExtractorError(f"{_OUTPUT_DIR_ENV} is not set; this code must run inside a Nominal extractor")
+        input_dir = env.get(_INPUT_DIR_ENV, _DEFAULT_INPUT_DIR)
+        return self._context_cls(
+            output_dir=Path(output_dir),
+            _env=env,
+            _input_dir=Path(input_dir),
+            _input_specs=_parse_input_specs(env),
+            _param_specs=_parse_param_specs(env),
+        )
+
+
+def single_file_extractor(fn: Callable[[SingleFileExtractorContext], None]) -> Extractor[SingleFileExtractorContext]:
+    """Turn ``def fn(ctx: SingleFileExtractorContext) -> None`` into a single-file extractor entrypoint.
+
+    For images registered with a single-file output format (``PARQUET``, ``CSV``, ...): the ingest
+    pipeline ingests exactly one output file, parsed per the registered format. Declare it with
+    :meth:`SingleFileExtractorContext.set_output`. If the image's registered format turns out to be
+    ``MANIFEST``, :meth:`Extractor.run` fails at startup with a clear error.
+
+    Example::
+
+        from nominal.experimental.extractor import SingleFileExtractorContext, single_file_extractor
+
+        @single_file_extractor
+        def convert(ctx: SingleFileExtractorContext) -> None:
+            table = read_input(ctx.input())
+            out = ctx.output_dir / "converted.parquet"
+            write_parquet(table, out)
+            ctx.set_output(out)
+
+        if __name__ == "__main__":
+            convert.run()
+    """
+    return Extractor(fn, SingleFileExtractorContext)
+
+
+def manifest_extractor(fn: Callable[[ManifestExtractorContext], None]) -> Extractor[ManifestExtractorContext]:
+    """Turn ``def fn(ctx: ManifestExtractorContext) -> None`` into a manifest extractor entrypoint.
+
+    For images registered with the ``MANIFEST`` output format: declare each output file (and its
+    per-file ingest type, tag columns, channel prefix, and optional epoch timestamp metadata) with
+    :meth:`ManifestExtractorContext.add_output`; ``manifest.json`` is written automatically when
+    the function returns. If the image's registered format is not ``MANIFEST``, :meth:`Extractor.run`
+    fails at startup with a clear error.
+
+    Example::
+
+        from nominal.experimental.extractor import IngestType, ManifestExtractorContext, manifest_extractor
+
+        @manifest_extractor
+        def split(ctx: ManifestExtractorContext) -> None:
+            table = read_parquet(ctx.input())
+            for i, chunk in enumerate(chunks_of(table, int(ctx.get_param("PARTS", "2")))):
+                out = ctx.output_dir / f"part_{i}.parquet"
+                write_parquet(chunk, out)
+                ctx.add_output(out, ingest_type=IngestType.TABULAR)
+
+        if __name__ == "__main__":
+            split.run()
+    """
+    return Extractor(fn, ManifestExtractorContext)

--- a/tests/experimental/test_extractor.py
+++ b/tests/experimental/test_extractor.py
@@ -1,0 +1,638 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from nominal import ts
+from nominal.experimental.extractor import (
+    ExtractorError,
+    IngestType,
+    ManifestExtractorContext,
+    SingleFileExtractorContext,
+    TimestampMetadata,
+    manifest_extractor,
+    single_file_extractor,
+)
+
+
+def _env(input_dir: Path, output_dir: Path, **extra: str) -> dict[str, str]:
+    return {
+        "OUTPUT_DIR": str(output_dir),
+        "NOMINAL_EXTRACTOR_INPUT_DIR": str(input_dir),
+        **extra,
+    }
+
+
+@pytest.fixture
+def dirs(tmp_path: Path) -> tuple[Path, Path]:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    return input_dir, output_dir
+
+
+def test_single_input_and_output_passthrough(dirs: tuple[Path, Path]) -> None:
+    """A plain @extractor resolves the sole input and writes its single output without a manifest."""
+    input_dir, output_dir = dirs
+    (input_dir / "data.parquet").write_text("payload")
+
+    @single_file_extractor
+    def passthrough(ctx: SingleFileExtractorContext) -> None:
+        out = ctx.output_dir / "out.parquet"
+        out.write_text(ctx.input().read_text())
+        ctx.set_output(out)
+
+    passthrough.run(env=_env(input_dir, output_dir), exit=False)
+
+    assert (output_dir / "out.parquet").read_text() == "payload"
+    assert not (output_dir / "manifest.json").exists()  # single-file mode writes no manifest
+
+
+def test_manifest_mode_writes_manifest_from_outputs(dirs: tuple[Path, Path]) -> None:
+    """Manifest mode writes manifest.json describing every add_output call."""
+    input_dir, output_dir = dirs
+    (input_dir / "data.parquet").write_text("rows")
+
+    @manifest_extractor
+    def split(ctx: ManifestExtractorContext) -> None:
+        for i in range(2):
+            part = ctx.output_dir / f"part_{i}.parquet"
+            part.write_text(f"part-{i}")
+            ctx.add_output(part, ingest_type=IngestType.TABULAR, tag_columns={"vehicle": "veh_id"})
+
+    ctx = split.run(env=_env(input_dir, output_dir), exit=False)
+
+    manifest = json.loads((output_dir / "manifest.json").read_text())
+    assert ctx.build_manifest() == manifest  # the public accessor is the same single serialization path
+    entry = {
+        "ingestType": "TABULAR",
+        "tagColumns": {"vehicle": "veh_id"},
+        "channelPrefix": None,
+        "timestampMetadata": None,
+    }
+    assert manifest == {
+        "outputs": [
+            {**entry, "relativePath": "part_0.parquet"},
+            {**entry, "relativePath": "part_1.parquet"},
+        ]
+    }
+
+
+def test_manifest_includes_channel_prefix_when_set(dirs: tuple[Path, Path]) -> None:
+    """A manifest entry carries channelPrefix when the output declares one."""
+    input_dir, output_dir = dirs
+
+    @manifest_extractor
+    def emit(ctx: ManifestExtractorContext) -> None:
+        out = ctx.output_dir / "telemetry.jsonl"
+        out.write_text("{}")
+        ctx.add_output(out, ingest_type=IngestType.JSON_L, channel_prefix="telemetry/")
+
+    emit.run(env=_env(input_dir, output_dir), exit=False)
+
+    [entry] = json.loads((output_dir / "manifest.json").read_text())["outputs"]
+    assert entry["channelPrefix"] == "telemetry/"
+
+
+def test_manifest_includes_timestamp_metadata_when_set(dirs: tuple[Path, Path]) -> None:
+    """A manifest entry carries per-output timestampMetadata when the output declares it."""
+    input_dir, output_dir = dirs
+
+    @manifest_extractor
+    def emit(ctx: ManifestExtractorContext) -> None:
+        out = ctx.output_dir / "telemetry.jsonl"
+        out.write_text("{}")
+        ctx.add_output(
+            out,
+            ingest_type=IngestType.JSON_L,
+            timestamp_column="ts",
+            timestamp_type="epoch_microseconds",
+        )
+
+    emit.run(env=_env(input_dir, output_dir), exit=False)
+
+    [entry] = json.loads((output_dir / "manifest.json").read_text())["outputs"]
+    assert entry["timestampMetadata"] == {"seriesName": "ts", "epochTimeUnit": "MICROSECONDS"}
+
+
+def test_manifest_leaves_timestamp_metadata_null_when_unset(dirs: tuple[Path, Path]) -> None:
+    """Manifest entries carry a null timestampMetadata when unset, deferring to the job-level metadata."""
+    input_dir, output_dir = dirs
+
+    @manifest_extractor
+    def emit(ctx: ManifestExtractorContext) -> None:
+        out = ctx.output_dir / "data.parquet"
+        out.write_text("rows")
+        ctx.add_output(out)
+
+    emit.run(env=_env(input_dir, output_dir), exit=False)
+
+    [entry] = json.loads((output_dir / "manifest.json").read_text())["outputs"]
+    assert entry["timestampMetadata"] is None
+
+
+def test_manifest_mode_rejects_zero_outputs(dirs: tuple[Path, Path]) -> None:
+    """Manifest mode fails when the extractor declares no outputs."""
+    input_dir, output_dir = dirs
+
+    @manifest_extractor
+    def noop(ctx: ManifestExtractorContext) -> None:
+        return None
+
+    with pytest.raises(ExtractorError, match="no outputs"):
+        noop.run(env=_env(input_dir, output_dir), exit=False)
+
+
+def test_param_and_get_param_read_strings(dirs: tuple[Path, Path]) -> None:
+    """param() returns the raw string; get_param() falls back to its default when unset."""
+    input_dir, output_dir = dirs
+    captured: dict[str, object] = {}
+
+    @single_file_extractor
+    def read_params(ctx: SingleFileExtractorContext) -> None:
+        captured["parts"] = int(ctx.param("PARTS"))
+        captured["missing"] = ctx.get_param("ABSENT")
+        captured["fallback"] = ctx.get_param("ABSENT", "7")
+        out = ctx.output_dir / "out.bin"
+        out.write_text("x")
+        ctx.set_output(out)
+
+    read_params.run(env=_env(input_dir, output_dir, PARTS="3"), exit=False)
+
+    assert captured == {"parts": 3, "missing": None, "fallback": "7"}
+
+
+def test_param_missing_raises(dirs: tuple[Path, Path]) -> None:
+    """param() raises when the parameter is not set."""
+    input_dir, output_dir = dirs
+
+    @single_file_extractor
+    def needs_param(ctx: SingleFileExtractorContext) -> None:
+        ctx.param("MODE")
+
+    with pytest.raises(ExtractorError, match="required parameter 'MODE'"):
+        needs_param.run(env=_env(input_dir, output_dir), exit=False)
+
+
+def test_input_by_env_var_name(dirs: tuple[Path, Path]) -> None:
+    """input(name) resolves a mounted input by its environment variable."""
+    input_dir, output_dir = dirs
+    target = input_dir / "data.parquet"
+    target.write_text("x")
+
+    @single_file_extractor
+    def by_name(ctx: SingleFileExtractorContext) -> None:
+        assert ctx.input("INPUT_FILE") == target
+        out = ctx.output_dir / "out.bin"
+        out.write_text("x")
+        ctx.set_output(out)
+
+    by_name.run(env=_env(input_dir, output_dir, INPUT_FILE=str(target)), exit=False)
+
+
+def test_add_output_rejects_file_outside_output_dir(dirs: tuple[Path, Path]) -> None:
+    """add_output rejects files that are not inside the output directory."""
+    input_dir, output_dir = dirs
+    stray = input_dir / "stray.parquet"
+    stray.write_text("x")
+
+    @manifest_extractor
+    def misplaced(ctx: ManifestExtractorContext) -> None:
+        ctx.add_output(stray)
+
+    with pytest.raises(ExtractorError, match="not inside the output directory"):
+        misplaced.run(env=_env(input_dir, output_dir), exit=False)
+
+
+def test_inputs_enumerated_from_nominal_inputs_metadata(dirs: tuple[Path, Path]) -> None:
+    """Inputs and input() resolve from _NOMINAL_INPUTS metadata instead of listing the mount."""
+    input_dir, output_dir = dirs
+    nominal_inputs = json.dumps(
+        [
+            {
+                "name": "Telemetry",
+                "environmentVariable": "TELEMETRY",
+                "path": "/input/telemetry.parquet",
+                "required": True,
+            },
+            {"name": "Events", "environmentVariable": "EVENTS", "path": "/input/events.parquet", "required": False},
+        ]
+    )
+
+    @single_file_extractor
+    def reads_inputs(ctx: SingleFileExtractorContext) -> None:
+        # Enumerated from metadata (in the order Nominal serializes it), without listing the filesystem.
+        assert ctx.inputs == [Path("/input/telemetry.parquet"), Path("/input/events.parquet")]
+        # Resolvable by environment variable or by registered display name.
+        assert ctx.input("EVENTS") == Path("/input/events.parquet")
+        assert ctx.input("Telemetry") == Path("/input/telemetry.parquet")
+        out = ctx.output_dir / "out.parquet"
+        out.write_text("x")
+        ctx.set_output(out)
+
+    reads_inputs.run(
+        env=_env(input_dir, output_dir, _NOMINAL_OUTPUT_FORMAT="PARQUET", _NOMINAL_INPUTS=nominal_inputs),
+        exit=False,
+    )
+
+
+def test_input_unknown_name_with_contract_raises(dirs: tuple[Path, Path]) -> None:
+    """input(name) on a name absent from _NOMINAL_INPUTS raises ExtractorError, not 'unknown'."""
+    input_dir, output_dir = dirs
+    nominal_inputs = json.dumps(
+        [{"name": "Telemetry", "environmentVariable": "TELEMETRY", "path": "/input/telemetry.parquet"}]
+    )
+
+    @single_file_extractor
+    def reads(ctx: SingleFileExtractorContext) -> None:
+        ctx.input("OTHER")
+
+    with pytest.raises(ExtractorError, match="not among this run's inputs"):
+        reads.run(env=_env(input_dir, output_dir, _NOMINAL_INPUTS=nominal_inputs), exit=False)
+
+
+def test_param_resolved_by_registered_display_name(dirs: tuple[Path, Path]) -> None:
+    """param() resolves a parameter by its registered display name via _NOMINAL_PARAMETERS."""
+    input_dir, output_dir = dirs
+    nominal_parameters = json.dumps([{"name": "Chunk Size", "environmentVariable": "PARTS", "required": False}])
+
+    @single_file_extractor
+    def read_by_display_name(ctx: SingleFileExtractorContext) -> None:
+        assert ctx.param("Chunk Size") == "3"
+        assert ctx.get_param("PARTS") == "3"
+        out = ctx.output_dir / "out.bin"
+        out.write_text("x")
+        ctx.set_output(out)
+
+    read_by_display_name.run(
+        env=_env(input_dir, output_dir, PARTS="3", _NOMINAL_PARAMETERS=nominal_parameters), exit=False
+    )
+
+
+def test_param_unknown_name_with_contract_raises(dirs: tuple[Path, Path]) -> None:
+    """param() on a name absent from the registered contract raises ExtractorError."""
+    input_dir, output_dir = dirs
+    nominal_parameters = json.dumps([{"name": "Parts", "environmentVariable": "PARTS", "required": True}])
+
+    @single_file_extractor
+    def reads(ctx: SingleFileExtractorContext) -> None:
+        ctx.param("NOPE")
+
+    with pytest.raises(ExtractorError, match="registered parameters are"):
+        reads.run(env=_env(input_dir, output_dir, PARTS="3", _NOMINAL_PARAMETERS=nominal_parameters), exit=False)
+
+
+def test_get_param_returns_default_for_registered_unset_param(dirs: tuple[Path, Path]) -> None:
+    """get_param() returns its default for a registered-but-unprovided optional parameter."""
+    input_dir, output_dir = dirs
+    nominal_parameters = json.dumps([{"name": "Mode", "environmentVariable": "MODE", "required": False}])
+    captured: dict[str, object] = {}
+
+    @single_file_extractor
+    def reads(ctx: SingleFileExtractorContext) -> None:
+        captured["mode"] = ctx.get_param("MODE", "fallback")
+        out = ctx.output_dir / "out.bin"
+        out.write_text("x")
+        ctx.set_output(out)
+
+    reads.run(env=_env(input_dir, output_dir, _NOMINAL_PARAMETERS=nominal_parameters), exit=False)
+
+    assert captured == {"mode": "fallback"}
+
+
+def test_finalize_rejects_undeclared_output_files(dirs: tuple[Path, Path]) -> None:
+    """Files in the output directory never declared as outputs fail the run."""
+    input_dir, output_dir = dirs
+
+    @single_file_extractor
+    def forgets_to_declare(ctx: SingleFileExtractorContext) -> None:
+        declared = ctx.output_dir / "declared.bin"
+        declared.write_text("x")
+        (ctx.output_dir / "stray.bin").write_text("x")
+        ctx.set_output(declared)
+
+    with pytest.raises(ExtractorError, match="not passed to ctx.set_output"):
+        forgets_to_declare.run(env=_env(input_dir, output_dir), exit=False)
+
+
+def test_run_exits_nonzero_on_failure(dirs: tuple[Path, Path]) -> None:
+    """run() prints a traceback and exits non-zero when the extractor raises."""
+    input_dir, output_dir = dirs
+
+    @single_file_extractor
+    def boom(ctx: SingleFileExtractorContext) -> None:
+        raise ValueError("kaboom")
+
+    with pytest.raises(SystemExit) as exc:
+        boom.run(env=_env(input_dir, output_dir), exit=True)
+    assert exc.value.code == 1
+
+
+def test_system_metadata_exposed_when_injected(dirs: tuple[Path, Path]) -> None:
+    """The pipeline-injected job/dataset RIDs, tags, and job-level timestamp metadata are exposed on the context."""
+    input_dir, output_dir = dirs
+    (input_dir / "data.parquet").write_text("payload")
+    job_timestamp = {
+        "seriesName": "ts",
+        "timestampType": {
+            "type": "absolute",
+            "absolute": {"type": "epochOfTimeUnit", "epochOfTimeUnit": {"timeUnit": "MICROSECONDS"}},
+        },
+    }
+
+    @single_file_extractor
+    def passthrough(ctx: SingleFileExtractorContext) -> None:
+        out = ctx.output_dir / "out.parquet"
+        out.write_text("done")
+        ctx.set_output(out)
+
+    ctx = passthrough.run(
+        env=_env(
+            input_dir,
+            output_dir,
+            _NOMINAL_INGEST_JOB_RID="ri.ingest-job.x",
+            _NOMINAL_DATASET_RID="ri.dataset.y",
+            _NOMINAL_ADDITIONAL_TAGS=json.dumps({"vehicle": "veh-1"}),
+            _NOMINAL_TIMESTAMP_METADATA=json.dumps(job_timestamp),
+        ),
+        exit=False,
+    )
+
+    assert ctx.ingest_job_rid == "ri.ingest-job.x"
+    assert ctx.dataset_rid == "ri.dataset.y"
+    assert ctx.additional_tags == {"vehicle": "veh-1"}
+    assert ctx.job_timestamp_metadata == TimestampMetadata(series_name="ts", timestamp_type=ts.Epoch("microseconds"))
+
+
+def test_system_metadata_defaults_when_not_injected(dirs: tuple[Path, Path]) -> None:
+    """System metadata degrades to None/empty on pipelines and local runs that don't inject it."""
+    input_dir, output_dir = dirs
+    (input_dir / "data.parquet").write_text("payload")
+
+    @single_file_extractor
+    def passthrough(ctx: SingleFileExtractorContext) -> None:
+        out = ctx.output_dir / "out.parquet"
+        out.write_text("done")
+        ctx.set_output(out)
+
+    ctx = passthrough.run(env=_env(input_dir, output_dir), exit=False)
+
+    assert ctx.ingest_job_rid is None
+    assert ctx.dataset_rid is None
+    assert ctx.additional_tags == {}
+    assert ctx.job_timestamp_metadata is None
+
+
+def test_system_metadata_bad_json_raises(dirs: tuple[Path, Path]) -> None:
+    """Malformed injected tag JSON raises ExtractorError on access instead of passing through."""
+    input_dir, output_dir = dirs
+    (input_dir / "data.parquet").write_text("payload")
+
+    @single_file_extractor
+    def reads_tags(ctx: SingleFileExtractorContext) -> None:
+        ctx.additional_tags
+
+    with pytest.raises(ExtractorError, match="_NOMINAL_ADDITIONAL_TAGS"):
+        reads_tags.run(env=_env(input_dir, output_dir, _NOMINAL_ADDITIONAL_TAGS="{not json"), exit=False)
+
+
+def test_per_output_timestamp_rejects_non_epoch_types(dirs: tuple[Path, Path]) -> None:
+    """Per-output timestamp metadata rejects timestamp types the manifest contract cannot express."""
+    input_dir, output_dir = dirs
+
+    @manifest_extractor
+    def emit(ctx: ManifestExtractorContext) -> None:
+        out = ctx.output_dir / "data.csv"
+        out.write_text("ts,x")
+        ctx.add_output(out, timestamp_column="ts", timestamp_type="iso_8601")
+
+    with pytest.raises(ExtractorError, match="numeric epoch"):
+        emit.run(env=_env(input_dir, output_dir), exit=False)
+
+
+def test_per_output_timestamp_requires_both_column_and_type(dirs: tuple[Path, Path]) -> None:
+    """timestamp_column and timestamp_type must be provided together."""
+    input_dir, output_dir = dirs
+
+    @manifest_extractor
+    def emit(ctx: ManifestExtractorContext) -> None:
+        out = ctx.output_dir / "data.csv"
+        out.write_text("ts,x")
+        ctx.add_output(out, timestamp_column="ts")
+
+    with pytest.raises(ExtractorError, match="together"):
+        emit.run(env=_env(input_dir, output_dir), exit=False)
+
+
+def test_decorator_preserves_function_metadata() -> None:
+    """@extractor carries the wrapped function's name and docstring like a well-behaved decorator."""
+
+    @single_file_extractor
+    def my_extractor(ctx: SingleFileExtractorContext) -> None:
+        """Does things."""
+
+    assert my_extractor.__name__ == "my_extractor"
+    assert my_extractor.__doc__ == "Does things."
+
+
+def test_malformed_nominal_inputs_entry_raises_extractor_error(dirs: tuple[Path, Path]) -> None:
+    """A _NOMINAL_INPUTS entry missing a required key raises ExtractorError naming the variable."""
+    input_dir, output_dir = dirs
+    bad = json.dumps([{"name": "Telemetry"}])  # missing environmentVariable and path
+
+    @single_file_extractor
+    def noop(ctx: SingleFileExtractorContext) -> None:  # pragma: no cover - must fail before the body runs
+        raise AssertionError("body should not run")
+
+    with pytest.raises(ExtractorError, match="_NOMINAL_INPUTS"):
+        noop.run(env=_env(input_dir, output_dir, _NOMINAL_INPUTS=bad), exit=False)
+
+
+def test_non_list_nominal_parameters_raises_extractor_error(dirs: tuple[Path, Path]) -> None:
+    """_NOMINAL_PARAMETERS that decodes to a non-list raises ExtractorError instead of TypeError."""
+    input_dir, output_dir = dirs
+
+    @single_file_extractor
+    def noop(ctx: SingleFileExtractorContext) -> None:  # pragma: no cover - must fail before the body runs
+        raise AssertionError("body should not run")
+
+    with pytest.raises(ExtractorError, match="_NOMINAL_PARAMETERS"):
+        noop.run(env=_env(input_dir, output_dir, _NOMINAL_PARAMETERS=json.dumps({"a": 1})), exit=False)
+
+
+def test_additional_tags_rejects_non_string_values(dirs: tuple[Path, Path]) -> None:
+    """Injected tags with non-string values raise instead of being stringified."""
+    input_dir, output_dir = dirs
+
+    @single_file_extractor
+    def reads_tags(ctx: SingleFileExtractorContext) -> None:
+        ctx.additional_tags
+
+    with pytest.raises(ExtractorError, match="string"):
+        reads_tags.run(env=_env(input_dir, output_dir, _NOMINAL_ADDITIONAL_TAGS=json.dumps({"vehicle": 1})), exit=False)
+
+
+def test_single_file_second_set_output_raises(dirs: tuple[Path, Path]) -> None:
+    """set_output() enforces the single-file contract: a second call raises."""
+    input_dir, output_dir = dirs
+
+    @single_file_extractor
+    def two_outputs(ctx: SingleFileExtractorContext) -> None:
+        for i in range(2):
+            part = ctx.output_dir / f"part_{i}.parquet"
+            part.write_text("x")
+            ctx.set_output(part)
+
+    with pytest.raises(ExtractorError, match="already called"):
+        two_outputs.run(env=_env(input_dir, output_dir), exit=False)
+
+
+def test_single_file_no_output_raises(dirs: tuple[Path, Path]) -> None:
+    """A single-file extractor that never calls set_output() fails the run."""
+    input_dir, output_dir = dirs
+
+    @single_file_extractor
+    def noop(ctx: SingleFileExtractorContext) -> None:
+        return None
+
+    with pytest.raises(ExtractorError, match="no output"):
+        noop.run(env=_env(input_dir, output_dir), exit=False)
+
+
+def test_single_file_decorator_rejects_manifest_registration(dirs: tuple[Path, Path]) -> None:
+    """@single_file_extractor fails at startup when the image is registered MANIFEST."""
+    input_dir, output_dir = dirs
+
+    @single_file_extractor
+    def convert(ctx: SingleFileExtractorContext) -> None:  # pragma: no cover - must fail before the body runs
+        raise AssertionError("body should not run")
+
+    with pytest.raises(ExtractorError, match="disagrees with the image's registered output format"):
+        convert.run(env=_env(input_dir, output_dir, _NOMINAL_OUTPUT_FORMAT="MANIFEST"), exit=False)
+
+
+def test_manifest_decorator_rejects_single_file_registration(dirs: tuple[Path, Path]) -> None:
+    """@manifest_extractor fails at startup when the image is registered with a single-file format."""
+    input_dir, output_dir = dirs
+
+    @manifest_extractor
+    def split(ctx: ManifestExtractorContext) -> None:  # pragma: no cover - must fail before the body runs
+        raise AssertionError("body should not run")
+
+    with pytest.raises(ExtractorError, match="disagrees with the image's registered output format"):
+        split.run(env=_env(input_dir, output_dir, _NOMINAL_OUTPUT_FORMAT="PARQUET"), exit=False)
+
+
+def test_decorators_accept_agreeing_registration(dirs: tuple[Path, Path]) -> None:
+    """Each decorator runs normally when the registered output format agrees."""
+    input_dir, output_dir = dirs
+
+    @single_file_extractor
+    def convert(ctx: SingleFileExtractorContext) -> None:
+        out = ctx.output_dir / "out.parquet"
+        out.write_text("x")
+        ctx.set_output(out)
+
+    convert.run(env=_env(input_dir, output_dir, _NOMINAL_OUTPUT_FORMAT="PARQUET"), exit=False)
+    (output_dir / "out.parquet").unlink()
+
+    @manifest_extractor
+    def split(ctx: ManifestExtractorContext) -> None:
+        out = ctx.output_dir / "part_0.parquet"
+        out.write_text("x")
+        ctx.add_output(out)
+
+    split.run(env=_env(input_dir, output_dir, _NOMINAL_OUTPUT_FORMAT="MANIFEST"), exit=False)
+    assert (output_dir / "manifest.json").exists()
+
+
+def test_add_output_rejects_manifest_filename_collision(dirs: tuple[Path, Path]) -> None:
+    """add_output rejects a file named manifest.json: the runtime writes that file itself."""
+    input_dir, output_dir = dirs
+
+    @manifest_extractor
+    def clobbers_manifest(ctx: ManifestExtractorContext) -> None:
+        out = ctx.output_dir / "manifest.json"
+        out.write_text("{}")
+        ctx.add_output(out)
+
+    with pytest.raises(ExtractorError, match="written automatically"):
+        clobbers_manifest.run(env=_env(input_dir, output_dir), exit=False)
+
+
+def test_manifest_relative_path_uses_forward_slashes(dirs: tuple[Path, Path]) -> None:
+    """A nested output's relativePath uses forward slashes in the manifest, even on Windows."""
+    input_dir, output_dir = dirs
+
+    @manifest_extractor
+    def emit(ctx: ManifestExtractorContext) -> None:
+        sub = ctx.output_dir / "sub"
+        sub.mkdir()
+        out = sub / "part.parquet"
+        out.write_text("rows")
+        ctx.add_output(out)
+
+    emit.run(env=_env(input_dir, output_dir), exit=False)
+
+    [entry] = json.loads((output_dir / "manifest.json").read_text())["outputs"]
+    assert entry["relativePath"] == "sub/part.parquet"
+
+
+def test_run_logs_completion_with_output_count(dirs: tuple[Path, Path], caplog: pytest.LogCaptureFixture) -> None:
+    """run() logs completion with the finalized output count."""
+    input_dir, output_dir = dirs
+
+    @single_file_extractor
+    def convert(ctx: SingleFileExtractorContext) -> None:
+        out = ctx.output_dir / "out.parquet"
+        out.write_text("x")
+        ctx.set_output(out)
+
+    with caplog.at_level(logging.INFO, logger="nominal.experimental.extractor._extractor"):
+        convert.run(env=_env(input_dir, output_dir), exit=False)
+
+    assert "completed with 1 output(s)" in caplog.text
+
+
+def test_startup_warns_when_registered_required_param_unset(
+    dirs: tuple[Path, Path], caplog: pytest.LogCaptureFixture
+) -> None:
+    """A registered-required parameter with no value set warns once at startup."""
+    input_dir, output_dir = dirs
+    nominal_parameters = json.dumps([{"name": "Mode", "environmentVariable": "MODE", "required": True}])
+
+    @single_file_extractor
+    def ignores_mode(ctx: SingleFileExtractorContext) -> None:
+        out = ctx.output_dir / "out.bin"
+        out.write_text("x")
+        ctx.set_output(out)
+
+    with caplog.at_level(logging.WARNING, logger="nominal.experimental.extractor._extractor"):
+        ignores_mode.run(env=_env(input_dir, output_dir, _NOMINAL_PARAMETERS=nominal_parameters), exit=False)
+
+    assert len([r for r in caplog.records if "has no value set" in r.getMessage()]) == 1
+
+
+def test_startup_warns_when_registered_input_path_missing(
+    dirs: tuple[Path, Path], caplog: pytest.LogCaptureFixture
+) -> None:
+    """A registered input whose mounted path does not exist warns at startup; the run proceeds."""
+    input_dir, output_dir = dirs
+    nominal_inputs = json.dumps(
+        [{"name": "Telemetry", "environmentVariable": "TELEMETRY", "path": "/no/such/file.parquet", "required": True}]
+    )
+
+    @single_file_extractor
+    def ignores_input(ctx: SingleFileExtractorContext) -> None:
+        out = ctx.output_dir / "out.bin"
+        out.write_text("x")
+        ctx.set_output(out)
+
+    with caplog.at_level(logging.WARNING, logger="nominal.experimental.extractor._extractor"):
+        ignores_input.run(env=_env(input_dir, output_dir, _NOMINAL_INPUTS=nominal_inputs), exit=False)
+
+    assert "is not present at" in caplog.text


### PR DESCRIPTION
Revamp of #826 off latest `main`, squashed to a single commit.

Adds `nominal.experimental.extractor` — the in-container runtime for authoring Nominal Hosted containerized extractors. One decorator per output contract; the context resolves everything from the injected environment; `run()` is the container entrypoint.

## API

- `@single_file_extractor` — image registered with a single-file output format (`PARQUET`, `CSV`, ...). Declare the one output via `ctx.set_output(path)`; a second call raises.
- `@manifest_extractor` — image registered with `MANIFEST`. Declare each file via `ctx.add_output(path, *, ingest_type=TABULAR, tag_columns=None, channel_prefix=None, timestamp_column=None, timestamp_type=None)`; `manifest.json` is written automatically on return.
- Shared `ExtractorContext` base: `output_dir`, `inputs` / `input(name)`, `param(name) -> str` (required, raises when unset), `get_param(name, default) -> str | None` (optional, `os.environ.get`-style overloads), plus injected system metadata: `ingest_job_rid`, `dataset_rid`, `additional_tags`, `job_timestamp_metadata`.
- `Extractor[_CtxT].run(*, env=None, exit=True) -> _CtxT` — builds the context from the environment, runs the function, finalizes outputs, exits non-zero on any failure (traceback to stderr). `exit=False` re-raises (tests).

## Behavior

- Decorator contract is asserted against the registered output format (`_NOMINAL_OUTPUT_FORMAT`) at startup; mismatch fails with an actionable error before user code runs. Metadata absent ⇒ local run; the decorator's word is law.
- Contract metadata is authoritative when injected: unknown parameter names raise listing the registered parameters; `input(name)` misses raise "not among this run's inputs" (optional inputs not provided by the request are not listed). Local runs resolve names as env vars directly.
- Startup validation over the parsed contract (no knowledge of what the code reads): warns once per registered-required parameter with no value and per registered input whose mounted path is missing.
- Parameters are strings, matching the platform contract; coercion is the author's job.
- Finalize rejects files in the output directory never declared as outputs; single-file mode requires exactly one. `manifest.json` is a reserved output name. Manifest `relativePath` is always POSIX-style.
- Per-output `timestamp_column`/`timestamp_type` accepts numeric epoch types only (seconds → nanoseconds); richer types defer to the job-level timestamp metadata.

## Testing

- 36 unit tests: both contracts end-to-end against real tmp dirs, mode mismatch both directions, closed-world resolution + local-mode fallback, startup validation warnings, undeclared-file/collision rejection, manifest serialization incl. per-output timestamp metadata and nested outputs.
- mypy strict clean on 3.10–3.14; `run()` returns the precise context subclass.

<details>
<summary><b>User guide: authoring a containerized extractor</b></summary>

A containerized extractor is a Docker image Nominal runs during ingest: your uploaded file(s) are mounted read-only, your code transforms them, and whatever you write to the output directory gets ingested. This module is the in-container runtime — you write one function, decorate it, and make `run()` your entrypoint.

### Single-file extractor

For images registered with a single-file output format (`PARQUET`, `CSV`, ...). Your job: produce exactly one file.

```python
from nominal.experimental.extractor import SingleFileExtractorContext, single_file_extractor

@single_file_extractor
def convert(ctx: SingleFileExtractorContext) -> None:
    table = read_somehow(ctx.input())        # the one mounted input
    out = ctx.output_dir / "converted.parquet"
    write_parquet(table, out)
    ctx.set_output(out)                       # declare it; exactly one, or the run fails

if __name__ == "__main__":
    convert.run()
```

### Manifest extractor

For images registered with the `MANIFEST` output format. Emit any number of files, each with its own ingest metadata; `manifest.json` is written for you.

```python
from nominal.experimental.extractor import IngestType, ManifestExtractorContext, manifest_extractor

@manifest_extractor
def split(ctx: ManifestExtractorContext) -> None:
    table = read_parquet(ctx.input())
    for i, chunk in enumerate(chunks_of(table, int(ctx.get_param("PARTS", "2")))):
        out = ctx.output_dir / f"part_{i}.parquet"
        write_parquet(chunk, out)
        ctx.add_output(out, ingest_type=IngestType.TABULAR, tag_columns={"vehicle": "veh_id"})

if __name__ == "__main__":
    split.run()
```

`add_output` metadata per file: `ingest_type` (`TABULAR`, `AVRO_STREAM`, `JSON_L` — JSON_L is log ingest; each line needs a `MESSAGE` field), `tag_columns` (column → tag name), `channel_prefix`, and `timestamp_column`/`timestamp_type` to override the job-level timestamp metadata for that file (numeric epoch units only, seconds through nanoseconds).

### Inputs

- `ctx.input()` — the single mounted input; raises unless there is exactly one.
- `ctx.input("TELEMETRY")` or `ctx.input("Telemetry Data")` — by the input's environment variable or registered display name.
- `ctx.inputs` — all mounted inputs, in registration order.
- An optional input the ingest request didn't provide is absent; `ctx.input(...)` for it raises "not among this run's inputs".

### Parameters

Parameter values are always strings — coerce them yourself.

- `ctx.param("PARTS")` — required; raises if unset.
- `ctx.get_param("PARTS")` / `ctx.get_param("PARTS", "2")` — optional; returns `None` or the default.
- Both accept the registered display name or the environment variable. Names not in the registered contract raise (the error lists what is registered).

### System metadata

`ctx.ingest_job_rid`, `ctx.dataset_rid`, `ctx.additional_tags` (tags the ingest request applies to all data), and `ctx.job_timestamp_metadata` (the job-level timestamp metadata your outputs default to). All are `None`/empty when not injected (e.g. local runs).

### Rules

- Declare every file you write to the output directory (`set_output` / `add_output`); undeclared files fail the run.
- `manifest.json` is reserved — the runtime writes it.
- The decorator must match the image's registered output format; a mismatch fails at startup with instructions to fix either side.
- Any exception exits non-zero so the ingest job fails cleanly; warnings and lifecycle logs go to the job log.

### Local testing

Drive `run()` with an explicit environment; `exit=False` re-raises instead of exiting:

```python
ctx = my_extractor.run(
    env={
        "OUTPUT_DIR": "/tmp/out",
        "NOMINAL_EXTRACTOR_INPUT_DIR": "/tmp/in",   # point input discovery at a local dir
        "PARTS": "4",                                # parameters are just env vars
    },
    exit=False,
)
```

Without the `_NOMINAL_*` contract metadata (the local-run case), names passed to `input()`/`param()` are treated directly as environment variables.

### Registering the image

Building and registering the image is a separate step — see the containerized-extractor APIs in `nominal.core.container_image` (`FileOutputFormat`, `FileExtractionInput`, `FileExtractionParameter`) and the `nom` CLI's container commands. The output format you register is what selects the decorator you should use.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
