### PR TITLE
fix(migration): defer run-scoped workbooks whose run spans multiple assets

### DIFF
--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -315,7 +315,13 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                 continue
             if not workbook.run_rids:
                 continue
-            if len(workbook.run_rids) == 1:
+            # A workbook scoped to a single run must still be deferred if that run is itself
+            # owned by more than one asset: copying it now would only carry a RID mapping for
+            # `source_asset`, leaving the run's other owning asset(s) unmapped. The RID-clone
+            # step used by the copy can't tell "unmapped resource RID" apart from "internal id
+            # that should get a fresh UUID", so it would silently regenerate a bogus RID for
+            # every reference to those other assets instead of waiting for a complete mapping.
+            if len(workbook.run_rids) == 1 and len(source_run.assets) <= 1:
                 workbook_migrator.copy_from(
                     workbook,
                     WorkbookCopyOptions(

--- a/tests/core/test_asset_migrator.py
+++ b/tests/core/test_asset_migrator.py
@@ -349,10 +349,10 @@ class TestAssetMigratorWorkbookRouting:
 
     @patch("nominal.experimental.migration.migrator.asset_migrator.WorkbookMigrator")
     def test_multi_run_workbook_always_enqueued_single_run_uses_copy_from(self, mock_wm_cls: MagicMock) -> None:
-        """Single-run workbooks go to copy_from; multi-run workbooks are always enqueued
-        for deferred migration without an upfront scope check. Also verifies that finding
-        the same multi-run workbook via two different runs overwrites the pending entry
-        idempotently.
+        """Single-run workbooks (run owned by exactly one asset) go to copy_from; multi-run
+        workbooks are always enqueued for deferred migration without an upfront scope check.
+        Also verifies that finding the same multi-run workbook via two different runs overwrites
+        the pending entry idempotently.
         """
         r1, r2 = _run_rid(1), _run_rid(2)
         new_r1, new_r2 = _run_rid(101), _run_rid(102)
@@ -369,12 +369,14 @@ class TestAssetMigratorWorkbookRouting:
 
         run1 = MagicMock()
         run1.rid = r1
+        run1.assets = [source_asset.rid]  # single owning asset
         run1.search_workbooks.return_value = [
             _stub_workbook(wb_single_run, run_rids=[r1]),
             _stub_workbook(wb_multi_run, run_rids=[r1, r2]),
         ]
         run2 = MagicMock()
         run2.rid = r2
+        run2.assets = [source_asset.rid, _asset_rid(2)]
         # wb_multi_run found again via run2 — should overwrite pending, not duplicate
         run2.search_workbooks.return_value = [
             _stub_workbook(wb_multi_run, run_rids=[r1, r2]),
@@ -394,6 +396,49 @@ class TestAssetMigratorWorkbookRouting:
         assert wb_multi_run in state.pending_multi_run_workbooks
         assert state.pending_multi_run_workbooks[wb_multi_run] == [r1, r2]
         assert len(state.pending_multi_run_workbooks) == 1  # not duplicated
+
+    @patch("nominal.experimental.migration.migrator.asset_migrator.WorkbookMigrator")
+    def test_single_run_workbook_owned_by_multiple_assets_is_deferred(self, mock_wm_cls: MagicMock) -> None:
+        """A workbook scoped to a *single* run (NotebookDataScope.run_rids == [X]) must still be
+        deferred if run X itself is owned by more than one asset. Copying it immediately — using
+        only the one asset mapping known at this point in the migration — would build an
+        incomplete RID override map: everywhere the workbook's content/layout/state references
+        the *other* owning asset(s), the RID-clone step has no override for them and silently
+        regenerates a fresh, unmapped UUID (same stack prefix) instead of leaving them for a
+        later, complete pass. Deferring (like the already-handled multi-asset and multi-run
+        cases) ensures the workbook is only copied once every asset it depends on is mapped.
+        """
+        a1, a2 = _asset_rid(1), _asset_rid(2)
+        new_a1 = _asset_rid(101)
+        r1 = _run_rid(1)
+        new_r1 = _run_rid(101)
+        wb_run_scoped = _wb_rid(1)
+
+        ctx = _make_context()
+        ctx.migration_state.record_mapping(ResourceType.RUN, r1, new_r1)
+        # Only a1 has been mapped so far; a2 (the run's other owning asset) has not.
+        ctx.migration_state.record_mapping(ResourceType.ASSET, a1, new_a1)
+
+        source_asset = _make_source_asset(rid=a1)
+        new_asset = _make_dest_asset(rid=new_a1)
+        source_asset.search_workbooks.return_value = []
+
+        run1 = MagicMock()
+        run1.rid = r1
+        run1.assets = [a1, a2]  # run is owned by two assets
+        run1.search_workbooks.return_value = [
+            _stub_workbook(wb_run_scoped, run_rids=[r1]),  # single-run scope on the workbook itself
+        ]
+        source_asset.list_runs.return_value = [run1]
+
+        migrator = AssetMigrator(ctx)
+        migrator._copy_asset_and_run_workbooks(source_asset, new_asset, include_runs=True)
+
+        mock_wm = mock_wm_cls.return_value
+        mock_wm.copy_from.assert_not_called()
+
+        state = ctx.migration_state
+        assert wb_run_scoped in state.pending_multi_run_workbooks
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When migrating a workbook whose `NotebookDataScope` is **run-scoped** (`run_rids=[X]`), and run `X` is owned by **more than one asset**, the migrated workbook's content and layout end up with corrupted RID references.

Single-asset run-scoped workbooks migrate correctly today; the defect is specific to a run-scoped workbook whose underlying run has multiple owning assets.

## Root cause

`AssetMigrator._copy_run_workbooks` copies a run-scoped workbook as soon as it's discovered while iterating one owning asset's runs, passing only that one asset's RID mapping as an override. If the run has other owning assets that haven't been migrated yet, their mapping is missing from the override set at copy time.

The RID-clone step used to copy a workbook's layout/content (`clone_conjure_objects_with_rid_overrides`) can't distinguish "a resource RID the migration hasn't mapped yet" from "an internal id that should get a fresh UUID on every copy" — anything not in the override map is silently replaced with a newly generated, unmapped UUID (same RID prefix as the original). So any reference elsewhere in the workbook's content to the run's *other* owning asset(s) gets replaced with a bogus RID that exists in neither stack, instead of the correct destination asset RID.

This exact class of problem — copying a workbook before every resource it depends on is mapped — was already solved for two other cases: workbooks with `NotebookDataScope.asset_rids` spanning 2+ assets, and workbooks with `run_rids` spanning 2+ runs. Both are deferred until all their dependencies are mapped. The run-scoped, single-run case (a workbook scoped to one run, where *the run itself* is owned by multiple assets) fell through this net because the routing check only looked at `len(workbook.run_rids)`, not at how many assets the run belongs to.

## Fix

In `_copy_run_workbooks`, before copying a single-run workbook immediately, also check `len(source_run.assets) <= 1` (the run's already-loaded list of owning asset RIDs — no extra network call needed). If the run has more than one owning asset, the workbook is queued via the existing `pending_multi_run_workbooks` deferred-migration path instead of being copied right away. When deferred workbooks are later migrated (`migrate_deferred_workbooks`), the copy runs with the full asset and run RID mapping built up over the whole migration, so no reference is left unmapped.

## Test

Added `test_single_run_workbook_owned_by_multiple_assets_is_deferred` in `tests/core/test_asset_migrator.py`: a workbook scoped to a single run whose run is owned by two assets (only one of which is mapped so far) must be deferred rather than copied immediately. This test fails against the prior behavior and passes with the fix.

Also updated the existing `test_multi_run_workbook_always_enqueued_single_run_uses_copy_from` test to set `run.assets` on its stubbed runs (single owning asset), since the routing logic now reads that field.

## Test plan

- [x] New unit test reproduces the bug and passes with the fix
- [x] `uv run pytest tests/ --ignore=tests/e2e` — 541 passed
- [x] `just check-format` / `just check-imports` — clean