### PR TITLE
fix(migration): skip run workbooks with out-of-scope owners

### DIFF
--- a/nominal/experimental/migration/migration_state.py
+++ b/nominal/experimental/migration/migration_state.py
@@ -64,6 +64,20 @@ class MigrationState:
         """Record a multi-run workbook for deferred migration. Overwrites any prior entry for idempotency."""
         self.pending_multi_run_workbooks[workbook_rid] = run_rids
 
+    def record_pending_multi_asset_workbook_unless_skipped(self, workbook_rid: str, asset_rids: list[str]) -> bool:
+        """Record a pending multi-asset workbook unless the workbook has already been skipped."""
+        if self.workbook_was_skipped(workbook_rid):
+            return False
+        self.pending_multi_asset_workbooks[workbook_rid] = asset_rids
+        return True
+
+    def record_pending_multi_run_workbook_unless_skipped(self, workbook_rid: str, run_rids: list[str]) -> bool:
+        """Record a pending multi-run workbook unless the workbook has already been skipped."""
+        if self.workbook_was_skipped(workbook_rid):
+            return False
+        self.pending_multi_run_workbooks[workbook_rid] = run_rids
+        return True
+
     def clear_pending_multi_asset_workbook(self, workbook_rid: str) -> None:
         self.pending_multi_asset_workbooks.pop(workbook_rid, None)
 
@@ -72,3 +86,19 @@ class MigrationState:
 
     def record_skip(self, resource_type: ResourceType, source_rid: str, reason: str) -> None:
         self.skipped_resources.append(SkippedResource(resource_type.value, source_rid, reason))
+
+    def record_workbook_skip_and_clear_pending(self, workbook_rid: str, reason: str) -> bool:
+        """Record a workbook skip as a terminal state and clear any stale pending entries."""
+        changed = workbook_rid in self.pending_multi_asset_workbooks or workbook_rid in self.pending_multi_run_workbooks
+        self.pending_multi_asset_workbooks.pop(workbook_rid, None)
+        self.pending_multi_run_workbooks.pop(workbook_rid, None)
+        if self.workbook_was_skipped(workbook_rid):
+            return changed
+        self.skipped_resources.append(SkippedResource(ResourceType.WORKBOOK.value, workbook_rid, reason))
+        return True
+
+    def workbook_was_skipped(self, workbook_rid: str) -> bool:
+        return any(
+            skipped.resource_type == ResourceType.WORKBOOK.value and skipped.source_rid == workbook_rid
+            for skipped in self.skipped_resources
+        )

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -321,7 +321,7 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             # step used by the copy can't tell "unmapped resource RID" apart from "internal id
             # that should get a fresh UUID", so it would silently regenerate a bogus RID for
             # every reference to those other assets instead of waiting for a complete mapping.
