### PR TITLE
fix: add workspace prefixes to frontend URLs

### DIFF
--- a/nominal/core/_utils/frontend_urls.py
+++ b/nominal/core/_utils/frontend_urls.py
@@ -1,0 +1,57 @@
+from typing import Protocol
+
+
+class _FrontendUrlClients(Protocol):
+    @property
+    def app_base_url(self) -> str: ...
+
+    def resolve_default_workspace_rid(self) -> str: ...
+
+
+def _resource_url(clients: _FrontendUrlClients, path: str) -> str:
+    workspace_rid = clients.resolve_default_workspace_rid()
+    return f"{clients.app_base_url.rstrip('/')}/w/{workspace_rid}/{path.lstrip('/')}"
+
+
+def asset_url(clients: _FrontendUrlClients, asset_rid: str) -> str:
+    return _resource_url(clients, f"/assets/{asset_rid}")
+
+
+def checklist_url(clients: _FrontendUrlClients, checklist_rid: str) -> str:
+    return _resource_url(clients, f"/checklists/{checklist_rid}")
+
+
+def checklist_preview_url(clients: _FrontendUrlClients, checklist_rid: str, run_rid: str) -> str:
+    return f"{checklist_url(clients, checklist_rid)}?previewRunRid={run_rid}"
+
+
+def data_review_url(clients: _FrontendUrlClients, run_rid: str, data_review_rid: str) -> str:
+    return _resource_url(
+        clients,
+        f"/runs/{run_rid}/?tab=checklist-executions"
+        f"&checklistExecution={data_review_rid}&openCheckExecutionErrorReview=",
+    )
+
+
+def data_review_events_url(clients: _FrontendUrlClients, run_rid: str, data_review_rid: str) -> str:
+    return _resource_url(clients, f"/runs/{run_rid}/?tab=events&checklistExecution={data_review_rid}")
+
+
+def dataset_url(clients: _FrontendUrlClients, dataset_rid: str) -> str:
+    return _resource_url(clients, f"/datasets/{dataset_rid}")
+
+
+def ingestion_job_url(clients: _FrontendUrlClients, ingestion_job_rid: str) -> str:
+    return _resource_url(clients, f"/ingestion/{ingestion_job_rid}")
+
+
+def run_url(clients: _FrontendUrlClients, run_rid: str) -> str:
+    return _resource_url(clients, f"/runs/{run_rid}")
+
+
+def workbook_url(clients: _FrontendUrlClients, workbook_rid: str) -> str:
+    return _resource_url(clients, f"/workbooks/{workbook_rid}")
+
+
+def workbook_template_url(clients: _FrontendUrlClients, workbook_template_rid: str) -> str:
+    return _resource_url(clients, f"/workbooks/templates/{workbook_template_rid}")

--- a/nominal/core/_utils/frontend_urls.py
+++ b/nominal/core/_utils/frontend_urls.py
@@ -1,31 +1,29 @@
-from typing import Protocol
+"""Links to resource pages in the Nominal app.
+
+Frontend routes are workspace-scoped, so every URL is built under `/w/{workspace_rid}/`.
+"""
+
+from nominal.core._clientsbunch import HasScoutParams
 
 
-class _FrontendUrlClients(Protocol):
-    @property
-    def app_base_url(self) -> str: ...
-
-    def resolve_default_workspace_rid(self) -> str: ...
-
-
-def _resource_url(clients: _FrontendUrlClients, path: str) -> str:
+def _resource_url(clients: HasScoutParams, path: str) -> str:
     workspace_rid = clients.resolve_default_workspace_rid()
     return f"{clients.app_base_url.rstrip('/')}/w/{workspace_rid}/{path.lstrip('/')}"
 
 
-def asset_url(clients: _FrontendUrlClients, asset_rid: str) -> str:
+def asset_url(clients: HasScoutParams, asset_rid: str) -> str:
     return _resource_url(clients, f"/assets/{asset_rid}")
 
 
