### PR TITLE
feat: migrate secrets service to gRPC

### DIFF
--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -22,7 +22,6 @@ from nominal_api import (
     scout_datasource,
     scout_datasource_connection,
     scout_video,
-    secrets_api,
     storage_datasource_api,
     storage_writer_api,
     timeseries_channelmetadata,
@@ -43,6 +42,7 @@ from nominal.protos.comments.v1 import comments_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2_grpc
 from nominal.protos.sandbox.v1 import sandbox_workspace_pb2_grpc
+from nominal.protos.secrets.v1 import secrets_pb2_grpc
 from nominal.protos.units.v1 import units_pb2_grpc
 from nominal.protos.workspaces.v1 import workspaces_pb2, workspaces_pb2_grpc
 from nominal.ts import IntegralNanosecondsUTC
@@ -172,7 +172,7 @@ class ClientsBunch:
     workspace: workspaces_pb2_grpc.WorkspaceServiceStub
     containerized_extractor: containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
     registry: registry_pb2_grpc.RegistryServiceStub
-    secrets: secrets_api.SecretService
+    secrets: secrets_pb2_grpc.SecretServiceStub
     roles: roles_pb2_grpc.RoleServiceStub
     sandbox_workspace: sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub
 
@@ -329,12 +329,12 @@ class ClientsBunch:
             event=client_factory(event.EventService),
             channel_metadata=client_factory(timeseries_channelmetadata.ChannelMetadataService),
             series_metadata=client_factory(timeseries_metadata.SeriesMetadataService),
-            secrets=client_factory(secrets_api.SecretService),
             # GRPC Service Stubs
             comments=grpc_factory(comments_pb2_grpc.CommentsServiceStub),
             workspace=grpc_factory(workspaces_pb2_grpc.WorkspaceServiceStub),
             containerized_extractor=grpc_factory(containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub),
             registry=grpc_factory(registry_pb2_grpc.RegistryServiceStub),
+            secrets=grpc_factory(secrets_pb2_grpc.SecretServiceStub),
             roles=grpc_factory(roles_pb2_grpc.RoleServiceStub),
             sandbox_workspace=grpc_factory(sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub),
         )

--- a/nominal/core/_utils/pagination_tools.py
+++ b/nominal/core/_utils/pagination_tools.py
@@ -18,13 +18,13 @@ from nominal_api import (
     scout_template_api,
     scout_video,
     scout_video_api,
-    secrets_api,
 )
 
 from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.protos.ingest.v2 import containerized_extractor_pb2, containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2, registry_pb2_grpc
+from nominal.protos.secrets.v1 import secrets_pb2, secrets_pb2_grpc
 
 DEFAULT_PAGE_SIZE = 100
 
