### PR TITLE
feat: register container images from existing images

### DIFF
--- a/nominal/core/containerized_extractor.py
+++ b/nominal/core/containerized_extractor.py
@@ -36,6 +36,16 @@ from nominal.protos.registry.v2 import registry_pb2
 from nominal.ts import IntegralNanosecondsUTC
 
 
+def _validate_registerable_output_format(output_format: FileOutputFormat) -> None:
+    if output_format not in REGISTERABLE_OUTPUT_FORMATS:
+        supported = ", ".join(sorted(fmt.name for fmt in REGISTERABLE_OUTPUT_FORMATS))
+        raise ValueError(
+            f"Output format {output_format.name} is not currently supported for containerized "
+            f"extraction ingest; an image registered with it could never ingest data successfully. "
+            f"Supported formats: {supported}."
+        )
+
+
 @dataclass(frozen=True)
 class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extractor_pb2.ContainerizedExtractor]):
     """A v2 (Nominal-hosted) containerized extractor (nominal.ingest.v2)."""
@@ -189,13 +199,7 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
             NominalAlreadyExistsError: If an image with this tag is already registered for this
                 extractor.
         """
-        if output_format not in REGISTERABLE_OUTPUT_FORMATS:
-            supported = ", ".join(sorted(fmt.name for fmt in REGISTERABLE_OUTPUT_FORMATS))
-            raise ValueError(
-                f"Output format {output_format.name} is not currently supported for containerized "
-                f"extraction ingest; an image registered with it could never ingest data successfully. "
-                f"Supported formats: {supported}."
-            )
+        _validate_registerable_output_format(output_format)
         s3_path = upload_multipart_file(
             self._clients.auth_header,
             self._workspace_rid,
@@ -219,6 +223,81 @@ class ContainerizedExtractor(HasRid, RefreshableGrpcMixin[containerized_extracto
         with translate_grpc_errors():
             response = self._clients.registry.CreateImage(request)
         return ContainerImage._from_proto(self._clients, self._workspace_rid, response.image)
+
+    def register_image_from(
+        self,
+        source_image: ContainerImage | str,
+        *,
+        tag: str,
+        inputs: Sequence[FileExtractionInput] | None = None,
+        default_timestamp_column: str | None = None,
+        default_timestamp_type: ts._AnyTimestampType | None = None,
+        output_format: FileOutputFormat | None = None,
+        parameters: Sequence[FileExtractionParameter] | None = None,
+    ) -> ContainerImage:
+        """Register a new image that reuses an existing image's binary.
+
+        The source image is unchanged. Omitted execution-contract fields are inherited from it;
+        provided fields describe the newly registered image. This avoids uploading and pushing the
+        same container binary again when only its tag or execution contract changes.
+
+        Args:
+            source_image: Existing image (or RID) whose stored binary is reused. The backend requires
+                it to be READY and registered against this extractor in the same workspace.
+            tag: Tag for the new image.
+            inputs: Input contract for the new image. Inherits the source inputs when omitted.
+            default_timestamp_column: Timestamp column for the new image. Must be provided together
+                with `default_timestamp_type`; both inherit from the source when omitted.
+            default_timestamp_type: Timestamp encoding for `default_timestamp_column`.
+            output_format: Output format for the new image. Inherits from the source when omitted.
+            parameters: Parameter contract for the new image. Inherits from the source when omitted;
+                pass an empty sequence to clear the parameters.
+
+        Returns:
+            The newly registered image.
+
+        Raises:
+            ValueError: If only one timestamp override is provided, the effective timestamp metadata
+                is absent, or the effective output format cannot be ingested.
+            NominalAlreadyExistsError: If `tag` is already registered against this extractor.
+        """
+        if isinstance(source_image, str):
+            with translate_grpc_errors():
+                get_response = self._clients.registry.GetImage(
+                    registry_pb2.GetImageRequest(rid=source_image, workspace_rid=self._workspace_rid)
+                )
+            source_image = ContainerImage._from_proto(self._clients, self._workspace_rid, get_response.image)
+
+        timestamp_metadata: TimestampMetadata | None
+        if (default_timestamp_column is None) != (default_timestamp_type is None):
+            raise ValueError("default_timestamp_column and default_timestamp_type must be provided together")
+        if default_timestamp_column is not None and default_timestamp_type is not None:
+            timestamp_metadata = TimestampMetadata(
+                series_name=default_timestamp_column,
+                timestamp_type=default_timestamp_type,
+            )
+        else:
+            timestamp_metadata = source_image.default_timestamp_metadata
+        if timestamp_metadata is None:
+            raise ValueError("The source image has no default timestamp metadata to inherit")
+
+        effective_inputs = source_image.inputs if inputs is None else inputs
+        effective_parameters = source_image.parameters if parameters is None else parameters
+        effective_output_format = source_image.file_output_format if output_format is None else output_format
+        _validate_registerable_output_format(effective_output_format)
+        request = registry_pb2.CreateImageRequest(
+            workspace_rid=self._workspace_rid,
+            tag=tag,
+            extractor_rid=self.rid,
+            inputs=[i._to_proto() for i in effective_inputs],
+            parameters=[p._to_proto() for p in effective_parameters],
+            file_output_format=effective_output_format._to_proto(),
+            default_timestamp_metadata=timestamp_metadata._to_proto(),
+            source_image_rid=source_image.rid,
+        )
+        with translate_grpc_errors():
+            create_response = self._clients.registry.CreateImage(request)
+        return ContainerImage._from_proto(self._clients, self._workspace_rid, create_response.image)
 
     def search_container_images(
         self, *, tag: str | None = None, status: ContainerImageStatus | None = None

--- a/tests/core/test_containerized_extractor.py
+++ b/tests/core/test_containerized_extractor.py
@@ -4,7 +4,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from nominal.core.container_image import FileOutputFormat
+from nominal.core.container_image import (
+    ContainerImage,
+    ContainerImageStatus,
+    FileExtractionInput,
+    FileExtractionParameter,
+    FileOutputFormat,
+    TimestampMetadata,
+)
 from nominal.core.containerized_extractor import (
     ContainerizedExtractor,
     _create_containerized_extractor,
@@ -31,6 +38,25 @@ def _ext(rid: str) -> containerized_extractor_pb2.ContainerizedExtractor:
 
 def _img(rid: str, status: registry_pb2.ContainerImageStatus.ValueType) -> registry_pb2.ContainerImage:
     return registry_pb2.ContainerImage(rid=rid, tag="v1", extractor_rid="ri.ext", status=status)
+
+
+def _source_image(clients: MagicMock, *, with_timestamp_metadata: bool = True) -> ContainerImage:
+    return ContainerImage(
+        rid="ri.img.source",
+        tag="v1",
+        status=ContainerImageStatus.READY,
+        size_bytes=123,
+        created_at=0,
+        extractor_rid="ri.ext",
+        inputs=(FileExtractionInput(name="data", environment_variable="INPUT_PATH", file_suffixes=("csv",)),),
+        parameters=(FileExtractionParameter(name="scale", environment_variable="SCALE"),),
+        file_output_format=FileOutputFormat.PARQUET,
+        default_timestamp_metadata=(
+            TimestampMetadata(series_name="time", timestamp_type="iso_8601") if with_timestamp_metadata else None
+        ),
+        _workspace_rid="ri.workspace.default",
+        _clients=clients,
+    )
 
 
 def test_search_extractors_follows_pagination_cursors() -> None:
@@ -117,6 +143,131 @@ def test_register_image_rejects_non_ingestible_output_formats_before_uploading(
         )
 
     clients.upload.initiate_multipart_upload.assert_not_called()
+    clients.registry.CreateImage.assert_not_called()
+
+
+def test_register_image_from_inherits_contract_and_reuses_source_binary() -> None:
+    """Registering from an image creates a new tag without uploading or changing its execution contract."""
+    clients = _clients()
+    extractor = ContainerizedExtractor._from_proto(clients, _ext("ri.ext"))
+    source = _source_image(clients)
+    clients.registry.CreateImage.return_value = registry_pb2.CreateImageResponse(
+        image=_img("ri.img.new", registry_pb2.CONTAINER_IMAGE_STATUS_READY)
+    )
+
+    image = extractor.register_image_from(source, tag="v2")
+
+    request = clients.registry.CreateImage.call_args.args[0]
+    assert request.source_image_rid == "ri.img.source"
+    assert request.object_path == ""
+    assert request.tag == "v2"
+    assert request.inputs[0].name == "data"
+    assert request.parameters[0].name == "scale"
+    assert request.file_output_format == registry_pb2.FILE_OUTPUT_FORMAT_PARQUET
+    assert request.default_timestamp_metadata.series_name == "time"
+    assert image.rid == "ri.img.new"
+    clients.upload.initiate_multipart_upload.assert_not_called()
+
+
+def test_register_image_from_allows_execution_contract_overrides() -> None:
+    """Callers can change the new image's contract while reusing the source image binary."""
+    clients = _clients()
+    extractor = ContainerizedExtractor._from_proto(clients, _ext("ri.ext"))
+    source = _source_image(clients)
+    clients.registry.CreateImage.return_value = registry_pb2.CreateImageResponse(
+        image=_img("ri.img.new", registry_pb2.CONTAINER_IMAGE_STATUS_READY)
+    )
+
+    extractor.register_image_from(
+        source,
+        tag="v2",
+        inputs=(FileExtractionInput(name="new", environment_variable="NEW_PATH"),),
+        parameters=(),
+        output_format=FileOutputFormat.CSV,
+        default_timestamp_column="new_time",
+        default_timestamp_type="iso_8601",
+    )
+
+    request = clients.registry.CreateImage.call_args.args[0]
+    assert request.inputs[0].name == "new"
+    assert list(request.parameters) == []
+    assert request.file_output_format == registry_pb2.FILE_OUTPUT_FORMAT_CSV
+    assert request.default_timestamp_metadata.series_name == "new_time"
+
+
+def test_register_image_from_resolves_source_rid_in_the_extractors_workspace() -> None:
+    """A source RID is fetched in the extractor's workspace before its contract is inherited."""
+    clients = _clients()
+    extractor = ContainerizedExtractor._from_proto(clients, _ext("ri.ext"))
+    clients.registry.GetImage.return_value = registry_pb2.GetImageResponse(
+        image=registry_pb2.ContainerImage(
+            rid="ri.img.source",
+            tag="v1",
+            extractor_rid="ri.ext",
+            status=registry_pb2.CONTAINER_IMAGE_STATUS_READY,
+            inputs=[registry_pb2.FileExtractionInput(name="data", environment_variable="INPUT_PATH")],
+            file_output_format=registry_pb2.FILE_OUTPUT_FORMAT_PARQUET,
+            default_timestamp_metadata=TimestampMetadata(series_name="time", timestamp_type="iso_8601")._to_proto(),
+        )
+    )
+    clients.registry.CreateImage.return_value = registry_pb2.CreateImageResponse(
+        image=_img("ri.img.new", registry_pb2.CONTAINER_IMAGE_STATUS_READY)
+    )
+
+    extractor.register_image_from("ri.img.source", tag="v2")
+
+    get_request = clients.registry.GetImage.call_args.args[0]
+    assert get_request.rid == "ri.img.source"
+    assert get_request.workspace_rid == "ri.workspace.default"
+    create_request = clients.registry.CreateImage.call_args.args[0]
+    assert create_request.source_image_rid == "ri.img.source"
+    assert create_request.inputs[0].name == "data"
+
+
+@pytest.mark.parametrize(
+    "timestamp_overrides",
+    [
+        {"default_timestamp_column": "new_time"},
+        {"default_timestamp_type": "iso_8601"},
+    ],
+)
+def test_register_image_from_requires_timestamp_overrides_together(timestamp_overrides: dict[str, object]) -> None:
+    """A partial timestamp override is rejected rather than silently mixing old and new metadata."""
+    clients = _clients()
+    extractor = ContainerizedExtractor._from_proto(clients, _ext("ri.ext"))
+    clients.registry.CreateImage.return_value = registry_pb2.CreateImageResponse(
+        image=_img("ri.img.new", registry_pb2.CONTAINER_IMAGE_STATUS_READY)
+    )
+
+    with pytest.raises(ValueError, match="provided together"):
+        extractor.register_image_from(_source_image(clients), tag="v2", **timestamp_overrides)
+
+    clients.registry.CreateImage.assert_not_called()
+
+
+def test_register_image_from_requires_timestamp_metadata_when_the_source_has_none() -> None:
+    """Legacy images without timestamp metadata require an explicit replacement contract."""
+    clients = _clients()
+    extractor = ContainerizedExtractor._from_proto(clients, _ext("ri.ext"))
+
+    with pytest.raises(ValueError, match="no default timestamp metadata"):
+        extractor.register_image_from(_source_image(clients, with_timestamp_metadata=False), tag="v2")
+
+    clients.registry.CreateImage.assert_not_called()
+
+
+@pytest.mark.parametrize("output_format", [FileOutputFormat.JSON_L, FileOutputFormat.PARQUET_TAR])
+def test_register_image_from_rejects_non_ingestible_output_formats(output_format: FileOutputFormat) -> None:
+    """Derived images apply the same output-format guard as tarball registrations."""
+    clients = _clients()
+    extractor = ContainerizedExtractor._from_proto(clients, _ext("ri.ext"))
+    clients.registry.CreateImage.return_value = registry_pb2.CreateImageResponse(
+        image=_img("ri.img.new", registry_pb2.CONTAINER_IMAGE_STATUS_READY)
+    )
+
+    with pytest.raises(ValueError, match=output_format.name):
+        extractor.register_image_from(_source_image(clients), tag="v2", output_format=output_format)
+
     clients.registry.CreateImage.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

Adds `ContainerizedExtractor.register_image_from` so callers can register a new image tag and execution contract while reusing an existing READY image's stored binary.

The source can be provided as a `ContainerImage` or RID. Inputs, parameters, output format, and timestamp metadata inherit by default and may be overridden for the new image.

## Verification

- `uv lock --check`
- `uv run ruff format --check`
- `uv run ruff check`
- `uv run mypy`
- `uv run pytest -q --no-cov` (331 passed, 13 skipped)

Stacked on #880.