### PR TITLE
fix(migration): route mcap and dataflash through native ingest

### DIFF
--- a/nominal/core/filetype.py
+++ b/nominal/core/filetype.py
@@ -127,7 +127,6 @@ class FileType(NamedTuple):
 
 
 class FileTypes:
-    ARDUPILOT_DATAFLASH: FileType = FileType(".bin", "application/octet-stream")
     AVI: FileType = FileType(".avi", "video/x-msvideo")
     AVRO_STREAM: FileType = FileType(".avro", "application/avro")
     BINARY: FileType = FileType("", "application/octet-stream")
@@ -151,7 +150,7 @@ class FileTypes:
     JOURNAL_JSONL_GZ: FileType = FileType(".jsonl.gz", "application/jsonl")
     ZIP: FileType = FileType(".zip", "application/zip")
 
-    _ARDUPILOT_DATAFLASH_TYPES = (ARDUPILOT_DATAFLASH,)
+    _ARDUPILOT_DATAFLASH_TYPES = (DATAFLASH,)
     _CSV_TYPES = (CSV, CSV_GZ)
     _MCAP_TYPES = (MCAP,)
     _PARQUET_FILE_TYPES = (PARQUET_GZ, PARQUET)

--- a/nominal/core/filetype.py
+++ b/nominal/core/filetype.py
@@ -83,7 +83,7 @@ class FileType(NamedTuple):
         return self in FileTypes._MCAP_TYPES
 
     def is_ardupilot_dataflash(self) -> bool:
-        return self in FileTypes._ARDUPILOT_DATAFLASH_TYPES
+        return self in FileTypes._ARDUPILOT_TYPES
 
     @classmethod
     def from_path_dataset(cls, path: PathLike) -> FileType:
@@ -150,7 +150,7 @@ class FileTypes:
     JOURNAL_JSONL_GZ: FileType = FileType(".jsonl.gz", "application/jsonl")
     ZIP: FileType = FileType(".zip", "application/zip")
 
-    _ARDUPILOT_DATAFLASH_TYPES = (DATAFLASH,)
+    _ARDUPILOT_TYPES = (DATAFLASH,)
     _CSV_TYPES = (CSV, CSV_GZ)
     _MCAP_TYPES = (MCAP,)
     _PARQUET_FILE_TYPES = (PARQUET_GZ, PARQUET)

--- a/nominal/core/filetype.py
+++ b/nominal/core/filetype.py
@@ -79,6 +79,12 @@ class FileType(NamedTuple):
     def is_video(self) -> bool:
         return self in FileTypes._VIDEO_TYPES
 
+    def is_mcap(self) -> bool:
+        return self in FileTypes._MCAP_TYPES
+
+    def is_ardupilot_dataflash(self) -> bool:
+        return self in FileTypes._ARDUPILOT_DATAFLASH_TYPES
+
     @classmethod
     def from_path_dataset(cls, path: PathLike) -> FileType:
         file_type = cls.from_path(path)
@@ -121,6 +127,7 @@ class FileType(NamedTuple):
 
 
 class FileTypes:
+    ARDUPILOT_DATAFLASH: FileType = FileType(".bin", "application/octet-stream")
     AVI: FileType = FileType(".avi", "video/x-msvideo")
     AVRO_STREAM: FileType = FileType(".avro", "application/avro")
     BINARY: FileType = FileType("", "application/octet-stream")
@@ -144,7 +151,9 @@ class FileTypes:
     JOURNAL_JSONL_GZ: FileType = FileType(".jsonl.gz", "application/jsonl")
     ZIP: FileType = FileType(".zip", "application/zip")
 
+    _ARDUPILOT_DATAFLASH_TYPES = (ARDUPILOT_DATAFLASH,)
     _CSV_TYPES = (CSV, CSV_GZ)
+    _MCAP_TYPES = (MCAP,)
     _PARQUET_FILE_TYPES = (PARQUET_GZ, PARQUET)
     _PARQUET_ARCHIVE_TYPES = (PARQUET_TAR_GZ, PARQUET_TAR, PARQUET_ZIP)
     _JOURNAL_TYPES = (JOURNAL_JSONL, JOURNAL_JSONL_GZ)

--- a/nominal/experimental/migration/utils/file_utils.py
+++ b/nominal/experimental/migration/utils/file_utils.py
@@ -9,7 +9,7 @@ from typing import BinaryIO, cast
 
 import requests
 
