### PR TITLE
docs: correct exact_match and search_text semantics in search methods

### DIFF
--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -380,16 +380,17 @@ class NominalClient:
         workspace: WorkspaceSearchT | None = WorkspaceSearchType.DEFAULT,
         archive_status: ArchiveStatusFilter = ArchiveStatusFilter.NOT_ARCHIVED,
     ) -> Sequence[Dataset]:
-        """Search for datasets the specified filters.
-        Filters are ANDed together, e.g. `(secret.label == label) AND (secret.property == property)`
+        """Search for datasets meeting the specified filters.
+        Filters are ANDed together, e.g. `(dataset.label == label) AND (dataset.property == property)`
 
         Args:
-            exact_match: Searches for an exact substring of dataset name
-            search_text: Searches for a (case-insensitive) substring across all text fields.
-            labels: A sequence of labels that must ALL be present on a secret to be included.
-            properties: A mapping of key-value pairs that must ALL be present on a secret to be included.
-            before: Searches for datasets created before some time (inclusive).
-            after: Searches for datasets created before after time (inclusive).
+            exact_match: Case-insensitive substring of the dataset's name, description, labels, or properties.
+            search_text: Fuzzy (tokenized and similarity) match across those same fields, so results need not
+                contain the given text verbatim.
+            labels: A sequence of labels that must ALL be present on a dataset to be included.
+            properties: A mapping of key-value pairs that must ALL be present on a dataset to be included.
+            before: Searches for datasets ingested before some time (inclusive).
+            after: Searches for datasets ingested after some time (inclusive).
             workspace: Filters search to given workspace.
             archive_status: Filter results to the given archive status.
 
@@ -711,8 +712,9 @@ class NominalClient:
             name_substring: Searches for a (case-insensitive) substring in the name.
             labels: A sequence of labels that must ALL be present on a run to be included.
             properties: A mapping of key-value pairs that must ALL be present on a run to be included.
-            exact_match: A case-insensitive substring that must be matched exactly.
-            search_text: A case-insensitive substring to perform fuzzy-search on all fields with
+            exact_match: Case-insensitive substring of the run's name, description, labels, or properties.
+            search_text: Fuzzy (tokenized and similarity) match across those same fields, so results need not
+                contain the given text verbatim.
             created_after: Filter runs created after this timestamp (exclusive).
             created_before: Filter runs created before this timestamp (exclusive).
             workspace: Filters search to given workspace.
@@ -1507,8 +1509,8 @@ class NominalClient:
         Filters are ANDed together, e.g. `(workbook.label == label) AND (workbook.created_by == "rid")`
 
         Args:
-            exact_match: Searches for a string to match exactly in the workbook's metadata
-            search_text: Fuzzy-searches for a string in the workbook's metadata
+            exact_match: Case-insensitive substring of the workbook's title.
+            search_text: Case-insensitive substring of the workbook's title or description.
             labels: A list of labels that must ALL be present on an workbook to be included.
             properties: A mapping of key-value pairs that must ALL be present on an workbook to be included.
             asset: Searches for workbooks that include the given asset
@@ -1578,8 +1580,8 @@ class NominalClient:
         Filters are ANDed together, e.g. `(workbook.label == label) AND (workbook.author_rid == "rid")`
 
         Args:
-            exact_match: Searches for a string to match exactly in the template's metadata
-            search_text: Fuzzy-searches for a string in the template's metadata
+            exact_match: Case-insensitive substring of the template's title.
+            search_text: Fuzzy (similarity) match against the template's title or description.
             labels: A list of labels that must ALL be present on an workbook to be included.
             properties: A mapping of key-value pairs that must ALL be present on an workbook to be included.
             created_by: Searches for workbook templates with the given creator's rid

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -1178,7 +1178,8 @@ class NominalClient:
             search_text: case-insensitive search for any of the keywords in all string fields
             labels: A sequence of labels that must ALL be present on a asset to be included.
             properties: A mapping of key-value pairs that must ALL be present on a asset to be included.
-            exact_substring: case-insensitive search for exact string match in all string fields
+            exact_substring: Case-insensitive substring of the asset's name, description, labels or properties.
+                Unlike `search_text`, results always contain the given text verbatim.
             workspace: Filters search to given workspace.
             archive_status: Filter by archive status. Defaults to NOT_ARCHIVED.
 

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -385,8 +385,8 @@ class NominalClient:
 
         Args:
             exact_match: Case-insensitive substring of the dataset's name, description, labels, or properties.
