### PR TITLE
ci(e2e): file-upload special-char e2e tests on S3 + Azure Blob

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,5 +1,7 @@
 # End-to-end tests against Nominal staging.
 # Requires the E2E_NOMINAL_STAGING_API_KEY repository secret.
+# The file-upload-e2e Azure leg additionally requires E2E_NOMINAL_AZURE_STAGING_API_KEY /
+# E2E_NOMINAL_AZURE_STAGING_WORKSPACE_RID.
 
 name: E2E Tests (Staging)
 
@@ -133,5 +135,74 @@ jobs:
           uv run pytest tests/e2e/migration \
             --dest-profile staging-e2e \
             --source-profile production-e2e \
+            --no-cov \
+            -v
+
+  # Runs the special-character filename tests against each object-store backend. These guard the
+  # filename-encoding fix (PR #877): S3 tolerates every character on upload, so it can only catch a
+  # stored-name regression, while Azure Blob is where the original SAS bug lived and must be
+  # exercised directly. Scope is intentionally narrow — Azure staging's broader e2e suite is flaky
+  # (unrelated failures), so only these tests run here; broaden later if that changes.
+  file-upload-e2e:
+    name: File Upload E2E (${{ matrix.env.name }})
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 15
+
+    # Fork PRs don't have access to secrets — skip gracefully.
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
+
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - name: aws
+            base_url: https://api-staging.gov.nominal.io/api
+            token_secret: E2E_NOMINAL_STAGING_API_KEY
+            workspace_secret: E2E_NOMINAL_STAGING_WORKSPACE_RID
+          - name: azure
+            base_url: https://api-staging.azure.nominal.io/api
+            token_secret: E2E_NOMINAL_AZURE_STAGING_API_KEY
+            workspace_secret: E2E_NOMINAL_AZURE_STAGING_WORKSPACE_RID
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+        with:
+          version: "0.8.x"
+          enable-cache: false
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.13"
+
+      - name: Install just
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
+
+      - name: Install dependencies
+        run: just install
+
+      - name: Write ${{ matrix.env.name }} staging profile
+        env:
+          NOMINAL_E2E_TOKEN: ${{ secrets[matrix.env.token_secret] }}
+          NOMINAL_E2E_WORKSPACE_RID: ${{ secrets[matrix.env.workspace_secret] }}
+        run: |
+          if [[ -z "${NOMINAL_E2E_TOKEN}" ]]; then
+            echo "::error::${{ matrix.env.token_secret }} secret is not configured"
+            exit 1
+          fi
+          uv run nom config profile add file-upload-e2e \
+            --base-url ${{ matrix.env.base_url }} \
+            --workspace-rid ${NOMINAL_E2E_WORKSPACE_RID} \
+            --token ${NOMINAL_E2E_TOKEN} \
+            --validate \
+            -vv
+
+      - name: Run file upload e2e tests
+        run: |
+          uv run pytest tests/e2e/test_core.py \
+            -k "special_char or unsafe_char" \
+            --profile file-upload-e2e \
             --no-cov \
             -v

--- a/tests/e2e/test_core.py
+++ b/tests/e2e/test_core.py
@@ -467,9 +467,22 @@ def test_batch_add_channels(client: NominalClient, archive: ArchiveFn) -> None:
 @pytest.mark.parametrize(
     "stem",
     [
+        # The full set of special characters the client allows (see UNSAFE_UPLOAD_CHARS for the
+        # rejected ones). Each is uploaded for real against every backend in this job's matrix, so
+        # if any character that passes our client-side validation starts failing server-side — in
+        # scout or the cloud storage layer — this test goes red and we hear about it immediately.
         "paren(reduced)",  # the original Azure bug — was stored as paren%28reduced%29.csv
         "with space",
         "amp&ersand",
+        "plus+plus",
+        "hash#tag",
+        "bracket[1]",
+        "at@sign",
+        "equals=sign",
+        "comma,comma",
+        "semi;colon",
+        "tilde~caret^",
+        "dollar$sign",
         "unicode_résumé",
     ],
 )


### PR DESCRIPTION
Adds a `file-upload-e2e` matrix job that runs the special-character filename tests against each object-store backend — **aws** (gov/S3) and **azure** (Blob).

## What it covers

`test_special_char_filename_round_trips` uploads a file named with **every special character the client allows** and asserts it ingests and round-trips its stored name — run for real against **both** backends. This is a cross-backend **drift canary**: unit tests mock the upload client, so they can only verify our client-side logic; only a real upload can catch a character that passes client-side validation but fails **server-side** (in scout or the cloud storage layer). If AWS, Azure, or the backend ever starts rejecting or mangling an allowed character, the matrix leg for that backend goes red immediately.

The unsafe characters (`/ \ ? % { } '`) are rejected client-side *before any upload*, so they keep a single smoke check — e2e can't observe backend behavior for them since they never leave the client.

## Scope & rationale

**Intentionally narrow** (only the filename tests): the broader Azure staging suite has unrelated flaky failures today (e.g. a file-download test), which would make a full-suite Azure job red for reasons unrelated to this change. This is a stopgap — **once a general Azure staging e2e suite lands, it will run these checks and this dedicated file-upload job will be folded into / replaced by it.**

Each matrix leg **fails loudly** if its secret is missing (no silent skips). AWS reuses the existing staging secrets; Azure uses `E2E_NOMINAL_AZURE_STAGING_API_KEY` / `E2E_NOMINAL_AZURE_STAGING_WORKSPACE_RID`.

## Note on CI

This workflow only triggers on PRs targeting `main`, so it won't run on this stacked PR until it's retargeted to `main` (after the base PR merges). The tests were verified locally against both backends (**14 passed each**: 13 allowed characters round-trip + 1 unsafe character rejected).

Stacked on #877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
