### PR TITLE
feat(video): channel-based live streaming, deprecate legacy video api

### DIFF
--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -13,7 +13,7 @@ from nominal_api import (
     scout_assets,
     scout_run_api,
 )
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 from nominal.core import data_review, streaming_checklist
 from nominal.core._clientsbunch import HasScoutParams
@@ -233,6 +233,10 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
         )
         self._clients.assets.add_data_scopes_to_asset(self.rid, self._clients.auth_header, request)
 
+    @deprecated(
+        "Attaching a standalone `Video` to an asset is deprecated in favor of video channels on a dataset. Attach the "
+        "dataset that carries the video channels with `Asset.add_dataset` instead."
+    )
     def add_video(self, data_scope_name: str, video: Video | str) -> None:
         """Add a video to this asset.
 
@@ -360,6 +364,10 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
         )
         return dataset
 
+    @deprecated(
+        "`Asset.get_or_create_video` is deprecated in favor of video channels on a dataset. Use "
+        "`Asset.get_or_create_dataset`, then `Dataset.add_video` to upload video to a channel on it."
+    )
     def get_or_create_video(
         self,
         data_scope_name: str,
@@ -504,6 +512,10 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
 
         return Connection._from_conjure(self._clients, _get_connection(self._clients, connection_rid))
 
+    @deprecated(
+        "Resolving a standalone `Video` data scope is deprecated in favor of video channels on a dataset. Use "
+        "`Asset.get_dataset` with the data scope name, then `Dataset.list_video_files` to reach the video files."
+    )
     def get_video(self, data_scope_name: str) -> Video:
         """Retrieve a video by data scope name.
 

--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -36,6 +36,7 @@ from nominal.core.connection import Connection, _get_connection, _get_connection
 from nominal.core.dataset import Dataset, _create_dataset, _DatasetWrapper, _get_dataset, _get_datasets
 from nominal.core.datasource import DataSource
 from nominal.core.event import Event, _create_event, _search_events
+from nominal.core.exceptions import LegacyVideoDeprecationWarning
 from nominal.core.video import Video, _create_video, _get_video
 from nominal.core.workbook import Workbook, _search_workbooks
 from nominal.protos.comments.v1 import comments_pb2_grpc
