### PR TITLE
feat: register and activate a container image in one call

### DIFF
--- a/nominal/cli/container.py
+++ b/nominal/cli/container.py
@@ -186,6 +186,11 @@ _OUTPUT_FORMAT_CHOICES = tuple(sorted(fmt.name.lower() for fmt in REGISTERABLE_O
     help="file format the extractor writes  [default: parquet]",
 )
 @click.option("--wait/--no-wait", default=True, show_default=True, help="wait until the image is READY")
+@click.option(
+    "--activate",
+    is_flag=True,
+    help="activate the image on the extractor after registering (polls it to readiness first)",
+)
 @client_options
 @global_options
 def register_image(
@@ -197,18 +202,18 @@ def register_image(
     timestamp_type: str | None,
     output_format: str | None,
     wait: bool,
+    activate: bool,
     client: NominalClient,
 ) -> None:
     r"""Upload a `docker save` tarball and register it as a container image for an extractor.
 
     Prints the resulting container image RID on stdout (status messages go to stderr), suitable
-    for capturing in CI:
+    for capturing in CI. Registering does not change which image the extractor runs: activate the
+    image with `set-active-image` (release-gated pipelines), or pass --activate to register and
+    deploy in one step (continuous-deploy pipelines):
 
-        IMAGE_RID=$(nom container extractor register-image -r "$EXTRACTOR_RID" \
-            -f image.tar -t $(git rev-parse --short HEAD) -c extractor-config.json)
-        nom container extractor set-active-image -r "$EXTRACTOR_RID" -i "$IMAGE_RID"
-
-    The registered image starts PENDING and must be activated with `set-active-image` once READY.
+        nom container extractor register-image -r "$EXTRACTOR_RID" \
+            -f image.tar -t $(git rev-parse --short HEAD) -c extractor-config.json --activate
     """
     parsed = _parse_config(_load_config(config_file))
     tag = tag if tag is not None else parsed.tag
@@ -233,8 +238,11 @@ def register_image(
         default_timestamp_column=timestamp_column,
         default_timestamp_type=cast(ts._AnyTimestampType, timestamp_type),
         output_format=format_enum if format_enum is not None else FileOutputFormat.PARQUET,
+        activate=activate,
     )
-    if wait:
+    if activate:
+        click.secho(f"Activated image {image.rid} ({image.tag}) on {extractor.name}", fg="green", err=True)
+    elif wait:
         click.secho(f"Waiting for image {image.rid} ({image.tag}) to become READY...", fg="cyan", err=True)
         image.poll_until_ready()
     click.echo(image.rid)

--- a/nominal/core/containerized_extractor.py
+++ b/nominal/core/containerized_extractor.py
@@ -153,13 +153,14 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
         default_timestamp_type: ts._AnyTimestampType,
         output_format: FileOutputFormat = FileOutputFormat.PARQUET,
         parameters: Sequence[FileExtractionParameter] = (),
+        activate: bool = False,
     ) -> ContainerImage:
         """Upload a `docker save` tarball and register it as a container image for this extractor.
 
         Registering attaches the image to this extractor in Nominal's registry, but does not change
-        which image the extractor runs: the new image must be activated with `set_active_image`.
-        This extractor instance is unmodified. Tags are immutable — registering an already-registered
-        tag raises `NominalAlreadyExistsError`.
+        which image the extractor runs: the new image must be activated with `set_active_image`, or
+        pass `activate=True` to register and activate in one call. Tags are immutable — registering
+        an already-registered tag raises `NominalAlreadyExistsError`.
 
         Args:
             tarball: Path to a `docker save` tarball of the extractor image.
@@ -177,6 +178,10 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
                 `REGISTERABLE_OUTPUT_FORMATS` — the backend cannot currently ingest the others, so
                 registering an image with one would produce an extractor whose ingests always fail.
             parameters: Scalar parameters passed to the extractor.
+            activate: If true, activate the registered image on this extractor (polling it to
+                readiness first, in case the backend processed the push asynchronously), refreshing
+                this instance in place. If false (the default), registration is side-effect-free on
+                what the extractor runs — the staging state for gated rollouts.
 
         Returns:
             The newly registered image. Current backends push the image to the registry within this
@@ -188,6 +193,8 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
             ValueError: If `output_format` is not currently ingestible via containerized extraction.
             NominalAlreadyExistsError: If an image with this tag is already registered for this
                 extractor.
+            NominalContainerImageError: If `activate` is true and the image reaches a state from
+                which it cannot become READY.
         """
         if output_format not in REGISTERABLE_OUTPUT_FORMATS:
             supported = ", ".join(sorted(fmt.name for fmt in REGISTERABLE_OUTPUT_FORMATS))
@@ -218,7 +225,10 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
         )
         with translate_grpc_errors():
             response = self._clients.registry.CreateImage(request)
-        return ContainerImage._from_proto(self._clients, self._workspace_rid, response.image)
+        image = ContainerImage._from_proto(self._clients, self._workspace_rid, response.image)
+        if activate:
+            self.set_active_image(image, poll_until_ready=True)
+        return image
 
     def search_container_images(
         self, *, tag: str | None = None, status: ContainerImageStatus | None = None


### PR DESCRIPTION
Adds an opt-in one-step register-and-deploy flow, keeping registration side-effect-free by default. Builds on #865's corrected `register_image` semantics.

## SDK

`ContainerizedExtractor.register_image(..., activate: bool = False)` — when true, the freshly registered image is activated on the extractor via `set_active_image`, which **polls the image to readiness first**: current backends push synchronously and return READY, but the poll keeps the flow correct if a backend ever processes asynchronously (and for any legacy non-READY rows). The extractor instance refreshes in place; failure modes are documented in `Raises:` (`NominalAlreadyExistsError` for immutable-tag collisions, `NominalContainerImageError` if the image can't become READY).

The default stays `False` — registration remains the staging state, preserving gated-rollout and rollback workflows (many registered images, one active).

## CLI

`nom container extractor register-image --activate` — one-step deploy for continuous-deployment pipelines:

```console
nom container extractor register-image -r "$EXTRACTOR_RID"     -f image.tar -t $(git rev-parse --short HEAD) -c extractor-config.json --activate
```

stdout stays RID-only (activation status goes to stderr), so `$(...)` capture is unaffected. Release-gated pipelines keep the two-step register / `set-active-image` flow.

## Testing note

The `activate` path is a two-line composition over `set_active_image`, whose poll-then-activate behavior is already covered by `tests/core/test_containerized_extractor.py`. A direct happy-path test of `register_image` would require intercepting the multipart upload's raw HTTP PUTs (not reachable via MagicMock clients), which is why no such test exists for the method today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)