### PR TITLE
chore: bump PR review to Claude 5 models

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -44,7 +44,7 @@ jobs:
         uses: anthropics/claude-code-action@dde2242db6af13460b916652159b6ba19a598f30 # v1.0.120
         env:
           # Run subagents using cheaper, faster agents while leaving higher level thinking
-          # to the higher tier model (opus 4.8)
+          # to the higher tier model (opus 5)
           CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-6
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -138,6 +138,6 @@ jobs:
           #   - `Skill` is granted so the review can invoke the thermo-nuclear-code-quality-review
           #     skill; without it the Skill tool is blocked and the skill silently never loads.
           claude_args: |
-            --model claude-opus-4-8
+            --model claude-opus-5
             --max-turns 100
             --allowedTools "Skill,mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),mcp__github__get_pull_request_comments,mcp__github__get_pull_request_reviews,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(cat:*),Bash(ls:*),Bash(find:*),Bash(wc:*),WebFetch,WebSearch"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           # Run subagents using cheaper, faster agents while leaving higher level thinking
           # to the higher tier model (opus 5)
-          CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-6
+          CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-5
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: Review with Claude
-        uses: anthropics/claude-code-action@dde2242db6af13460b916652159b6ba19a598f30 # v1.0.120
+        uses: anthropics/claude-code-action@e0cf66d1d257526b5d07f141838c338921cb8455 # v1.0.182
         env:
           # Run subagents using cheaper, faster agents while leaving higher level thinking
           # to the higher tier model (opus 5)


### PR DESCRIPTION
Moves the Claude Code Review action onto the Claude 5 family and updates the pinned action.

## Changes

| Setting | Before | After |
| --- | --- | --- |
| Review model (`claude_args --model`) | `claude-opus-4-8` | `claude-opus-5` |
| Subagent model (`CLAUDE_CODE_SUBAGENT_MODEL`) | `claude-sonnet-4-6` | `claude-sonnet-5` |
| `anthropics/claude-code-action` | `dde2242d` (v1.0.120) | `e0cf66d1` (v1.0.182) |

Also updated the adjacent comment that named the higher-tier model as "opus 4.8".

The cheaper-subagents / higher-tier-orchestrator split is preserved: Sonnet 5 ($3/$15 per MTok) stays the cheaper tier relative to the Opus 5 review model ($5/$25 per MTok), so the comment above the env var remains accurate.

## On the code-review plugin

The `code-review` plugin has no version to bump. The action's `plugins` input takes `name@marketplace` only — there is no version component in the syntax — and the marketplace manifest pins the plugin at `1.0.0` sourced from a directory on the marketplace repo's default branch. Every run already resolves the newest plugin code, so there is nothing to pin forward.

## Verification

- Both model IDs are exact, with no date suffix.
- All ten action inputs this workflow passes (`anthropic_api_key`, `track_progress`, `allowed_bots`, `plugin_marketplaces`, `plugins`, `classify_inline_comments`, `include_fix_links`, `additional_permissions`, `prompt`, `claude_args`) still exist and are undeprecated at v1.0.182.
- No release notes between v1.0.120 and v1.0.182 mention breaking changes, removals, or renames.
- The new pin is the dereferenced commit SHA of the `v1.0.182` annotated tag, not the tag object.
- Workflow still parses as valid YAML with all settings resolving as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)