-def checklist_url(clients: _FrontendUrlClients, checklist_rid: str) -> str:
+def checklist_url(clients: HasScoutParams, checklist_rid: str) -> str:
     return _resource_url(clients, f"/checklists/{checklist_rid}")
 
 
-def checklist_preview_url(clients: _FrontendUrlClients, checklist_rid: str, run_rid: str) -> str:
+def checklist_preview_url(clients: HasScoutParams, checklist_rid: str, run_rid: str) -> str:
     return f"{checklist_url(clients, checklist_rid)}?previewRunRid={run_rid}"
 
 
-def data_review_url(clients: _FrontendUrlClients, run_rid: str, data_review_rid: str) -> str:
+def data_review_url(clients: HasScoutParams, run_rid: str, data_review_rid: str) -> str:
     return _resource_url(
         clients,
         f"/runs/{run_rid}/?tab=checklist-executions"
@@ -33,25 +31,25 @@ def data_review_url(clients: _FrontendUrlClients, run_rid: str, data_review_rid:
     )
 
 
-def data_review_events_url(clients: _FrontendUrlClients, run_rid: str, data_review_rid: str) -> str:
+def data_review_events_url(clients: HasScoutParams, run_rid: str, data_review_rid: str) -> str:
     return _resource_url(clients, f"/runs/{run_rid}/?tab=events&checklistExecution={data_review_rid}")
 
 
-def dataset_url(clients: _FrontendUrlClients, dataset_rid: str) -> str:
+def dataset_url(clients: HasScoutParams, dataset_rid: str) -> str:
     return _resource_url(clients, f"/datasets/{dataset_rid}")
 
 
-def ingestion_job_url(clients: _FrontendUrlClients, ingestion_job_rid: str) -> str:
+def ingestion_job_url(clients: HasScoutParams, ingestion_job_rid: str) -> str:
     return _resource_url(clients, f"/ingestion/{ingestion_job_rid}")
 
 
-def run_url(clients: _FrontendUrlClients, run_rid: str) -> str:
+def run_url(clients: HasScoutParams, run_rid: str) -> str:
     return _resource_url(clients, f"/runs/{run_rid}")
 
 
-def workbook_url(clients: _FrontendUrlClients, workbook_rid: str) -> str:
+def workbook_url(clients: HasScoutParams, workbook_rid: str) -> str:
     return _resource_url(clients, f"/workbooks/{workbook_rid}")
 
 
-def workbook_template_url(clients: _FrontendUrlClients, workbook_template_rid: str) -> str:
+def workbook_template_url(clients: HasScoutParams, workbook_template_rid: str) -> str:
     return _resource_url(clients, f"/workbooks/templates/{workbook_template_rid}")

--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -29,6 +29,7 @@ from nominal.core._utils.api_tools import (
     filter_scopes,
     rid_from_instance_or_string,
 )
+from nominal.core._utils.frontend_urls import asset_url
 from nominal.core._utils.pagination_tools import search_runs_by_asset_paginated
 from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.core.attachment import Attachment, _iter_get_attachments
@@ -81,7 +82,7 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
     @property
     def nominal_url(self) -> str:
         """Returns a link to the page for this Asset in the Nominal app"""
-        return f"{self._clients.app_base_url}/assets/{self.rid}"
+        return asset_url(self._clients, self.rid)
 
     def _get_latest_api(self) -> scout_asset_api.Asset:
         response = self._clients.assets.get_assets(self._clients.auth_header, [self.rid])

--- a/nominal/core/checklist.py
+++ b/nominal/core/checklist.py
@@ -17,6 +17,7 @@ from typing_extensions import Self
 from nominal.core import run as core_run
 from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin, rid_from_instance_or_string
+from nominal.core._utils.frontend_urls import checklist_preview_url, checklist_url
 from nominal.core.asset import Asset
 from nominal.core.data_review import DataReview
 from nominal.ts import _to_api_duration
@@ -165,9 +166,9 @@ class Checklist(HasRid, RefreshableConjureMixin[scout_checks_api.VersionedCheckl
     @property
     def nominal_url(self) -> str:
         """Returns a link to the page for this checklist in the Nominal app"""
-        return f"{self._clients.app_base_url}/checklists/{self.rid}"
+        return checklist_url(self._clients, self.rid)
 
     def preview_for_run_url(self, run: core_run.Run | str) -> str:
         """Returns a link to the page for previewing this checklist on a given run in the Nominal app"""
         run_rid = rid_from_instance_or_string(run)
-        return f"{self.nominal_url}?previewRunRid={run_rid}"
+        return checklist_preview_url(self._clients, self.rid, run_rid)

--- a/nominal/core/data_review.py
+++ b/nominal/core/data_review.py
@@ -21,6 +21,7 @@ from typing_extensions import Self
 from nominal.core._checklist_types import Priority, _conjure_priority_to_priority
 from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils.api_tools import HasRid, rid_from_instance_or_string
+from nominal.core._utils.frontend_urls import data_review_events_url, data_review_url
 from nominal.core._utils.pagination_tools import search_data_reviews_paginated
 from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.core.event import Event
@@ -118,14 +119,12 @@ class DataReview(HasRid):
     @property
     def nominal_url(self) -> str:
         """Returns a link to the page for this Data Review in the Nominal app"""
-        run = self._clients.run.get_run(self._clients.auth_header, self.run_rid)
-        return f"{self._clients.app_base_url}/runs/{run.run_number}/?tab=checklist-executions&checklistExecution={self.rid}&openCheckExecutionErrorReview="  # noqa: E501
+        return data_review_url(self._clients, self.run_rid, self.rid)
 
     @property
     def events_url(self) -> str:
         """Returns a link to the page for events for this Data Review in the Nominal app"""
-        run = self._clients.run.get_run(self._clients.auth_header, self.run_rid)
-        return f"{self._clients.app_base_url}/runs/{run.run_number}/?tab=events&checklistExecution={self.rid}"
+        return data_review_events_url(self._clients, self.run_rid, self.rid)
 
 
 @dataclass(frozen=True)

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -16,6 +16,7 @@ from nominal.core._stream.batch_processor import process_log_batch
 from nominal.core._stream.write_stream import LogStream, WriteStream
 from nominal.core._types import PathLike
 from nominal.core._utils.api_tools import RefreshableConjureMixin
+from nominal.core._utils.frontend_urls import dataset_url
 from nominal.core._utils.multipart import path_upload_name, upload_multipart_file, upload_multipart_io
 from nominal.core._utils.pagination_tools import search_dataset_files_paginated
 from nominal.core._utils.query_tools import create_search_dataset_files_query
@@ -57,7 +58,7 @@ class Dataset(DataSource, RefreshableConjureMixin[scout_catalog.EnrichedDataset]
     @property
     def nominal_url(self) -> str:
         """Returns a URL to the page in the nominal app containing this dataset"""
-        return f"{self._clients.app_base_url}/data-sources/{self.rid}"
+        return dataset_url(self._clients, self.rid)
 
     def _get_latest_api(self) -> scout_catalog.EnrichedDataset:
         return _get_dataset(self._clients.auth_header, self._clients.catalog, self.rid)

--- a/nominal/core/ingestion_job.py
+++ b/nominal/core/ingestion_job.py
@@ -9,6 +9,7 @@ from nominal_api import ingest_api
 from typing_extensions import Self
 
 from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin
+from nominal.core._utils.frontend_urls import ingestion_job_url
 from nominal.core.dataset_file import DatasetFile, _dataset_file_from_conjure
 from nominal.core.dataset_file import as_files_ingested as _as_files_ingested
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
@@ -134,7 +135,7 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
     @property
     def nominal_url(self) -> str:
         """Returns a link to the page for this ingest job in the Nominal app."""
-        return f"{self._clients.app_base_url}/ingestion/{self.rid}"
+        return ingestion_job_url(self._clients, self.rid)
 
     @classmethod
     def _from_conjure(cls, clients: _Clients, job: ingest_api.IngestJob) -> Self:

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -24,6 +24,7 @@ from nominal.core._utils.api_tools import (
     filter_scopes,
     rid_from_instance_or_string,
 )
+from nominal.core._utils.frontend_urls import run_url
 from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.query_tools import ArchiveStatusFilter, AssetMatch
 from nominal.core.attachment import Attachment, _iter_get_attachments
@@ -78,7 +79,7 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
     @property
     def nominal_url(self) -> str:
         """Returns a link to the page for this Run in the Nominal app"""
-        return f"{self._clients.app_base_url}/runs/{self.run_number}"
+        return run_url(self._clients, self.rid)
 
     def _get_latest_api(self) -> scout_run_api.Run:
         return self._clients.run.get_run(self._clients.auth_header, self.rid)

--- a/nominal/core/workbook.py
+++ b/nominal/core/workbook.py
@@ -10,6 +10,7 @@ from typing_extensions import Self
 
 from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin
+from nominal.core._utils.frontend_urls import workbook_url
 from nominal.core._utils.pagination_tools import search_workbooks_paginated
 from nominal.core._utils.query_tools import ArchiveStatusFilter, create_search_workbooks_query
 
@@ -115,7 +116,7 @@ class Workbook(HasRid, RefreshableConjureMixin[scout_notebook_api.Notebook]):
     @property
     def nominal_url(self) -> str:
         """Returns a link to the page for this Workbook in the Nominal app"""
-        return f"{self._clients.app_base_url}/workbooks/{self.rid}"
+        return workbook_url(self._clients, self.rid)
 
     def _get_latest_api(self) -> scout_notebook_api.Notebook:
         return self._clients.notebook.get(self._clients.auth_header, self.rid)

--- a/nominal/core/workbook_template.py
+++ b/nominal/core/workbook_template.py
@@ -15,6 +15,7 @@ from typing_extensions import Self
 
 from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin, rid_from_instance_or_string
+from nominal.core._utils.frontend_urls import workbook_template_url
 from nominal.core.asset import Asset
 from nominal.core.run import Run
 from nominal.core.workbook import Workbook, WorkbookType
@@ -85,7 +86,7 @@ class WorkbookTemplate(HasRid, RefreshableConjureMixin[scout_template_api.Templa
     @property
     def nominal_url(self) -> str:
         """Returns a link to the page for this Workbook Template in the Nominal app"""
-        return f"{self._clients.app_base_url}/workbooks/templates/{self.rid}"
+        return workbook_template_url(self._clients, self.rid)
 
     def _get_latest_api(self) -> scout_template_api.Template:
         return self._clients.template.get(self._clients.auth_header, self.rid)

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -436,3 +436,11 @@ def test_data_scope_journal_json_rejects_a_half_pair_before_resolving_the_scope(
             _StubWrapper().add_journal_json("scope", "logs.jsonl", **kwargs)
 
     get_scope.assert_not_called()
+
+
+def test_nominal_url_uses_the_current_datasets_route(mock_dataset, mock_clients):
+    """Dataset pages live under /datasets/, not the legacy /data-sources/ route."""
+    mock_clients.app_base_url = "https://app.nominal.test"
+    mock_clients.resolve_default_workspace_rid.return_value = "ri.workspace.test"
+
+    assert mock_dataset.nominal_url == "https://app.nominal.test/w/ri.workspace.test/datasets/test-rid"

--- a/tests/core/test_frontend_urls.py
+++ b/tests/core/test_frontend_urls.py
@@ -1,0 +1,69 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from nominal.core._utils.frontend_urls import (
+    asset_url,
+    checklist_preview_url,
+    checklist_url,
+    data_review_events_url,
+    data_review_url,
+    dataset_url,
+    ingestion_job_url,
+    run_url,
+    workbook_template_url,
+    workbook_url,
+)
+
+_APP_BASE_URL = "https://app.nominal.test"
+_WORKSPACE_RID = "ri.workspace.main.workspace.test"
+_RESOURCE_RID = "ri.resource.test"
+
+
+@pytest.fixture
+def clients() -> MagicMock:
+    clients = MagicMock()
+    clients.app_base_url = _APP_BASE_URL
+    clients.resolve_default_workspace_rid.return_value = _WORKSPACE_RID
+    return clients
+
+
+@pytest.mark.parametrize(
+    ("url_builder", "expected_path"),
+    [
+        (lambda clients: asset_url(clients, _RESOURCE_RID), f"assets/{_RESOURCE_RID}"),
+        (lambda clients: checklist_url(clients, _RESOURCE_RID), f"checklists/{_RESOURCE_RID}"),
+        (lambda clients: dataset_url(clients, _RESOURCE_RID), f"datasets/{_RESOURCE_RID}"),
+        (lambda clients: ingestion_job_url(clients, _RESOURCE_RID), f"ingestion/{_RESOURCE_RID}"),
+        (lambda clients: run_url(clients, "ri.run.test"), "runs/ri.run.test"),
+        (lambda clients: workbook_url(clients, _RESOURCE_RID), f"workbooks/{_RESOURCE_RID}"),
+        (
+            lambda clients: workbook_template_url(clients, _RESOURCE_RID),
+            f"workbooks/templates/{_RESOURCE_RID}",
+        ),
+    ],
+)
+def test_resource_url_includes_workspace_prefix(clients, url_builder, expected_path):
+    assert url_builder(clients) == f"{_APP_BASE_URL}/w/{_WORKSPACE_RID}/{expected_path}"
+
+
+def test_checklist_preview_url_includes_workspace_prefix(clients):
+    assert checklist_preview_url(clients, _RESOURCE_RID, "ri.run.test") == (
+        f"{_APP_BASE_URL}/w/{_WORKSPACE_RID}/checklists/{_RESOURCE_RID}?previewRunRid=ri.run.test"
+    )
+
+
+def test_data_review_urls_include_workspace_prefix(clients):
+    assert data_review_url(clients, "ri.run.test", _RESOURCE_RID) == (
+        f"{_APP_BASE_URL}/w/{_WORKSPACE_RID}/runs/ri.run.test/"
+        f"?tab=checklist-executions&checklistExecution={_RESOURCE_RID}&openCheckExecutionErrorReview="
+    )
+    assert data_review_events_url(clients, "ri.run.test", _RESOURCE_RID) == (
+        f"{_APP_BASE_URL}/w/{_WORKSPACE_RID}/runs/ri.run.test/?tab=events&checklistExecution={_RESOURCE_RID}"
+    )
+
+
+def test_resource_url_resolves_the_default_workspace(clients):
+    asset_url(clients, _RESOURCE_RID)
+
+    clients.resolve_default_workspace_rid.assert_called_once_with()

--- a/tests/core/test_frontend_urls.py
+++ b/tests/core/test_frontend_urls.py
@@ -2,22 +2,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from nominal.core._utils.frontend_urls import (
-    asset_url,
-    checklist_preview_url,
-    checklist_url,
-    data_review_events_url,
-    data_review_url,
-    dataset_url,
-    ingestion_job_url,
-    run_url,
-    workbook_template_url,
-    workbook_url,
-)
+from nominal.core._utils.frontend_urls import asset_url
 
 _APP_BASE_URL = "https://app.nominal.test"
 _WORKSPACE_RID = "ri.workspace.main.workspace.test"
-_RESOURCE_RID = "ri.resource.test"
 
 
 @pytest.fixture
@@ -28,42 +16,9 @@ def clients() -> MagicMock:
     return clients
 
 
-@pytest.mark.parametrize(
-    ("url_builder", "expected_path"),
-    [
-        (lambda clients: asset_url(clients, _RESOURCE_RID), f"assets/{_RESOURCE_RID}"),
-        (lambda clients: checklist_url(clients, _RESOURCE_RID), f"checklists/{_RESOURCE_RID}"),
-        (lambda clients: dataset_url(clients, _RESOURCE_RID), f"datasets/{_RESOURCE_RID}"),
-        (lambda clients: ingestion_job_url(clients, _RESOURCE_RID), f"ingestion/{_RESOURCE_RID}"),
-        (lambda clients: run_url(clients, "ri.run.test"), "runs/ri.run.test"),
-        (lambda clients: workbook_url(clients, _RESOURCE_RID), f"workbooks/{_RESOURCE_RID}"),
-        (
-            lambda clients: workbook_template_url(clients, _RESOURCE_RID),
-            f"workbooks/templates/{_RESOURCE_RID}",
-        ),
-    ],
-)
-def test_resource_url_includes_workspace_prefix(clients, url_builder, expected_path):
-    assert url_builder(clients) == f"{_APP_BASE_URL}/w/{_WORKSPACE_RID}/{expected_path}"
+@pytest.mark.parametrize("base_url", [_APP_BASE_URL, f"{_APP_BASE_URL}/"])
+def test_resource_urls_are_workspace_scoped_without_double_slashes(clients, base_url):
+    """Callers pass leading-slash paths, and app_base_url may carry a trailing slash."""
+    clients.app_base_url = base_url
 
-
-def test_checklist_preview_url_includes_workspace_prefix(clients):
-    assert checklist_preview_url(clients, _RESOURCE_RID, "ri.run.test") == (
-        f"{_APP_BASE_URL}/w/{_WORKSPACE_RID}/checklists/{_RESOURCE_RID}?previewRunRid=ri.run.test"
-    )
-
-
-def test_data_review_urls_include_workspace_prefix(clients):
-    assert data_review_url(clients, "ri.run.test", _RESOURCE_RID) == (
-        f"{_APP_BASE_URL}/w/{_WORKSPACE_RID}/runs/ri.run.test/"
-        f"?tab=checklist-executions&checklistExecution={_RESOURCE_RID}&openCheckExecutionErrorReview="
-    )
-    assert data_review_events_url(clients, "ri.run.test", _RESOURCE_RID) == (
-        f"{_APP_BASE_URL}/w/{_WORKSPACE_RID}/runs/ri.run.test/?tab=events&checklistExecution={_RESOURCE_RID}"
-    )
-
-
-def test_resource_url_resolves_the_default_workspace(clients):
-    asset_url(clients, _RESOURCE_RID)
-
-    clients.resolve_default_workspace_rid.assert_called_once_with()
+    assert asset_url(clients, "ri.asset.test") == f"{_APP_BASE_URL}/w/{_WORKSPACE_RID}/assets/ri.asset.test"

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -69,3 +69,11 @@ def test_search_events_empty_assets_returns_no_events(make_run, mock_clients):
 
     assert result == []
     mock_clients.event.search_events.assert_not_called()
+
+
+def test_nominal_url_identifies_the_run_by_rid(mock_run, mock_clients):
+    """Run pages are addressed by rid: the app no longer serves run-number URLs."""
+    mock_clients.app_base_url = "https://app.nominal.test"
+    mock_clients.resolve_default_workspace_rid.return_value = "ri.workspace.test"
+
+    assert mock_run.nominal_url == "https://app.nominal.test/w/ri.workspace.test/runs/run-rid-1"


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Centralizes frontend resource URL construction and prefixes each route with `/w/{workspaceRid}`.
Updates run links to use run RIDs, dataset links to use `/datasets`, and removes data-review run lookups.
Tests: `just test` and `just check`.