-from nominal.core import Dataset, DatasetFile, FileType, FileTypes
+from nominal.core import Dataset, DatasetFile, FileType
 
 logger = logging.getLogger(__name__)
 
@@ -34,24 +34,18 @@ def copy_file_to_dataset(
         file_stem = _resolve_destination_file_stem(file_name)
 
         if file_type.is_journal():
-            tmp_path = None
-            try:
-                with tempfile.NamedTemporaryFile(suffix=file_type.extension, delete=False) as tmp:
-                    tmp_path = Path(tmp.name)
-                    with response:
-                        shutil.copyfileobj(response.raw, tmp)
-                new_file = destination_dataset.add_journal_json(tmp_path)
-                new_file.poll_until_ingestion_completed()
-            finally:
-                if tmp_path is not None:
-                    tmp_path.unlink(missing_ok=True)
-        elif file_type == FileTypes.MCAP:
+            new_file = _ingest_from_temp_file(
+                response,
+                file_name,
+                destination_dataset.add_journal_json,
+            )
+        elif file_type.is_mcap():
             new_file = _ingest_from_temp_file(
                 response,
                 file_name,
                 lambda path: destination_dataset.add_mcap(path, tags=source_file.file_tags),
             )
-        elif file_type == FileTypes.DATAFLASH:
+        elif file_type.is_ardupilot_dataflash():
             new_file = _ingest_from_temp_file(
                 response,
                 file_name,
@@ -87,7 +81,7 @@ def _ingest_from_temp_file(
 ) -> DatasetFile:
     """Stream the response body to a temp file and ingest it via the given native ingest function.
 
-    Used for file types (e.g. MCAP, ArduPilot Dataflash) that must be re-ingested through their
+    Used for file types (journal, MCAP, ArduPilot Dataflash) that must be re-ingested through their
     dedicated ingest path rather than as raw CSV/parquet, so the destination reprocesses them the
     same way the source did. The original file name is preserved so the upload name is meaningful.
     """

--- a/nominal/experimental/migration/utils/file_utils.py
+++ b/nominal/experimental/migration/utils/file_utils.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import logging
 import shutil
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 from typing import BinaryIO, cast
 
 import requests
 
-from nominal.core import Dataset, DatasetFile, FileType
+from nominal.core import Dataset, DatasetFile, FileType, FileTypes
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,18 @@ def copy_file_to_dataset(
             finally:
                 if tmp_path is not None:
                     tmp_path.unlink(missing_ok=True)
+        elif file_type == FileTypes.MCAP:
+            new_file = _ingest_from_temp_file(
+                response,
+                file_name,
+                lambda path: destination_dataset.add_mcap(path, tags=source_file.file_tags),
+            )
+        elif file_type == FileTypes.DATAFLASH:
+            new_file = _ingest_from_temp_file(
+                response,
+                file_name,
+                lambda path: destination_dataset.add_ardupilot_dataflash(path, tags=source_file.file_tags),
+            )
         elif source_file.timestamp_channel is not None and source_file.timestamp_type is not None:
             new_file = destination_dataset.add_from_io(
                 dataset=cast(BinaryIO, response.raw),
@@ -65,6 +78,27 @@ def copy_file_to_dataset(
         )
         return new_file
     raise ValueError("Unsupported file handle type or missing timestamp information.")
+
+
+def _ingest_from_temp_file(
+    response: requests.Response,
+    file_name: str,
+    ingest_fn: Callable[[Path], DatasetFile],
+) -> DatasetFile:
+    """Stream the response body to a temp file and ingest it via the given native ingest function.
+
+    Used for file types (e.g. MCAP, ArduPilot Dataflash) that must be re-ingested through their
+    dedicated ingest path rather than as raw CSV/parquet, so the destination reprocesses them the
+    same way the source did. The original file name is preserved so the upload name is meaningful.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir) / file_name
+        with response:
+            with tmp_path.open("wb") as tmp:
+                shutil.copyfileobj(response.raw, tmp)
+        new_file = ingest_fn(tmp_path)
+        new_file.poll_until_ingestion_completed()
+        return new_file
 
 
 def _resolve_destination_file_stem(file_name: str) -> str:

--- a/tests/core/test_file_utils.py
+++ b/tests/core/test_file_utils.py
@@ -164,6 +164,78 @@ class TestCopyFileToDataset:
         assert result is new_file
 
     @patch("nominal.experimental.migration.utils.file_utils.requests.get")
+    def test_mcap_calls_add_mcap(self, mock_get: MagicMock) -> None:
+        """MCAP files are re-ingested via add_mcap, not add_from_io."""
+        source_file = _make_source_file(
+            s3_key="2026-01-01T00:00:00Z_drone.mcap",
+            timestamp_channel="__ingest_timestamp",
+            timestamp_type="epoch_seconds",
+        )
+        source_file.file_tags = {"vehicle": "drone-1"}
+        mock_get.return_value = _make_http_response(b"mcap-bytes")
+
+        destination_dataset = MagicMock()
+        new_file = MagicMock()
+        destination_dataset.add_mcap.return_value = new_file
+
+        result = copy_file_to_dataset(source_file, destination_dataset)
+
+        destination_dataset.add_mcap.assert_called_once()
+        destination_dataset.add_from_io.assert_not_called()
+        call_args = destination_dataset.add_mcap.call_args
+        assert call_args.args[0].name == "2026-01-01T00:00:00Z_drone.mcap"
+        assert call_args.kwargs["tags"] == {"vehicle": "drone-1"}
+        new_file.poll_until_ingestion_completed.assert_called_once()
+        assert result is new_file
+
+    @patch("nominal.experimental.migration.utils.file_utils.requests.get")
+    def test_dataflash_calls_add_ardupilot_dataflash(self, mock_get: MagicMock) -> None:
+        """ArduPilot Dataflash (.bin) files are re-ingested via add_ardupilot_dataflash."""
+        source_file = _make_source_file(
+            s3_key="2026-01-01T00:00:00Z_flight.bin",
+            timestamp_channel="timestamp",
+            timestamp_type="epoch_seconds",
+        )
+        mock_get.return_value = _make_http_response(b"dataflash-bytes")
+
+        destination_dataset = MagicMock()
+        new_file = MagicMock()
+        destination_dataset.add_ardupilot_dataflash.return_value = new_file
+
+        result = copy_file_to_dataset(source_file, destination_dataset)
+
+        destination_dataset.add_ardupilot_dataflash.assert_called_once()
+        destination_dataset.add_from_io.assert_not_called()
+        call_args = destination_dataset.add_ardupilot_dataflash.call_args
+        assert call_args.args[0].name == "2026-01-01T00:00:00Z_flight.bin"
+        new_file.poll_until_ingestion_completed.assert_called_once()
+        assert result is new_file
+
+    @patch("nominal.experimental.migration.utils.file_utils.requests.get")
+    def test_dataflash_temp_file_cleaned_up(self, mock_get: MagicMock) -> None:
+        """Temp file is deleted after the native ingest returns."""
+        source_file = _make_source_file(
+            s3_key="2026-01-01T00:00:00Z_flight.bin",
+            timestamp_channel=None,
+            timestamp_type=None,
+        )
+        mock_get.return_value = _make_http_response(b"dataflash-bytes")
+
+        captured_path: list[str] = []
+
+        def capture_path(path: object, **_kwargs: object) -> MagicMock:
+            captured_path.append(str(path))
+            return MagicMock()
+
+        destination_dataset = MagicMock()
+        destination_dataset.add_ardupilot_dataflash.side_effect = capture_path
+
+        copy_file_to_dataset(source_file, destination_dataset)
+
+        assert captured_path, "add_ardupilot_dataflash was not called"
+        assert not os.path.exists(captured_path[0]), "Temp file was not cleaned up"
+
+    @patch("nominal.experimental.migration.utils.file_utils.requests.get")
     def test_missing_timestamp_metadata_raises(self, mock_get: MagicMock) -> None:
         """Non-journal files with no timestamp metadata raise ValueError."""
         source_file = _make_source_file(


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Routes migrated MCAP and ArduPilot Dataflash files through `Dataset.add_mcap` and `Dataset.add_ardupilot_dataflash` instead of generic tabular ingestion. The source object is streamed to a temporary file so native ingestion receives the original filename and file tags, then the temporary file is cleaned up after ingestion completes.

Adds explicit `FileType` predicates for MCAP and Dataflash while reusing the canonical `FileTypes.DATAFLASH` value. Journal, MCAP, and Dataflash migration now share the same temporary-file ingestion helper.

Tests cover native routing, filename/tag preservation, polling, and cleanup.

Linear: https://linear.app/nominal-io/issue/CON-2757/route-mcap-and-dataflash-migration-through-native-ingest

Link to Devin session: https://app.devin.ai/sessions/20d77beca15049d681c806f0b41c66d3
Requested by: @ckniffin-nominal