### PR TITLE
feat(migration): offline `nom migrate summary` command + shared dry-run log constants

### DIFF
--- a/nominal/experimental/migration/README.md
+++ b/nominal/experimental/migration/README.md
@@ -60,6 +60,25 @@ Optional flags:
   - Previous state files are automatically versioned (e.g. `migration_state.json` → `migration_state_v2.json`) so no history is lost.
 - `--max-workers <n>` — number of assets/templates to migrate concurrently (default: 1). Start with 2–4
   workers and adjust based on performance and API rate limits.
+- `--dry-run` — log what would be created without writing anything to the destination tenant or state file.
+
+**`nom migrate summary`** — summarize a migration as a markdown table. Fully offline: no profiles or
+tokens required. Provide exactly one source:
+
+```sh
+# Offline size check from one or more config files (repeat the flag per file)
+nom migrate summary --from-config my_migration.yml
+
+# Tally what a dry run would create from a captured log
+# (the "[DRY RUN] Would create ..." lines are INFO-level, so run copy with -v or -vv)
+nom migrate copy ... --dry-run -vv 2>&1 | tee dry_run.log
+nom migrate summary --from-log dry_run.log
+
+# Count what a real migration created, from its state file
+nom migrate summary --from-state migration_state.json
+```
+
+Pass `--output <path>` to also append the markdown to a file (e.g. `$GITHUB_STEP_SUMMARY` in CI).
 
 ## Understanding the config YAML
 

--- a/nominal/experimental/migration/dry_run.py
+++ b/nominal/experimental/migration/dry_run.py
@@ -1,0 +1,36 @@
+"""Shared dry-run logging vocabulary.
+
+The dry-run log lines emitted by the migrators are parsed downstream (e.g. by
+``nom migrate summary --from-log`` and CI job summaries), so both sides must agree on the
+exact wording. Build dry-run "would create" log messages with :func:`would_create_message`
+and parse them with :func:`dry_run_create_pattern` so the two can never drift.
+"""
+
+from __future__ import annotations
+
+import re
+
+from nominal.experimental.migration.resource_type import ResourceType, resource_label
+
+DRY_RUN_PREFIX = "[DRY RUN]"
+
+_WOULD_CREATE = "Would create"
+
+
+def would_create_message(resource_type: ResourceType) -> str:
+    """Logging format string for a dry-run create line, with %s placeholders for name and source RID."""
+    return f"{DRY_RUN_PREFIX} {_WOULD_CREATE} {resource_label(resource_type)} '%s' (source: %s)"
+
+
+def dry_run_create_pattern() -> re.Pattern[str]:
+    """Regex matching lines produced by :func:`would_create_message`, capturing the resource label as ``type``.
+
+    Labels are alternated longest-first so multi-word labels (e.g. "workbook template") are not
+    truncated to their first word ("workbook").
+    """
+    labels = sorted((resource_label(resource_type) for resource_type in ResourceType), key=len, reverse=True)
+    alternation = "|".join(re.escape(label) for label in labels)
+    return re.compile(
+        rf"{re.escape(DRY_RUN_PREFIX)}\s+{_WOULD_CREATE}\s+(?P<type>{alternation})\b",
+        re.IGNORECASE,
+    )

--- a/nominal/experimental/migration/migration_cli.py
+++ b/nominal/experimental/migration/migration_cli.py
@@ -17,6 +17,7 @@ from nominal.experimental.migration.config.migration_data_config import AssetInc
 from nominal.experimental.migration.config.migration_resources import AssetResources, MigrationResources
 from nominal.experimental.migration.migration_decorators import migration_client_options
 from nominal.experimental.migration.migration_runner import MigrationRunner
+from nominal.experimental.migration.migration_summary import build_summary, load_migration_block
 from nominal.experimental.migration.migrator.context import DestinationClientResolver
 from nominal.experimental.migration.parallel_migration_runner import run_parallel_migration
 from nominal.experimental.migration.resource_type import ResourceType
