### PR TITLE
chore: bump nominal-api version to 0.1337.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "conjure-python-client>=3.1.0,<4",
     "exceptiongroup>=1.3.0",
-    "nominal-api==0.1305.0",
-    "nominal-api-protos==0.1305.0",
+    "nominal-api==0.1337.0",
+    "nominal-api-protos==0.1337.0",
     "truststore>=0.10.4",
     "typing-extensions>=4,<5",
     "pandas>=2.0.0",

--- a/tests/experimental/test_extractor.py
+++ b/tests/experimental/test_extractor.py
@@ -116,7 +116,7 @@ def test_manifest_includes_timestamp_metadata_when_set(dirs: tuple[Path, Path]) 
     emit.run(env=_env(input_dir, output_dir), exit=False)
 
     [entry] = json.loads((output_dir / "manifest.json").read_text())["outputs"]
-    assert entry["timestampMetadata"] == {"seriesName": "ts", "epochTimeUnit": "MICROSECONDS"}
+    assert entry["timestampMetadata"] == {"seriesName": "ts", "epochTimeUnit": "MICROSECONDS", "relativeOffset": None}
 
 
 def test_manifest_leaves_timestamp_metadata_null_when_unset(dirs: tuple[Path, Path]) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -795,8 +795,8 @@ requires-dist = [
     { name = "conjure-python-client", specifier = ">=3.1.0,<4" },
     { name = "exceptiongroup", specifier = ">=1.3.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
-    { name = "nominal-api", specifier = "==0.1305.0" },
-    { name = "nominal-api-protos", specifier = "==0.1305.0" },
+    { name = "nominal-api", specifier = "==0.1337.0" },
+    { name = "nominal-api-protos", specifier = "==0.1337.0" },
     { name = "nominal-streaming", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')", specifier = "==0.8.2" },
     { name = "nominal-tdms", marker = "extra == 'tdms'", editable = "packages/nominal-tdms" },
     { name = "nominal-video", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin' and extra == 'video') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'video') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'video') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32' and extra == 'video')", specifier = "==0.1.9" },
@@ -837,19 +837,19 @@ dev = [
 
 [[package]]
 name = "nominal-api"
-version = "0.1305.0"
+version = "0.1337.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "conjure-python-client" },
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/a2/e2f9756d818ab075f4c28c895257046c118d5ecf0b771c0a69d62470c7cb/nominal_api-0.1305.0-py3-none-any.whl", hash = "sha256:99ebfd22c9c36ff0f57386f79d861cf59a49472b2ae3baf590b9e4a22d8a122c", size = 905244, upload-time = "2026-07-02T17:02:21.33Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c5/ffdbdb251441835112f90bf6841a1f0124b551000d9f70e29178308f12ce/nominal_api-0.1337.0-py3-none-any.whl", hash = "sha256:20c6dce43eeacb45591072d7b237b54261a01ca3373674f6671723727727890d", size = 929392, upload-time = "2026-07-20T19:05:45.411Z" },
 ]
 
 [[package]]
 name = "nominal-api-protos"
-version = "0.1305.0"
+version = "0.1337.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -857,7 +857,7 @@ dependencies = [
     { name = "protobuf" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/2b/120d30fd11875be1c6556c11cf2c047f9d4d015abc3a7d9263cce694b6b7/nominal_api_protos-0.1305.0-py3-none-any.whl", hash = "sha256:eaf81b31893884bd116edd84441fe52e9885675c0731e2bce9e1a514b9f9b643", size = 535462, upload-time = "2026-07-02T17:02:23.396Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/69/e17555cd89965cb7bb0e48e6a6d99a09cbf3fc4f6b6742f1ba9364eba96f/nominal_api_protos-0.1337.0-py3-none-any.whl", hash = "sha256:82503c8ac65cb416ff345894f11ff54cdaac3fcac691f911b27261a9915976df", size = 608075, upload-time = "2026-07-20T19:05:47.231Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `nominal-api` / `nominal-api-protos` 0.1305.0 → 0.1337.0.

Picks up `ManifestTimestampMetadata.relativeOffset` from [scout#16012](https://github.com/nominal-io/scout/pull/16012) (relative timestamps in manifest-style extractors), which a follow-up PR adopts in the experimental extractor decorator library.

Reviewed the full binding delta for both transports. Every flagged breaking change turned out not to touch this client:
- `ingest_api.ContainerizedExtractor` gained a required `exit_code_mappings` field, but the client never constructs the conjure bean (its `ContainerizedExtractor` is the gRPC-backed class in `nominal/core/containerized_extractor.py`).
- The multipart upload endpoints (`sign_part`, `list_parts`, `complete_multipart_upload`, `abort_multipart_upload`) gained a `bucket` parameter, which is `Optional[str] = None` in the generated signatures, so existing call sites in `nominal/core/_utils/multipart.py` are unaffected.
- The removed `direct_channel_writer.v2` proto messages (`Points`, `ArrayPoints`, `LogPoint`, …) are same-named types from a package the client does not import; the streaming write path uses `nominal.protos.write.nominal_write_pb2`, whose messages are all unchanged.

One test needed updating: the generated conjure encoder now serializes the new optional `relativeOffset` field as an explicit `null` on manifest `timestampMetadata`, so the exact-dict assertion in `test_manifest_includes_timestamp_metadata_when_set` gains that key. Conjure decoders treat `null` as absent, so the manifest wire contract is unchanged for the backend.

### Testing plan

- `just test` — 404 passed, 13 skipped.
- `just check` — ruff format, mypy, and ruff lint all clean.
- Verified all `nominal.protos.*` / `nominal_api.*` modules the client imports load cleanly against 0.1337.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)