### PR TITLE
fix(tests): scope dataset archive-status search to its own datasets

### DIFF
--- a/tests/e2e/test_search.py
+++ b/tests/e2e/test_search.py
@@ -69,6 +69,8 @@ class ArchiveSearchContext:
 
     archived_run: Run
     archived_asset: Asset
+    dataset_tag: str
+    active_dataset: Dataset
     archived_dataset: Dataset
     active_secret: Secret
     archived_secret: Secret
@@ -215,7 +217,12 @@ def archive_search_context(  # noqa: PLR0915
     )
     archived_asset.archive()
 
-    archived_dataset = client.create_dataset(f"dataset-archived-{search_context.tag}")
+    # Videos are dual-written as datasets sharing the video's name, so the session tag alone matches
+    # the fixture's videos too: dataset search needs a tag that only its own datasets carry. The test
+    # filters on exact_match, since dataset search_text is tokenized and would match the tag alone.
+    dataset_tag = f"archive-dataset-{search_context.tag}"
+    active_dataset = client.create_dataset(f"{dataset_tag}-active")
+    archived_dataset = client.create_dataset(f"{dataset_tag}-archived")
     archived_dataset.archive()
 
     active_secret = client.create_secret(f"secret-active-{search_context.tag}", "active secret value")
@@ -295,6 +302,8 @@ def archive_search_context(  # noqa: PLR0915
     ctx = ArchiveSearchContext(
         archived_run=archived_run,
         archived_asset=archived_asset,
+        dataset_tag=dataset_tag,
+        active_dataset=active_dataset,
         archived_dataset=archived_dataset,
         active_secret=active_secret,
         archived_secret=archived_secret,
@@ -331,6 +340,7 @@ def archive_search_context(  # noqa: PLR0915
     active_secret.archive()
     archived_secret.archive()
     archived_video.archive()
+    active_dataset.archive()
     archived_dataset.archive()
     archived_asset.archive()
     archived_run.archive()
@@ -502,16 +512,15 @@ def test_search_videos_archive_status(
 
 def test_search_datasets_archive_status(
     client: NominalClient,
-    search_context: SearchContext,
     archive_search_context: ArchiveSearchContext,
 ) -> None:
     """Dataset search honors archive_status filtering."""
     _assert_archive_status_behavior(
         lambda archive_status: client.search_datasets(
-            search_text=search_context.tag,
+            exact_match=archive_search_context.dataset_tag,
             archive_status=archive_status,
         ),
-        active_rids={search_context.dataset.rid},
+        active_rids={archive_search_context.active_dataset.rid},
         archived_rids={archive_search_context.archived_dataset.rid},
     )
 

--- a/tests/e2e/test_search.py
+++ b/tests/e2e/test_search.py
@@ -218,8 +218,7 @@ def archive_search_context(  # noqa: PLR0915
     archived_asset.archive()
 
     # Videos are dual-written as datasets sharing the video's name, so the session tag alone matches
-    # the fixture's videos too: dataset search needs a tag that only its own datasets carry. The test
-    # filters on exact_match, since dataset search_text is tokenized and would match the tag alone.
+    # the fixture's videos too: dataset search needs a tag that only its own datasets carry.
     dataset_tag = f"archive-dataset-{search_context.tag}"
     active_dataset = client.create_dataset(f"{dataset_tag}-active")
     archived_dataset = client.create_dataset(f"{dataset_tag}-archived")
@@ -517,6 +516,8 @@ def test_search_datasets_archive_status(
     """Dataset search honors archive_status filtering."""
     _assert_archive_status_behavior(
         lambda archive_status: client.search_datasets(
+            # exact_match, not search_text: dataset search_text is tokenized, so even this compound
+            # tag matches every resource carrying the session tag.
             exact_match=archive_search_context.dataset_tag,
             archive_status=archive_status,
         ),


### PR DESCRIPTION
## Why

`test_search_datasets_archive_status` has been failing on `main` ([run 30395772598](https://github.com/nominal-io/nominal-client/actions/runs/30395772598/job/90398164037)) with one extra dataset in the `NOT_ARCHIVED` result set.

Videos now also surface as datasets in dataset search, carrying the video's name and mirroring its archive state. The search fixture creates `video-{tag}` and `video-archived-{tag}` alongside its datasets, so `search_datasets(search_text=tag)` legitimately returned two non-archived datasets while the test asserted exact equality against one.

This is not a regression in the SDK's archive handling. Verified against staging: `NOT_ARCHIVED` / `ARCHIVED` / `ANY` partition the fixture's rows exactly as intended, and the results are identical for `workspace=DEFAULT` and `workspace=ALL`, so the search-workspace default is not implicated either.

## What

- Give the dataset archive-status case its own resources in `archive_search_context`: an `archive-dataset-{tag}-active` / `archive-dataset-{tag}-archived` pair, archived in teardown alongside the rest.
- Filter with `exact_match=dataset_tag` instead of `search_text=tag`.

`search_text` cannot do this job: dataset search tokenizes it, so even a dataset-specific compound tag matches every resource carrying the session tag. Measured against staging with a session dataset, the archive pair, and two videos in scope:

| filter | NOT_ARCHIVED | ARCHIVED | ANY |
| --- | --- | --- | --- |
| `search_text` | 3 hits (want 1) | 2 hits (want 1) | 5 hits (want 2) |
| `exact_match` | ✅ | ✅ | ✅ |
| `labels` | ✅ | ✅ | ✅ |
| `properties` | ✅ | ✅ | ✅ |

`exact_match` keeps the case on the name-text path; `labels` and `properties` were equally correct if we'd rather match on terms.

## Testing

Against the `staging` profile:

- `pytest tests/e2e/test_search.py::test_search_datasets_archive_status` — passes (fails on `main` with the same assertion as CI).
- `pytest tests/e2e/test_search.py` — 30 passed.
- `ruff check`, `ruff format --check`, `mypy` — clean.

## Follow-up (not in this PR)

Videos surfacing in `search_datasets` affects every caller of that method, not just this test, and there is no field on the dataset search query that would let the SDK filter them out. Worth confirming with the video team whether that visibility is intended for the migration window.

## Docs impact

- [x] **Is this a user-facing change?** No — e2e test isolation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