@@ -235,7 +236,8 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
 
     @deprecated(
         "Attaching a standalone `Video` to an asset is deprecated in favor of video channels on a dataset. Attach the "
-        "dataset that carries the video channels with `Asset.add_dataset` instead."
+        "dataset that carries the video channels with `Asset.add_dataset` instead.",
+        category=LegacyVideoDeprecationWarning,
     )
     def add_video(self, data_scope_name: str, video: Video | str) -> None:
         """Add a video to this asset.
@@ -366,7 +368,8 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
 
     @deprecated(
         "`Asset.get_or_create_video` is deprecated in favor of video channels on a dataset. Use "
-        "`Asset.get_or_create_dataset`, then `Dataset.add_video` to upload video to a channel on it."
+        "`Asset.get_or_create_dataset`, then `Dataset.add_video` to upload video to a channel on it.",
+        category=LegacyVideoDeprecationWarning,
     )
     def get_or_create_video(
         self,
@@ -514,7 +517,8 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
 
     @deprecated(
         "Resolving a standalone `Video` data scope is deprecated in favor of video channels on a dataset. Use "
-        "`Asset.get_dataset` with the data scope name, then `Dataset.list_video_files` to reach the video files."
+        "`Asset.get_dataset` with the data scope name, then `Dataset.list_video_files` to reach the video files.",
+        category=LegacyVideoDeprecationWarning,
     )
     def get_video(self, data_scope_name: str) -> Video:
         """Retrieve a video by data scope name.

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -95,6 +95,7 @@ from nominal.core.dataset_file import DatasetFile
 from nominal.core.datasource import DataSource
 from nominal.core.event import Event, _create_event, _search_events
 from nominal.core.exceptions import (
+    LegacyVideoDeprecationWarning,
     NominalConfigError,
     NominalError,
     NominalInvalidArgumentError,
@@ -542,7 +543,8 @@ class NominalClient:
 
     @deprecated(
         "`NominalClient.search_videos` is deprecated in favor of video channels on a dataset. Search for the dataset "
-        "with `NominalClient.search_datasets`, then list its video files with `Dataset.list_video_files`."
+        "with `NominalClient.search_datasets`, then list its video files with `Dataset.list_video_files`.",
+        category=LegacyVideoDeprecationWarning,
     )
     def search_videos(
         self,
@@ -790,7 +792,9 @@ class NominalClient:
 
     @deprecated(
         "`NominalClient.create_video` is deprecated in favor of video channels on a dataset. Create a dataset with "
-        "`NominalClient.create_dataset`, then upload video to a channel on it with `Dataset.add_video`."
+        "`NominalClient.create_dataset`, then upload video to a channel on it with `Dataset.add_video`. The "
+        "experimental `VideoStream` API is the exception: live streaming still requires a standalone `Video`.",
+        category=LegacyVideoDeprecationWarning,
     )
     def create_video(
         self,
@@ -826,7 +830,8 @@ class NominalClient:
 
     @deprecated(
         "`NominalClient.get_video` is deprecated in favor of video channels on a dataset. Fetch the dataset with "
-        "`NominalClient.get_dataset`, then use `Dataset.list_video_files` or `Dataset.get_video_file`."
+        "`NominalClient.get_dataset`, then use `Dataset.list_video_files` or `Dataset.get_video_file`.",
+        category=LegacyVideoDeprecationWarning,
     )
     def get_video(self, rid: str) -> Video:
         """Retrieve a video by its RID."""
@@ -840,7 +845,8 @@ class NominalClient:
 
     @deprecated(
         "`NominalClient.get_videos` is deprecated in favor of video channels on a dataset. Fetch the datasets with "
-        "`NominalClient.get_datasets`, then use `Dataset.list_video_files`."
+        "`NominalClient.get_datasets`, then use `Dataset.list_video_files`.",
+        category=LegacyVideoDeprecationWarning,
     )
     def get_videos(self, rids: Iterable[str]) -> Sequence[Video]:
         """Retrieve videos by their RID."""

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -540,6 +540,10 @@ class NominalClient:
         for video in search_videos_paginated(self._clients.video, self._clients.auth_header, query, archive_status):
             yield Video._from_conjure(self._clients, video)
 
+    @deprecated(
+        "`NominalClient.search_videos` is deprecated in favor of video channels on a dataset. Search for the dataset "
+        "with `NominalClient.search_datasets`, then list its video files with `Dataset.list_video_files`."
+    )
     def search_videos(
         self,
         search_text: str | None = None,
@@ -784,6 +788,10 @@ class NominalClient:
 
         return dataset
 
+    @deprecated(
+        "`NominalClient.create_video` is deprecated in favor of video channels on a dataset. Create a dataset with "
+        "`NominalClient.create_dataset`, then upload video to a channel on it with `Dataset.add_video`."
+    )
     def create_video(
         self,
         name: str,
@@ -816,6 +824,10 @@ class NominalClient:
 
     create_empty_video = create_video
 
+    @deprecated(
+        "`NominalClient.get_video` is deprecated in favor of video channels on a dataset. Fetch the dataset with "
+        "`NominalClient.get_dataset`, then use `Dataset.list_video_files` or `Dataset.get_video_file`."
+    )
     def get_video(self, rid: str) -> Video:
         """Retrieve a video by its RID."""
         response = self._clients.video.get(self._clients.auth_header, rid)
@@ -826,6 +838,10 @@ class NominalClient:
         for response in self._clients.video.batch_get(self._clients.auth_header, request).responses:
             yield Video._from_conjure(self._clients, response)
 
+    @deprecated(
+        "`NominalClient.get_videos` is deprecated in favor of video channels on a dataset. Fetch the datasets with "
+        "`NominalClient.get_datasets`, then use `Dataset.list_video_files`."
+    )
     def get_videos(self, rids: Iterable[str]) -> Sequence[Video]:
         """Retrieve videos by their RID."""
         return list(self._iter_get_videos(rids))

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -792,8 +792,7 @@ class NominalClient:
 
     @deprecated(
         "`NominalClient.create_video` is deprecated in favor of video channels on a dataset. Create a dataset with "
-        "`NominalClient.create_dataset`, then upload video to a channel on it with `Dataset.add_video`. The "
-        "experimental `VideoStream` API is the exception: live streaming still requires a standalone `Video`.",
+        "`NominalClient.create_dataset`, then upload video to a channel on it with `Dataset.add_video`.",
         category=LegacyVideoDeprecationWarning,
     )
     def create_video(

--- a/nominal/core/exceptions.py
+++ b/nominal/core/exceptions.py
@@ -8,6 +8,14 @@ class NominalError(Exception):
     """Base class for Nominal exceptions."""
 
 
+class LegacyVideoDeprecationWarning(DeprecationWarning):
+    """Emitted by the legacy standalone-video API, superseded by video channels on a dataset.
+
+    Subclasses DeprecationWarning so it can be filtered on its own without muting every other
+    deprecation, e.g. `warnings.filterwarnings("ignore", category=LegacyVideoDeprecationWarning)`.
+    """
+
+
 class NominalIngestError(NominalError):
     """An error occurred during ingest."""
 

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -12,7 +12,7 @@ from nominal_api import (
     scout_assets,
     scout_run_api,
 )
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 from nominal.core._event_types import EventType, SearchEventOriginType
 from nominal.core._utils.api_tools import (
@@ -385,6 +385,10 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
         }
         self._clients.run.add_data_sources_to_run(self._clients.auth_header, data_sources, self.rid)
 
+    @deprecated(
+        "Attaching a standalone `Video` to a run is deprecated in favor of video channels on a dataset. Attach the "
+        "dataset that carries the video channels with `Run.add_dataset` instead."
+    )
     def add_video(self, ref_name: str, video: Video | str) -> None:
         """Add a video to a run via video object or RID."""
         request = scout_run_api.CreateRunDataSource(
@@ -494,6 +498,10 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
 
         return Connection._from_conjure(self._clients, _get_connection(self._clients, connection_rid))
 
+    @deprecated(
+        "Resolving a standalone `Video` ref is deprecated in favor of video channels on a dataset. Use "
+        "`Run.get_dataset` with the ref name, then `Dataset.list_video_files` to reach the video files."
+    )
     def get_video(self, ref_name: str) -> Video:
         """Get a video for this run by its ref name.
 

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -32,6 +32,7 @@ from nominal.core.connection import Connection, _get_connection, _get_connection
 from nominal.core.dataset import Dataset, _DatasetWrapper, _get_dataset, _get_datasets
 from nominal.core.datasource import DataSource
 from nominal.core.event import Event, _create_event, _search_events
+from nominal.core.exceptions import LegacyVideoDeprecationWarning
 from nominal.core.video import Video, _get_video
 from nominal.core.workbook import Workbook, _search_workbooks
 from nominal.protos.comments.v1 import comments_pb2, comments_pb2_grpc
@@ -387,7 +388,8 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
 
     @deprecated(
         "Attaching a standalone `Video` to a run is deprecated in favor of video channels on a dataset. Attach the "
-        "dataset that carries the video channels with `Run.add_dataset` instead."
+        "dataset that carries the video channels with `Run.add_dataset` instead.",
+        category=LegacyVideoDeprecationWarning,
     )
     def add_video(self, ref_name: str, video: Video | str) -> None:
         """Add a video to a run via video object or RID."""
@@ -500,7 +502,8 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
 
     @deprecated(
         "Resolving a standalone `Video` ref is deprecated in favor of video channels on a dataset. Use "
-        "`Run.get_dataset` with the ref name, then `Dataset.list_video_files` to reach the video files."
+        "`Run.get_dataset` with the ref name, then `Dataset.list_video_files` to reach the video files.",
+        category=LegacyVideoDeprecationWarning,
     )
     def get_video(self, ref_name: str) -> Video:
         """Get a video for this run by its ref name.

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -18,7 +18,7 @@ from nominal.core._types import PathLike
 from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin
 from nominal.core._utils.multipart import path_upload_name, upload_multipart_io
 from nominal.core._utils.networking import HeaderProvider
-from nominal.core.exceptions import NominalIngestError, NominalIngestFailed
+from nominal.core.exceptions import LegacyVideoDeprecationWarning, NominalIngestError, NominalIngestFailed
 from nominal.core.filetype import FileType, FileTypes
 from nominal.core.video_file import VideoFile
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
@@ -51,7 +51,8 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
 
     @deprecated(
         "Polling a standalone `Video` is deprecated in favor of video channels on a dataset. Poll the individual files "
-        "returned by `Dataset.add_video` or `Dataset.list_video_files` instead."
+        "returned by `Dataset.add_video` or `Dataset.list_video_files` instead.",
+        category=LegacyVideoDeprecationWarning,
     )
     def poll_until_ingestion_completed(self, interval: timedelta = timedelta(seconds=1)) -> None:
         """Block until video ingestion has completed.
@@ -87,7 +88,8 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
 
     @deprecated(
         "Updating a standalone `Video` is deprecated in favor of video channels on a dataset. Use `Dataset.update` for "
-        "the dataset's own metadata, or `VideoDatasetFile.update` for a video file's title and timing."
+        "the dataset's own metadata, or `VideoDatasetFile.update` for a video file's title and timing.",
+        category=LegacyVideoDeprecationWarning,
     )
     def update(
         self,
@@ -121,7 +123,8 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
 
     @deprecated(
         "Archiving a standalone `Video` is deprecated in favor of video channels on a dataset. Archive the backing "
-        "dataset with `Dataset.archive` instead."
+        "dataset with `Dataset.archive` instead.",
+        category=LegacyVideoDeprecationWarning,
     )
     def archive(self) -> None:
         """Archive this video.
@@ -131,7 +134,8 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
 
     @deprecated(
         "Unarchiving a standalone `Video` is deprecated in favor of video channels on a dataset. Unarchive the backing "
-        "dataset with `Dataset.unarchive` instead."
+        "dataset with `Dataset.unarchive` instead.",
+        category=LegacyVideoDeprecationWarning,
     )
     def unarchive(self) -> None:
         """Unarchives this video, allowing it to show up in the 'All Videos' pane in the UI."""
@@ -159,7 +163,8 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
 
     @deprecated(
         "Adding a file to a standalone `Video` is deprecated in favor of video channels on a dataset. Use "
-        "`Dataset.add_video` on a new or existing dataset instead."
+        "`Dataset.add_video` on a new or existing dataset instead.",
+        category=LegacyVideoDeprecationWarning,
     )
     def add_file(
         self,
@@ -237,7 +242,8 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
 
     @deprecated(
         "Adding a file to a standalone `Video` is deprecated in favor of video channels on a dataset. Use "
-        "`Dataset.add_video_from_io` on a new or existing dataset instead."
+        "`Dataset.add_video_from_io` on a new or existing dataset instead.",
+        category=LegacyVideoDeprecationWarning,
     )
     def add_from_io(
         self,
@@ -322,7 +328,8 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
 
     @deprecated(
         "Adding an MCAP file to a standalone `Video` is deprecated in favor of video channels on a dataset. Use "
-        "`Dataset.add_mcap_video` on a new or existing dataset instead."
+        "`Dataset.add_mcap_video` on a new or existing dataset instead.",
+        category=LegacyVideoDeprecationWarning,
     )
     def add_mcap(
         self,
@@ -363,7 +370,8 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
 
     @deprecated(
         "Adding an MCAP file to a standalone `Video` is deprecated in favor of video channels on a dataset. Use "
-        "`Dataset.add_mcap_video_from_io` on a new or existing dataset instead."
+        "`Dataset.add_mcap_video_from_io` on a new or existing dataset instead.",
+        category=LegacyVideoDeprecationWarning,
     )
     def add_mcap_from_io(
         self,
@@ -437,7 +445,8 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
 
     @deprecated(
         "Listing the files of a standalone `Video` is deprecated in favor of video channels on a dataset. Use "
-        "`Dataset.list_video_files` instead."
+        "`Dataset.list_video_files` instead.",
+        category=LegacyVideoDeprecationWarning,
     )
     def list_files(self) -> Sequence[VideoFile]:
         """List all video files associated with the video."""

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -11,7 +11,7 @@ from types import MappingProxyType
 from typing import BinaryIO, Mapping, Protocol, Sequence, overload
 
 from nominal_api import api, ingest_api, scout_catalog, scout_video, scout_video_api, upload_api
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._types import PathLike
@@ -49,6 +49,10 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
         @property
         def catalog(self) -> scout_catalog.CatalogService: ...
 
+    @deprecated(
+        "Polling a standalone `Video` is deprecated in favor of video channels on a dataset. Poll the individual files "
+        "returned by `Dataset.add_video` or `Dataset.list_video_files` instead."
+    )
     def poll_until_ingestion_completed(self, interval: timedelta = timedelta(seconds=1)) -> None:
         """Block until video ingestion has completed.
         This method polls Nominal for ingest status after uploading a video on an interval.
@@ -81,6 +85,10 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
     def _get_latest_api(self) -> scout_video_api.Video:
         return self._clients.video.get(self._clients.auth_header, self.rid)
 
+    @deprecated(
+        "Updating a standalone `Video` is deprecated in favor of video channels on a dataset. Use `Dataset.update` for "
+        "the dataset's own metadata, or `VideoDatasetFile.update` for a video file's title and timing."
+    )
     def update(
         self,
         *,
@@ -111,12 +119,20 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
         updated_video = self._clients.video.update_metadata(self._clients.auth_header, request, self.rid)
         return self._refresh_from_api(updated_video)
 
+    @deprecated(
+        "Archiving a standalone `Video` is deprecated in favor of video channels on a dataset. Archive the backing "
+        "dataset with `Dataset.archive` instead."
+    )
     def archive(self) -> None:
         """Archive this video.
         Archived videos are not deleted, but are hidden from the UI.
         """
         self._clients.video.archive(self._clients.auth_header, self.rid)
 
+    @deprecated(
+        "Unarchiving a standalone `Video` is deprecated in favor of video channels on a dataset. Unarchive the backing "
+        "dataset with `Dataset.unarchive` instead."
+    )
     def unarchive(self) -> None:
         """Unarchives this video, allowing it to show up in the 'All Videos' pane in the UI."""
         self._clients.video.unarchive(self._clients.auth_header, self.rid)
@@ -141,6 +157,10 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
         overwrite_overlapping: bool = False,
     ) -> VideoFile: ...
 
+    @deprecated(
+        "Adding a file to a standalone `Video` is deprecated in favor of video channels on a dataset. Use "
+        "`Dataset.add_video` on a new or existing dataset instead."
+    )
     def add_file(
         self,
         path: PathLike,
@@ -215,6 +235,10 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
         overwrite_overlapping: bool = False,
     ) -> VideoFile: ...
 
+    @deprecated(
+        "Adding a file to a standalone `Video` is deprecated in favor of video channels on a dataset. Use "
+        "`Dataset.add_video_from_io` on a new or existing dataset instead."
+    )
     def add_from_io(
         self,
         video: BinaryIO,
@@ -296,6 +320,10 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
 
     add_to_video_from_io = add_from_io
 
+    @deprecated(
+        "Adding an MCAP file to a standalone `Video` is deprecated in favor of video channels on a dataset. Use "
+        "`Dataset.add_mcap_video` on a new or existing dataset instead."
+    )
     def add_mcap(
         self,
         path: PathLike,
@@ -333,6 +361,10 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
 
     add_mcap_to_video = add_mcap
 
+    @deprecated(
+        "Adding an MCAP file to a standalone `Video` is deprecated in favor of video channels on a dataset. Use "
+        "`Dataset.add_mcap_video_from_io` on a new or existing dataset instead."
+    )
     def add_mcap_from_io(
         self,
         mcap: BinaryIO,
@@ -403,6 +435,10 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
 
     add_mcap_to_video_from_io = add_mcap_from_io
 
+    @deprecated(
+        "Listing the files of a standalone `Video` is deprecated in favor of video channels on a dataset. Use "
+        "`Dataset.list_video_files` instead."
+    )
     def list_files(self) -> Sequence[VideoFile]:
         """List all video files associated with the video."""
         raw_videos = self._clients.video_file.list_files_in_video(self._clients.auth_header, self.rid)

--- a/nominal/core/video_file.py
+++ b/nominal/core/video_file.py
@@ -12,7 +12,7 @@ from typing_extensions import Self, deprecated
 from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin
 from nominal.core._video_types import McapVideoDetails, TimestampOptions
-from nominal.core.exceptions import NominalIngestError, NominalIngestFailed
+from nominal.core.exceptions import LegacyVideoDeprecationWarning, NominalIngestError, NominalIngestFailed
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
 
 logger = logging.getLogger(__name__)
@@ -34,7 +34,8 @@ class VideoFile(HasRid, RefreshableConjureMixin[scout_video_api.VideoFile]):
 
     @deprecated(
         "`VideoFile` is deprecated in favor of video channels on a dataset. Video dataset files are deleted rather "
-        "than archived: use `VideoDatasetFile.delete` instead."
+        "than archived: use `VideoDatasetFile.delete` instead.",
+        category=LegacyVideoDeprecationWarning,
     )
     def archive(self) -> None:
         """Archive the video file, disallowing it to appear when playing back the video"""
@@ -42,7 +43,8 @@ class VideoFile(HasRid, RefreshableConjureMixin[scout_video_api.VideoFile]):
 
     @deprecated(
         "`VideoFile` is deprecated in favor of video channels on a dataset. Video dataset files are deleted rather "
-        "than archived, so there is no unarchive: see `VideoDatasetFile`."
+        "than archived, so there is no unarchive: see `VideoDatasetFile`.",
+        category=LegacyVideoDeprecationWarning,
     )
     def unarchive(self) -> None:
         """Unarchive the video file, allowing it to appear when playing back the video"""
@@ -53,7 +55,8 @@ class VideoFile(HasRid, RefreshableConjureMixin[scout_video_api.VideoFile]):
 
     @deprecated(
         "`VideoFile.update` is deprecated in favor of video channels on a dataset. Use `VideoDatasetFile.update` on a "
-        "file from `Dataset.list_video_files` instead."
+        "file from `Dataset.list_video_files` instead.",
+        category=LegacyVideoDeprecationWarning,
     )
     def update(
         self,
@@ -118,7 +121,8 @@ class VideoFile(HasRid, RefreshableConjureMixin[scout_video_api.VideoFile]):
 
     @deprecated(
         "`VideoFile` is deprecated in favor of video channels on a dataset. Use "
-        "`VideoDatasetFile.poll_until_ingestion_completed` instead."
+        "`VideoDatasetFile.poll_until_ingestion_completed` instead.",
+        category=LegacyVideoDeprecationWarning,
     )
     def poll_until_ingestion_completed(self, interval: timedelta = timedelta(seconds=1)) -> None:
         """Block until video ingestion has completed.

--- a/nominal/core/video_file.py
+++ b/nominal/core/video_file.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from typing import Protocol, Tuple
 
 from nominal_api import scout_catalog, scout_video, scout_video_api
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin
@@ -32,10 +32,18 @@ class VideoFile(HasRid, RefreshableConjureMixin[scout_video_api.VideoFile]):
         @property
         def catalog(self) -> scout_catalog.CatalogService: ...
 
+    @deprecated(
+        "`VideoFile` is deprecated in favor of video channels on a dataset. Video dataset files are deleted rather "
+        "than archived: use `VideoDatasetFile.delete` instead."
+    )
     def archive(self) -> None:
         """Archive the video file, disallowing it to appear when playing back the video"""
         self._clients.video_file.archive(self._clients.auth_header, self.rid)
 
+    @deprecated(
+        "`VideoFile` is deprecated in favor of video channels on a dataset. Video dataset files are deleted rather "
+        "than archived, so there is no unarchive: see `VideoDatasetFile`."
+    )
     def unarchive(self) -> None:
         """Unarchive the video file, allowing it to appear when playing back the video"""
         self._clients.video_file.unarchive(self._clients.auth_header, self.rid)
@@ -43,6 +51,10 @@ class VideoFile(HasRid, RefreshableConjureMixin[scout_video_api.VideoFile]):
     def _get_latest_api(self) -> scout_video_api.VideoFile:
         return self._clients.video_file.get(self._clients.auth_header, self.rid)
 
+    @deprecated(
+        "`VideoFile.update` is deprecated in favor of video channels on a dataset. Use `VideoDatasetFile.update` on a "
+        "file from `Dataset.list_video_files` instead."
+    )
     def update(
         self,
         *,
@@ -104,6 +116,10 @@ class VideoFile(HasRid, RefreshableConjureMixin[scout_video_api.VideoFile]):
         )
         return self._refresh_from_api(updated_file)
 
+    @deprecated(
+        "`VideoFile` is deprecated in favor of video channels on a dataset. Use "
+        "`VideoDatasetFile.poll_until_ingestion_completed` instead."
+    )
     def poll_until_ingestion_completed(self, interval: timedelta = timedelta(seconds=1)) -> None:
         """Block until video ingestion has completed.
         This method polls Nominal for ingest status after uploading a video file on an interval.

--- a/nominal/experimental/video/_video_stream.py
+++ b/nominal/experimental/video/_video_stream.py
@@ -23,6 +23,10 @@ logger = logging.getLogger(__name__)
 class VideoStream:
     """A live video stream from any source to a Nominal video via WHIP.
 
+    Note: this targets a legacy standalone :class:`~nominal.core.video.Video`. The platform also supports
+    streaming to a video channel on a dataset (``generate_whip_stream_v2``), which this helper has not been
+    ported to yet; until then it is the one place a deprecated ``create_video`` call is still expected.
+
     Use ``VideoStream.create()`` to construct — it resolves the WHIP endpoint
     from the Nominal video and prepares the pipeline configuration. The pipeline
     itself is not started until ``open()`` is called (or the context manager is entered).
@@ -33,8 +37,8 @@ class VideoStream:
 
         from nominal.experimental.video import VideoStream, Src, StreamOptions
 
-        # Live streaming still targets a standalone `Video`: it has no video-channel
-        # equivalent yet, so `create_video` is used here despite being deprecated.
+        # `VideoStream` has not been ported to video channels yet, so it still takes a
+        # standalone `Video` and `create_video` is used here despite being deprecated.
         video = client.create_video("my stream")
 
         # Context manager — open/close handled automatically:

--- a/nominal/experimental/video/_video_stream.py
+++ b/nominal/experimental/video/_video_stream.py
@@ -33,6 +33,8 @@ class VideoStream:
 
         from nominal.experimental.video import VideoStream, Src, StreamOptions
 
+        # Live streaming still targets a standalone `Video`: it has no video-channel
+        # equivalent yet, so `create_video` is used here despite being deprecated.
         video = client.create_video("my stream")
 
         # Context manager — open/close handled automatically:

--- a/nominal/experimental/video/_video_stream.py
+++ b/nominal/experimental/video/_video_stream.py
@@ -2,18 +2,25 @@ from __future__ import annotations
 
 import logging
 import urllib.parse
+import warnings
 from dataclasses import dataclass, field
 from datetime import timedelta
 from types import TracebackType
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING, Mapping, Type
 
 from conjure_python_client import ConjureHTTPError
+from nominal_api import scout_video_api
 from nominal_video import Sink, Src, Stream, StreamOptions
 
-from nominal.core.exceptions import NominalVideoStreamError, NominalVideoStreamNotOpenError
+from nominal.core.exceptions import (
+    LegacyVideoDeprecationWarning,
+    NominalVideoStreamError,
+    NominalVideoStreamNotOpenError,
+)
 from nominal.ts import IntegralNanosecondsUTC
 
 if TYPE_CHECKING:
+    from nominal.core.dataset import Dataset
     from nominal.core.video import Video
 
 logger = logging.getLogger(__name__)
@@ -21,11 +28,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class VideoStream:
-    """A live video stream from any source to a Nominal video via WHIP.
-
-    Note: this targets a legacy standalone :class:`~nominal.core.video.Video`. The platform also supports
-    streaming to a video channel on a dataset (``generate_whip_stream_v2``), which this helper has not been
-    ported to yet; until then it is the one place a deprecated ``create_video`` call is still expected.
+    """A live video stream from any source to a video channel on a Nominal dataset via WHIP.
 
     Use ``VideoStream.create()`` to construct — it resolves the WHIP endpoint
     from the Nominal video and prepares the pipeline configuration. The pipeline
@@ -37,12 +40,10 @@ class VideoStream:
 
         from nominal.experimental.video import VideoStream, Src, StreamOptions
 
-        # `VideoStream` has not been ported to video channels yet, so it still takes a
-        # standalone `Video` and `create_video` is used here despite being deprecated.
-        video = client.create_video("my stream")
+        dataset = client.create_dataset("my stream")
 
         # Context manager — open/close handled automatically:
-        with VideoStream.create(video, Src.camera()) as stream:
+        with VideoStream.create(dataset, Src.camera(), channel="camera/front") as stream:
             stream.run()
 
         # Timed stream — run for a fixed timeout then exit:
@@ -79,17 +80,21 @@ class VideoStream:
     @classmethod
     def create(
         cls,
-        video: Video,
+        target: Dataset | Video,
         src: Src,
         options: StreamOptions | None = None,
+        *,
+        channel: str | None = None,
+        tags: Mapping[str, str] | None = None,
     ) -> VideoStream:
-        """Create a VideoStream for a Nominal video.
+        """Create a VideoStream for a video channel on a dataset.
 
         Resolves the WHIP endpoint from Nominal and configures the pipeline.
         The pipeline is not started until ``open()`` is called.
 
         Args:
-            video: The Nominal video to stream to.
+            target: The dataset owning the video channel to stream to. Passing a legacy standalone
+                `Video` is deprecated.
             src: Video source. Common options:
 
                 - ``Src.camera()`` — local webcam
@@ -101,14 +106,18 @@ class VideoStream:
 
             options: Encoding options — codec, bitrate, resolution, overlay, fps, etc.
                 Defaults to H264 at 4 Mbps with no overlay.
+            channel: Name of the video channel on the dataset to stream to. Required when streaming to a
+                dataset; unused when streaming to a legacy `Video`.
+            tags: Tags identifying the channel's series. Defaults to none.
 
         Returns:
             A configured VideoStream, ready to open.
+
+        Raises:
+            ValueError: `channel` was omitted for a dataset target, or supplied for a `Video` target.
+            NominalVideoStreamError: Nominal rejected the request for a WHIP endpoint.
         """
-        try:
-            resp = video._clients.video.generate_whip_stream(video._clients.auth_header, video.rid)
-        except ConjureHTTPError as e:
-            raise NominalVideoStreamError(f"failed to create WHIP stream for video {video.rid!r}: {e}") from e
+        resp = cls._request_whip_stream(target, channel=channel, tags=tags)
 
         whip_url = resp.whip_url
         parsed = urllib.parse.urlparse(whip_url)
@@ -129,7 +138,52 @@ class VideoStream:
                 stun_url = resp.ice_servers[0].urls[0].replace("stun:", "stun://", 1)
 
         whip_sink = Sink.whip(endpoint=endpoint, token=token, stun_server=stun_url)
-        return cls(rid=video.rid, src=src, options=options, whip_sink=whip_sink)
+        return cls(rid=target.rid, src=src, options=options, whip_sink=whip_sink)
+
+    @staticmethod
+    def _request_whip_stream(
+        target: Dataset | Video,
+        *,
+        channel: str | None,
+        tags: Mapping[str, str] | None,
+    ) -> scout_video_api.GenerateWhipStreamResponse:
+        """Resolve a WHIP endpoint for a dataset channel, or for a legacy video (deprecated)."""
+        # Imported here rather than at module scope: nominal.core.video imports this package lazily,
+        # and a top-level import would close that cycle.
+        from nominal.core.video import Video
+
+        clients = target._clients
+        if isinstance(target, Video):
+            if channel is not None:
+                raise ValueError("'channel' does not apply when streaming to a legacy `Video`")
+            warnings.warn(
+                "Streaming to a standalone `Video` is deprecated in favor of video channels on a dataset. "
+                "Pass a `Dataset` with `channel=...` instead.",
+                LegacyVideoDeprecationWarning,
+                stacklevel=3,
+            )
+            try:
+                return clients.video.generate_whip_stream(clients.auth_header, target.rid)
+            except ConjureHTTPError as e:
+                raise NominalVideoStreamError(f"failed to create WHIP stream for video {target.rid!r}: {e}") from e
+
+        if channel is None:
+            raise ValueError("'channel' is required when streaming to a dataset")
+        request = scout_video_api.GenerateWhipStreamV2Request(
+            channel_series=scout_video_api.VideoChannelSeries(
+                data_source=scout_video_api.VideoDataSourceChannel(
+                    channel=channel,
+                    data_source_rid=target.rid,
+                    tags={**(tags or {})},
+                )
+            )
+        )
+        try:
+            return clients.video.generate_whip_stream_v2(clients.auth_header, request)
+        except ConjureHTTPError as e:
+            raise NominalVideoStreamError(
+                f"failed to create WHIP stream for channel {channel!r} on dataset {target.rid!r}: {e}"
+            ) from e
 
     def open(self) -> None:
         """Build and start the GStreamer pipeline. Idempotent — safe to call multiple times.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,9 @@ disable_error_code = ["no-untyped-def"]
 [tool.pytest.ini_options]
 filterwarnings = [
     "error", # transform all warnings into errors, except ignore: ones.
+    # The legacy standalone-video API is deprecated but still supported, and tests/e2e exercises it
+    # on purpose to keep covering it. Scoped to those deprecations by message.
+    "ignore:.*video channels on a dataset:DeprecationWarning",
 ]
 testpaths = ["tests"]
 # make tests/e2e opt-in (they require a Nominal instance)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,8 +192,8 @@ disable_error_code = ["no-untyped-def"]
 filterwarnings = [
     "error", # transform all warnings into errors, except ignore: ones.
     # The legacy standalone-video API is deprecated but still supported, and tests/e2e exercises it
-    # on purpose to keep covering it. Scoped to those deprecations by message.
-    "ignore:.*video channels on a dataset:DeprecationWarning",
+    # on purpose to keep covering it. Scoped to that one migration by warning class.
+    "ignore::nominal.core.exceptions.LegacyVideoDeprecationWarning",
 ]
 testpaths = ["tests"]
 # make tests/e2e opt-in (they require a Nominal instance)

--- a/tests/experimental/test_video_stream.py
+++ b/tests/experimental/test_video_stream.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nominal.core.exceptions import LegacyVideoDeprecationWarning
+from nominal.core.video import Video
+
+# Requires the `video` extra (and GStreamer) to import the rust bindings.
+pytest.importorskip("nominal_video")
+
+from nominal.experimental.video import Src, VideoStream  # noqa: E402
+
+
+def _clients_returning_whip_url(response_attr: str) -> MagicMock:
+    clients = MagicMock()
+    response = MagicMock(whip_url="https://mediamtx.example/whip/abc?token=tok", ice_servers=[])
+    getattr(clients.video, response_attr).return_value = response
+    return clients
+
+
+def _dataset(clients: MagicMock, rid: str = "ri.catalog.dataset.1") -> MagicMock:
+    # A bare mock is deliberately not a Video, so create() takes the dataset arm.
+    dataset = MagicMock()
+    dataset.rid = rid
+    dataset._clients = clients
+    return dataset
+
+
+def test_create_streams_to_a_dataset_channel():
+    """A dataset target resolves its WHIP endpoint from the channel-series v2 endpoint."""
+    clients = _clients_returning_whip_url("generate_whip_stream_v2")
+    stream = VideoStream.create(
+        _dataset(clients), Src.file("in.mp4"), channel="camera/front", tags={"vehicle": "alpha"}
+    )
+
+    clients.video.generate_whip_stream.assert_not_called()
+    _auth, request = clients.video.generate_whip_stream_v2.call_args[0]
+    source = request.channel_series.data_source
+    assert (source.data_source_rid, source.channel, source.tags) == (
+        "ri.catalog.dataset.1",
+        "camera/front",
+        {"vehicle": "alpha"},
+    )
+    assert stream.rid == "ri.catalog.dataset.1"
+
+
+def test_create_requires_a_channel_for_a_dataset():
+    """Without a channel there is no series to stream to, so fail before calling Nominal."""
+    clients = _clients_returning_whip_url("generate_whip_stream_v2")
+    with pytest.raises(ValueError, match="'channel' is required"):
+        VideoStream.create(_dataset(clients), Src.file("in.mp4"))
+    clients.video.generate_whip_stream_v2.assert_not_called()
+
+
+def test_create_to_legacy_video_warns_and_uses_v1():
+    """The legacy Video arm still works, on the v1 endpoint, and warns."""
+    clients = _clients_returning_whip_url("generate_whip_stream")
+    video = MagicMock(spec=Video)
+    video.rid = "ri.video.v.1"
+    video._clients = clients
+
+    with pytest.warns(LegacyVideoDeprecationWarning, match="video channels on a dataset"):
+        stream = VideoStream.create(video, Src.file("in.mp4"))
+
+    clients.video.generate_whip_stream.assert_called_once()
+    clients.video.generate_whip_stream_v2.assert_not_called()
+    assert stream.rid == "ri.video.v.1"
+
+
+def test_create_rejects_a_channel_for_a_legacy_video():
+    """A channel is meaningless for a standalone video; don't silently ignore it."""
+    clients = _clients_returning_whip_url("generate_whip_stream")
+    video = MagicMock(spec=Video)
+    video._clients = clients
+    with pytest.raises(ValueError, match="does not apply"):
+        VideoStream.create(video, Src.file("in.mp4"), channel="camera/front")
+    clients.video.generate_whip_stream.assert_not_called()

--- a/tests/experimental/test_video_stream.py
+++ b/tests/experimental/test_video_stream.py
@@ -7,8 +7,10 @@ import pytest
 from nominal.core.exceptions import LegacyVideoDeprecationWarning
 from nominal.core.video import Video
 
-# Requires the `video` extra (and GStreamer) to import the rust bindings.
-pytest.importorskip("nominal_video")
+# Requires the `video` extra to import the rust bindings, plus GStreamer at load time. exc_type covers
+# the CI case where the package is installed but its GStreamer libs are not (ImportError on import),
+# which importorskip otherwise reports as a warning rather than a skip.
+pytest.importorskip("nominal_video", exc_type=ImportError)
 
 from nominal.experimental.video import Src, VideoStream  # noqa: E402
 


### PR DESCRIPTION
The Python-client counterpart to [scout#17811](https://github.com/nominal-io/scout/pull/17811), which deprecated the same surface in the API. Now that #896 has landed the channels-on-datasets video surface, the legacy standalone-`Video` API has a full replacement, so callers get an IDE strikethrough and a runtime `DeprecationWarning` naming the specific method to use instead.

Nothing is removed and no behavior changes — legacy video keeps working.

| Deprecated | Use instead |
| --- | --- |
| `NominalClient.create_video` | `NominalClient.create_dataset` + `Dataset.add_video` |
| `NominalClient.get_video` / `get_videos` | `NominalClient.get_dataset` / `get_datasets` + `Dataset.list_video_files` |
| `NominalClient.search_videos` | `NominalClient.search_datasets` + `Dataset.list_video_files` |
| `Video.add_file` / `add_from_io` | `Dataset.add_video` / `add_video_from_io` |
| `Video.add_mcap` / `add_mcap_from_io` | `Dataset.add_mcap_video` / `add_mcap_video_from_io` |
| `Video.list_files` | `Dataset.list_video_files` |
| `Video.update` | `Dataset.update` (dataset metadata) or `VideoDatasetFile.update` (file title/timing) |
| `Video.archive` / `unarchive` | `Dataset.archive` / `unarchive` |
| `Video.poll_until_ingestion_completed` | `VideoDatasetFile.poll_until_ingestion_completed` |
| `VideoFile.update` | `VideoDatasetFile.update` |
| `VideoFile.archive` / `unarchive` | `VideoDatasetFile.delete` (files are deleted, not archived, in the new model) |
| `VideoFile.poll_until_ingestion_completed` | `VideoDatasetFile.poll_until_ingestion_completed` |
| `Run.add_video` / `Asset.add_video` | `Run.add_dataset` / `Asset.add_dataset` (attach the dataset carrying the video channels) |
| `Run.get_video` / `Asset.get_video` | `Run.get_dataset` / `Asset.get_dataset` + `Dataset.list_video_files` |
| `Asset.get_or_create_video` | `Asset.get_or_create_dataset` + `Dataset.add_video` |

**Not deprecated:** the `Video` / `VideoFile` classes themselves. They're constructed internally by our own read paths (`_from_conjure`), so decorating the classes would fire warnings on calls that aren't the user's doing. The methods carry the signal instead.

**Also ports the one first-party caller.** The experimental `VideoStream` helper was still streaming to a standalone `Video` via the v1 `generate_whip_stream` (itself deprecated by [scout#17811](https://github.com/nominal-io/scout/pull/17811)), which would have left this PR deprecating an API our own code depends on. `VideoStream.create` now takes the dataset owning the channel plus `channel=` (and optional `tags=`) and resolves its endpoint from `generateWhipStreamV2`:

```python
dataset = client.create_dataset("my stream")
with VideoStream.create(dataset, Src.camera(), channel="camera/front") as stream:
    stream.run()
```

Passing a legacy `Video` still works and warns with the same category. Only `create()` ever called the server — `open`/`close`/`run`/`restart` are local GStreamer work — so no `endStream` equivalent was needed, which matters because `endStream` and `getStream` are the two streaming endpoints with no v2 twin. The v2 streaming endpoints are datasource-backed only, hence a dataset target and no asset arm.

**Known warning noise:** `experimental/migration` legitimately drives the legacy API (its job is migrating off it), so it emits these warnings at runtime. Left as-is — silencing them there would hide the signal we're adding.

**One config change worth a look:** `pytest` runs with `filterwarnings = ["error"]`, and `tests/e2e` deliberately exercises the legacy video API (`test_search.py`'s fixtures, `test_migration.py`, `test_core.py`) to keep covering a surface we still support. Rather than wrapping ~20 call sites in `pytest.warns` or migrating tests off the API they exist to test, the deprecations emit a dedicated category:

```python
# nominal/core/exceptions.py
class LegacyVideoDeprecationWarning(DeprecationWarning): ...
```

passed as `category=` on all 22 decorators, with one structural filter:

```toml
"ignore::nominal.core.exceptions.LegacyVideoDeprecationWarning",
```

So the `error` policy stays absolute for every other deprecation, and callers get a handle to filter this one migration on its own instead of muting `DeprecationWarning` wholesale. (Per the review bot's suggestion — the first cut keyed the filter on message prose, which would have broken silently if any message were reworded.)

### Testing plan

- Full suite passes (647), `mypy` clean on 156 files, `ruff check` + `format` clean.
- Verified the warning filter empirically with throwaway tests (not committed): a real deprecated call (`Video.list_files`) passes under warnings-as-errors, and an unrelated `DeprecationWarning` is still promoted to an error — confirming the filter is scoped rather than blanket.
- On the bot's overload question: `@deprecated` sits on the overload *implementations*. Confirmed with both mypy 1.18 (`--enable-error-code=deprecated`) and pyright 1.1.411 (`reportDeprecated`) that each reports the call site from the implementation decorator alone, so per-overload copies would add nothing.
- Adds `tests/experimental/test_video_stream.py`, the module's first tests: the dataset arm's request shape, the legacy arm's warning and v1 fallback, and both argument-validation errors. Guarded with `importorskip` since the helper needs the `video` extra and GStreamer.
- No unit tests call the deprecated methods otherwise; the e2e legacy-video tests are covered by the filter above and unchanged.