@@ -71,17 +72,6 @@ def _parse_asset_entry(
         templates.append(template_resource)
 
     return AssetResources(asset=asset_resource, source_workbook_templates=templates)
-
-
-def _load_migration_block(raw: Any) -> dict[str, Any]:
-    if not isinstance(raw, dict) or "migration" not in raw:
-        raise click.UsageError("Config must be a mapping with a top-level 'migration' key.")
-
-    m = raw["migration"]
-    if not isinstance(m, dict):
-        raise click.UsageError("'migration' must be a mapping.")
-
-    return m
 
 
 def _require_non_empty_string(value: Any, label: str) -> str:
@@ -360,7 +350,7 @@ def _load_migration_config(
     with config_path.open("r", encoding="utf-8") as f:
         raw: Any = yaml.safe_load(f)
 
-    m = _load_migration_block(raw)
+    m = load_migration_block(raw)
 
     name = _require_non_empty_string(m.get("name"), "migration.name")
     include_dataset_files = _require_bool(m.get("include_dataset_files"), "migration.include_dataset_files")
@@ -678,3 +668,47 @@ def prep(client: NominalClient, migration_name: str, output_path: Path) -> None:
     with output_path.open("w", encoding="utf-8") as f:
         yaml.dump(config, f, default_flow_style=False, sort_keys=False)
     logger.info("Wrote migration config to %s", output_path)
+
+
+@migrate_cmd.command(
+    name="summary",
+    help="Summarize a migration as a markdown table. Fully offline: no profiles or tokens required.",
+)
+@global_options
+@click.option(
+    "--from-config",
+    "config_paths",
+    multiple=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Migration config YAML for an offline size check. Repeat the flag to summarize several configs.",
+)
+@click.option(
+    "--from-log",
+    "log_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Captured 'nom migrate copy --dry-run' log to tally would-create lines from.",
+)
+@click.option(
+    "--from-state",
+    "state_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Migration-state JSON to count created resources from.",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="File to append the markdown summary to, e.g. $GITHUB_STEP_SUMMARY.",
+)
+def summary(
+    config_paths: tuple[Path, ...],
+    log_path: Path | None,
+    state_path: Path | None,
+    output_path: Path | None,
+) -> None:
+    """Emit a markdown summary of a migration from a config, dry-run log, or state file."""
+    rendered = build_summary(config_paths, log_path, state_path)
+    click.echo(rendered)
+    if output_path is not None:
+        with output_path.open("a", encoding="utf-8") as f:
+            f.write(rendered + "\n")

--- a/nominal/experimental/migration/migration_runner.py
+++ b/nominal/experimental/migration/migration_runner.py
@@ -9,6 +9,7 @@ from nominal.core import NominalClient
 from nominal.core._clientsbunch import ClientsBunch
 from nominal.experimental.migration.config.migration_data_config import AssetInclusionConfig, MigrationDatasetConfig
 from nominal.experimental.migration.config.migration_resources import MigrationResources
+from nominal.experimental.migration.dry_run import DRY_RUN_PREFIX
 from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.migrator.asset_migrator import AssetCopyOptions, AssetMigrator
 from nominal.experimental.migration.migrator.checklist_migrator import ChecklistCopyOptions, ChecklistMigrator
@@ -138,7 +139,7 @@ class MigrationRunner:
 
     def save_state(self) -> None:
         if self.dry_run:
-            logger.info("[DRY RUN] Skipping migration state write to %s", self.migration_state_path)
+            logger.info(f"{DRY_RUN_PREFIX} Skipping migration state write to %s", self.migration_state_path)
             return
         self.migration_state_path.parent.mkdir(parents=True, exist_ok=True)
         self.migration_state_path.write_text(self.migration_state.to_json(), encoding="utf-8")

--- a/nominal/experimental/migration/migration_summary.py
+++ b/nominal/experimental/migration/migration_summary.py
@@ -23,6 +23,7 @@ import yaml
 
 from nominal.experimental.migration.dry_run import dry_run_create_pattern
 from nominal.experimental.migration.migration_state import MigrationState
+from nominal.experimental.migration.resource_type import format_resource_label
 
 
 def load_migration_block(raw: Any) -> dict[str, Any]:
@@ -59,10 +60,14 @@ def summarize_config(path: Path) -> tuple[str, dict[str, int]]:
 
     source_asset_rids = migration.get("source_asset_rids")
     source_assets = migration.get("source_assets")
-    # Mirror _load_asset_resources: `nom migrate copy` rejects configs with both forms, so the
-    # size check must not silently pick one and report misleading counts.
+    # Mirror _load_asset_resources: whatever `nom migrate copy` rejects, the size check must
+    # reject too rather than silently reporting misleading counts.
     if source_asset_rids is not None and source_assets is not None:
         raise click.UsageError("Provide only one of 'migration.source_asset_rids' or 'migration.source_assets'.")
+    if source_asset_rids is not None and not isinstance(source_asset_rids, list):
+        raise click.UsageError("'migration.source_asset_rids' must be a list.")
+    if source_assets is not None and (not isinstance(source_assets, dict) or not source_assets):
+        raise click.UsageError("'migration.source_assets' must be a non-empty mapping.")
     template_total = 0
     if isinstance(source_asset_rids, list):
         counts["assets"] = len(source_asset_rids)
@@ -108,7 +113,7 @@ def summarize_state(path: Path) -> tuple[str, dict[str, int]]:
     """Count old->new RID mappings per resource type from a migration-state JSON file."""
     state = MigrationState.from_json(path.read_text(encoding="utf-8"))
     counts = {
-        resource_type.lower().replace("_", " "): len(mapping)
+        format_resource_label(resource_type): len(mapping)
         for resource_type, mapping in state.rid_mapping.items()
         if isinstance(mapping, dict)
     }

--- a/nominal/experimental/migration/migration_summary.py
+++ b/nominal/experimental/migration/migration_summary.py
@@ -59,6 +59,10 @@ def summarize_config(path: Path) -> tuple[str, dict[str, int]]:
 
     source_asset_rids = migration.get("source_asset_rids")
     source_assets = migration.get("source_assets")
+    # Mirror _load_asset_resources: `nom migrate copy` rejects configs with both forms, so the
+    # size check must not silently pick one and report misleading counts.
+    if source_asset_rids is not None and source_assets is not None:
+        raise click.UsageError("Provide only one of 'migration.source_asset_rids' or 'migration.source_assets'.")
     template_total = 0
     if isinstance(source_asset_rids, list):
         counts["assets"] = len(source_asset_rids)

--- a/nominal/experimental/migration/migration_summary.py
+++ b/nominal/experimental/migration/migration_summary.py
@@ -1,0 +1,143 @@
+"""Produce a human-readable summary of a migration as a markdown table.
+
+Three modes, all fully offline (no profiles, no tokens, no network):
+
+* from a config YAML — static counts (assets, workbook templates, standalone checklists) for a
+  quick size check before running a migration.
+* from a captured ``nom migrate copy --dry-run`` log — tallies the ``[DRY RUN] Would create``
+  lines by resource type, using the same shared vocabulary the migrators log with
+  (see :mod:`nominal.experimental.migration.dry_run`).
+* from a migration-state JSON — counts old->new RID mappings by resource type to report what a
+  real (non-dry-run) migration actually created.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping
+
+import click
+import yaml
+
+from nominal.experimental.migration.dry_run import dry_run_create_pattern
+from nominal.experimental.migration.migration_state import MigrationState
+
+
+def load_migration_block(raw: Any) -> dict[str, Any]:
+    """Return the top-level ``migration`` mapping of a parsed config, or raise a usage error."""
+    if not isinstance(raw, dict) or "migration" not in raw:
+        raise click.UsageError("Config must be a mapping with a top-level 'migration' key.")
+
+    m = raw["migration"]
+    if not isinstance(m, dict):
+        raise click.UsageError("'migration' must be a mapping.")
+
+    return m
+
+
+def render_summary_table(title: str, counts: Mapping[str, int]) -> str:
+    """Render resource-type counts as a markdown table with a total row."""
+    lines = [f"## {title}", "", "| Resource type | Count |", "| --- | ---: |"]
+    if not counts:
+        lines.append("| _(none)_ | 0 |")
+    else:
+        for resource_type in sorted(counts):
+            lines.append(f"| {resource_type} | {counts[resource_type]} |")
+        lines.append(f"| **Total** | **{sum(counts.values())}** |")
+    return "\n".join(lines) + "\n"
+
+
+def summarize_config(path: Path) -> tuple[str, dict[str, int]]:
+    """Static counts from a config YAML, without contacting any tenant."""
+    with path.open("r", encoding="utf-8") as f:
+        raw: Any = yaml.safe_load(f)
+    migration = load_migration_block(raw)
+
+    counts: dict[str, int] = {}
+
+    source_asset_rids = migration.get("source_asset_rids")
+    source_assets = migration.get("source_assets")
+    template_total = 0
+    if isinstance(source_asset_rids, list):
+        counts["assets"] = len(source_asset_rids)
+        entries: list[Any] = source_asset_rids
+    elif isinstance(source_assets, dict):
+        counts["assets"] = len(source_assets)
+        entries = list(source_assets.values())
+    else:
+        counts["assets"] = 0
+        entries = []
+    for entry in entries:
+        if isinstance(entry, dict) and isinstance(entry.get("workbook_template_rids"), list):
+            template_total += len(entry["workbook_template_rids"])
+
+    if template_total:
+        counts["asset workbook templates"] = template_total
+
+    standalone_templates = migration.get("standalone_workbook_template_rids")
+    if isinstance(standalone_templates, list):
+        counts["standalone workbook templates"] = len(standalone_templates)
+
+    standalone_checklists = migration.get("standalone_checklist_rids")
+    if isinstance(standalone_checklists, list):
+        counts["standalone checklists"] = len(standalone_checklists)
+
+    name = migration.get("name") or path.name
+    return f"Config size check: {name} ({path.name})", counts
+
+
+def summarize_log(path: Path) -> tuple[str, dict[str, int]]:
+    """Tally dry-run "would create" lines from a captured ``nom migrate copy --dry-run`` log."""
+    pattern = dry_run_create_pattern()
+    counts: Counter[str] = Counter()
+    with path.open("r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            match = pattern.search(line)
+            if match:
+                counts[match.group("type").lower()] += 1
+    return "Dry-run summary — resources that would be created", dict(counts)
+
+
+def summarize_state(path: Path) -> tuple[str, dict[str, int]]:
+    """Count old->new RID mappings per resource type from a migration-state JSON file."""
+    state = MigrationState.from_json(path.read_text(encoding="utf-8"))
+    counts = {
+        resource_type.lower().replace("_", " "): len(mapping)
+        for resource_type, mapping in state.rid_mapping.items()
+        if isinstance(mapping, dict)
+    }
+    return "Migration summary — resources created", counts
+
+
+def build_summary(
+    config_paths: tuple[Path, ...],
+    log_path: Path | None,
+    state_path: Path | None,
+) -> str:
+    """Build the full markdown summary for exactly one of the three source modes.
+
+    Raises:
+        click.UsageError: if not exactly one source mode is provided.
+    """
+    provided = sum([bool(config_paths), log_path is not None, state_path is not None])
+    if provided != 1:
+        raise click.UsageError("Provide exactly one of --from-config, --from-log, or --from-state.")
+
+    sections: list[str] = []
+    try:
+        if config_paths:
+            for config_path in config_paths:
+                title, counts = summarize_config(config_path)
+                sections.append(render_summary_table(title, counts))
+        elif log_path is not None:
+            title, counts = summarize_log(log_path)
+            sections.append(render_summary_table(title, counts))
+        elif state_path is not None:
+            title, counts = summarize_state(state_path)
+            sections.append(render_summary_table(title, counts))
+    except (OSError, ValueError, yaml.YAMLError, json.JSONDecodeError) as exc:
+        raise click.ClickException(f"could not build migration summary: {exc}") from exc
+
+    return "\n".join(sections)

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -12,6 +12,7 @@ from nominal.core.asset import Asset
 from nominal.core.run import Run
 from nominal.core.workbook import Workbook
 from nominal.experimental.migration.config.migration_data_config import MigrationDatasetConfig
+from nominal.experimental.migration.dry_run import DRY_RUN_PREFIX, would_create_message
 from nominal.experimental.migration.migrator.attachment_migrator import AttachmentMigrator
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.migrator.checklist_migrator import ChecklistCopyOptions, ChecklistMigrator
@@ -108,7 +109,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             return existing_asset
 
         if self.ctx.dry_run:
-            logger.info("[DRY RUN] Would create asset '%s' (source: %s)", source_asset.name, source_asset.rid)
+            logger.info(would_create_message(self.resource_type), source_asset.name, source_asset.rid)
             self.ctx.migration_state.record_mapping(self.resource_type, source_asset.rid, source_asset.rid)
             return source_asset
 
@@ -166,7 +167,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             if self.ctx.migration_state.get_mapped_rid(ResourceType.ASSET_DATA_SCOPE, scope_key) is None:
                 if self.ctx.dry_run:
                     logger.info(
-                        "[DRY RUN] Would add dataset '%s' to asset '%s' scope '%s'",
+                        f"{DRY_RUN_PREFIX} Would add dataset '%s' to asset '%s' scope '%s'",
                         new_dataset.name,
                         destination_asset.name,
                         source_data_scope_name,
@@ -209,7 +210,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             if self.ctx.migration_state.get_mapped_rid(ResourceType.DATA_REVIEW, source_data_review.rid) is None:
                 if self.ctx.dry_run:
                     logger.info(
-                        "[DRY RUN] Would execute checklist '%s' against run %s",
+                        f"{DRY_RUN_PREFIX} Would execute checklist '%s' against run %s",
                         destination_checklist.name,
                         destination_run_rid,
                     )
@@ -232,7 +233,9 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
         if new_attachments:
             if self.ctx.dry_run:
                 logger.info(
-                    "[DRY RUN] Would add %d attachment(s) to asset '%s'", len(new_attachments), destination_asset.name
+                    f"{DRY_RUN_PREFIX} Would add %d attachment(s) to asset '%s'",
+                    len(new_attachments),
+                    destination_asset.name,
                 )
             else:
                 destination_asset.add_attachments(new_attachments)
@@ -250,7 +253,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             if self.ctx.migration_state.get_mapped_rid(ResourceType.ASSET_DATA_SCOPE, scope_key) is None:
                 if self.ctx.dry_run:
                     logger.info(
-                        "[DRY RUN] Would add video '%s' to asset '%s' scope '%s'",
+                        f"{DRY_RUN_PREFIX} Would add video '%s' to asset '%s' scope '%s'",
                         new_video_dataset.name,
                         new_asset.name,
                         data_scope,

--- a/nominal/experimental/migration/migrator/attachment_migrator.py
+++ b/nominal/experimental/migration/migrator/attachment_migrator.py
@@ -7,6 +7,7 @@ from nominal.core import NominalClient
 from nominal.core._clientsbunch import ClientsBunch
 from nominal.core.attachment import Attachment
 from nominal.core.filetype import FileType, FileTypes
+from nominal.experimental.migration.dry_run import would_create_message
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.resource_type import ResourceType
 
@@ -45,7 +46,7 @@ class AttachmentMigrator(Migrator[Attachment, ResourceCopyOptions]):
             return existing_attachment
 
         if self.ctx.dry_run:
-            logger.info("[DRY RUN] Would create attachment '%s' (source: %s)", source.name, source.rid)
+            logger.info(would_create_message(self.resource_type), source.name, source.rid)
             self.ctx.migration_state.record_mapping(self.resource_type, source.rid, source.rid)
             return source
 

--- a/nominal/experimental/migration/migrator/base.py
+++ b/nominal/experimental/migration/migrator/base.py
@@ -8,7 +8,7 @@ from typing import Generic, TypeVar
 from nominal.core import NominalClient
 from nominal.core._utils.api_tools import HasRid
 from nominal.experimental.migration.migrator.context import MigrationContext
-from nominal.experimental.migration.resource_type import ResourceType
+from nominal.experimental.migration.resource_type import ResourceType, resource_label
 
 Resource = TypeVar("Resource", bound=HasRid)
 CopyOptions = TypeVar("CopyOptions", bound="ResourceCopyOptions")
@@ -93,7 +93,7 @@ class Migrator(ABC, Generic[Resource, CopyOptions]):
 
     @property
     def resource_label(self) -> str:
-        return self.resource_type.value.lower().replace("_", " ")
+        return resource_label(self.resource_type)
 
     def use_singleflight(self) -> bool:
         """Whether concurrent callers should be deduped for a given source RID."""

--- a/nominal/experimental/migration/migrator/checklist_migrator.py
+++ b/nominal/experimental/migration/migrator/checklist_migrator.py
@@ -12,6 +12,7 @@ from nominal.experimental.checklist_utils.checklist_utils import (
     _to_create_checklist_entries,
     _to_unresolved_checklist_variables,
 )
+from nominal.experimental.migration.dry_run import would_create_message
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.resource_type import ResourceType
 
@@ -81,7 +82,7 @@ class ChecklistMigrator(Migrator[Checklist, ChecklistCopyOptions]):
         workspace_rid = destination_client.get_workspace(destination_client._clients.workspace_rid).rid
 
         if self.ctx.dry_run:
-            logger.info("[DRY RUN] Would create checklist '%s' (source: %s)", source.name, source.rid)
+            logger.info(would_create_message(self.resource_type), source.name, source.rid)
             self.ctx.migration_state.record_mapping(self.resource_type, source.rid, source.rid)
             return source
 

--- a/nominal/experimental/migration/migrator/dataset_file_migrator.py
+++ b/nominal/experimental/migration/migrator/dataset_file_migrator.py
@@ -4,6 +4,7 @@ import logging
 
 from nominal.core.dataset import Dataset
 from nominal.core.dataset_file import DatasetFile
+from nominal.experimental.migration.dry_run import DRY_RUN_PREFIX
 from nominal.experimental.migration.migrator.context import MigrationContext
 from nominal.experimental.migration.resource_type import ResourceType
 from nominal.experimental.migration.utils.file_utils import copy_file_to_dataset
@@ -23,7 +24,7 @@ class DatasetFileMigrator:
             return
 
         if self.ctx.dry_run:
-            logger.info("[DRY RUN] Would copy dataset file %s to destination", source_file.id)
+            logger.info(f"{DRY_RUN_PREFIX} Would copy dataset file %s to destination", source_file.id)
             return
 
         new_file = copy_file_to_dataset(source_file, destination_dataset)

--- a/nominal/experimental/migration/migrator/dataset_migrator.py
+++ b/nominal/experimental/migration/migrator/dataset_migrator.py
@@ -10,6 +10,7 @@ from nominal.core.dataset import Dataset
 from nominal.core.datasource import CreateChannelRequest
 from nominal.experimental.dataset_utils import create_dataset_with_uuid
 from nominal.experimental.id_utils.id_utils import UUID_PATTERN
+from nominal.experimental.migration.dry_run import would_create_message
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.migrator.dataset_file_migrator import DatasetFileMigrator
 from nominal.experimental.migration.resource_type import ResourceType
@@ -69,7 +70,7 @@ class DatasetMigrator(Migrator[Dataset, DatasetCopyOptions]):
         dataset_labels = options.new_dataset_labels if options.new_dataset_labels is not None else source.labels
 
         if self.ctx.dry_run:
-            logger.info("[DRY RUN] Would create dataset '%s' (source: %s)", source.name, source.rid)
+            logger.info(would_create_message(self.resource_type), source.name, source.rid)
             self.ctx.migration_state.record_mapping(self.resource_type, source.rid, source.rid)
             return source
 

--- a/nominal/experimental/migration/migrator/event_migrator.py
+++ b/nominal/experimental/migration/migrator/event_migrator.py
@@ -9,6 +9,7 @@ from nominal.core import NominalClient
 from nominal.core._event_types import EventType
 from nominal.core.asset import Asset
 from nominal.core.event import Event
+from nominal.experimental.migration.dry_run import would_create_message
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.resource_type import ResourceType
 from nominal.ts import IntegralNanosecondsDuration, IntegralNanosecondsUTC
@@ -45,7 +46,7 @@ class EventMigrator(Migrator[Event, EventCopyOptions]):
             return existing_event
 
         if self.ctx.dry_run:
-            logger.info("[DRY RUN] Would create event '%s' (source: %s)", source.name, source.rid)
+            logger.info(would_create_message(self.resource_type), source.name, source.rid)
             self.ctx.migration_state.record_mapping(self.resource_type, source.rid, source.rid)
             return source
 

--- a/nominal/experimental/migration/migrator/run_migrator.py
+++ b/nominal/experimental/migration/migrator/run_migrator.py
@@ -10,6 +10,7 @@ from nominal.core._utils.api_tools import Link, LinkDict, rid_from_instance_or_s
 from nominal.core.asset import Asset
 from nominal.core.attachment import Attachment
 from nominal.core.run import Run
+from nominal.experimental.migration.dry_run import DRY_RUN_PREFIX, would_create_message
 from nominal.experimental.migration.migrator.attachment_migrator import AttachmentMigrator
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.resource_type import ResourceType
@@ -57,7 +58,7 @@ class RunMigrator(Migrator[Run, RunCopyOptions]):
             attachments = [attachment_migrator.copy_from(a) for a in source.list_attachments()]
 
         if self.ctx.dry_run:
-            logger.info("[DRY RUN] Would create run '%s' (source: %s)", source.name, source.rid)
+            logger.info(would_create_message(self.resource_type), source.name, source.rid)
             self.ctx.migration_state.record_mapping(self.resource_type, source.rid, source.rid)
             return source
 
@@ -90,7 +91,7 @@ class RunMigrator(Migrator[Run, RunCopyOptions]):
         if not missing_rids:
             return run
         if self.ctx.dry_run:
-            logger.info("[DRY RUN] Would add %d asset(s) to existing run %s", len(missing_rids), run.rid)
+            logger.info(f"{DRY_RUN_PREFIX} Would add %d asset(s) to existing run %s", len(missing_rids), run.rid)
             return run
         logger.debug("Adding %d missing asset(s) to existing run %s", len(missing_rids), run.rid)
         return run.update(assets=[*existing_rids, *missing_rids])

--- a/nominal/experimental/migration/migrator/video_file_migrator.py
+++ b/nominal/experimental/migration/migrator/video_file_migrator.py
@@ -4,6 +4,7 @@ import logging
 
 from nominal.core.video import Video
 from nominal.core.video_file import VideoFile
+from nominal.experimental.migration.dry_run import DRY_RUN_PREFIX
 from nominal.experimental.migration.migrator.context import MigrationContext
 from nominal.experimental.migration.resource_type import ResourceType
 from nominal.experimental.migration.utils.video_file_utils import copy_video_file_to_video_dataset
@@ -23,7 +24,7 @@ class VideoFileMigrator:
             return
 
         if self.ctx.dry_run:
-            logger.info("[DRY RUN] Would copy video file %s to destination", source_file.rid)
+            logger.info(f"{DRY_RUN_PREFIX} Would copy video file %s to destination", source_file.rid)
             return
 
         new_file = copy_video_file_to_video_dataset(source_file, destination_video)

--- a/nominal/experimental/migration/migrator/video_migrator.py
+++ b/nominal/experimental/migration/migrator/video_migrator.py
@@ -6,6 +6,7 @@ from typing import Any, Sequence
 
 from nominal.core import NominalClient
 from nominal.core.video import Video
+from nominal.experimental.migration.dry_run import would_create_message
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.migrator.video_file_migrator import VideoFileMigrator
 from nominal.experimental.migration.resource_type import ResourceType
@@ -49,7 +50,7 @@ class VideoMigrator(Migrator[Video, VideoCopyOptions]):
             return existing_video
 
         if self.ctx.dry_run:
-            logger.info("[DRY RUN] Would create video '%s' (source: %s)", source.name, source.rid)
+            logger.info(would_create_message(self.resource_type), source.name, source.rid)
             self.ctx.migration_state.record_mapping(self.resource_type, source.rid, source.rid)
             return source
 

--- a/nominal/experimental/migration/migrator/workbook_migrator.py
+++ b/nominal/experimental/migration/migrator/workbook_migrator.py
@@ -15,6 +15,7 @@ from nominal.core import NominalClient
 from nominal.core._clientsbunch import ClientsBunch
 from nominal.core.workbook import Workbook
 from nominal.experimental.id_utils.id_utils import UUID_RE
+from nominal.experimental.migration.dry_run import would_create_message
 from nominal.experimental.migration.migrator.attachment_migrator import AttachmentMigrator
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.resource_type import ResourceType
@@ -108,7 +109,7 @@ class WorkbookMigrator(Migrator[Workbook, WorkbookCopyOptions]):
             raise ValueError(f"Missing content for workbook {source.rid}")
 
         if self.ctx.dry_run:
-            logger.info("[DRY RUN] Would create workbook '%s' (source: %s)", raw_notebook.metadata.title, source.rid)
+            logger.info(would_create_message(ResourceType.WORKBOOK), raw_notebook.metadata.title, source.rid)
             self.ctx.migration_state.record_mapping(ResourceType.WORKBOOK, source.rid, source.rid)
             return source
 

--- a/nominal/experimental/migration/migrator/workbook_template_migrator.py
+++ b/nominal/experimental/migration/migrator/workbook_template_migrator.py
@@ -15,6 +15,7 @@ from nominal.core import NominalClient
 from nominal.core._clientsbunch import ClientsBunch
 from nominal.core.workbook_template import WorkbookTemplate, _create_workbook_template_with_content_and_layout
 from nominal.experimental.id_utils.id_utils import UUID_RE
+from nominal.experimental.migration.dry_run import would_create_message
 from nominal.experimental.migration.migrator.attachment_migrator import AttachmentMigrator
 from nominal.experimental.migration.migrator.base import Migrator, ResourceCopyOptions
 from nominal.experimental.migration.resource_type import ResourceType
@@ -56,7 +57,7 @@ class WorkbookTemplateMigrator(Migrator[WorkbookTemplate, WorkbookTemplateCopyOp
         raw_source_template = source._clients.template.get(source._clients.auth_header, source.rid)
 
         if self.ctx.dry_run:
-            logger.info("[DRY RUN] Would create workbook template '%s' (source: %s)", source.title, source.rid)
+            logger.info(would_create_message(self.resource_type), source.title, source.rid)
             self.ctx.migration_state.record_mapping(self.resource_type, source.rid, source.rid)
             return source
 

--- a/nominal/experimental/migration/resource_type.py
+++ b/nominal/experimental/migration/resource_type.py
@@ -19,3 +19,8 @@ class ResourceType(Enum):
     ASSET_DATA_SCOPE = "ASSET_DATA_SCOPE"
     DATASET_CHANNEL = "DATASET_CHANNEL"
     DATASET_BOUNDS = "DATASET_BOUNDS"
+
+
+def resource_label(resource_type: ResourceType) -> str:
+    """Human-readable label for a resource type, as used in log messages (e.g. "workbook template")."""
+    return resource_type.value.lower().replace("_", " ")

--- a/nominal/experimental/migration/resource_type.py
+++ b/nominal/experimental/migration/resource_type.py
@@ -21,6 +21,15 @@ class ResourceType(Enum):
     DATASET_BOUNDS = "DATASET_BOUNDS"
 
 
+def format_resource_label(value: str) -> str:
+    """Format a raw resource-type string as a human-readable label (e.g. "WORKBOOK_TEMPLATE" -> "workbook template").
+
+    String-level so it also applies to type keys read back from state JSON, which may predate the
+    current ResourceType members.
+    """
+    return value.lower().replace("_", " ")
+
+
 def resource_label(resource_type: ResourceType) -> str:
     """Human-readable label for a resource type, as used in log messages (e.g. "workbook template")."""
-    return resource_type.value.lower().replace("_", " ")
+    return format_resource_label(resource_type.value)

--- a/nominal/experimental/migration/sample_migration_config.yml
+++ b/nominal/experimental/migration/sample_migration_config.yml
@@ -1,3 +1,7 @@
+# IMPORTANT: never store tokens, API keys, base URLs, or workspace RIDs in this
+# config. Connection details come from `nom config profile` profiles (or masked
+# CI inputs); this file only describes WHAT to migrate.
+
 migration:
   # Human-readable name for this migration run. Appears in logs.
   name: "my-migration"

--- a/tests/cli/test_migrate_summary_cli.py
+++ b/tests/cli/test_migrate_summary_cli.py
@@ -1,0 +1,93 @@
+"""End-to-end tests for `nom migrate summary` (offline; no profile or token required)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+if sys.version_info < (3, 13):
+    pytest.skip("Migration module requires Python 3.13+ (TypeVar default parameter)", allow_module_level=True)
+
+from nominal.experimental.migration.dry_run import would_create_message
+from nominal.experimental.migration.migration_cli import migrate_cmd
+from nominal.experimental.migration.migration_state import MigrationState
+from nominal.experimental.migration.resource_type import ResourceType
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _write_config(tmp_path: Path, name: str = "cfg") -> Path:
+    path = tmp_path / f"{name}.yml"
+    path.write_text(
+        f"migration:\n  name: {name}\n  source_asset_rids:\n    - asset_rid: ri.a.1\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_from_config(runner: CliRunner, tmp_path: Path) -> None:
+    config = _write_config(tmp_path)
+    result = runner.invoke(migrate_cmd, ["summary", "--from-config", str(config)])
+    assert result.exit_code == 0, result.output
+    assert "| assets | 1 |" in result.output
+
+
+def test_from_config_repeatable(runner: CliRunner, tmp_path: Path) -> None:
+    configs = [_write_config(tmp_path, f"cfg{i}") for i in range(2)]
+    args = ["summary"]
+    for config in configs:
+        args += ["--from-config", str(config)]
+    result = runner.invoke(migrate_cmd, args)
+    assert result.exit_code == 0, result.output
+    assert "cfg0" in result.output
+    assert "cfg1" in result.output
+
+
+def test_from_log(runner: CliRunner, tmp_path: Path) -> None:
+    log = tmp_path / "run.log"
+    log.write_text(would_create_message(ResourceType.ASSET) % ("A", "r"), encoding="utf-8")
+    result = runner.invoke(migrate_cmd, ["summary", "--from-log", str(log)])
+    assert result.exit_code == 0, result.output
+    assert "| asset | 1 |" in result.output
+
+
+def test_from_state(runner: CliRunner, tmp_path: Path) -> None:
+    state = MigrationState()
+    state.record_mapping(ResourceType.RUN, "a", "b")
+    path = tmp_path / "state.json"
+    path.write_text(state.to_json(), encoding="utf-8")
+    result = runner.invoke(migrate_cmd, ["summary", "--from-state", str(path)])
+    assert result.exit_code == 0, result.output
+    assert "| run | 1 |" in result.output
+
+
+def test_output_appends(runner: CliRunner, tmp_path: Path) -> None:
+    config = _write_config(tmp_path)
+    output = tmp_path / "summary.md"
+    output.write_text("existing\n", encoding="utf-8")
+    result = runner.invoke(migrate_cmd, ["summary", "--from-config", str(config), "--output", str(output)])
+    assert result.exit_code == 0, result.output
+    contents = output.read_text(encoding="utf-8")
+    assert contents.startswith("existing\n")
+    assert "| assets | 1 |" in contents
+
+
+def test_no_source_is_usage_error(runner: CliRunner) -> None:
+    result = runner.invoke(migrate_cmd, ["summary"])
+    assert result.exit_code == 2
+    assert "exactly one of" in result.output
+
+
+def test_two_sources_is_usage_error(runner: CliRunner, tmp_path: Path) -> None:
+    config = _write_config(tmp_path)
+    log = tmp_path / "run.log"
+    log.write_text("", encoding="utf-8")
+    result = runner.invoke(migrate_cmd, ["summary", "--from-config", str(config), "--from-log", str(log)])
+    assert result.exit_code == 2
+    assert "exactly one of" in result.output

--- a/tests/core/test_asset_migrator.py
+++ b/tests/core/test_asset_migrator.py
@@ -10,6 +10,7 @@ import pytest
 if sys.version_info < (3, 13):
     pytest.skip("Migration module requires Python 3.13+ (TypeVar default parameter)", allow_module_level=True)
 
+from nominal.experimental.migration.dry_run import would_create_message
 from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.migrator.asset_migrator import AssetCopyOptions, AssetMigrator
 from nominal.experimental.migration.migrator.context import MigrationContext
@@ -451,6 +452,8 @@ class TestAssetMigratorDryRun:
 
         ctx = _make_dry_run_context()
         migrator = AssetMigrator(ctx)
+        source_asset = _make_source_asset(name="MyNewAsset")
         with caplog.at_level(logging.INFO):
-            migrator.copy_from(_make_source_asset(name="MyNewAsset"), _NO_CHILD_OPTIONS)
-        assert any("[DRY RUN] Would create asset" in r.message for r in caplog.records)
+            migrator.copy_from(source_asset, _NO_CHILD_OPTIONS)
+        expected = would_create_message(ResourceType.ASSET) % (source_asset.name, source_asset.rid)
+        assert any(expected in r.getMessage() for r in caplog.records)

--- a/tests/core/test_migration_summary.py
+++ b/tests/core/test_migration_summary.py
@@ -1,0 +1,197 @@
+"""Tests for the offline migration summary helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import click
+import pytest
+
+if sys.version_info < (3, 13):
+    pytest.skip("Migration module requires Python 3.13+ (TypeVar default parameter)", allow_module_level=True)
+
+from nominal.experimental.migration.dry_run import DRY_RUN_PREFIX, dry_run_create_pattern, would_create_message
+from nominal.experimental.migration.migration_state import MigrationState
+from nominal.experimental.migration.migration_summary import (
+    build_summary,
+    load_migration_block,
+    render_summary_table,
+    summarize_config,
+    summarize_log,
+    summarize_state,
+)
+from nominal.experimental.migration.resource_type import ResourceType, resource_label
+
+
+def test_dry_run_prefix_is_stable() -> None:
+    """External consumers grep run logs for this marker — changing it is a breaking change."""
+    assert DRY_RUN_PREFIX == "[DRY RUN]"
+
+
+class TestRenderSummaryTable:
+    def test_empty_counts(self) -> None:
+        table = render_summary_table("Empty", {})
+        assert "| _(none)_ | 0 |" in table
+        assert "**Total**" not in table
+
+    def test_rows_sorted_with_total(self) -> None:
+        table = render_summary_table("T", {"run": 2, "asset": 3})
+        lines = table.splitlines()
+        assert lines.index("| asset | 3 |") < lines.index("| run | 2 |")
+        assert "| **Total** | **5** |" in table
+
+
+class TestSummarizeConfig:
+    def _write(self, tmp_path: Path, content: str) -> Path:
+        path = tmp_path / "config.yml"
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_list_form_with_per_asset_templates(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            """
+migration:
+  name: list-form
+  source_asset_rids:
+    - asset_rid: ri.a.1
+      workbook_template_rids: [ri.t.1, ri.t.2]
+    - asset_rid: ri.a.2
+  standalone_workbook_template_rids: [ri.t.3]
+  standalone_checklist_rids: [ri.c.1, ri.c.2]
+""",
+        )
+        title, counts = summarize_config(path)
+        assert "list-form" in title
+        assert counts == {
+            "assets": 2,
+            "asset workbook templates": 2,
+            "standalone workbook templates": 1,
+            "standalone checklists": 2,
+        }
+
+    def test_map_form(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            """
+migration:
+  name: map-form
+  source_assets:
+    ri.a.1:
+      workbook_template_rids: [ri.t.1]
+    ri.a.2: {}
+""",
+        )
+        _, counts = summarize_config(path)
+        assert counts == {"assets": 2, "asset workbook templates": 1}
+
+    def test_no_assets(self, tmp_path: Path) -> None:
+        path = self._write(tmp_path, "migration:\n  name: empty\n")
+        _, counts = summarize_config(path)
+        assert counts == {"assets": 0}
+
+    def test_missing_migration_key_raises(self, tmp_path: Path) -> None:
+        path = self._write(tmp_path, "not_migration: {}\n")
+        with pytest.raises(click.UsageError):
+            summarize_config(path)
+
+    def test_non_mapping_migration_raises(self, tmp_path: Path) -> None:
+        path = self._write(tmp_path, "migration: [1, 2]\n")
+        with pytest.raises(click.UsageError):
+            summarize_config(path)
+
+
+class TestLoadMigrationBlock:
+    def test_returns_migration_mapping(self) -> None:
+        assert load_migration_block({"migration": {"name": "x"}}) == {"name": "x"}
+
+    def test_rejects_non_mapping_document(self) -> None:
+        with pytest.raises(click.UsageError):
+            load_migration_block(["migration"])
+
+
+class TestSummarizeLog:
+    def test_counts_every_resource_label(self, tmp_path: Path) -> None:
+        """Every resource type's would-create line round-trips through the shared pattern."""
+        lines = [would_create_message(rt) % (f"name-{rt.value}", f"rid-{rt.value}") for rt in ResourceType]
+        log = tmp_path / "run.log"
+        log.write_text("\n".join(lines), encoding="utf-8")
+        _, counts = summarize_log(log)
+        assert counts == {resource_label(rt): 1 for rt in ResourceType}
+
+    def test_multiword_label_not_truncated(self, tmp_path: Path) -> None:
+        """Regression: 'workbook template' lines must not be miscounted as 'workbook'."""
+        log = tmp_path / "run.log"
+        log.write_text(would_create_message(ResourceType.WORKBOOK_TEMPLATE) % ("T", "r"), encoding="utf-8")
+        _, counts = summarize_log(log)
+        assert counts == {"workbook template": 1}
+
+    def test_non_create_dry_run_lines_ignored(self, tmp_path: Path) -> None:
+        log = tmp_path / "run.log"
+        log.write_text(
+            "\n".join(
+                [
+                    f"{DRY_RUN_PREFIX} Would add 3 attachment(s) to asset 'A'",
+                    f"{DRY_RUN_PREFIX} Would copy dataset file f1 to destination",
+                    f"{DRY_RUN_PREFIX} Would execute checklist 'C' against run r1",
+                    f"{DRY_RUN_PREFIX} Skipping migration state write to state.json",
+                    "Copying events for asset A (rid: r1)",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        _, counts = summarize_log(log)
+        assert counts == {}
+
+    def test_pattern_matches_amid_log_formatting(self) -> None:
+        line = f"2026-07-08 12:00:00 INFO {would_create_message(ResourceType.ASSET) % ('A', 'r')}"
+        match = dry_run_create_pattern().search(line)
+        assert match is not None
+        assert match.group("type") == "asset"
+
+
+class TestSummarizeState:
+    def test_counts_rid_mappings_snake_case(self, tmp_path: Path) -> None:
+        state = MigrationState()
+        state.record_mapping(ResourceType.ASSET, "a1", "b1")
+        state.record_mapping(ResourceType.ASSET, "a2", "b2")
+        state.record_mapping(ResourceType.WORKBOOK_TEMPLATE, "t1", "t2")
+        path = tmp_path / "state.json"
+        path.write_text(state.to_json(), encoding="utf-8")
+        _, counts = summarize_state(path)
+        assert counts == {"asset": 2, "workbook template": 1}
+
+    def test_counts_rid_mappings_camel_case(self, tmp_path: Path) -> None:
+        path = tmp_path / "state.json"
+        path.write_text('{"ridMapping": {"RUN": {"a": "b"}}}', encoding="utf-8")
+        _, counts = summarize_state(path)
+        assert counts == {"run": 1}
+
+
+class TestBuildSummary:
+    def test_requires_exactly_one_source(self, tmp_path: Path) -> None:
+        with pytest.raises(click.UsageError):
+            build_summary((), None, None)
+        log = tmp_path / "run.log"
+        log.write_text("", encoding="utf-8")
+        state = tmp_path / "state.json"
+        state.write_text("{}", encoding="utf-8")
+        with pytest.raises(click.UsageError):
+            build_summary((), log, state)
+
+    def test_invalid_json_becomes_click_exception(self, tmp_path: Path) -> None:
+        state = tmp_path / "state.json"
+        state.write_text("not-json", encoding="utf-8")
+        with pytest.raises(click.ClickException):
+            build_summary((), None, state)
+
+    def test_multiple_configs_render_one_section_each(self, tmp_path: Path) -> None:
+        paths = []
+        for i in range(2):
+            path = tmp_path / f"c{i}.yml"
+            path.write_text(f"migration:\n  name: cfg-{i}\n", encoding="utf-8")
+            paths.append(path)
+        rendered = build_summary(tuple(paths), None, None)
+        assert "cfg-0" in rendered
+        assert "cfg-1" in rendered

--- a/tests/core/test_migration_summary.py
+++ b/tests/core/test_migration_summary.py
@@ -21,12 +21,18 @@ from nominal.experimental.migration.migration_summary import (
     summarize_log,
     summarize_state,
 )
-from nominal.experimental.migration.resource_type import ResourceType, resource_label
+from nominal.experimental.migration.resource_type import ResourceType, format_resource_label, resource_label
 
 
 def test_dry_run_prefix_is_stable() -> None:
     """External consumers grep run logs for this marker — changing it is a breaking change."""
     assert DRY_RUN_PREFIX == "[DRY RUN]"
+
+
+def test_resource_label_delegates_to_string_formatter() -> None:
+    """Log labels and state-summary labels must come from the same formatter."""
+    for rt in ResourceType:
+        assert resource_label(rt) == format_resource_label(rt.value)
 
 
 class TestRenderSummaryTable:
@@ -104,6 +110,22 @@ migration:
 """,
         )
         with pytest.raises(click.UsageError):
+            summarize_config(path)
+
+    def test_non_list_source_asset_rids_raises(self, tmp_path: Path) -> None:
+        """`nom migrate copy` raises for a non-list source_asset_rids; the summary must not report 0."""
+        path = self._write(tmp_path, "migration:\n  name: bad\n  source_asset_rids: oops\n")
+        with pytest.raises(click.UsageError, match="must be a list"):
+            summarize_config(path)
+
+    def test_non_mapping_source_assets_raises(self, tmp_path: Path) -> None:
+        path = self._write(tmp_path, "migration:\n  name: bad\n  source_assets: [ri.a.1]\n")
+        with pytest.raises(click.UsageError, match="non-empty mapping"):
+            summarize_config(path)
+
+    def test_empty_source_assets_raises(self, tmp_path: Path) -> None:
+        path = self._write(tmp_path, "migration:\n  name: bad\n  source_assets: {}\n")
+        with pytest.raises(click.UsageError, match="non-empty mapping"):
             summarize_config(path)
 
     def test_missing_migration_key_raises(self, tmp_path: Path) -> None:

--- a/tests/core/test_migration_summary.py
+++ b/tests/core/test_migration_summary.py
@@ -91,6 +91,21 @@ migration:
         _, counts = summarize_config(path)
         assert counts == {"assets": 0}
 
+    def test_both_asset_forms_raises(self, tmp_path: Path) -> None:
+        """`nom migrate copy` rejects configs with both forms; the summary must too."""
+        path = self._write(
+            tmp_path,
+            """
+migration:
+  name: both-forms
+  source_asset_rids: []
+  source_assets:
+    ri.a.1: {}
+""",
+        )
+        with pytest.raises(click.UsageError):
+            summarize_config(path)
+
     def test_missing_migration_key_raises(self, tmp_path: Path) -> None:
         path = self._write(tmp_path, "not_migration: {}\n")
         with pytest.raises(click.UsageError):


### PR DESCRIPTION
Follow-up to review comments on [internal-tools PR #45](https://github.com/nominal-io/internal-tools/pull/45): the migration summary tool moves into this repo so it lives next to the dry-run code it parses, benefits users of this repo alone, and cannot drift from the migrator log statements. Companion PR consuming this: [nominal-io/internal-tools#49](https://github.com/nominal-io/internal-tools/pull/49) — **this PR must merge and release first** (predicted `1.152.0`).

**What's here:**

- **`nominal/experimental/migration/dry_run.py`** (new) — shared dry-run logging vocabulary: `DRY_RUN_PREFIX`, `would_create_message(resource_type)` (builds the exact `[DRY RUN] Would create <label> '%s' (source: %s)` format string), and `dry_run_create_pattern()` (the parsing regex built from the same constants and `ResourceType` labels). Labels are alternated longest-first, which also fixes a real bug in the internal-tools parser: `workbook template` lines were miscounted as `workbook`.
- **All 16 dry-run log sites** in the migrators/runner now build their messages from the shared constants. Wording is byte-identical to before.
- **`nominal/experimental/migration/migration_summary.py`** (new) + **`nom migrate summary`** subcommand — emits a markdown resource-count table from one of three sources: `--from-config <yml>` (repeatable; offline size check), `--from-log <log>` (tallies dry-run would-create lines), `--from-state <json>` (counts `rid_mapping` entries via `MigrationState.from_json`). `--output` appends to a file such as `$GITHUB_STEP_SUMMARY`. Fully offline — no profiles or tokens required (`@global_options` only).
- `load_migration_block` moved out of `migration_cli.py` into the new module for reuse (import direction: cli → summary, no cycle).
- Sample config and README updated; the sample now carries the never-store-tokens warning previously only in internal-tools.

**From review:**
- `summarize_config` mirrors all of `copy`'s config validation — both-asset-forms, non-list `source_asset_rids`, and non-mapping/empty `source_assets` are rejected with `copy`'s exact error messages instead of silently reporting 0 assets (Cursor Bugbot + Claude reviewer).
- New string-level `format_resource_label()` in `resource_type.py`; `resource_label()` delegates to it and `summarize_state` uses it, so state-summary labels come from the same formatter as log labels (Claude reviewer).
- On why two asset forms exist (`source_asset_rids` list vs `source_assets` map): both are pre-existing `copy` schema — see the [thread](https://github.com/nominal-io/nominal-client/pull/872#discussion_r3544749147); consolidation would be a breaking config change, offered as a follow-up.

**Tests:** new `tests/core/test_migration_summary.py` (round-trips every `ResourceType` through message-builder → parser; multi-word-label regression; non-create lines ignored; config validation rejections; snake/camelCase state; `DRY_RUN_PREFIX` lock; label-formatter delegation) and `tests/cli/test_migrate_summary_cli.py` (each mode end-to-end via `CliRunner` with no profile configured; `--output` append; usage errors). Existing literal assertion in `test_asset_migrator.py` now derives from the constants.

**Verification:** full suite passes under Python 3.13, `ruff format --check`/`ruff check` clean, `mypy -p nominal.experimental.migration` strict clean. Devin Review: no issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fc2sY63WBF9rruL6xLEWpM