-            source_run_asset_rids = list(getattr(source_run, "assets", []) or [])
+            source_run_asset_rids = list(source_run.assets)
             if len(workbook.run_rids) == 1 and len(source_run_asset_rids) <= 1:
                 workbook_migrator.copy_from(
                     workbook,
@@ -334,34 +334,38 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                 self._enqueue_multi_run_workbook(workbook, list(workbook.run_rids), source_run_asset_rids)
 
     def _enqueue_multi_asset_workbook(self, workbook: Workbook, source_asset_rids: list[str]) -> None:
-        missing = self._find_assets_outside_migration_scope(source_asset_rids)
-        if missing:
-            reason = f"assets not in migration scope: {missing}"
-            logger.warning("Skipping multi-asset workbook %s: %s", workbook.rid, reason)
-            self._record_workbook_skip(workbook.rid, reason)
-            self.ctx.migration_state.clear_pending_multi_asset_workbook(workbook.rid)
-            return
-        if self._workbook_was_skipped(workbook.rid):
-            logger.debug("Not queuing multi-asset workbook %s: already skipped", workbook.rid)
+        if not self._should_enqueue_deferred_workbook(workbook, source_asset_rids):
             return
         logger.debug("Queuing multi-asset workbook %s for deferred migration", workbook.rid)
-        self.ctx.migration_state.record_pending_multi_asset_workbook(workbook.rid, source_asset_rids)
+        queued = self.ctx.migration_state.record_pending_multi_asset_workbook_unless_skipped(
+            workbook.rid, source_asset_rids
+        )
+        if not queued:
+            logger.debug("Not queuing multi-asset workbook %s: already skipped", workbook.rid)
 
     def _enqueue_multi_run_workbook(
         self, workbook: Workbook, source_run_rids: list[str], source_asset_rids: list[str]
     ) -> None:
+        if not self._should_enqueue_deferred_workbook(workbook, source_asset_rids):
+            return
+        logger.debug("Queuing multi-run workbook %s for deferred migration", workbook.rid)
+        queued = self.ctx.migration_state.record_pending_multi_run_workbook_unless_skipped(
+            workbook.rid, source_run_rids
+        )
+        if not queued:
+            logger.debug("Not queuing multi-run workbook %s: already skipped", workbook.rid)
+
+    def _should_enqueue_deferred_workbook(self, workbook: Workbook, source_asset_rids: list[str]) -> bool:
         missing = self._find_assets_outside_migration_scope(source_asset_rids)
         if missing:
             reason = f"assets not in migration scope: {missing}"
-            logger.warning("Skipping run-scoped workbook %s: %s", workbook.rid, reason)
-            self._record_workbook_skip(workbook.rid, reason)
-            self.ctx.migration_state.clear_pending_multi_run_workbook(workbook.rid)
-            return
-        if self._workbook_was_skipped(workbook.rid):
-            logger.debug("Not queuing multi-run workbook %s: already skipped", workbook.rid)
-            return
-        logger.debug("Queuing multi-run workbook %s for deferred migration", workbook.rid)
-        self.ctx.migration_state.record_pending_multi_run_workbook(workbook.rid, source_run_rids)
+            logger.warning("Skipping deferred workbook %s: %s", workbook.rid, reason)
+            self.ctx.migration_state.record_workbook_skip_and_clear_pending(workbook.rid, reason)
+            return False
+        if self.ctx.migration_state.workbook_was_skipped(workbook.rid):
+            logger.debug("Not queuing deferred workbook %s: already skipped", workbook.rid)
+            return False
+        return True
 
     def _find_assets_outside_migration_scope(self, source_asset_rids: Sequence[str]) -> list[str]:
         return [
@@ -370,14 +374,3 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             if rid not in self.ctx.source_asset_rids
             and self.ctx.migration_state.get_mapped_rid(ResourceType.ASSET, rid) is None
         ]
-
-    def _record_workbook_skip(self, workbook_rid: str, reason: str) -> None:
-        if self._workbook_was_skipped(workbook_rid):
-            return
-        self.ctx.migration_state.record_skip(ResourceType.WORKBOOK, workbook_rid, reason)
-
-    def _workbook_was_skipped(self, workbook_rid: str) -> bool:
-        return any(
-            skipped.resource_type == ResourceType.WORKBOOK.value and skipped.source_rid == workbook_rid
-            for skipped in self.ctx.migration_state.skipped_resources
-        )

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -321,7 +321,8 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             # step used by the copy can't tell "unmapped resource RID" apart from "internal id
             # that should get a fresh UUID", so it would silently regenerate a bogus RID for
             # every reference to those other assets instead of waiting for a complete mapping.
-            if len(workbook.run_rids) == 1 and len(source_run.assets) <= 1:
+            source_run_asset_rids = list(getattr(source_run, "assets", []) or [])
+            if len(workbook.run_rids) == 1 and len(source_run_asset_rids) <= 1:
                 workbook_migrator.copy_from(
                     workbook,
                     WorkbookCopyOptions(
@@ -330,23 +331,53 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                     ),
                 )
             else:
-                self._enqueue_multi_run_workbook(workbook, list(workbook.run_rids))
+                self._enqueue_multi_run_workbook(workbook, list(workbook.run_rids), source_run_asset_rids)
 
     def _enqueue_multi_asset_workbook(self, workbook: Workbook, source_asset_rids: list[str]) -> None:
-        missing = [
+        missing = self._find_assets_outside_migration_scope(source_asset_rids)
+        if missing:
+            reason = f"assets not in migration scope: {missing}"
+            logger.warning("Skipping multi-asset workbook %s: %s", workbook.rid, reason)
+            self._record_workbook_skip(workbook.rid, reason)
+            self.ctx.migration_state.clear_pending_multi_asset_workbook(workbook.rid)
+            return
+        if self._workbook_was_skipped(workbook.rid):
+            logger.debug("Not queuing multi-asset workbook %s: already skipped", workbook.rid)
+            return
+        logger.debug("Queuing multi-asset workbook %s for deferred migration", workbook.rid)
+        self.ctx.migration_state.record_pending_multi_asset_workbook(workbook.rid, source_asset_rids)
+
+    def _enqueue_multi_run_workbook(
+        self, workbook: Workbook, source_run_rids: list[str], source_asset_rids: list[str]
+    ) -> None:
+        missing = self._find_assets_outside_migration_scope(source_asset_rids)
+        if missing:
+            reason = f"assets not in migration scope: {missing}"
+            logger.warning("Skipping run-scoped workbook %s: %s", workbook.rid, reason)
+            self._record_workbook_skip(workbook.rid, reason)
+            self.ctx.migration_state.clear_pending_multi_run_workbook(workbook.rid)
+            return
+        if self._workbook_was_skipped(workbook.rid):
+            logger.debug("Not queuing multi-run workbook %s: already skipped", workbook.rid)
+            return
+        logger.debug("Queuing multi-run workbook %s for deferred migration", workbook.rid)
+        self.ctx.migration_state.record_pending_multi_run_workbook(workbook.rid, source_run_rids)
+
+    def _find_assets_outside_migration_scope(self, source_asset_rids: Sequence[str]) -> list[str]:
+        return [
             rid
             for rid in source_asset_rids
             if rid not in self.ctx.source_asset_rids
             and self.ctx.migration_state.get_mapped_rid(ResourceType.ASSET, rid) is None
         ]
-        if missing:
-            reason = f"assets not in migration scope: {missing}"
-            logger.warning("Skipping multi-asset workbook %s: %s", workbook.rid, reason)
-            self.ctx.migration_state.record_skip(ResourceType.WORKBOOK, workbook.rid, reason)
-        else:
-            logger.debug("Queuing multi-asset workbook %s for deferred migration", workbook.rid)
-            self.ctx.migration_state.record_pending_multi_asset_workbook(workbook.rid, source_asset_rids)
 
-    def _enqueue_multi_run_workbook(self, workbook: Workbook, source_run_rids: list[str]) -> None:
-        logger.debug("Queuing multi-run workbook %s for deferred migration", workbook.rid)
-        self.ctx.migration_state.record_pending_multi_run_workbook(workbook.rid, source_run_rids)
+    def _record_workbook_skip(self, workbook_rid: str, reason: str) -> None:
+        if self._workbook_was_skipped(workbook_rid):
+            return
+        self.ctx.migration_state.record_skip(ResourceType.WORKBOOK, workbook_rid, reason)
+
+    def _workbook_was_skipped(self, workbook_rid: str) -> bool:
+        return any(
+            skipped.resource_type == ResourceType.WORKBOOK.value and skipped.source_rid == workbook_rid
+            for skipped in self.ctx.migration_state.skipped_resources
+        )

--- a/nominal/experimental/migration/parallel_migration_state.py
+++ b/nominal/experimental/migration/parallel_migration_state.py
@@ -62,6 +62,20 @@ class ThreadSafeMigrationState(MigrationState):
             super().record_pending_multi_run_workbook(workbook_rid, run_rids)
         self._persist()
 
+    def record_pending_multi_asset_workbook_unless_skipped(self, workbook_rid: str, asset_rids: list[str]) -> bool:
+        with self._lock:
+            recorded = super().record_pending_multi_asset_workbook_unless_skipped(workbook_rid, asset_rids)
+        if recorded:
+            self._persist()
+        return recorded
+
+    def record_pending_multi_run_workbook_unless_skipped(self, workbook_rid: str, run_rids: list[str]) -> bool:
+        with self._lock:
+            recorded = super().record_pending_multi_run_workbook_unless_skipped(workbook_rid, run_rids)
+        if recorded:
+            self._persist()
+        return recorded
+
     def clear_pending_multi_asset_workbook(self, workbook_rid: str) -> None:
         with self._lock:
             super().clear_pending_multi_asset_workbook(workbook_rid)
@@ -76,6 +90,17 @@ class ThreadSafeMigrationState(MigrationState):
         with self._lock:
             super().record_skip(resource_type, source_rid, reason)
         self._persist()
+
+    def record_workbook_skip_and_clear_pending(self, workbook_rid: str, reason: str) -> bool:
+        with self._lock:
+            changed = super().record_workbook_skip_and_clear_pending(workbook_rid, reason)
+        if changed:
+            self._persist()
+        return changed
+
+    def workbook_was_skipped(self, workbook_rid: str) -> bool:
+        with self._lock:
+            return super().workbook_was_skipped(workbook_rid)
 
     def to_json(self) -> str:
         # Serialization walks every nested dict, so it must hold the same lock as the

--- a/tests/core/test_asset_migrator.py
+++ b/tests/core/test_asset_migrator.py
@@ -478,9 +478,7 @@ class TestAssetMigratorWorkbookRouting:
         assert a2 in state.skipped_resources[0].reason
 
     @patch("nominal.experimental.migration.migrator.asset_migrator.WorkbookMigrator")
-    def test_multi_run_workbook_with_out_of_scope_owning_asset_is_not_requeued(
-        self, mock_wm_cls: MagicMock
-    ) -> None:
+    def test_multi_run_workbook_with_out_of_scope_owning_asset_is_not_requeued(self, mock_wm_cls: MagicMock) -> None:
         """If any observed run owner is out of scope, later sightings must not re-queue the workbook."""
         a1, a2 = _asset_rid(1), _asset_rid(2)
         r1, r2 = _run_rid(1), _run_rid(2)

--- a/tests/core/test_asset_migrator.py
+++ b/tests/core/test_asset_migrator.py
@@ -348,35 +348,36 @@ class TestAssetMigratorWorkbookRouting:
         assert copied_rids == {wb_asset, wb_run_allowed}
 
     @patch("nominal.experimental.migration.migrator.asset_migrator.WorkbookMigrator")
-    def test_multi_run_workbook_always_enqueued_single_run_uses_copy_from(self, mock_wm_cls: MagicMock) -> None:
+    def test_multi_run_workbook_enqueued_single_run_uses_copy_from(self, mock_wm_cls: MagicMock) -> None:
         """Single-run workbooks (run owned by exactly one asset) go to copy_from; multi-run
-        workbooks are always enqueued for deferred migration without an upfront scope check.
-        Also verifies that finding the same multi-run workbook via two different runs overwrites
-        the pending entry idempotently.
+        workbooks are enqueued for deferred migration when all observed owning assets are in
+        scope. Also verifies that finding the same multi-run workbook via two different runs
+        overwrites the pending entry idempotently.
         """
+        a1, a2 = _asset_rid(1), _asset_rid(2)
         r1, r2 = _run_rid(1), _run_rid(2)
         new_r1, new_r2 = _run_rid(101), _run_rid(102)
         wb_single_run = _wb_rid(1)
         wb_multi_run = _wb_rid(2)
 
-        ctx = _make_context()
+        ctx = _make_context(source_asset_rids=frozenset([a1, a2]))
         ctx.migration_state.record_mapping(ResourceType.RUN, r1, new_r1)
         ctx.migration_state.record_mapping(ResourceType.RUN, r2, new_r2)
 
-        source_asset = _make_source_asset()
+        source_asset = _make_source_asset(rid=a1)
         new_asset = _make_dest_asset()
         source_asset.search_workbooks.return_value = []
 
         run1 = MagicMock()
         run1.rid = r1
-        run1.assets = [source_asset.rid]  # single owning asset
+        run1.assets = [a1]  # single owning asset
         run1.search_workbooks.return_value = [
             _stub_workbook(wb_single_run, run_rids=[r1]),
             _stub_workbook(wb_multi_run, run_rids=[r1, r2]),
         ]
         run2 = MagicMock()
         run2.rid = r2
-        run2.assets = [source_asset.rid, _asset_rid(2)]
+        run2.assets = [a1, a2]
         # wb_multi_run found again via run2 — should overwrite pending, not duplicate
         run2.search_workbooks.return_value = [
             _stub_workbook(wb_multi_run, run_rids=[r1, r2]),
@@ -414,7 +415,7 @@ class TestAssetMigratorWorkbookRouting:
         new_r1 = _run_rid(101)
         wb_run_scoped = _wb_rid(1)
 
-        ctx = _make_context()
+        ctx = _make_context(source_asset_rids=frozenset([a1, a2]))
         ctx.migration_state.record_mapping(ResourceType.RUN, r1, new_r1)
         # Only a1 has been mapped so far; a2 (the run's other owning asset) has not.
         ctx.migration_state.record_mapping(ResourceType.ASSET, a1, new_a1)
@@ -439,6 +440,87 @@ class TestAssetMigratorWorkbookRouting:
 
         state = ctx.migration_state
         assert wb_run_scoped in state.pending_multi_run_workbooks
+
+    @patch("nominal.experimental.migration.migrator.asset_migrator.WorkbookMigrator")
+    def test_single_run_workbook_with_out_of_scope_owning_asset_is_skipped(self, mock_wm_cls: MagicMock) -> None:
+        """A deferred run-scoped workbook is skipped if any owning asset is outside migration scope."""
+        a1, a2 = _asset_rid(1), _asset_rid(2)
+        new_a1 = _asset_rid(101)
+        r1 = _run_rid(1)
+        new_r1 = _run_rid(101)
+        wb_run_scoped = _wb_rid(1)
+
+        ctx = _make_context(source_asset_rids=frozenset([a1]))
+        ctx.migration_state.record_mapping(ResourceType.RUN, r1, new_r1)
+        ctx.migration_state.record_mapping(ResourceType.ASSET, a1, new_a1)
+
+        source_asset = _make_source_asset(rid=a1)
+        new_asset = _make_dest_asset(rid=new_a1)
+        source_asset.search_workbooks.return_value = []
+
+        run1 = MagicMock()
+        run1.rid = r1
+        run1.assets = [a1, a2]
+        run1.search_workbooks.return_value = [
+            _stub_workbook(wb_run_scoped, run_rids=[r1]),
+        ]
+        source_asset.list_runs.return_value = [run1]
+
+        migrator = AssetMigrator(ctx)
+        migrator._copy_asset_and_run_workbooks(source_asset, new_asset, include_runs=True)
+
+        mock_wm_cls.return_value.copy_from.assert_not_called()
+
+        state = ctx.migration_state
+        assert wb_run_scoped not in state.pending_multi_run_workbooks
+        assert len(state.skipped_resources) == 1
+        assert state.skipped_resources[0].source_rid == wb_run_scoped
+        assert a2 in state.skipped_resources[0].reason
+
+    @patch("nominal.experimental.migration.migrator.asset_migrator.WorkbookMigrator")
+    def test_multi_run_workbook_with_out_of_scope_owning_asset_is_not_requeued(
+        self, mock_wm_cls: MagicMock
+    ) -> None:
+        """If any observed run owner is out of scope, later sightings must not re-queue the workbook."""
+        a1, a2 = _asset_rid(1), _asset_rid(2)
+        r1, r2 = _run_rid(1), _run_rid(2)
+        new_r1, new_r2 = _run_rid(101), _run_rid(102)
+        wb_multi_run = _wb_rid(1)
+
+        ctx = _make_context(source_asset_rids=frozenset([a1]))
+        ctx.migration_state.record_mapping(ResourceType.RUN, r1, new_r1)
+        ctx.migration_state.record_mapping(ResourceType.RUN, r2, new_r2)
+
+        source_asset = _make_source_asset(rid=a1)
+        new_asset = _make_dest_asset()
+        source_asset.search_workbooks.return_value = []
+
+        run_with_missing_owner = MagicMock()
+        run_with_missing_owner.rid = r2
+        run_with_missing_owner.assets = [a1, a2]
+        run_with_missing_owner.search_workbooks.return_value = [
+            _stub_workbook(wb_multi_run, run_rids=[r1, r2]),
+        ]
+
+        run_in_scope = MagicMock()
+        run_in_scope.rid = r1
+        run_in_scope.assets = [a1]
+        run_in_scope.search_workbooks.return_value = [
+            _stub_workbook(wb_multi_run, run_rids=[r1, r2]),
+        ]
+
+        source_asset.list_runs.return_value = [run_with_missing_owner, run_in_scope]
+
+        migrator = AssetMigrator(ctx)
+        migrator._copy_asset_and_run_workbooks(source_asset, new_asset, include_runs=True)
+
+        mock_wm_cls.return_value.copy_from.assert_not_called()
+
+        state = ctx.migration_state
+        assert wb_multi_run not in state.pending_multi_run_workbooks
+        assert len(state.skipped_resources) == 1
+        assert state.skipped_resources[0].source_rid == wb_multi_run
+        assert a2 in state.skipped_resources[0].reason
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_asset_migrator.py
+++ b/tests/core/test_asset_migrator.py
@@ -329,6 +329,7 @@ class TestAssetMigratorWorkbookRouting:
 
         run1 = MagicMock()
         run1.rid = r1
+        run1.assets = [a1]
         run1.search_workbooks.return_value = [
             _stub_workbook(wb_run_allowed, run_rids=[r1]),
             _stub_workbook(wb_run_blocked, run_rids=[r1]),

--- a/tests/core/test_migration_state_persistence.py
+++ b/tests/core/test_migration_state_persistence.py
@@ -170,6 +170,19 @@ class TestPersistHook:
         state.record_skip(ResourceType.WORKBOOK, "wb2", "out of scope")
         assert len(saves) == 6
 
+    def test_compound_workbook_queue_mutations_trigger_the_hook(self) -> None:
+        """Atomic workbook queue/skip helpers must persist the same way as primitive mutators."""
+        saves: list[str] = []
+        state = ThreadSafeMigrationState()
+        state.set_persist_hook(lambda: saves.append("save"))
+
+        assert state.record_pending_multi_asset_workbook_unless_skipped("wb", ["a1"]) is True
+        assert state.record_pending_multi_run_workbook_unless_skipped("wb", ["r1"]) is True
+        assert state.record_workbook_skip_and_clear_pending("wb", "out of scope") is True
+        assert state.record_pending_multi_asset_workbook_unless_skipped("wb", ["a1"]) is False
+
+        assert saves == ["save", "save", "save"]
+
     def test_reads_do_not_trigger_the_hook(self) -> None:
         """Only mutations persist — lookups happen constantly and must stay write-free."""
         saves: list[str] = []

--- a/tests/core/test_multi_workbook_migration.py
+++ b/tests/core/test_multi_workbook_migration.py
@@ -110,6 +110,30 @@ class TestMigrationStatePendingAndSkips:
         assert reasons[_wb_rid(1)] == "asset out of scope"
         assert reasons[_wb_rid(2)] == "run not in state"
 
+    def test_workbook_skip_is_terminal_for_pending_queues(self) -> None:
+        """A workbook skip clears stale pending entries and prevents later queue attempts."""
+        state = MigrationState()
+        wb = _wb_rid(1)
+        assets = [_asset_rid(1), _asset_rid(2)]
+        runs = [_run_rid(1), _run_rid(2)]
+
+        assert state.record_pending_multi_asset_workbook_unless_skipped(wb, assets) is True
+        assert state.record_pending_multi_run_workbook_unless_skipped(wb, runs) is True
+
+        assert state.record_workbook_skip_and_clear_pending(wb, "assets not in migration scope") is True
+        assert wb not in state.pending_multi_asset_workbooks
+        assert wb not in state.pending_multi_run_workbooks
+        assert state.workbook_was_skipped(wb) is True
+
+        assert state.record_pending_multi_asset_workbook_unless_skipped(wb, assets) is False
+        assert state.record_pending_multi_run_workbook_unless_skipped(wb, runs) is False
+        assert wb not in state.pending_multi_asset_workbooks
+        assert wb not in state.pending_multi_run_workbooks
+
+        assert state.record_workbook_skip_and_clear_pending(wb, "duplicate skip") is False
+        assert len(state.skipped_resources) == 1
+        assert state.skipped_resources[0].reason == "assets not in migration scope"
+
 
 # ---------------------------------------------------------------------------
 # WorkbookMigrator._copy_from_impl (via copy_from)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

## Summary
- Reuse the existing asset-scope guard for deferred run-scoped workbook routing.
- Skip run-scoped workbooks when an observed owning asset is neither in the migration config nor already mapped.
- Make workbook skip vs pending-queue decisions atomic in `MigrationState`/`ThreadSafeMigrationState`, so skipped workbooks cannot be re-queued by a parallel worker.
- Use direct `Run.assets` access in the run workbook path and share the deferred-workbook guard between multi-asset and run-scoped queueing.

## Intent and key decisions
This is a follow-up to the multi-asset run workbook migration fix. The earlier change deferred single-run workbooks whose run has multiple owning assets, but the deferred copy can still build an incomplete RID override map if any owning asset is outside the migration scope. This change records those workbooks as skipped instead of queueing them for a guaranteed incomplete copy.

The review follow-up moves the terminal skip invariant into migration state itself: skipping a workbook clears stale pending entries, and pending queue attempts now no-op once a workbook has been skipped. `ThreadSafeMigrationState` wraps those compound operations under one lock for parallel migrations.

## Potential pitfalls
- The guard only uses owning assets observed from the run objects encountered during asset traversal; it does not add new network calls to discover additional run ownership.
- Skipped workbook records are treated as terminal for that workbook during routing so later sightings do not re-add pending work.

## Validation
- `uv run --python 3.13 pytest tests/core/test_asset_migrator.py tests/core/test_multi_workbook_migration.py tests/core/test_migration_state_persistence.py -q` — 45 passed
- `uv run --python 3.13 pytest tests/ --ignore=tests/e2e -q` — 545 passed
- `just check-format` — passed
- `just check-imports` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

