### PR TITLE
chore: bump nominal-api version to 0.1328.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "conjure-python-client>=3.1.0,<4",
     "exceptiongroup>=1.3.0",
-    "nominal-api==0.1305.0",
-    "nominal-api-protos==0.1305.0",
+    "nominal-api==0.1328.0",
+    "nominal-api-protos==0.1328.0",
     "truststore>=0.10.4",
     "typing-extensions>=4,<5",
     "pandas>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -795,8 +795,8 @@ requires-dist = [
     { name = "conjure-python-client", specifier = ">=3.1.0,<4" },
     { name = "exceptiongroup", specifier = ">=1.3.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
-    { name = "nominal-api", specifier = "==0.1305.0" },
-    { name = "nominal-api-protos", specifier = "==0.1305.0" },
+    { name = "nominal-api", specifier = "==0.1328.0" },
+    { name = "nominal-api-protos", specifier = "==0.1328.0" },
     { name = "nominal-streaming", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')", specifier = "==0.8.2" },
     { name = "nominal-tdms", marker = "extra == 'tdms'", editable = "packages/nominal-tdms" },
     { name = "nominal-video", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin' and extra == 'video') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'video') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'video') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32' and extra == 'video')", specifier = "==0.1.9" },
@@ -837,19 +837,19 @@ dev = [
 
 [[package]]
 name = "nominal-api"
-version = "0.1305.0"
+version = "0.1328.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "conjure-python-client" },
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/a2/e2f9756d818ab075f4c28c895257046c118d5ecf0b771c0a69d62470c7cb/nominal_api-0.1305.0-py3-none-any.whl", hash = "sha256:99ebfd22c9c36ff0f57386f79d861cf59a49472b2ae3baf590b9e4a22d8a122c", size = 905244, upload-time = "2026-07-02T17:02:21.33Z" },
+    { url = "https://files.pythonhosted.org/packages/48/0a/d181144b56fdb6140ffa66435898363d94f93ec3fe4f319503af5ea4fce2/nominal_api-0.1328.0-py3-none-any.whl", hash = "sha256:358c4901094cb2359c8d5545c913932cb743d63df7907257218d87956f3cd953", size = 924931, upload-time = "2026-07-14T14:47:51.091Z" },
 ]
 
 [[package]]
 name = "nominal-api-protos"
-version = "0.1305.0"
+version = "0.1328.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -857,7 +857,7 @@ dependencies = [
     { name = "protobuf" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/2b/120d30fd11875be1c6556c11cf2c047f9d4d015abc3a7d9263cce694b6b7/nominal_api_protos-0.1305.0-py3-none-any.whl", hash = "sha256:eaf81b31893884bd116edd84441fe52e9885675c0731e2bce9e1a514b9f9b643", size = 535462, upload-time = "2026-07-02T17:02:23.396Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4a/a45b1ba2a883cd3329ac0954db597d61ca41107c2ece596255576bcf7757/nominal_api_protos-0.1328.0-py3-none-any.whl", hash = "sha256:9ec02d96c321da6777700d8e4d1bb659227fdf8839dd374155b1523dc2012b62", size = 531059, upload-time = "2026-07-14T14:47:52.499Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `nominal-api` and `nominal-api-protos` from 0.1305.0 to 0.1328.0 and refreshes the lockfile. No client code changes are required.

## Verification

- `uv lock --check`
- `uv run ruff format --check`
- `uv run ruff check`
- `uv run mypy`
- `uv run pytest -q --no-cov` — 323 passed, 13 skipped
- `uv build --all-packages`