### PR TITLE
feat(experimental): relative timestamps for manifest extractor outputs

### DIFF
--- a/nominal/experimental/extractor/_extractor.py
+++ b/nominal/experimental/extractor/_extractor.py
@@ -18,8 +18,8 @@ pipeline applies, and this module provides one decorator per contract:
 - :func:`manifest_extractor` -- for images registered with the ``MANIFEST`` output format.
   The pipeline reads a ``manifest.json`` describing every output file; your function
   declares each file (with per-file ingest type, tag columns, channel prefix, and optional
-  epoch timestamp metadata) with :meth:`ManifestExtractorContext.add_output`, and
-  :meth:`Extractor.run` writes the manifest automatically.
+  epoch or relative timestamp metadata) with :meth:`ManifestExtractorContext.add_output`,
+  and :meth:`Extractor.run` writes the manifest automatically.
 
 Both decorators turn ``def fn(ctx) -> None`` into a container entrypoint: ``ctx`` resolves
 inputs and parameters from the environment, and :meth:`Extractor.run` finalizes the outputs
@@ -129,26 +129,36 @@ _MANIFEST_EPOCH_UNITS: dict[str, ingest_manifest.ManifestEpochTimeUnit] = {
 }
 
 
-def _manifest_epoch_time_unit(timestamp_type: ts._AnyTimestampType) -> ingest_manifest.ManifestEpochTimeUnit:
+def _manifest_timestamp_metadata(
+    series_name: str, timestamp_type: ts._AnyTimestampType
+) -> ingest_manifest.ManifestTimestampMetadata:
     """Validate a per-output timestamp type against the manifest contract and convert it.
 
-    Manifest outputs can only express numeric epoch timestamps in seconds through nanoseconds;
-    outputs needing richer types (ISO 8601, custom formats, relative offsets) must omit per-output
-    metadata and rely on the job-level timestamp metadata, which supports the full range.
+    Manifest outputs express numeric timestamps in seconds through nanoseconds, either absolute
+    (:class:`ts.Epoch`) or offsets from a starting time (:class:`ts.Relative`); outputs needing
+    richer types (ISO 8601, custom formats) must omit per-output metadata and rely on the
+    job-level timestamp metadata, which supports the full range.
     """
     typed = ts._to_typed_timestamp_type(timestamp_type)
-    if not isinstance(typed, ts.Epoch):
+    if not isinstance(typed, (ts.Epoch, ts.Relative)):
         raise ExtractorError(
-            f"per-output timestamp metadata only supports numeric epoch timestamps, not {typed!r}; "
+            f"per-output timestamp metadata only supports numeric epoch timestamps (ts.Epoch) and "
+            f"relative timestamps (ts.Relative), not {typed!r}; "
             "omit it and rely on the job-level timestamp metadata for richer timestamp types"
         )
     unit = _MANIFEST_EPOCH_UNITS.get(typed.unit)
     if unit is None:
         raise ExtractorError(
-            f"per-output timestamp metadata does not support epoch unit {typed.unit!r}; "
+            f"per-output timestamp metadata does not support time unit {typed.unit!r}; "
             f"supported units are {', '.join(_MANIFEST_EPOCH_UNITS)}"
         )
-    return unit
+    return ingest_manifest.ManifestTimestampMetadata(
+        series_name=series_name,
+        epoch_time_unit=unit,
+        relative_offset=ts._SecondsNanos.from_flexible(typed.start).to_iso8601()
+        if isinstance(typed, ts.Relative)
+        else None,
+    )
 
 
 @dataclass(frozen=True)
@@ -472,7 +482,8 @@ class ManifestExtractorContext(ExtractorContext):
         Records the file (it must already exist under ``output_dir``); it does not write anything
         itself. ``timestamp_column``/``timestamp_type`` (provided together) override the job-level
         timestamp metadata for this output, so each file can carry its own timestamp field. Only
-        numeric epoch timestamp types (seconds through nanoseconds) are supported here; outputs
+        numeric timestamp types (seconds through nanoseconds) are supported here -- absolute
+        epochs (:class:`ts.Epoch`) or offsets from a starting time (:class:`ts.Relative`); outputs
         needing richer types should omit the pair and rely on the job-level metadata. For
         ``JSON_L`` outputs each line must still contain a ``MESSAGE`` field; that path is log
         ingest.
@@ -487,10 +498,7 @@ class ManifestExtractorContext(ExtractorContext):
             )
         timestamp_metadata = None
         if timestamp_column is not None and timestamp_type is not None:
-            timestamp_metadata = ingest_manifest.ManifestTimestampMetadata(
-                series_name=timestamp_column,
-                epoch_time_unit=_manifest_epoch_time_unit(timestamp_type),
-            )
+            timestamp_metadata = _manifest_timestamp_metadata(timestamp_column, timestamp_type)
         logger.debug("declared output %s (%s)", relative, ingest_type.value)
         self._outputs.append(
             ingest_manifest.ManifestOutput(
@@ -670,10 +678,10 @@ def manifest_extractor(fn: Callable[[ManifestExtractorContext], None]) -> Extrac
     """Turn ``def fn(ctx: ManifestExtractorContext) -> None`` into a manifest extractor entrypoint.
 
     For images registered with the ``MANIFEST`` output format: declare each output file (and its
-    per-file ingest type, tag columns, channel prefix, and optional epoch timestamp metadata) with
-    :meth:`ManifestExtractorContext.add_output`; ``manifest.json`` is written automatically when
-    the function returns. If the image's registered format is not ``MANIFEST``, :meth:`Extractor.run`
-    fails at startup with a clear error.
+    per-file ingest type, tag columns, channel prefix, and optional epoch or relative timestamp
+    metadata) with :meth:`ManifestExtractorContext.add_output`; ``manifest.json`` is written
+    automatically when the function returns. If the image's registered format is not ``MANIFEST``,
+    :meth:`Extractor.run` fails at startup with a clear error.
 
     Example::
 

--- a/tests/experimental/test_extractor.py
+++ b/tests/experimental/test_extractor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -117,6 +118,30 @@ def test_manifest_includes_timestamp_metadata_when_set(dirs: tuple[Path, Path]) 
 
     [entry] = json.loads((output_dir / "manifest.json").read_text())["outputs"]
     assert entry["timestampMetadata"] == {"seriesName": "ts", "epochTimeUnit": "MICROSECONDS", "relativeOffset": None}
+
+
+def test_manifest_includes_relative_timestamp_metadata_when_set(dirs: tuple[Path, Path]) -> None:
+    """A manifest entry carries a relativeOffset when the output declares a ts.Relative timestamp type."""
+    input_dir, output_dir = dirs
+
+    @manifest_extractor
+    def emit(ctx: ManifestExtractorContext) -> None:
+        out = ctx.output_dir / "run.csv"
+        out.write_text("elapsed,x")
+        ctx.add_output(
+            out,
+            timestamp_column="elapsed",
+            timestamp_type=ts.Relative("milliseconds", start=datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        )
+
+    emit.run(env=_env(input_dir, output_dir), exit=False)
+
+    [entry] = json.loads((output_dir / "manifest.json").read_text())["outputs"]
+    assert entry["timestampMetadata"] == {
+        "seriesName": "elapsed",
+        "epochTimeUnit": "MILLISECONDS",
+        "relativeOffset": "2026-01-01T00:00:00.000000000Z",
+    }
 
 
 def test_manifest_leaves_timestamp_metadata_null_when_unset(dirs: tuple[Path, Path]) -> None:
@@ -411,6 +436,24 @@ def test_per_output_timestamp_rejects_non_epoch_types(dirs: tuple[Path, Path]) -
         ctx.add_output(out, timestamp_column="ts", timestamp_type="iso_8601")
 
     with pytest.raises(ExtractorError, match="numeric epoch"):
+        emit.run(env=_env(input_dir, output_dir), exit=False)
+
+
+def test_per_output_timestamp_rejects_units_outside_manifest_contract(dirs: tuple[Path, Path]) -> None:
+    """Per-output timestamp metadata rejects time units the manifest contract cannot express."""
+    input_dir, output_dir = dirs
+
+    @manifest_extractor
+    def emit(ctx: ManifestExtractorContext) -> None:
+        out = ctx.output_dir / "data.csv"
+        out.write_text("elapsed,x")
+        ctx.add_output(
+            out,
+            timestamp_column="elapsed",
+            timestamp_type=ts.Relative("hours", start=datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        )
+
+    with pytest.raises(ExtractorError, match="does not support time unit 'hours'"):
         emit.run(env=_env(input_dir, output_dir), exit=False)
 
 


### PR DESCRIPTION
Manifest-style containerized extractors can now declare per-output **relative** timestamp metadata through the decorator runtime, matching the backend support added in a recent backend release.

`ManifestExtractorContext.add_output` accepts `ts.Relative` for `timestamp_type` (alongside the existing `ts.Epoch`), so an output whose timestamp column holds numeric offsets (e.g. seconds since test start) no longer needs post-extraction surgery to rewrite every value into an absolute epoch:

```python
ctx.add_output(
    out,
    timestamp_column="elapsed",
    timestamp_type=ts.Relative("milliseconds", start=datetime(2026, 1, 1, tzinfo=timezone.utc)),
)
```

This emits the new optional `relativeOffset` manifest field (ISO-8601, serialized through the same `_SecondsNanos` path the regular ingest API uses for relative timestamps):

```json
{ "seriesName": "elapsed", "epochTimeUnit": "MILLISECONDS", "relativeOffset": "2026-01-01T00:00:00.000000000Z" }
```

Implementation: `_manifest_epoch_time_unit` is replaced by `_manifest_timestamp_metadata`, which builds the full `ManifestTimestampMetadata` for both absolute and relative types under the same unit contract (seconds through nanoseconds). Richer types (ISO 8601 columns, custom formats) are still rejected with a pointer to the job-level timestamp metadata. Requires `nominal-api>=0.1329.0`; already satisfied by the 0.1337.0 bump (#888).

### Testing plan

- New unit tests: relative timestamp metadata lands in `manifest.json` with the expected `relativeOffset`; time units outside the manifest contract (e.g. `ts.Relative("hours", ...)`) are rejected; absolute-epoch behavior unchanged.
- `just test` — 406 passed, 13 skipped; `just check` — ruff format, mypy, ruff lint all clean.
- Drove a manifest extractor end-to-end with the pipeline contract env (`_NOMINAL_OUTPUT_FORMAT=MANIFEST`) and verified the written `manifest.json` matches the shape documented in scout#16012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)