-            search_text: Fuzzy (tokenized and similarity) match across those same fields, so results need not
-                contain the given text verbatim.
+            search_text: Fuzzy match: tokenized across name, description, labels, and properties, plus similarity
+                on name and description, so results need not contain the given text verbatim.
             labels: A sequence of labels that must ALL be present on a dataset to be included.
             properties: A mapping of key-value pairs that must ALL be present on a dataset to be included.
             before: Searches for datasets ingested before some time (inclusive).
@@ -509,7 +509,8 @@ class NominalClient:
         Filters are ANDed together, e.g. `(secret.label == label) AND (secret.property == property)`
 
         Args:
-            search_text: Searches for a (case-insensitive) substring across all text fields.
+            search_text: Fuzzy match: tokenized across name, description, labels, and properties, plus similarity
+                on name and description, so results need not contain the given text verbatim.
             labels: A sequence of labels that must ALL be present on a secret to be included.
             properties: A mapping of key-value pairs that must ALL be present on a secret to be included.
             workspace: Filters search to given workspace.
@@ -553,7 +554,8 @@ class NominalClient:
         Filters are ANDed together, e.g. `(video.label == label) AND (video.property == property)`
 
         Args:
-            search_text: Searches for a (case-insensitive) substring across all text fields.
+            search_text: Fuzzy match: tokenized across name, description, labels, and properties, plus similarity
+                on name and description, so results need not contain the given text verbatim.
             labels: A sequence of labels that must ALL be present on a video to be included.
             properties: A mapping of key-value pairs that must ALL be present on a video to be included.
             workspace: Filters search to given workspace.
@@ -709,12 +711,13 @@ class NominalClient:
         Args:
             start: Inclusive start time for filtering runs.
             end: Inclusive end time for filtering runs.
-            name_substring: Searches for a (case-insensitive) substring in the name.
+            name_substring: Alias for `exact_match`: despite the name, this matches a case-insensitive substring
+                of the run's name, description, labels, or properties.
             labels: A sequence of labels that must ALL be present on a run to be included.
             properties: A mapping of key-value pairs that must ALL be present on a run to be included.
             exact_match: Case-insensitive substring of the run's name, description, labels, or properties.
-            search_text: Fuzzy (tokenized and similarity) match across those same fields, so results need not
-                contain the given text verbatim.
+            search_text: Fuzzy match: tokenized across name, description, labels, and properties, plus similarity
+                on name and description, so results need not contain the given text verbatim.
             created_after: Filter runs created after this timestamp (exclusive).
             created_before: Filter runs created before this timestamp (exclusive).
             workspace: Filters search to given workspace.

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -712,7 +712,8 @@ class NominalClient:
             start: Inclusive start time for filtering runs.
             end: Inclusive end time for filtering runs.
             name_substring: Alias for `exact_match`: despite the name, this matches a case-insensitive substring
-                of the run's name, description, labels, or properties.
+                of the run's name, description, labels, or properties. For name-only matching, filter the
+                returned runs on their names.
             labels: A sequence of labels that must ALL be present on a run to be included.
             properties: A mapping of key-value pairs that must ALL be present on a run to be included.
             exact_match: Case-insensitive substring of the run's name, description, labels, or properties.

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -385,8 +385,9 @@ class NominalClient:
 
         Args:
             exact_match: Case-insensitive substring of the dataset's name, description, labels, or properties.
-            search_text: Fuzzy match: tokenized across name, description, labels, and properties, plus similarity
-                on name and description, so results need not contain the given text verbatim.
+            search_text: Fuzzy match: tokenized across name, description, labels, and properties, with additional
+                substring and similarity matching on name and description, so results need not contain the given
+                text verbatim.
             labels: A sequence of labels that must ALL be present on a dataset to be included.
             properties: A mapping of key-value pairs that must ALL be present on a dataset to be included.
             before: Searches for datasets ingested before some time (inclusive).
@@ -509,8 +510,9 @@ class NominalClient:
         Filters are ANDed together, e.g. `(secret.label == label) AND (secret.property == property)`
 
         Args:
-            search_text: Fuzzy match: tokenized across name, description, labels, and properties, plus similarity
-                on name and description, so results need not contain the given text verbatim.
+            search_text: Fuzzy match: tokenized across name, description, labels, and properties, with additional
+                substring and similarity matching on name and description, so results need not contain the given
+                text verbatim.
             labels: A sequence of labels that must ALL be present on a secret to be included.
             properties: A mapping of key-value pairs that must ALL be present on a secret to be included.
             workspace: Filters search to given workspace.
