### PR TITLE
ci: run check-and-test on PRs against any base branch

### DIFF
--- a/.github/workflows/build-check-test.yml
+++ b/.github/workflows/build-check-test.yml
@@ -6,9 +6,11 @@ name: Check and test
 on:
   push:
     branches: ["main"]
+  # Run on every PR regardless of base branch — these checks are cheap and hermetic, so
+  # stacked PRs (targeting a feature branch rather than main) get unit/build/lint signal too.
+  # (Fork PRs still run; they need no secrets here.)
   pull_request:
     types: [opened, reopened, synchronize]
-    branches: ["main"]
 
 jobs:
   check-and-test:


### PR DESCRIPTION
Drops the `branches: ["main"]` filter on the **`check-and-test`** workflow's `pull_request` trigger, so unit/build/lint run on **every** PR — not only PRs targeting `main`.

**Why:** stacked PRs (based on a feature branch rather than `main`) currently get *no* `check-and-test` signal at all — the trigger's base-branch filter silently skips them. These checks are cheap and hermetic (no secrets, no external services), so there's no cost reason to gate them by base branch. Fork PRs already run fine here since this workflow needs no secrets.

**Left intentionally main-gated** (separate concerns, not bundled here):
- `e2e-tests` — hits real staging environments; running it on every stacked/intermediate PR multiplies staging load (the workflow's own concurrency comment calls this out). A better follow-up would make it opt-in via a label, but that's its own change.
- `claude-review` — runs a paid model review per PR; broadening it is a cost decision to make deliberately.

Self-contained one-line trigger change; no job logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)