### PR TITLE
feat: migrate sandbox workspace service to gRPC

### DIFF
--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -21,7 +21,6 @@ from nominal_api import (
     scout_datareview_api,
     scout_datasource,
     scout_datasource_connection,
-    scout_sandbox_api,
     scout_video,
     secrets_api,
     storage_datasource_api,
@@ -43,6 +42,7 @@ from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2_grpc
+from nominal.protos.sandbox.v1 import sandbox_workspace_pb2_grpc
 from nominal.protos.units.v1 import units_pb2_grpc
 from nominal.protos.workspaces.v1 import workspaces_pb2, workspaces_pb2_grpc
 from nominal.ts import IntegralNanosecondsUTC
@@ -174,7 +174,7 @@ class ClientsBunch:
     registry: registry_pb2_grpc.RegistryServiceStub
     secrets: secrets_api.SecretService
     roles: roles_pb2_grpc.RoleServiceStub
-    sandbox_workspace: scout_sandbox_api.SandboxWorkspaceService
+    sandbox_workspace: sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub
 
     def _get_workspace_by_rid(self, workspace_rid: str) -> workspaces_pb2.Workspace:
         """Fetch a single workspace by its RID via the gRPC workspace service.
@@ -330,13 +330,13 @@ class ClientsBunch:
             channel_metadata=client_factory(timeseries_channelmetadata.ChannelMetadataService),
             series_metadata=client_factory(timeseries_metadata.SeriesMetadataService),
             secrets=client_factory(secrets_api.SecretService),
-            sandbox_workspace=client_factory(scout_sandbox_api.SandboxWorkspaceService),
             # GRPC Service Stubs
             comments=grpc_factory(comments_pb2_grpc.CommentsServiceStub),
             workspace=grpc_factory(workspaces_pb2_grpc.WorkspaceServiceStub),
             containerized_extractor=grpc_factory(containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub),
             registry=grpc_factory(registry_pb2_grpc.RegistryServiceStub),
             roles=grpc_factory(roles_pb2_grpc.RoleServiceStub),
+            sandbox_workspace=grpc_factory(sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub),
         )
 
 

--- a/nominal/experimental/migration/migration_cli.py
+++ b/nominal/experimental/migration/migration_cli.py
@@ -448,8 +448,7 @@ def _update_demo_workbooks(target_client: NominalClient, runner: MigrationRunner
     workspace_rid = target_client.get_workspace().rid
     sandbox_service = target_client._clients.sandbox_workspace
 
-    # TODO: collapse the get-merge-set below into the atomic AddDemoWorkbooks RPC (the server already
-    # implements it; deliberately deferred from #868 to keep the migration parity-only).
+    # TODO: collapse the get-merge-set below into the atomic AddDemoWorkbooks RPC (the server already implements it)
     with translate_grpc_errors():
         existing_response = sandbox_service.GetDemoWorkbooks(
             sandbox_workspace_pb2.GetDemoWorkbooksRequest(workspace_rid=workspace_rid)

--- a/nominal/experimental/migration/migration_cli.py
+++ b/nominal/experimental/migration/migration_cli.py
@@ -8,10 +8,10 @@ from typing import Any, Literal, Sequence
 
 import click
 import yaml
-from nominal_api.scout_sandbox_api import SetDemoWorkbooksRequest
 
 from nominal.cli.util.global_decorators import client_options, global_options
 from nominal.core import ArchiveStatusFilter, Asset, Checklist, NominalClient, Workbook
+from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.experimental import as_user
 from nominal.experimental.migration.config.migration_data_config import AssetInclusionConfig, MigrationDatasetConfig
 from nominal.experimental.migration.config.migration_resources import AssetResources, MigrationResources
@@ -21,6 +21,7 @@ from nominal.experimental.migration.migration_summary import build_summary, load
 from nominal.experimental.migration.migrator.context import DestinationClientResolver
 from nominal.experimental.migration.parallel_migration_runner import run_parallel_migration
 from nominal.experimental.migration.resource_type import ResourceType
+from nominal.protos.sandbox.v1 import sandbox_workspace_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -445,17 +446,26 @@ def _update_demo_workbooks(target_client: NominalClient, runner: MigrationRunner
         return
 
     workspace_rid = target_client.get_workspace().rid
-    auth_header = target_client._clients.auth_header
     sandbox_service = target_client._clients.sandbox_workspace
 
-    existing_response = sandbox_service.get_demo_workbooks(auth_header, workspace_rid)
-    existing_rids = existing_response.notebook_rids
+    # TODO: collapse the get-merge-set below into the atomic AddDemoWorkbooks RPC (the server already
+    # implements it; deliberately deferred from #868 to keep the migration parity-only).
+    with translate_grpc_errors():
+        existing_response = sandbox_service.GetDemoWorkbooks(
+            sandbox_workspace_pb2.GetDemoWorkbooksRequest(workspace_rid=workspace_rid)
+        )
 
-    combined_rids = list(dict.fromkeys(existing_rids + new_workbook_rids))
-    sandbox_service.set_demo_workbooks(auth_header, SetDemoWorkbooksRequest(notebook_rids=combined_rids), workspace_rid)
+    combined_rids = list(dict.fromkeys([*existing_response.notebook_rids, *new_workbook_rids]))
+    with translate_grpc_errors():
+        sandbox_service.SetDemoWorkbooks(
+            sandbox_workspace_pb2.SetDemoWorkbooksRequestWrapper(
+                workspace_rid=workspace_rid,
+                request=sandbox_workspace_pb2.SetDemoWorkbooksRequest(notebook_rids=combined_rids),
+            )
+        )
     logger.info(
         "Updated demo workbooks: %d existing + %d new = %d total",
-        len(existing_rids),
+        len(existing_response.notebook_rids),
         len(new_workbook_rids),
         len(combined_rids),
     )

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -19,6 +19,7 @@ from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2_grpc
+from nominal.protos.sandbox.v1 import sandbox_workspace_pb2_grpc
 from nominal.protos.units.v1 import units_pb2_grpc
 from nominal.protos.workspaces.v1 import workspaces_pb2, workspaces_pb2_grpc
 
@@ -258,6 +259,7 @@ def test_from_config_wires_grpc_services_through_one_shared_channel(monkeypatch)
         clients.containerized_extractor, containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
     )
     assert isinstance(clients.registry, registry_pb2_grpc.RegistryServiceStub)
+    assert isinstance(clients.sandbox_workspace, sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub)
     # Exactly one channel, built from the right transport params and shared by every gRPC stub.
     create_grpc_channel.assert_called_once()
     assert create_grpc_channel.call_args.kwargs["auth_header"] == "Bearer token"

--- a/tests/core/test_migration_demo_workbooks.py
+++ b/tests/core/test_migration_demo_workbooks.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock
+
+from nominal.experimental.migration.migration_cli import _update_demo_workbooks
+from nominal.experimental.migration.resource_type import ResourceType
+from nominal.protos.sandbox.v1 import sandbox_workspace_pb2
+
+_WORKSPACE_RID = "ri.workspace.main.workspace.target"
+
+
+def _make_target_client(existing_rids: list[str]) -> MagicMock:
+    client = MagicMock()
+    client.get_workspace.return_value.rid = _WORKSPACE_RID
+    client._clients.sandbox_workspace.GetDemoWorkbooks.return_value = sandbox_workspace_pb2.GetDemoWorkbooksResponse(
+        notebook_rids=existing_rids
+    )
+    return client
+
+
+def _make_runner(new_rids: list[str]) -> MagicMock:
+    runner = MagicMock()
+    runner.migration_state.rid_mapping = {
+        ResourceType.WORKBOOK.value: {f"ri.notebook.source.{i}": rid for i, rid in enumerate(new_rids)}
+    }
+    return runner
+
+
+def test_update_demo_workbooks_appends_new_rids_after_existing_without_duplicates() -> None:
+    """Newly migrated workbook RIDs are appended after the existing demo list, de-duplicated, order preserved."""
+    client = _make_target_client(["ri.notebook.a", "ri.notebook.b"])
+    runner = _make_runner(["ri.notebook.b", "ri.notebook.c"])
+
+    _update_demo_workbooks(client, runner)
+
+    stub = client._clients.sandbox_workspace
+    get_request = stub.GetDemoWorkbooks.call_args.args[0]
+    assert get_request.workspace_rid == _WORKSPACE_RID
+    set_request = stub.SetDemoWorkbooks.call_args.args[0]
+    assert set_request.workspace_rid == _WORKSPACE_RID
+    assert list(set_request.request.notebook_rids) == ["ri.notebook.a", "ri.notebook.b", "ri.notebook.c"]
+
+
+def test_update_demo_workbooks_skips_sandbox_calls_when_no_workbooks_migrated() -> None:
+    """When the migration created no workbooks, the demo list is left untouched (no sandbox RPCs)."""
+    client = _make_target_client([])
+    runner = _make_runner([])
+
+    _update_demo_workbooks(client, runner)
+
+    client._clients.sandbox_workspace.GetDemoWorkbooks.assert_not_called()
+    client._clients.sandbox_workspace.SetDemoWorkbooks.assert_not_called()


### PR DESCRIPTION
## Summary

Migrates the sandbox workspace service from Conjure to gRPC without changing the migration CLI's demo-workbook behavior.

## Changes

- Wires `SandboxWorkspaceServiceStub` into `ClientsBunch` on the shared gRPC channel and removes the Conjure client.
- Ports demo-workbook reads and updates to protobuf requests with standard gRPC error translation.
- Preserves append order, de-duplication, and the no-op path when no workbooks were migrated.
- Adds coverage for service wiring and demo-workbook updates.

## Verification

- `uv run ruff check`
- `uv run ruff format --check`
- `uv run pytest -q --no-cov` — 325 passed, 13 skipped
- All GitHub Actions checks pass
