### PR TITLE
feat: add public Workbook.create_template

### DIFF
--- a/nominal/core/workbook.py
+++ b/nominal/core/workbook.py
@@ -9,9 +9,10 @@ from nominal_api import scout, scout_chartdefinition_api, scout_notebook_api, sc
 from typing_extensions import Self, deprecated
 
 from nominal.core._clientsbunch import HasScoutParams
-from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin
+from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin, rid_from_instance_or_string
 from nominal.core._utils.pagination_tools import search_workbooks_paginated
 from nominal.core._utils.query_tools import ArchiveStatusFilter, create_search_workbooks_query
+from nominal.core.workspace import Workspace
 
 logger = logging.getLogger(__name__)
 
@@ -266,7 +267,7 @@ class Workbook(HasRid, RefreshableConjureMixin[scout_notebook_api.Notebook]):
         description: str | None = None,
         labels: Sequence[str] | None = None,
         properties: Mapping[str, str] | None = None,
-        workspace_rid: str | None = None,
+        workspace: Workspace | str | None = None,
     ) -> WorkbookTemplate:
         """Create a workbook template from this workbook.
 
@@ -275,12 +276,16 @@ class Workbook(HasRid, RefreshableConjureMixin[scout_notebook_api.Notebook]):
             description: Description for the new template. Defaults to the current workbook description.
             labels: Labels for the new template. Defaults to the current workbook labels.
             properties: Properties for the new template. Defaults to the current workbook properties.
-            workspace_rid: Workspace RID to create the template in. Defaults to the client's workspace: the
-                configured `workspace_rid` if the client is pinned to one, otherwise a lazily-resolved
-                default workspace.
+            workspace: Workspace (or workspace RID) to create the template in. Defaults to the client's
+                workspace: the configured `workspace_rid` if the client is pinned to one, otherwise a
+                lazily-resolved default workspace.
 
         Returns:
             The created WorkbookTemplate
+
+        Raises:
+            ValueError: If this workbook is a comparison workbook, which templates do not yet support.
+            ValueError: If the workbook has no content to template.
         """
         from nominal.core.workbook_template import _create_workbook_template_with_content_and_layout
 
@@ -298,7 +303,11 @@ class Workbook(HasRid, RefreshableConjureMixin[scout_notebook_api.Notebook]):
             raise ValueError("Missing content for workbook")
 
         workbook_title = raw_workbook.metadata.title or "workbook"
-        workspace_rid = workspace_rid or self._clients.resolve_default_workspace_rid()
+        workspace_rid = (
+            rid_from_instance_or_string(workspace)
+            if workspace is not None
+            else self._clients.resolve_default_workspace_rid()
+        )
 
         return _create_workbook_template_with_content_and_layout(
             self._clients,
@@ -331,7 +340,7 @@ class Workbook(HasRid, RefreshableConjureMixin[scout_notebook_api.Notebook]):
             description=description,
             labels=labels,
             properties=properties,
-            workspace_rid=workspace_rid,
+            workspace=workspace_rid,
         )
 
     @classmethod

--- a/nominal/core/workbook.py
+++ b/nominal/core/workbook.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Iterable, Mapping, Protocol, Sequence
 
 from nominal_api import scout, scout_chartdefinition_api, scout_notebook_api, scout_workbookcommon_api
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin
@@ -259,7 +259,7 @@ class Workbook(HasRid, RefreshableConjureMixin[scout_notebook_api.Notebook]):
         """Delete the workbook permanently."""
         self._clients.notebook.delete(self._clients.auth_header, self.rid)
 
