### PR TITLE
feat(video): add Dataset.add_video for channel-native video ingest

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -846,6 +846,10 @@ class NominalClient:
 
         return dataset
 
+    @deprecated(
+        "Creating a standalone `Video` is deprecated in favor of video channels on a dataset. Use "
+        "`Dataset.add_video`/`add_video_from_io` on a new or existing dataset (see `create_dataset`) instead."
+    )
     def create_video(
         self,
         name: str,

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -27,6 +27,7 @@ from nominal.core.exceptions import NominalIngestError, NominalIngestMultiError,
 from nominal.core.filetype import FileType, FileTypes
 from nominal.core.ingestion_job import IngestionJob
 from nominal.core.log import LogPoint, _write_logs
+from nominal.core.video import _build_video_file_timestamp_manifest
 from nominal.ts import (
     IntegralNanosecondsUTC,
     _AnyTimestampType,
@@ -500,6 +501,186 @@ class Dataset(DataSource, RefreshableConjureMixin[scout_catalog.EnrichedDataset]
 
     # Backward compatibility
     add_ardupilot_dataflash_to_dataset = add_ardupilot_dataflash
+
+    @overload
+    def add_video(
+        self,
+        path: PathLike,
+        channel: str,
+        *,
+        start: datetime | IntegralNanosecondsUTC,
+        tags: Mapping[str, str] | None = None,
+        overwrite_overlapping: bool = False,
+    ) -> DatasetFile: ...
+
+    @overload
+    def add_video(
+        self,
+        path: PathLike,
+        channel: str,
+        *,
+        frame_timestamps: Sequence[IntegralNanosecondsUTC],
+        tags: Mapping[str, str] | None = None,
+        overwrite_overlapping: bool = False,
+    ) -> DatasetFile: ...
+
+    def add_video(
+        self,
+        path: PathLike,
+        channel: str,
+        *,
+        start: datetime | IntegralNanosecondsUTC | None = None,
+        frame_timestamps: Sequence[IntegralNanosecondsUTC] | None = None,
+        tags: Mapping[str, str] | None = None,
+        overwrite_overlapping: bool = False,
+    ) -> DatasetFile:
+        """Add a video file to this dataset as a video channel. Only one of start or frame_timestamps is allowed.
+
+        Args:
+            path: Path to the H264/H265-encoded video file to add to this dataset.
+            channel: Name of the video channel this file's frames belong to.
+            start: Starting timestamp of the video file in absolute UTC time.
+            frame_timestamps: Per-frame absolute nanosecond timestamps. Most usecases should instead use the
+                'start' parameter, unless precise per-frame metadata is available and desired.
+            tags: key-value pairs to apply as tags to all data uniformly in the file.
+            overwrite_overlapping: If True, any segments from other files on this channel that overlap with the
+                newly added file will be deleted before inserting the new segments.
+
+        Returns:
+            Reference to the created dataset file.
+        """
+        path = Path(path)
+        file_type = FileType.from_video(path)
+
+        with path.open("rb") as video_file:
+            if start is not None:
+                return self.add_video_from_io(
+                    video_file,
+                    channel,
+                    name=path_upload_name(path, file_type),
+                    start=start,
+                    tags=tags,
+                    file_type=file_type,
+                    overwrite_overlapping=overwrite_overlapping,
+                )
+            elif frame_timestamps is not None:
+                return self.add_video_from_io(
+                    video_file,
+                    channel,
+                    name=path_upload_name(path, file_type),
+                    frame_timestamps=frame_timestamps,
+                    tags=tags,
+                    file_type=file_type,
+                    overwrite_overlapping=overwrite_overlapping,
+                )
+            else:  # This should never be reached due to the validation in add_video_from_io
+                raise ValueError("Either 'start' or 'frame_timestamps' must be provided")
+
+    @overload
+    def add_video_from_io(
+        self,
+        video: BinaryIO,
+        channel: str,
+        name: str | None = None,
+        *,
+        start: datetime | IntegralNanosecondsUTC,
+        tags: Mapping[str, str] | None = None,
+        file_type: tuple[str, str] | FileType = FileTypes.MP4,
+        overwrite_overlapping: bool = False,
+    ) -> DatasetFile: ...
+
+    @overload
+    def add_video_from_io(
+        self,
+        video: BinaryIO,
+        channel: str,
+        name: str | None = None,
+        *,
+        frame_timestamps: Sequence[IntegralNanosecondsUTC],
+        tags: Mapping[str, str] | None = None,
+        file_type: tuple[str, str] | FileType = FileTypes.MP4,
+        overwrite_overlapping: bool = False,
+    ) -> DatasetFile: ...
+
+    def add_video_from_io(
+        self,
+        video: BinaryIO,
+        channel: str,
+        name: str | None = None,
+        *,
+        start: datetime | IntegralNanosecondsUTC | None = None,
+        frame_timestamps: Sequence[IntegralNanosecondsUTC] | None = None,
+        tags: Mapping[str, str] | None = None,
+        file_type: tuple[str, str] | FileType = FileTypes.MP4,
+        overwrite_overlapping: bool = False,
+    ) -> DatasetFile:
+        """Add a video file to this dataset as a video channel, from a file-like object.
+
+        The video must be a file-like object in binary mode, e.g. open(path, "rb") or io.BytesIO, containing
+        H264 or H265-encoded video data.
+
+        Args:
+            video: File-like object containing video data encoded in H264 or H265.
+            channel: Name of the video channel this file's frames belong to.
+            name: Name of the file to use when uploading to S3. Defaults to the dataset's name.
+            start: Starting timestamp of the video file in absolute UTC time.
+            frame_timestamps: Per-frame absolute nanosecond timestamps. Most usecases should instead use the
+                'start' parameter, unless precise per-frame metadata is available and desired.
+            tags: key-value pairs to apply as tags to all data uniformly in the file.
+            file_type: Metadata about the type of video file, e.g., MP4 vs. MKV.
+            overwrite_overlapping: If True, any segments from other files on this channel that overlap with the
+                newly added file will be deleted before inserting the new segments.
+
+        Returns:
+            Reference to the created dataset file.
+        """
+        if isinstance(video, TextIOBase):
+            raise TypeError(f"video {video} must be open in binary mode, rather than text mode")
+
+        if start is None and frame_timestamps is None:
+            raise ValueError("Either 'start' or 'frame_timestamps' must be provided")
+        if start is not None and frame_timestamps is not None:
+            raise ValueError("Only one of 'start' or 'frame_timestamps' may be provided")
+
+        if name is None:
+            name = self.name
+
+        workspace_rid = self._clients.resolve_default_workspace_rid()
+        timestamp_manifest = _build_video_file_timestamp_manifest(
+            self._clients.auth_header,
+            workspace_rid,
+            self._clients.upload,
+            start,
+            frame_timestamps,
+            header_provider=self._clients.header_provider,
+        )
+        file_type = FileType(*file_type)
+        s3_path = upload_multipart_io(
+            self._clients.auth_header,
+            workspace_rid,
+            video,
+            name,
+            file_type,
+            self._clients.upload,
+            header_provider=self._clients.header_provider,
+        )
+        target = ingest_api.DatasetIngestTarget(
+            existing=ingest_api.ExistingDatasetIngestDestination(dataset_rid=self.rid)
+        )
+        request = ingest_api.IngestRequest(
+            ingest_api.IngestOptions(
+                video_v2=ingest_api.VideoOptsV2(
+                    source=ingest_api.IngestSource(s3=ingest_api.S3IngestSource(s3_path)),
+                    target=target,
+                    timestamp_manifest=timestamp_manifest,
+                    channel=channel,
+                    tags=dict(tags) if tags is not None else {},
+                    over_write_segments=overwrite_overlapping or None,
+                )
+            )
+        )
+        resp = self._clients.ingest.ingest(self._clients.auth_header, request)
+        return self._handle_ingest_response(resp)
 
     @overload
     def add_containerized(

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -11,7 +11,7 @@ from types import MappingProxyType
 from typing import BinaryIO, Mapping, Protocol, Sequence, overload
 
 from nominal_api import api, ingest_api, scout_catalog, scout_video, scout_video_api, upload_api
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._types import PathLike
@@ -141,6 +141,10 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
         overwrite_overlapping: bool = False,
     ) -> VideoFile: ...
 
+    @deprecated(
+        "Adding a file to a standalone `Video` is deprecated in favor of video channels on a dataset. Use "
+        "`Dataset.add_video` on a new or existing dataset instead."
+    )
     def add_file(
         self,
         path: PathLike,
@@ -215,6 +219,10 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
         overwrite_overlapping: bool = False,
     ) -> VideoFile: ...
 
+    @deprecated(
+        "Adding a file to a standalone `Video` is deprecated in favor of video channels on a dataset. Use "
+        "`Dataset.add_video_from_io` on a new or existing dataset instead."
+    )
     def add_from_io(
         self,
         video: BinaryIO,
@@ -296,6 +304,9 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
 
     add_to_video_from_io = add_from_io
 
+    # Not yet deprecated: there is no video-channel replacement for MCAP-sourced video today. The v2 ingest
+    # proto's VideoTimestampManifest has no MCAP arm (server-side gap, not an SDK omission), so `Dataset.add_video`
+    # cannot represent this case yet. Revisit once that gap closes.
     def add_mcap(
         self,
         path: PathLike,

--- a/tests/core/test_dataset_add_video.py
+++ b/tests/core/test_dataset_add_video.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from nominal_api import api, ingest_api, scout_catalog
+
+from nominal.core.dataset import Dataset, DatasetBounds
+from nominal.core.dataset_file import DatasetFile
+
+
+def _dataset(clients: MagicMock) -> Dataset:
+    return Dataset(
+        rid="ri.dataset.1",
+        name="d",
+        description=None,
+        properties={},
+        labels=(),
+        bounds=DatasetBounds(start=0, end=1),
+        _clients=clients,
+    )
+
+
+def _dataset_file(dataset_rid: str, file_id: str) -> scout_catalog.DatasetFile:
+    return scout_catalog.DatasetFile(
+        id=file_id,
+        dataset_rid=dataset_rid,
+        name="video.mp4",
+        handle=scout_catalog.Handle(s3=scout_catalog.S3Handle(bucket="b", key="k")),
+        uploaded_at="2026-01-01T00:00:00Z",
+        ingest_status=api.IngestStatusV2(success=api.SuccessResult()),
+    )
+
+
+def test_add_video_from_io_maps_request_and_returns_dataset_file() -> None:
+    """The video is uploaded, the request targets this dataset/channel, and the response maps to a DatasetFile."""
+    clients = MagicMock()
+    dataset = _dataset(clients)
+    clients.ingest.ingest.return_value = ingest_api.IngestResponse(
+        details=ingest_api.IngestDetails(
+            dataset=ingest_api.IngestDatasetFileDetails(dataset_rid="ri.dataset.1", dataset_file_id="ri.file.1")
+        )
+    )
+    clients.catalog.get_dataset_file.return_value = _dataset_file("ri.dataset.1", "ri.file.1")
+
+    with patch("nominal.core.dataset.upload_multipart_io", return_value="s3://bucket/video.mp4") as mock_upload:
+        result = dataset.add_video_from_io(
+            BytesIO(b"not-real-video-bytes"),
+            "front_camera",
+            start=0,
+            tags={"site": "hq"},
+            overwrite_overlapping=True,
+        )
+
+    assert isinstance(result, DatasetFile)
+    assert result.id == "ri.file.1"
+    mock_upload.assert_called_once()
+
+    request = clients.ingest.ingest.call_args[0][1]
+    options = request.options.video_v2
+    assert options.channel == "front_camera"
+    assert options.tags == {"site": "hq"}
+    assert options.over_write_segments is True
+    assert options.target.existing.dataset_rid == "ri.dataset.1"
+    assert options.source.s3.path == "s3://bucket/video.mp4"
+    assert options.timestamp_manifest.no_manifest is not None
+
+
+def test_add_video_from_io_requires_start_or_frame_timestamps() -> None:
+    clients = MagicMock()
+    dataset = _dataset(clients)
+
+    with pytest.raises(ValueError, match="Either 'start' or 'frame_timestamps' must be provided"):
+        dataset.add_video_from_io(BytesIO(b"data"), "front_camera")
+
+    clients.ingest.ingest.assert_not_called()
+
+
+def test_add_video_from_io_rejects_both_start_and_frame_timestamps() -> None:
+    clients = MagicMock()
+    dataset = _dataset(clients)
+
+    with pytest.raises(ValueError, match="Only one of 'start' or 'frame_timestamps' may be provided"):
+        dataset.add_video_from_io(BytesIO(b"data"), "front_camera", start=0, frame_timestamps=[0, 1])
+
+    clients.ingest.ingest.assert_not_called()


### PR DESCRIPTION
Fixes <!-- no Linear ticket yet; SDK half of Phase 1 of the video-as-channels migration -->

Adds `Dataset.add_video`/`add_video_from_io`, mirroring `add_mcap`'s shape exactly: uploads an H264/H265 file and ingests it as a video channel on this dataset via `IngestOptions.video_v2` (`VideoOptsV2`), targeting this dataset directly instead of creating a standalone `Video` entity. This is the SDK-side counterpart to [nominal-io/scout#17133](https://github.com/nominal-io/scout/pull/17133), which lets these requests eventually route through the v2 gRPC ingest path server-side.

### Deprecations

Marks the standalone-video **creation** paths deprecated, pointing at the new method:
- `NominalClient.create_video` (and its `create_empty_video` alias)
- `Video.add_file`/`add_from_io` (and its `add_to_video_from_io` alias)

**Deliberately left undeprecated**, with reasons inline in the diff:
- `Video.add_mcap`/`add_mcap_from_io` — there's no video-channel replacement for MCAP-sourced video yet. The v2 ingest proto's `VideoTimestampManifest` has no MCAP arm (a server-side gap documented in #17133, not an SDK omission). Deprecating now would point users at a replacement that can't represent their case.
- `Run.add_video`/`Asset.add_video` — these attach an *existing* `Video` reference rather than creating new legacy debt, so they're outside the scope of "stop creating new standalone videos."
- `get_video`/`get_videos`/`search_videos`, and `Video`'s read/manage methods (`update`/`archive`/`unarchive`/`list_files`) — reading and managing existing legacy videos remains necessary for a long time; this migration isn't trying to discourage that.

### Testing plan

Added `tests/core/test_dataset_add_video.py` (3 mocked unit tests, following the existing `test_dataset_add_containerized.py` pattern): the happy path (request fields — channel/tags/target/source/manifest/overwrite — map correctly, response maps to a `DatasetFile`), and both validation guards (`start`/`frame_timestamps` mutual requirement/exclusivity).

Full verification run clean:
- `just check-types` (mypy) — clean on all changed files (2 pre-existing, unrelated errors elsewhere in `compute_as_code/` from a missing `nominal_compute` package, not touched by this PR)
- `just check-format` / `just check-imports` (ruff) — clean
- Full unit suite — 550 passed (minus the same 2 pre-existing `compute_as_code` collection failures, unrelated to this change)

**Honest gap**: this PR's automated coverage is mocked unit tests only. The existing `Video.add_file`/`add_mcap` methods get their real file-upload coverage from `tests/e2e/` against a live Nominal instance — I don't have a live test server available in this session, so `add_video_from_io` doesn't have equivalent e2e coverage yet. Worth adding before this sees heavy production use.