@@ -554,8 +556,9 @@ class NominalClient:
         Filters are ANDed together, e.g. `(video.label == label) AND (video.property == property)`
 
         Args:
-            search_text: Fuzzy match: tokenized across name, description, labels, and properties, plus similarity
-                on name and description, so results need not contain the given text verbatim.
+            search_text: Fuzzy match: tokenized across name, description, labels, and properties, with additional
+                substring and similarity matching on name and description, so results need not contain the given
+                text verbatim.
             labels: A sequence of labels that must ALL be present on a video to be included.
             properties: A mapping of key-value pairs that must ALL be present on a video to be included.
             workspace: Filters search to given workspace.
@@ -717,8 +720,9 @@ class NominalClient:
             labels: A sequence of labels that must ALL be present on a run to be included.
             properties: A mapping of key-value pairs that must ALL be present on a run to be included.
             exact_match: Case-insensitive substring of the run's name, description, labels, or properties.
-            search_text: Fuzzy match: tokenized across name, description, labels, and properties, plus similarity
-                on name and description, so results need not contain the given text verbatim.
+            search_text: Fuzzy match: tokenized across name, description, labels, and properties, with additional
+                substring and similarity matching on name and description, so results need not contain the given
+                text verbatim.
             created_after: Filter runs created after this timestamp (exclusive).
             created_before: Filter runs created before this timestamp (exclusive).
             workspace: Filters search to given workspace.
@@ -1175,10 +1179,12 @@ class NominalClient:
         Filters are ANDed together, e.g. `(asset.label == label) AND (asset.search_text =~ field)`
 
         Args:
-            search_text: case-insensitive search for any of the keywords in all string fields
+            search_text: Fuzzy match: tokenized across name, description, labels, and properties, with additional
+                substring and similarity matching on name and description, so results need not contain the given
+                text verbatim.
             labels: A sequence of labels that must ALL be present on a asset to be included.
             properties: A mapping of key-value pairs that must ALL be present on a asset to be included.
-            exact_substring: Case-insensitive substring of the asset's name, description, labels or properties.
+            exact_substring: Case-insensitive substring of the asset's name, description, labels, or properties.
                 Unlike `search_text`, results always contain the given text verbatim.
             workspace: Filters search to given workspace.
             archive_status: Filter by archive status. Defaults to NOT_ARCHIVED.