-    def _create_template_from_workbook(
+    def create_template(
         self,
         *,
         title: str | None = None,
@@ -275,7 +275,9 @@ class Workbook(HasRid, RefreshableConjureMixin[scout_notebook_api.Notebook]):
             description: Description for the new template. Defaults to the current workbook description.
             labels: Labels for the new template. Defaults to the current workbook labels.
             properties: Properties for the new template. Defaults to the current workbook properties.
-            workspace_rid: Workspace RID to create the template in. Defaults to the current workbook's workspace.
+            workspace_rid: Workspace RID to create the template in. Defaults to the client's workspace: the
+                configured `workspace_rid` if the client is pinned to one, otherwise a lazily-resolved
+                default workspace.
 
         Returns:
             The created WorkbookTemplate
@@ -308,6 +310,28 @@ class Workbook(HasRid, RefreshableConjureMixin[scout_notebook_api.Notebook]):
             labels=raw_workbook.metadata.labels if labels is None else [*labels],
             properties=raw_workbook.metadata.properties if properties is None else {**properties},
             commit_message="Initial version",
+        )
+
+    @deprecated(
+        "`Workbook._create_template_from_workbook` is deprecated in favor of the public "
+        "`Workbook.create_template`, and will be removed in a future version.",
+        category=UserWarning,
+    )
+    def _create_template_from_workbook(
+        self,
+        *,
+        title: str | None = None,
+        description: str | None = None,
+        labels: Sequence[str] | None = None,
+        properties: Mapping[str, str] | None = None,
+        workspace_rid: str | None = None,
+    ) -> WorkbookTemplate:
+        return self.create_template(
+            title=title,
+            description=description,
+            labels=labels,
+            properties=properties,
+            workspace_rid=workspace_rid,
         )
 
     @classmethod

--- a/tests/core/test_workbook_create_template.py
+++ b/tests/core/test_workbook_create_template.py
@@ -1,4 +1,4 @@
-"""Unit tests for workspace resolution in Workbook.create_template."""
+"""Unit tests for Workbook.create_template: workspace resolution and the documented ValueErrors."""
 
 from __future__ import annotations
 
@@ -15,17 +15,22 @@ _EXPLICIT_WORKSPACE_RID = "ri.scout.cerulean-staging.workspace.explicit"
 
 
 @pytest.fixture
-def workbook(mock_clients):
-    """A workbook whose raw notebook has no charts, so the content passes through untouched.
+def notebook(mock_clients):
+    """The raw Notebook returned by NotebookService.get, with no charts so content passes through untouched.
 
     `content_v2` is None so the legacy `content` field is used. create_template requires content_v2 to be a
     real UnifiedWorkbookContent when it is present.
     """
-    notebook = MagicMock()
-    notebook.content_v2 = None
-    notebook.content = scout_workbookcommon_api.WorkbookContent(channel_variables={}, charts={})
-    notebook.metadata.title = "Flight 12 review"
-    mock_clients.notebook.get.return_value = notebook
+    raw = MagicMock()
+    raw.content_v2 = None
+    raw.content = scout_workbookcommon_api.WorkbookContent(channel_variables={}, charts={})
+    raw.metadata.title = "Flight 12 review"
+    mock_clients.notebook.get.return_value = raw
+    return raw
+
+
+@pytest.fixture
+def workbook(mock_clients, notebook):
     mock_clients.resolve_default_workspace_rid.return_value = _CLIENT_WORKSPACE_RID
     return Workbook(
         rid="ri.scout.cerulean-staging.notebook.abc123",
@@ -59,3 +64,32 @@ def test_deprecated_alias_maps_workspace_rid_onto_workspace(workbook, mock_clien
         workbook._create_template_from_workbook(workspace_rid=_EXPLICIT_WORKSPACE_RID)
     request = mock_clients.template.create.call_args.args[1]
     assert request.workspace == _EXPLICIT_WORKSPACE_RID
+
+
+def test_comparison_workbook_type_is_rejected(workbook, mock_clients):
+    comparison = Workbook(
+        rid=workbook.rid,
+        title=workbook.title,
+        description=workbook.description,
+        workbook_type=WorkbookType.COMPARISON_WORKBOOK,
+        run_rids=workbook.run_rids,
+        asset_rids=None,
+        _clients=mock_clients,
+    )
+    with pytest.raises(ValueError, match="Comparison workbook types not yet supported"):
+        comparison.create_template()
+
+
+def test_comparison_content_is_rejected_for_a_standard_workbook_type(workbook, notebook):
+    """The rejection has two arms. This covers the content arm, which the workbook type check does not reach."""
+    notebook.content_v2 = scout_workbookcommon_api.UnifiedWorkbookContent(
+        workbook=None, comparison_workbook=MagicMock()
+    )
+    with pytest.raises(ValueError, match="Comparison workbook types not yet supported"):
+        workbook.create_template()
+
+
+def test_missing_content_is_rejected(workbook, notebook):
+    notebook.content = None
+    with pytest.raises(ValueError, match="Missing content for workbook"):
+        workbook.create_template()

--- a/tests/core/test_workbook_create_template.py
+++ b/tests/core/test_workbook_create_template.py
@@ -1,0 +1,61 @@
+"""Unit tests for workspace resolution in Workbook.create_template."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from nominal_api import scout_workbookcommon_api
+
+from nominal.core.workbook import Workbook, WorkbookType
+from nominal.core.workspace import Workspace
+
+_CLIENT_WORKSPACE_RID = "ri.scout.cerulean-staging.workspace.client-default"
+_EXPLICIT_WORKSPACE_RID = "ri.scout.cerulean-staging.workspace.explicit"
+
+
+@pytest.fixture
+def workbook(mock_clients):
+    """A workbook whose raw notebook has no charts, so the content passes through untouched.
+
+    `content_v2` is None so the legacy `content` field is used. create_template requires content_v2 to be a
+    real UnifiedWorkbookContent when it is present.
+    """
+    notebook = MagicMock()
+    notebook.content_v2 = None
+    notebook.content = scout_workbookcommon_api.WorkbookContent(channel_variables={}, charts={})
+    notebook.metadata.title = "Flight 12 review"
+    mock_clients.notebook.get.return_value = notebook
+    mock_clients.resolve_default_workspace_rid.return_value = _CLIENT_WORKSPACE_RID
+    return Workbook(
+        rid="ri.scout.cerulean-staging.notebook.abc123",
+        title="Flight 12 review",
+        description="post-flight",
+        workbook_type=WorkbookType.WORKBOOK,
+        run_rids=["ri.scout.cerulean-staging.run.def456"],
+        asset_rids=None,
+        _clients=mock_clients,
+    )
+
+
+@pytest.mark.parametrize(
+    ("workspace", "expected_rid"),
+    [
+        (None, _CLIENT_WORKSPACE_RID),
+        (_EXPLICIT_WORKSPACE_RID, _EXPLICIT_WORKSPACE_RID),
+        (Workspace(rid=_EXPLICIT_WORKSPACE_RID, id="ws-1", org="org-1"), _EXPLICIT_WORKSPACE_RID),
+    ],
+    ids=["defaults to the client workspace", "accepts a rid", "accepts an instance"],
+)
+def test_workspace_resolution(workbook, mock_clients, workspace, expected_rid):
+    workbook.create_template(workspace=workspace)
+    request = mock_clients.template.create.call_args.args[1]
+    assert request.workspace == expected_rid
+
+
+def test_deprecated_alias_maps_workspace_rid_onto_workspace(workbook, mock_clients):
+    """The alias keeps the old `workspace_rid` name, so the rename across the boundary must hold."""
+    with pytest.warns(UserWarning):
+        workbook._create_template_from_workbook(workspace_rid=_EXPLICIT_WORKSPACE_RID)
+    request = mock_clients.template.create.call_args.args[1]
+    assert request.workspace == _EXPLICIT_WORKSPACE_RID


### PR DESCRIPTION
### Summary

Promotes the private `Workbook._create_template_from_workbook` to the public `Workbook.create_template`.

### Naming

The public name drops the `_from_workbook` suffix, which only repeats the receiver. The keyword arguments override metadata on the new template, never the source. The neighbors already read this way:

- `WorkbookTemplate.create_workbook` creates a workbook from a template.
- `Workbook.clone` creates a workbook from a workbook.

### Workspace parameter

The method now takes `workspace: Workspace | str | None` in place of a bare `workspace_rid` string. This matches `NominalClient.create_workbook_template`, the only other creator that targets a workspace. A caller holding a `Workspace` no longer has to reach for `.rid`. The type is worth settling now, because a public `workspace_rid: str` would cost a deprecation cycle to narrow later.

### Deprecated alias

`_create_template_from_workbook` stays as a deprecated alias that warns and delegates. It keeps the original `workspace_rid` parameter and maps it onto `workspace`, so the old call shape still works. Nothing in the repo calls it, and the name was never public, so deleting it outright is the alternative. The alias warns with `UserWarning`, because Python hides `DeprecationWarning` outside `__main__`.

### Docstring correction

The `workspace_rid` docstring promised the workspace of the current workbook. The code calls `resolve_default_workspace_rid()`, which returns the workspace of the client. That is the configured `workspace_rid` of a pinned client, or a lazily resolved default.

The method would also need another API request to find the workspace of the workbook. The `Workbook` class holds no workspace field, and neither does the `scout_notebook_api.Notebook` that it wraps. The neighbor `Workbook.clone` resolves the workspace the same way, so this PR corrects the text and leaves the behavior alone.

### Testing plan

- `ruff check` and `ruff format --check` pass.
- `mypy` reports no new errors. The 4 remaining errors are in `nominal/experimental/compute_as_code` and come from the optional `nominal_compute` module.
- `tests/core` passes with 326 passed and 12 skipped.
- New tests cover workspace resolution for a default, a RID, and a `Workspace`, and both conditions in the `Raises` block.
- One test covers the `workspace_rid` mapping in the alias, which `mypy` cannot check because the parameter is optional.
