### PR TITLE
fix(ci): use shared release-please wrapper with app token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ permissions:
   issues: read
 
 concurrency:
-  group: release-please-${{ github.ref }}
+  group: release-please-${{ github.event.pull_request.base.ref || github.ref }}
   cancel-in-progress: false
 
 name: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,7 @@
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -9,14 +9,13 @@ permissions:
   issues: read
 
 concurrency:
-  group: release-please-${{ github.event.pull_request.base.ref || github.ref }}
+  group: release-please-${{ github.ref }}
   cancel-in-progress: false
 
 name: release-please
 
 jobs:
   release-please:
-    if: ${{ github.event.pull_request.merged == true }}
     uses: nominal-io/git-automations/.github/workflows/release-please-wrapper.yml@main
     secrets:
       bot-token: ${{ secrets.NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,42 +1,52 @@
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
   pull-requests: write
+  issues: read
+
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
 
 name: release-please
 
 jobs:
   release-please:
+    if: ${{ github.event.pull_request.merged == true }}
+    uses: nominal-io/git-automations/.github/workflows/release-please-wrapper.yml@main
+    secrets:
+      bot-token: ${{ secrets.NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      app-id: ${{ secrets.NOMBOT_APP_ID }}
+      app-private-key: ${{ secrets.NOMBOT_PRIVATE_KEY }}
+    with:
+      manifest-file: .release-please-manifest.json
+      config-file: release-please-config.json
+      should-expedite-release: false
+
+  sync-uv-lock:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.pr != '' }}
     runs-on: depot-ubuntu-24.04-small
     steps:
-      - uses: googleapis/release-please-action@v4
-        id: release
-        with:
-          token: ${{ secrets.NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN }}
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
-
       - name: Check out release PR branch
-        if: ${{ steps.release.outputs.pr }}
         uses: actions/checkout@v4
         with:
           # Using fromJSON since github refnames don't provide the release-please
           # branch, which is what this next commit needs to be based off of
-          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
           token: ${{ secrets.NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN }}
 
       - name: Install uv
-        if: ${{ steps.release.outputs.pr }}
         uses: astral-sh/setup-uv@v6
         with:
           version: "0.8.x"
 
       - name: Sync uv.lock to release PR
-        if: ${{ steps.release.outputs.pr }}
         run: |
           set -euo pipefail
           if uv lock --check; then


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

## Summary

Moves `release-please.yml` onto the shared `nominal-io/git-automations` wrapper that scout, galaxy, and fleet-infra use, so releases stop authenticating with the shared classic PAT that just got rate limited ([run](https://github.com/nominal-io/nominal-client/actions/runs/30560389069/attempts/1)).