@@ -245,21 +245,20 @@ def search_runs_by_asset_paginated(
 
 
 def search_secrets_paginated(
-    secrets: secrets_api.SecretService,
-    auth_header: str,
-    query: secrets_api.SearchSecretsQuery,
+    secrets: secrets_pb2_grpc.SecretServiceStub,
+    query: secrets_pb2.SearchSecretsQuery,
     archive_status: ArchiveStatusFilter = ArchiveStatusFilter.NOT_ARCHIVED,
-) -> Iterable[secrets_api.Secret]:
-    def factory(page_token: str | None) -> secrets_api.SearchSecretsRequest:
-        return secrets_api.SearchSecretsRequest(
+) -> Iterable[secrets_pb2.Secret]:
+    def factory(page_token: str | None) -> secrets_pb2.SearchSecretsRequest:
+        return secrets_pb2.SearchSecretsRequest(
             page_size=DEFAULT_PAGE_SIZE,
             query=query,
-            sort=secrets_api.SortOptions(field=secrets_api.SortField.CREATED_AT, is_descending=True),
-            archived_statuses=archive_status.to_api_archived_statuses(),
+            sort=secrets_pb2.SortOptions(field=secrets_pb2.SortField.CREATED_AT, is_descending=True),
+            archived_statuses=archive_status.to_proto_archived_statuses(),
             token=page_token,
         )
 
-    for response in paginate_rpc(secrets.search, auth_header, request_factory=factory):
+    for response in paginate_grpc(secrets.Search, request_factory=factory):
         yield from response.results
 
 

--- a/nominal/core/_utils/query_tools.py
+++ b/nominal/core/_utils/query_tools.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence, cast
+from typing import TYPE_CHECKING, Iterable, Mapping, Sequence, cast
 
 from nominal_api import (
     api,
@@ -17,12 +17,13 @@ from nominal_api import (
     scout_run_api,
     scout_template_api,
     scout_video_api,
-    secrets_api,
 )
 
 from nominal._utils.deprecation_tools import _NotProvided
 from nominal.core._utils.api_tools import rid_from_instance_or_string
 from nominal.protos.registry.v2 import registry_pb2
+from nominal.protos.secrets.v1 import secrets_pb2
+from nominal.protos.types import types_pb2
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
 
 if TYPE_CHECKING:
@@ -55,13 +56,26 @@ class ArchiveStatusFilter(Enum):
     ANY = "ANY"
 
     def to_api_archived_statuses(self) -> list[api.ArchivedStatus]:
-        """Convert to a list of ArchivedStatus values for use in search requests."""
+        """Convert to a list of conjure ArchivedStatus values for use in search requests.
+
+        TODO: delete once the remaining conjure search paths migrate to gRPC
+        (to_proto_archived_statuses is the successor).
+        """
         if self == ArchiveStatusFilter.ARCHIVED:
             return [api.ArchivedStatus.ARCHIVED]
         elif self == ArchiveStatusFilter.NOT_ARCHIVED:
             return [api.ArchivedStatus.NOT_ARCHIVED]
         else:  # ANY
             return [api.ArchivedStatus.ARCHIVED, api.ArchivedStatus.NOT_ARCHIVED]
+
+    def to_proto_archived_statuses(self) -> list[types_pb2.ArchivedStatus.ValueType]:
+        """Convert to a list of proto ArchivedStatus values for use in gRPC search requests."""
+        if self == ArchiveStatusFilter.ARCHIVED:
+            return [types_pb2.ArchivedStatus.ARCHIVED]
+        elif self == ArchiveStatusFilter.NOT_ARCHIVED:
+            return [types_pb2.ArchivedStatus.NOT_ARCHIVED]
+        else:  # ANY
+            return [types_pb2.ArchivedStatus.ARCHIVED, types_pb2.ArchivedStatus.NOT_ARCHIVED]
 
 
 def resolve_effective_archive_status(
@@ -176,19 +190,20 @@ def create_search_secrets_query(
     labels: Sequence[str] | None = None,
     properties: Mapping[str, str] | None = None,
     workspace_rid: str | None = None,
-) -> secrets_api.SearchSecretsQuery:
+) -> secrets_pb2.SearchSecretsQuery:
     queries = []
     if search_text is not None:
-        queries.append(secrets_api.SearchSecretsQuery(search_text=search_text))
+        queries.append(secrets_pb2.SearchSecretsQuery(search_text=search_text))
     if labels is not None:
         for label in labels:
-            queries.append(secrets_api.SearchSecretsQuery(label=label))
+            queries.append(secrets_pb2.SearchSecretsQuery(label=label))
     if properties is not None:
         for name, value in properties.items():
-            queries.append(secrets_api.SearchSecretsQuery(property=api.Property(name=name, value=value)))
+            queries.append(secrets_pb2.SearchSecretsQuery(property=types_pb2.Property(name=name, value=value)))
     if workspace_rid is not None:
-        queries.append(secrets_api.SearchSecretsQuery(workspace=workspace_rid))
-    return secrets_api.SearchSecretsQuery(and_=queries)
+        queries.append(secrets_pb2.SearchSecretsQuery(workspace=workspace_rid))
+    # `and` is a Python keyword, and generated typing stubs cannot expose it as a named argument.
+    return secrets_pb2.SearchSecretsQuery(**{"and": queries})  # type: ignore[arg-type]
 
 
 def create_search_videos_query(
@@ -243,10 +258,10 @@ def create_search_container_images_query(
     elif len(filters) == 1:
         return filters[0]
     else:
-        # `and` is a Python keyword, so mypy-protobuf can't expose it as a typed kwarg or attribute; pass it
-        # through a **mapping (which also avoids getattr/setattr on the generated message).
-        and_clause: dict[str, Any] = {"and": registry_pb2.AndFilter(clauses=filters)}
-        return registry_pb2.SearchFilter(**and_clause)
+        # `and` is a Python keyword, and generated typing stubs cannot expose it as a named argument.
+        return registry_pb2.SearchFilter(
+            **{"and": registry_pb2.AndFilter(clauses=filters)}  # type: ignore[arg-type]
+        )
 
 
 def create_search_assets_query(

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -24,7 +24,6 @@ from nominal_api import (
     scout_template_api,
     scout_video_api,
     scout_workbookcommon_api,
-    secrets_api,
     storage_datasource_api,
 )
 from typing_extensions import Self, deprecated
@@ -116,6 +115,7 @@ from nominal.core.video import Video, _create_video
 from nominal.core.workbook import Workbook, _search_workbooks
 from nominal.core.workbook_template import WorkbookTemplate
 from nominal.core.workspace import Workspace
+from nominal.protos.secrets.v1 import secrets_pb2
 from nominal.protos.units.v1 import units_pb2
 from nominal.protos.workspaces.v1 import workspaces_pb2
 from nominal.ts import (
@@ -482,7 +482,7 @@ class NominalClient:
             labels: Labels for the secret
             properties: Properties for the secret
         """
-        secret_request = secrets_api.CreateSecretRequest(
+        secret_request = secrets_pb2.CreateSecretRequest(
             name=name,
             description=description or "",
             decrypted_value=decrypted_value,
@@ -490,21 +490,27 @@ class NominalClient:
             labels=list(labels),
             properties={} if properties is None else dict(properties),
         )
-        resp = self._clients.secrets.create(self._clients.auth_header, secret_request)
-        return Secret._from_conjure(self._clients, resp)
+        with translate_grpc_errors():
+            response = self._clients.secrets.Create(secret_request)
+        return Secret._from_proto(self._clients, response.secret)
 
     def get_secret(self, rid: str) -> Secret:
-        """Retrieve a secret by RID."""
-        resp = self._clients.secrets.get(self._clients.auth_header, rid)
-        return Secret._from_conjure(self._clients, resp)
+        """Retrieve a secret by RID.
+
+        Raises:
+            NominalNotFoundError: If no secret with the given RID exists or it is not accessible to the user.
+        """
+        with translate_grpc_errors():
+            response = self._clients.secrets.Get(secrets_pb2.GetRequest(rid=rid))
+        return Secret._from_proto(self._clients, response.secret)
 
     def _iter_search_secrets(
         self,
-        query: secrets_api.SearchSecretsQuery,
+        query: secrets_pb2.SearchSecretsQuery,
         archive_status: ArchiveStatusFilter = ArchiveStatusFilter.NOT_ARCHIVED,
     ) -> Iterable[Secret]:
-        for secret in search_secrets_paginated(self._clients.secrets, self._clients.auth_header, query, archive_status):
-            yield Secret._from_conjure(self._clients, secret)
+        for secret in search_secrets_paginated(self._clients.secrets, query, archive_status):
+            yield Secret._from_proto(self._clients, secret)
 
     def search_secrets(
         self,

--- a/nominal/core/secret.py
+++ b/nominal/core/secret.py
@@ -3,16 +3,18 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Mapping, Protocol, Sequence
 
-from nominal_api import secrets_api
 from typing_extensions import Self
 
 from nominal.core._clientsbunch import HasScoutParams
-from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin
-from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
+from nominal.core._utils.api_tools import HasRid, RefreshableGrpcMixin
+from nominal.core._utils.grpc_tools import translate_grpc_errors
+from nominal.protos.secrets.v1 import secrets_pb2, secrets_pb2_grpc
+from nominal.protos.types import types_pb2
+from nominal.ts import IntegralNanosecondsUTC
 
 
 @dataclass(frozen=True)
-class Secret(HasRid, RefreshableConjureMixin[secrets_api.Secret]):
+class Secret(HasRid, RefreshableGrpcMixin[secrets_pb2.Secret]):
     rid: str
     name: str
     description: str
@@ -21,8 +23,9 @@ class Secret(HasRid, RefreshableConjureMixin[secrets_api.Secret]):
     created_at: IntegralNanosecondsUTC
     _clients: _Clients = field(repr=False)
 
-    def _get_latest_api(self) -> secrets_api.Secret:
-        return self._clients.secrets.get(self._clients.auth_header, self.rid)
+    def _get_latest_api(self) -> secrets_pb2.Secret:
+        with translate_grpc_errors():
+            return self._clients.secrets.Get(secrets_pb2.GetRequest(rid=self.rid)).secret
 
     def update(
         self,
@@ -36,46 +39,56 @@ class Secret(HasRid, RefreshableConjureMixin[secrets_api.Secret]):
 
         Args:
             name: New name of the secret
-            description: New name of the secret
+            description: New description of the secret
             properties: New properties for the secret
             labels: New labels for the secret
 
         Returns:
             Updated secret metadata.
+
+        Note:
+            Fields left as None are unchanged.
         """
-        request = secrets_api.UpdateSecretRequest(
-            name=name,
-            description=description,
-            labels=None if labels is None else list(labels),
-            properties=None if properties is None else dict(**properties),
+        request = secrets_pb2.UpdateRequest(
+            rid=self.rid,
+            request=secrets_pb2.UpdateSecretRequest(
+                name=name,
+                description=description,
+                labels=None if labels is None else types_pb2.LabelUpdateWrapper(labels=list(labels)),
+                properties=None if properties is None else types_pb2.PropertyUpdateWrapper(properties=dict(properties)),
+            ),
         )
-        updated_secret = self._clients.secrets.update(self._clients.auth_header, request, self.rid)
-        return self._refresh_from_api(updated_secret)
+        with translate_grpc_errors():
+            response = self._clients.secrets.Update(request)
+        return self._refresh_from_api(response.secret)
 
     def archive(self) -> None:
         """Archive the secret, disallowing it to appear from users."""
-        self._clients.secrets.archive(self._clients.auth_header, self.rid)
+        with translate_grpc_errors():
+            self._clients.secrets.Archive(secrets_pb2.ArchiveRequest(rid=self.rid))
 
     def unarchive(self) -> None:
         """Unarchive the secret, allowing it to appear to users."""
-        self._clients.secrets.unarchive(self._clients.auth_header, self.rid)
+        with translate_grpc_errors():
+            self._clients.secrets.Unarchive(secrets_pb2.UnarchiveRequest(rid=self.rid))
 
     def delete(self) -> None:
         """Permanently delete the secret, removing it from the database entirely."""
-        self._clients.secrets.delete(self._clients.auth_header, self.rid)
+        with translate_grpc_errors():
+            self._clients.secrets.Delete(secrets_pb2.DeleteRequest(rid=self.rid))
 
     class _Clients(HasScoutParams, Protocol):
         @property
-        def secrets(self) -> secrets_api.SecretService: ...
+        def secrets(self) -> secrets_pb2_grpc.SecretServiceStub: ...
 
     @classmethod
-    def _from_conjure(cls, clients: _Clients, raw_secret: secrets_api.Secret) -> Self:
+    def _from_proto(cls, clients: _Clients, raw_secret: secrets_pb2.Secret) -> Self:
         return cls(
             rid=raw_secret.rid,
             name=raw_secret.name,
             description=raw_secret.description,
-            properties=raw_secret.properties,
-            labels=raw_secret.labels,
-            created_at=_SecondsNanos.from_flexible(raw_secret.created_at).to_nanoseconds(),
+            properties=dict(raw_secret.properties),
+            labels=list(raw_secret.labels),
+            created_at=raw_secret.created_at.ToNanoseconds(),
             _clients=clients,
         )

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -20,6 +20,7 @@ from nominal.protos.comments.v1 import comments_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2_grpc
 from nominal.protos.sandbox.v1 import sandbox_workspace_pb2_grpc
+from nominal.protos.secrets.v1 import secrets_pb2_grpc
 from nominal.protos.units.v1 import units_pb2_grpc
 from nominal.protos.workspaces.v1 import workspaces_pb2, workspaces_pb2_grpc
 
@@ -260,6 +261,7 @@ def test_from_config_wires_grpc_services_through_one_shared_channel(monkeypatch)
     )
     assert isinstance(clients.registry, registry_pb2_grpc.RegistryServiceStub)
     assert isinstance(clients.sandbox_workspace, sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub)
+    assert isinstance(clients.secrets, secrets_pb2_grpc.SecretServiceStub)
     # Exactly one channel, built from the right transport params and shared by every gRPC stub.
     create_grpc_channel.assert_called_once()
     assert create_grpc_channel.call_args.kwargs["auth_header"] == "Bearer token"

--- a/tests/core/test_secret.py
+++ b/tests/core/test_secret.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import grpc
+import pytest
+from google.protobuf import timestamp_pb2
+
+from nominal.core.client import NominalClient
+from nominal.core.exceptions import NominalNotFoundError
+from nominal.core.secret import Secret
+from nominal.protos.secrets.v1 import secrets_pb2
+
+
+def _proto_secret(rid: str, **kwargs) -> secrets_pb2.Secret:
+    return secrets_pb2.Secret(rid=rid, created_at=timestamp_pb2.Timestamp(seconds=1), **kwargs)
+
+
+def _secret(clients: MagicMock, rid: str = "ri.secret.test") -> Secret:
+    return Secret._from_proto(clients, _proto_secret(rid, name="original", labels=["keep"]))
+
+
+def test_update_leaves_omitted_fields_absent_on_the_wire() -> None:
+    """Fields not passed to update() are absent from the request, so the backend leaves them unchanged."""
+    clients = MagicMock()
+    secret = _secret(clients)
+    clients.secrets.Update.return_value = secrets_pb2.UpdateResponse(
+        secret=_proto_secret(secret.rid, name="renamed", labels=["keep"])
+    )
+
+    secret.update(name="renamed")
+
+    request = clients.secrets.Update.call_args.args[0]
+    assert request.rid == secret.rid
+    assert request.request.name == "renamed"
+    assert not request.request.HasField("description")
+    assert not request.request.HasField("labels")
+    assert not request.request.HasField("properties")
+    assert secret.name == "renamed"
+
+
+def test_update_sends_empty_collections_as_explicit_clears() -> None:
+    """Passing empty labels/properties sends present-but-empty wrappers (clear), distinct from omission."""
+    clients = MagicMock()
+    secret = _secret(clients)
+    clients.secrets.Update.return_value = secrets_pb2.UpdateResponse(secret=_proto_secret(secret.rid))
+
+    secret.update(labels=[], properties={})
+
+    request = clients.secrets.Update.call_args.args[0]
+    assert request.request.HasField("labels")
+    assert list(request.request.labels.labels) == []
+    assert request.request.HasField("properties")
+    assert dict(request.request.properties.properties) == {}
+
+
+def test_get_secret_translates_not_found(fake_rpc_error) -> None:
+    """A NOT_FOUND status from the secrets service surfaces as NominalNotFoundError, not grpc.RpcError."""
+    clients = MagicMock()
+    client = NominalClient(_clients=clients)
+    clients.secrets.Get.side_effect = fake_rpc_error(grpc.StatusCode.NOT_FOUND)
+
+    with pytest.raises(NominalNotFoundError):
+        client.get_secret("ri.secret.missing")
+
+
+def test_secret_refresh_updates_fields_in_place() -> None:
+    """refresh() re-fetches via Get and updates the same instance."""
+    clients = MagicMock()
+    secret = _secret(clients)
+    clients.secrets.Get.return_value = secrets_pb2.GetResponse(
+        secret=_proto_secret(secret.rid, name="renamed", labels=["new-label"])
+    )
+
+    returned = secret.refresh()
+
+    assert returned is secret
+    assert secret.name == "renamed"
+    assert secret.labels == ["new-label"]
+    assert clients.secrets.Get.call_args.args[0].rid == secret.rid
+
+
+def test_search_secrets_follows_pagination_cursors_and_ands_filters() -> None:
+    """search_secrets accumulates results across pages and ANDs the provided filters into the query."""
+    clients = MagicMock()
+    client = NominalClient(_clients=clients)
+    page1 = secrets_pb2.SearchSecretsResponse(results=[_proto_secret("ri.secret.a")], next_page_token="tok")
+    page2 = secrets_pb2.SearchSecretsResponse(results=[_proto_secret("ri.secret.b")], next_page_token="")
+    clients.secrets.Search.side_effect = [page1, page2]
+
+    results = client.search_secrets(search_text="text", labels=["label"])
+
+    assert [s.rid for s in results] == ["ri.secret.a", "ri.secret.b"]
+    assert clients.secrets.Search.call_count == 2
+    first_request = clients.secrets.Search.call_args_list[0].args[0]
+    expected_query = secrets_pb2.SearchSecretsQuery(
+        **{
+            "and": [
+                secrets_pb2.SearchSecretsQuery(search_text="text"),
+                secrets_pb2.SearchSecretsQuery(label="label"),
+            ]
+        }
+    )
+    assert first_request.query == expected_query
+    second_request = clients.secrets.Search.call_args_list[1].args[0]
+    assert second_request.token == "tok"


### PR DESCRIPTION
## Summary

Migrates the secrets service from Conjure to gRPC while preserving the existing public SDK behavior, including search and partial-update semantics.

## Changes

- Wires `SecretServiceStub` into `ClientsBunch` on the shared gRPC channel and removes the Conjure secrets client.
- Converts create, get, update, archive, unarchive, delete, refresh, and search operations to protobuf requests with standard gRPC error translation.
- Preserves the distinction between omitted update fields and explicit empty labels or properties.
- Adds coverage for service wiring, partial updates, error translation, refresh, and paginated search.

## Verification

- `uv run ruff check`
- `uv run ruff format --check`
- `uv run pytest -q --no-cov` — 328 passed, 13 skipped
- All GitHub Actions checks pass