--- a/tests/e2e/test_search.py
+++ b/tests/e2e/test_search.py
@@ -351,7 +351,11 @@ def archive_search_context(  # noqa: PLR0915
 
 
 def test_search_runs_by_name_substring(client: NominalClient, search_context: SearchContext) -> None:
-    """Searching runs by name_substring returns only runs whose name contains the session tag."""
+    """Searching runs by name_substring narrows results to the run carrying the session tag.
+
+    name_substring is an alias for exact_match, which matches a run's name, description, labels and
+    properties, so this covers narrowing by the tag rather than name-scoped matching.
+    """
     results = client.search_runs(name_substring=search_context.tag)
     rids = {r.rid for r in results}
     assert rids == {search_context.run.rid}

--- a/tests/e2e/test_search.py
+++ b/tests/e2e/test_search.py
@@ -42,7 +42,11 @@ class SearchContext:
     """Unique 32-character hex string embedded in all entity names for isolation."""
 
     run: Run
-    """Plain run with search-test label and property."""
+    """Plain run with search-test label and properties.
+
+    Carries a `prop-only` property whose value appears nowhere in the run's name, so a search
+    matching on it can only have matched a non-name field.
+    """
 
     asset: Asset
     """Asset with search-test label and property; all baseline test events are attached here."""
@@ -134,7 +138,7 @@ def search_context(client: NominalClient, mp4_data: bytes) -> Iterator[SearchCon
         start,
         end,
         labels=["search-test"],
-        properties={"search-tag": tag},
+        properties={"search-tag": tag, "prop-only": f"proponly{tag}"},
     )
 
     event_info = client.create_event(f"event-info-{tag}", EventType.INFO, start, assets=[asset])
@@ -351,19 +355,24 @@ def archive_search_context(  # noqa: PLR0915
 
 
 def test_search_runs_by_name_substring(client: NominalClient, search_context: SearchContext) -> None:
-    """Searching runs by name_substring narrows results to the run carrying the session tag.
-
-    name_substring is an alias for exact_match, which matches a run's name, description, labels and
-    properties, so this covers narrowing by the tag rather than name-scoped matching.
-    """
+    """Searching runs by name_substring narrows results to the run carrying the session tag."""
     results = client.search_runs(name_substring=search_context.tag)
+    rids = {r.rid for r in results}
+    assert rids == {search_context.run.rid}
+
+
+def test_search_runs_by_name_substring_matches_non_name_fields(
+    client: NominalClient, search_context: SearchContext
+) -> None:
+    """name_substring matches a run by a property value absent from its name, so it is not name-scoped."""
+    results = client.search_runs(name_substring=f"proponly{search_context.tag}")
     rids = {r.rid for r in results}
     assert rids == {search_context.run.rid}
 
 
 def test_search_runs_by_labels(client: NominalClient, search_context: SearchContext) -> None:
     """Filtering by a label narrows results to only the run created with that label."""
-    results = client.search_runs(labels=["search-test"], name_substring=search_context.tag)
+    results = client.search_runs(labels=["search-test"], exact_match=search_context.tag)
     rids = {r.rid for r in results}
     assert rids == {search_context.run.rid}
 
@@ -383,7 +392,7 @@ def test_search_runs_archive_status(
     """Run search honors archive_status filtering."""
     _assert_archive_status_behavior(
         lambda archive_status: client.search_runs(
-            name_substring=search_context.tag,
+            exact_match=search_context.tag,
             archive_status=archive_status,
         ),
         active_rids={search_context.run.rid},
@@ -397,7 +406,7 @@ def test_search_runs_archive_status(
 
 
 def test_search_assets_by_name(client: NominalClient, search_context: SearchContext) -> None:
-    """Searching assets by name substring returns only the asset whose name contains the session tag."""
+    """Searching assets by search_text narrows results to the asset carrying the session tag."""
     results = client.search_assets(search_text=search_context.tag)
     rids = {a.rid for a in results}
     assert rids == {search_context.asset.rid}


### PR DESCRIPTION
## Why

Follow-up to #899. That test broke because we trusted `search_datasets`' docstring, which described `search_text` as "a (case-insensitive) substring across all text fields" — implying a longer, more specific string would narrow the results. It doesn't. Auditing the neighbouring filters turned up several more claims that mislead callers the same way, including one parameter that doesn't do what its name says at all.

Docstrings plus e2e test coverage for the one claim that had none. No behavior change.

## What I measured

All of it against a `staging` profile using only public SDK calls: create a throwaway resource carrying a unique token in **exactly one** field, then search for it.

Where a claim is about *mechanism* rather than field surface, each search runs twice — once for the token, once for a **near miss**, the same token with its last character changed so it is a substring of nothing that exists. A near-miss hit can only come from similarity matching; a near-miss miss means literal or token matching.

**`exact_match` is not name-scoped**, though `search_datasets` documented it as "an exact substring of dataset name":

| token lives in | `search_datasets(exact_match=…)` | `search_runs(exact_match=…)` |
| --- | --- | --- |
| description only | match | match |
| label only | match | match |
| property only | match | match |

**`search_text` is two mechanisms with different scopes**, which is why the new wording names them separately instead of saying "all text fields":

| token lives in | `search_text=token` | `search_text=near miss` |
| --- | --- | --- |
| name only | match | match |
| description only | match | match |
| label only | match | **no** |
| property only | match | **no** |

Token matching spans name, description, labels and properties; similarity is confined to name and description.

**The same result holds on secrets and videos**, which review correctly flagged as carrying a claim measured only on datasets:

| token lives in | secrets: token | secrets: near miss | videos: token | videos: near miss |
| --- | --- | --- | --- | --- |
| name only | match | match | match | match |
| description only | match | match | match | match |
| label only | match | **no** | match | **no** |
| property only | match | **no** | match | **no** |

**Workbook and template `search_text` genuinely differ**, so the asymmetry in the corrected prose is deliberate, not an oversight:

| search | `search_text=token` | `search_text=near miss` |
| --- | --- | --- |
| `search_workbook_templates` | match | **match** |
| `search_workbooks` | match | **no** |

Template search finds a title it was never given verbatim; workbook search doesn't.

**Workbook and template `exact_match` really is title-only** — narrower than the four-field surface above, so it was worth settling rather than assuming:

| token lives in | `search_workbook_templates(exact_match=…)` | `search_workbooks(exact_match=…)` |
| --- | --- | --- |
| title only | match | match |
| description only | **no** | **no** |
| label only | **no** | n/a |
| property only | **no** | n/a |

The near miss never matched either, so both are literal containment. Workbooks are probeable only on title and description, the only fields settable at creation.

**`search_assets(exact_substring=…)` covers all four fields and always matches verbatim** — so "all string fields" was the accurate half of its old description and "exact string match" was the misleading half. Token matched from name, description, label and property alike; the near miss matched from none of them.

## Grounded against the backend, not only the probes

The probes say *what* happens; they can't say *why*, or warn about behavior no fixture happens to exercise. So every corrected sentence was also checked against the server-side matching. All of them hold, and two things surfaced that black-box probing could not:

- The text filters on **datasets, runs, secrets, videos and assets are one shared implementation**, not five that happen to agree. That is the real answer to "separate services could diverge" — here they cannot, and workbooks and templates are the exception that proves it, being the two with their own text handling and the two where behavior actually splits.
- `search_text` also matches **name and description by plain substring**, on top of the tokenization and similarity already documented. A mid-word fragment matches a name but not a label. The earlier wording didn't imply that, so it's now stated.

## `name_substring` doesn't search the name

Surfaced by review of the first pass, two lines above the text I was already correcting. `search_runs(name_substring=…)` is sent as the *same* filter as `exact_match`, and the run search query exposes no name-scoped field at all — so it cannot be name-only. Measured on a run whose **name contains neither token**:

| token lives in | `search_runs(name_substring=…)` | `search_runs(exact_match=…)` |
| --- | --- | --- |
| description only | match | match |
| property only | match | match |

So anyone filtering runs by `name_substring` today is silently matching descriptions, labels and properties too. It is now documented as an alias, and callers needing name-only matching are told to filter the returned runs themselves — the only option available today. Whether the parameter should survive is an API question, deliberately left out of a docs PR; the regression test added below is what makes either answer safe to pick later.

## Changes

- `search_datasets` / `search_runs`: real field surface for `exact_match`; `search_text` described as token matching across name/description/labels/properties, plus substring and similarity on name and description.
- `search_runs`: `name_substring` documented as an `exact_match` alias, with guidance for name-only matching.
- `search_secrets` / `search_videos` / `search_assets`: the same corrected `search_text` wording. All three run the shared implementation, and `search_assets` was the last copy still describing it in its own words.
- `search_assets`: `exact_substring` is a substring across name, description, labels and properties — not an "exact string match" — with the contrast against `search_text` made explicit, since that is the choice a caller is actually making.
- `search_workbooks` / `search_workbook_templates`: `exact_match` is a title substring, not an exact match on "metadata"; `search_text` is scoped to title/description.
- `search_datasets` housekeeping in the same docstring: the summary line and `labels`/`properties` text described *secrets* (copy-paste), and `before`/`after` said "created" when both filters are on ingest time.
- `tests/e2e/test_search.py`:
  - New `test_search_runs_by_name_substring_matches_non_name_fields`. The run fixture now carries a property whose value appears nowhere in its name, and the test asserts `name_substring` matches it — so the alias claim this PR publishes is pinned by an assertion, and a filter later narrowed to name-only fails loudly instead of passing silently.
  - `test_search_runs_by_name_substring` docstring collapsed to the file's one-line convention.
  - `test_search_runs_by_labels` and `test_search_runs_archive_status` used `name_substring=` purely to narrow to the session tag; they now use `exact_match=`, an identical request, so the suite stops modelling the misleading spelling.
  - `test_search_assets_by_name` claimed name-scoped matching it cannot verify — its asset carries the session tag as a property too. Docstring corrected; assertion unchanged and still valid.

## Deliberately not included

- `search_users` and `search_checklists`: their text filters do not run the shared path, and I did not measure them. `search_checklists` keeps its "keywords in all string fields" wording, which is at least token-flavoured rather than claiming substring.
- Deprecating `name_substring`, and consolidating the ~12 independently-maintained `search_*` filter docstrings behind a single source. The drift this PR fixes is exactly the predictable cost of five hand-maintained copies of one shared behavior; keeping the prose next to the query builders is the durable fix. Both are follow-ups; neither belongs in a docs correction.

## Testing

- `ruff check`, `ruff format --check`, `mypy -p nominal` — clean.
- `pytest tests/core` — 253 passed, 12 skipped.
- The measurements above double as verification: every corrected sentence corresponds to a row in one of the tables, and each was additionally checked against the server-side matching.

## Docs impact

- [x] **Is this a user-facing change?** Yes — these docstrings are the published API reference. No separate docs update needed; the corrections are the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
