### PR TITLE
fix(ci): use the org's app-token action for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,7 +26,10 @@ jobs:
       - name: Get app token for release-please
         id: app-token
         if: ${{ env.USE_APP_TOKEN == 'true' }}
-        uses: nominal-io/workflow-application-token-action@d8644a5aa546f763f73b94c762b092e088486db7 # v0.0.1
+        # A minting failure degrades to the token below rather than blocking the
+        # release: a skipped or failed step leaves the output empty.
+        continue-on-error: true
+        uses: nominal-io/workflow-application-token-action@d8644a5aa546f763f73b94c762b092e088486db7 # 0.0.1
         with:
           application_id: ${{ secrets.NOMBOT_APP_ID }}
           application_private_key: ${{ secrets.NOMBOT_PRIVATE_KEY }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,10 +26,13 @@ jobs:
       - name: Get app token for release-please
         id: app-token
         if: ${{ env.USE_APP_TOKEN == 'true' }}
-        uses: actions/create-github-app-token@v2
+        uses: nominal-io/workflow-application-token-action@d8644a5aa546f763f73b94c762b092e088486db7 # v0.0.1
         with:
-          app-id: ${{ secrets.NOMBOT_APP_ID }}
-          private-key: ${{ secrets.NOMBOT_PRIVATE_KEY }}
+          application_id: ${{ secrets.NOMBOT_APP_ID }}
+          application_private_key: ${{ secrets.NOMBOT_PRIVATE_KEY }}
+          organization: "nominal-io"
+          permissions: "contents:write, pull_requests:write, issues:write"
+          revoke_token: true
 
       - uses: googleapis/release-please-action@v4
         id: release


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

The [first run after #904](https://github.com/nominal-io/nominal-client/actions/runs/30576378758) got past the previous startup failure — the workflow parsed, the job started, and the app credentials resolved — but the token step failed reading the key:

```
Failed to create token for "nominal-client" (attempt 1): Invalid keyData
[cause]: Error: Failed to read private key
```

So the credentials are present and it's purely a key-format mismatch: `actions/create-github-app-token` requires a PEM, and the stored key isn't in the form it accepts. Rather than guess at the encoding, this switches to `workflow-application-token-action` — the action every other repo here already mints this same key with, which accepts the format it's stored in. It's a public fork, so a public repo can use it.

Also passes `issues:write`, since release-please labels its release PR.

No release has been missed: the workflow bails before release-please runs, so the next merge to `main` picks it up.