### PR TITLE
feat(ingest): declare how numeric timestamps should be read for avro and journal json

### DIFF
--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -30,11 +30,15 @@ from nominal.core.log import LogPoint, _write_logs
 from nominal.core.video import _build_video_file_timestamp_manifest
 from nominal.core.video_dataset_file import VideoDatasetFile
 from nominal.ts import (
+    Epoch,
     IntegralNanosecondsUTC,
+    _AnyEpochTimestampType,
+    _AnyNumericTimestampType,
     _AnyTimestampType,
     _InferrableTimestampType,
     _SecondsNanos,
     _to_typed_timestamp_type,
+    _validate_timestamp_pair,
 )
 
 logger = logging.getLogger(__name__)
@@ -258,69 +262,86 @@ class Dataset(DataSource, RefreshableConjureMixin[scout_catalog.EnrichedDataset]
     def add_avro_stream(
         self,
         path: PathLike,
+        *,
+        timestamp_type: _AnyNumericTimestampType | None = None,
+        tags: Mapping[str, str] | None = None,
     ) -> DatasetFile:
-        """Upload an avro stream file with a specific schema, described below.
+        """Upload an avro-stream file, which must match the schema shown below.
 
         This is a "stream-like" file format to support
         use cases where a columnar/tabular format does not make sense. This closely matches Nominal's streaming
         API, making it useful for use cases where network connection drops during streaming and a backup file needs
         to be created.
 
-        For struct columns, values should be converted to JSON strings and wrapped in the JsonStruct record type.
-
-        If this schema is not used, will result in a failed ingestion.
-        {
-            "type": "record",
-            "name": "AvroStream",
-            "namespace": "io.nominal.ingest",
-            "fields": [
-                {
-                    "name": "channel",
-                    "type": "string",
-                    "doc": "Channel/series name (e.g., 'vehicle_id', 'col_1', 'temperature')",
-                },
-                {
-                    "name": "timestamps",
-                    "type": {"type": "array", "items": "long"},
-                    "doc": "Array of Unix timestamps in nanoseconds",
-                },
-                {
-                    "name": "values",
-                    "type": {"type": "array", "items": [
-                        "double",
-                        "string",
-                        "long",
-                        {"type": "record", "name": "DoubleArray", "fields": [{"name": "items", "type": {"type": "array", "items": "double"}}]},
-                        {"type": "record", "name": "StringArray", "fields": [{"name": "items", "type": {"type": "array", "items": "string"}}]},
-                        {"type": "record", "name": "JsonStruct", "fields": [{"name": "json", "type": "string"}]}
-                    ]},
-                    "doc": "Array of values. Can be doubles, longs, strings, arrays, or JSON structs",
-                },
-                {
-                    "name": "tags",
-                    "type": {"type": "map", "values": "string"},
-                    "default": {},
-                    "doc": "Key-value metadata tags",
-                },
-            ],
-        }
-
-        Note: The previous schema with only "double" and "string" value types is still fully supported.
-
         Args:
             path: Path to the .avro or .avro.gz file to upload
+            timestamp_type: How to read the numbers in the file's `timestamps` field: an absolute epoch
+                (`ts.Epoch`, or its string literal) or an offset from a start (`ts.Relative`). Defaults to
+                "epoch_nanoseconds".
+            tags: Key-value tags applied to all data in the file. Tags in the records themselves take
+                precedence -- these only fill keys a record does not already set.
 
         Returns:
             Reference to the ingesting DatasetFile
 
         Raises:
-            ValueError: `path` does not end in .avro or .avro.gz.
+            ValueError: `path` does not end in .avro or .avro.gz, or `timestamp_type` has no numeric
+                representation (e.g. an ISO 8601 or custom string format).
+
+        NOTE: For struct columns, values should be converted to JSON strings and wrapped in the JsonStruct record type.
+
+        NOTE: The previous schema with only "double" and "string" value types is still fully supported.
+
+        NOTE: If this schema is not used, will result in a failed ingestion.
+
+            {
+                "type": "record",
+                "name": "AvroStream",
+                "namespace": "io.nominal.ingest",
+                "fields": [
+                    {
+                        "name": "channel",
+                        "type": "string",
+                        "doc": "Channel/series name (e.g., 'vehicle_id', 'col_1', 'temperature')",
+                    },
+                    {
+                        "name": "timestamps",
+                        "type": {"type": "array", "items": "long"},
+                        "doc": "Array of numeric timestamps; see timestamp_type for how they are read",
+                    },
+                    {
+                        "name": "values",
+                        "type": {"type": "array", "items": [
+                            "double",
+                            "string",
+                            "long",
+                            {"type": "record", "name": "DoubleArray", "fields": [{"name": "items", "type": {"type": "array", "items": "double"}}]},
+                            {"type": "record", "name": "StringArray", "fields": [{"name": "items", "type": {"type": "array", "items": "string"}}]},
+                            {"type": "record", "name": "JsonStruct", "fields": [{"name": "json", "type": "string"}]}
+                        ]},
+                        "doc": "Array of values. Can be doubles, longs, strings, arrays, or JSON structs",
+                    },
+                    {
+                        "name": "tags",
+                        "type": {"type": "map", "values": "string"},
+                        "default": {},
+                        "doc": "Key-value metadata tags",
+                    },
+                ],
+            }
 
         """
         avro_path = Path(path)
-        # Also resolves .avro vs .avro.gz, which a hardcoded AVRO_STREAM would have described wrongly.
         file_type = FileType.from_avro_stream(avro_path)
+
+        timestamp_req = None
+        if timestamp_type is not None:
+            typed_timestamp_type = _to_typed_timestamp_type(timestamp_type)
+            timestamp_req = typed_timestamp_type._to_conjure_ingest_avro_api()
+
         workspace_rid = self._clients.resolve_default_workspace_rid()
+
+        # Upload to S3
         s3_path = upload_multipart_file(
             self._clients.auth_header,
             workspace_rid,
@@ -329,6 +350,8 @@ class Dataset(DataSource, RefreshableConjureMixin[scout_catalog.EnrichedDataset]
             file_type=file_type,
             header_provider=self._clients.header_provider,
         )
+
+        # Ingest to Nominal
         target = ingest_api.DatasetIngestTarget(
             existing=ingest_api.ExistingDatasetIngestDestination(dataset_rid=self.rid)
         )
@@ -339,37 +362,87 @@ class Dataset(DataSource, RefreshableConjureMixin[scout_catalog.EnrichedDataset]
                     avro_stream=ingest_api.AvroStreamOpts(
                         source=ingest_api.IngestSource(s3=ingest_api.S3IngestSource(s3_path)),
                         target=target,
+                        additional_file_tags={**tags} if tags else None,
+                        timestamp_type=timestamp_req,
                     )
                 )
             ),
         )
         return self._handle_ingest_response(resp)
 
+    @overload
     def add_journal_json(
         self,
         path: PathLike,
         *,
         channel: str | None = None,
+    ) -> DatasetFile: ...
+    @overload
+    def add_journal_json(
+        self,
+        path: PathLike,
+        *,
+        channel: str | None = None,
+        timestamp_column: str,
+        timestamp_type: _AnyEpochTimestampType,
+    ) -> DatasetFile: ...
+    def add_journal_json(
+        self,
+        path: PathLike,
+        *,
+        channel: str | None = None,
+        timestamp_column: str | None = None,
+        timestamp_type: _AnyEpochTimestampType | None = None,
     ) -> DatasetFile:
         """Add a journald jsonl file to an existing dataset.
 
-        Designed to support any valid journald-style jsonl files, there are a few key expectations for journal
-        json files:
-            - They must be .jsonl or .jsonl.gz files, and each line should contain a json payload
-            - Each json line *must* contain an epoch microsecond timestamp (__REALTIME_TIMESTAMP), which is treated
-              as an integer, and a `MESSAGE` field containing the primary log message. All other JSON key value pairs
-              are converted to args, though, except string literals.
+        Supports any journald-style jsonl file, with a few expectations:
+            - The file must be .jsonl or .jsonl.gz, and each line must be a json object.
+            - Each line must hold a timestamp field and a `MESSAGE` field carrying the primary log message.
+              The timestamp field is `__REALTIME_TIMESTAMP` unless `timestamp_column` names another one.
+              Lines missing either field are skipped.
+            - Every other top-level field becomes a log arg, with its value converted to a string.
 
         Args:
             path: Path to journal json file to ingest
             channel: Optionally, a channel name to use for ingested logs (defaults to 'logs')
+            timestamp_column: Optionally, the name of the field in each json payload holding a timestamp.
+                Defaults to __REALTIME_TIMESTAMP.
+            timestamp_type: Optionally, how to read the numbers in that field, given as a `ts.Epoch` or its
+                string literal, e.g. `"epoch_microseconds"`. Defaults to microseconds since the unix epoch.
 
         Returns:
             DatasetFile object which can be used to poll for ingestion completion
+
+        Raises:
+            ValueError: if only one of `timestamp_column` / `timestamp_type` is given, or if
+                `timestamp_type` is not an absolute epoch type.
         """
+        _validate_timestamp_pair(timestamp_column, timestamp_type)
+
+        timestamp_metadata = None
+        if timestamp_column is not None and timestamp_type is not None:
+            typed_timestamp_type = _to_typed_timestamp_type(timestamp_type)
+            # Journal ingest carries an epoch time unit with nowhere to record a starting offset, so a
+            # relative or string-format type cannot be expressed here.
+            # TODO(drake): once this routes through v2 ingest, which can carry a relative timestamp type,
+            # widen this guard and the _AnyEpochTimestampType annotations here and on _DatasetWrapper to
+            # accept ts.Relative. The log pipeline already reads relative timestamps -- only this request
+            # shape blocks it, and IngestBuilder.add_journal_json accepts them today.
+            if not isinstance(typed_timestamp_type, Epoch):
+                raise ValueError(
+                    f"journal json timestamps must be an absolute epoch type, received {typed_timestamp_type!r}"
+                )
+            timestamp_metadata = ingest_api.JournalTimestampMetadata(
+                epoch_of_time_unit=typed_timestamp_type._to_conjure_epoch_timestamp(),
+                field_name=timestamp_column,
+            )
+
         log_path = Path(path)
         file_type = FileType.from_path_journal_json(log_path)
         workspace_rid = self._clients.resolve_default_workspace_rid()
+
+        # Upload to S3
         s3_path = upload_multipart_file(
             self._clients.auth_header,
             workspace_rid,
@@ -378,6 +451,8 @@ class Dataset(DataSource, RefreshableConjureMixin[scout_catalog.EnrichedDataset]
             file_type=file_type,
             header_provider=self._clients.header_provider,
         )
+
+        # Trigger Ingest
         target = ingest_api.DatasetIngestTarget(
             existing=ingest_api.ExistingDatasetIngestDestination(dataset_rid=self.rid)
         )
@@ -389,6 +464,7 @@ class Dataset(DataSource, RefreshableConjureMixin[scout_catalog.EnrichedDataset]
                         source=ingest_api.IngestSource(s3=ingest_api.S3IngestSource(s3_path)),
                         target=target,
                         channel=channel,
+                        timestamp_metadata=timestamp_metadata,
                     )
                 )
             ),
@@ -891,14 +967,14 @@ class Dataset(DataSource, RefreshableConjureMixin[scout_catalog.EnrichedDataset]
         Returns:
             An `IngestionJob` handle for the asynchronous containerized ingest.
         """
+        _validate_timestamp_pair(timestamp_column, timestamp_type)
+
         timestamp_metadata = None
         if timestamp_column is not None and timestamp_type is not None:
             timestamp_metadata = ingest_api.TimestampMetadata(
                 series_name=timestamp_column,
                 timestamp_type=_to_typed_timestamp_type(timestamp_type)._to_conjure_ingest_api(),
             )
-        elif (timestamp_column is None) != (timestamp_type is None):
-            raise ValueError("Only one of `timestamp_column` and `timestamp_type` provided!")
 
         if isinstance(extractor, str):
             extractor = _get_containerized_extractor(self._clients, extractor)
@@ -1213,55 +1289,78 @@ class _DatasetWrapper(abc.ABC):
         self,
         data_scope_name: str,
         path: PathLike,
+        *,
+        timestamp_type: _AnyNumericTimestampType | None = None,
+        tags: Mapping[str, str] | None = None,
     ) -> DatasetFile:
         """Upload an avro stream file to the dataset selected by `data_scope_name`.
 
-        This method behaves like `nominal.core.Dataset.add_avro_stream`, with one important difference:
-        avro stream ingestion does not support applying scope tags. If the selected scope requires tags, this method
-        raises `RuntimeError` rather than ingesting (potentially) untagged data. This file may still be ingested
-        directly on the dataset itself if it is known to contain the correct set of tags.
+        This method behaves like `nominal.core.Dataset.add_avro_stream`, except that the data scope's required
+        tags are merged into `tags` before ingest (with user-provided tags taking precedence on key collisions).
+        Tags in the avro records take precedence over both, so a scope tag whose key a record already sets is
+        not applied to that record's data.
 
-        For schema requirements and return value details, see
+        For schema requirements, argument semantics, and return value details, see
         `nominal.core.Dataset.add_avro_stream`.
         """
         dataset, scope_tags = self._get_dataset_scope(data_scope_name)
+        return dataset.add_avro_stream(path, timestamp_type=timestamp_type, tags=_unify_tags(scope_tags, tags))
 
-        # TODO(drake): remove once avro stream supports ingest with tags
-        if scope_tags:
-            raise RuntimeError(
-                f"Cannot add avro files to datascope {data_scope_name}-- data would not get "
-                f"tagged with required tags: {scope_tags}"
-            )
-
-        return dataset.add_avro_stream(path)
-
+    @overload
+    def add_journal_json(self, data_scope_name: str, path: PathLike, *, channel: str | None = ...) -> DatasetFile: ...
+    @overload
+    def add_journal_json(
+        self,
+        data_scope_name: str,
+        path: PathLike,
+        *,
+        channel: str | None = ...,
+        timestamp_column: str,
+        timestamp_type: _AnyEpochTimestampType,
+    ) -> DatasetFile: ...
     def add_journal_json(
         self,
         data_scope_name: str,
         path: PathLike,
         *,
         channel: str | None = None,
+        timestamp_column: str | None = None,
+        timestamp_type: _AnyEpochTimestampType | None = None,
     ) -> DatasetFile:
         """Add a journald json file to the dataset selected by `data_scope_name`.
 
-        This method behaves like `nominal.core.Dataset.add_journal_json`, with one important difference:
-        journal json ingestion does not support applying scope tags as args. If the selected scope requires tags,
-        this method raises `RuntimeError` rather than potentially ingesting untagged data. This file may still be
-        ingested directly on the dataset itself if it is known to contain the correct set of args.
+        This method behaves like `nominal.core.Dataset.add_journal_json`, with one important difference: the
+        journal json ingest request has no field for tags, so a scope's required tags cannot be applied to the
+        ingested logs. If the selected scope requires tags, this method raises `RuntimeError` rather than
+        ingesting logs that would be missing them. The file can still be ingested on the dataset directly, if
+        its own contents already carry what the scope needs.
 
-        For file expectations and return value details, see
+        For file expectations, timestamp argument semantics, and return value details, see
         `nominal.core.Dataset.add_journal_json`.
         """
+        # Checked here as well as in the delegate, so a mispaired call fails on its own arguments rather
+        # than after a round trip to resolve the scope.
+        _validate_timestamp_pair(timestamp_column, timestamp_type)
+
         dataset, scope_tags = self._get_dataset_scope(data_scope_name)
 
         # TODO(drake): remove once journal json supports ingest with tags
         if scope_tags:
             raise RuntimeError(
-                f"Cannot add journal json files to datascope {data_scope_name}-- data would not get "
-                f"tagged with required arguments: {scope_tags}"
+                f"Cannot add journal json files to datascope {data_scope_name}: journal ingest cannot apply "
+                f"tags, so the logs would not get the scope's required tags {scope_tags}"
             )
 
-        return dataset.add_journal_json(path, channel=channel)
+        # `Dataset.add_journal_json`'s overloads take the timestamp pair together or not at all, but this
+        # pass-through holds each half as its own optional -- a shape no overload can accept, since the two
+        # are only correlated at runtime. Forwarding in one call gives up static checking here; the check
+        # above and the delegate's own conversion enforce the contract.
+        return dataset.add_journal_json(
+            path,
+            channel=channel,
+            timestamp_column=timestamp_column,  # type: ignore[arg-type]
+            timestamp_type=timestamp_type,  # type: ignore[arg-type]
+        )
 
     def add_mcap(
         self,
@@ -1346,21 +1445,16 @@ class _DatasetWrapper(abc.ABC):
         This method behaves like `nominal.core.Dataset.add_containerized`, except that the data scope's required
         tags are merged into `tags` before ingest (with user-provided tags taking precedence on key collisions).
 
-        This wrapper also enforces that `timestamp_column` and `timestamp_type` are provided together (or omitted
-        together) before delegating.
+        Pass both `timestamp_column` and `timestamp_type`, or neither; this wrapper enforces that before
+        delegating.
 
         For extractor inputs, tagging semantics, timestamp metadata behavior, and return value details, see
         `nominal.core.Dataset.add_containerized`.
         """
+        _validate_timestamp_pair(timestamp_column, timestamp_type)
+
         dataset, scope_tags = self._get_dataset_scope(data_scope_name)
-        if timestamp_column is None and timestamp_type is None:
-            return dataset.add_containerized(
-                extractor,
-                sources,
-                arguments=arguments,
-                tags=_unify_tags(scope_tags, tags),
-            )
-        elif timestamp_column is not None and timestamp_type is not None:
+        if timestamp_column is not None and timestamp_type is not None:
             return dataset.add_containerized(
                 extractor,
                 sources,
@@ -1369,11 +1463,12 @@ class _DatasetWrapper(abc.ABC):
                 timestamp_column=timestamp_column,
                 timestamp_type=timestamp_type,
             )
-        else:
-            raise ValueError(
-                "Only one of `timestamp_column` and `timestamp_type` were provided to `add_containerized`, "
-                "either both must or neither must be provided."
-            )
+        return dataset.add_containerized(
+            extractor,
+            sources,
+            arguments=arguments,
+            tags=_unify_tags(scope_tags, tags),
+        )
 
     def add_from_io(
         self,

--- a/nominal/experimental/extractor/README.md
+++ b/nominal/experimental/extractor/README.md
@@ -54,14 +54,15 @@ format, each exposing only the options that format actually uses. `manifest.json
 | Method | For | Options |
 |---|---|---|
 | `add_tabular` | `.csv` / `.parquet` (and `.gz`) | `tag_columns`, `channel_prefix`, `timestamp_column`/`timestamp_type` |
-| `add_avro_stream` | `.avro` / `.avro.gz` | `channel_prefix` |
+| `add_avro_stream` | `.avro` / `.avro.gz` | `channel_prefix`, `timestamp_type` |
 | `add_journal_json` | `.jsonl` / `.jsonl.gz`, ingested as logs | `timestamp_column`/`timestamp_type` |
 | `add_video` | any supported video container | `channel` (required), `start` or `frame_timestamps` |
 
-The gaps are deliberate. Avro records carry their own channel, timestamp, value, and tags, so there is
-nothing to map. Log samples carry no tags and all land on one channel, so tag columns and a channel
-prefix would be silently dropped. Each method also checks the file extension its format requires, so
-a mismatch fails at the call rather than server-side after upload.
+The gaps are deliberate. Avro records carry their own channel, values, and tags, so there is nothing
+to map — but their timestamps are bare numbers, so `add_avro_stream` still takes a `timestamp_type`
+saying how to read them. Log samples carry no tags and all land on one channel, so tag columns and a
+channel prefix would be silently dropped. Each method also checks the file extension its format
+requires, so a mismatch fails at the call rather than server-side after upload.
 
 ```python
 from nominal.experimental.extractor import ManifestExtractorContext, manifest_extractor
@@ -126,9 +127,18 @@ ctx.add_tabular(part, timestamp_column="ts", timestamp_type="epoch_microseconds"
 ctx.add_tabular(run, timestamp_column="elapsed", timestamp_type=ts.Relative("milliseconds", start=t0))
 ```
 
+`add_avro_stream` takes the type alone — the avro schema fixes which field holds the timestamps, so
+there is no column to name:
+
+```python
+ctx.add_avro_stream(records, timestamp_type="epoch_microseconds")
+```
+
 Only numeric types work here — absolute epochs (`ts.Epoch`) or offsets from a start (`ts.Relative`).
-Outputs needing ISO 8601 or custom string formats omit the pair and inherit the job-level metadata,
-which supports the full range.
+Outputs needing ISO 8601 or custom string formats omit the timestamp arguments and inherit the
+job-level metadata, which supports the full range. For an avro output, inheriting is only correct when
+the job-level type is numeric too, since avro timestamps are integers and a string format cannot read
+them.
 
 ## Inputs and parameters
 
@@ -154,9 +164,10 @@ ctx.job_timestamp_metadata     # what an output falls back to when it declares n
 ## Errors
 
 Rejections come back as `ExtractorError` when they are about the extractor's own contract — a
-reserved file name, an output outside `$OUTPUT_DIR`, no outputs declared — and as the ordinary
-argument errors the rest of the client raises (`ValueError` subclasses) when the arguments themselves
-are malformed, including a file extension the declared format cannot read.
+reserved file name, an output outside `$OUTPUT_DIR`, no outputs declared, a timestamp type the
+manifest cannot express — and as the ordinary argument errors the rest of the client raises
+(`ValueError` subclasses) when the arguments themselves are malformed, including a file extension the
+declared format cannot read, or half of a `timestamp_column` / `timestamp_type` pair.
 
 An undeclared file left in `$OUTPUT_DIR` is a warning, not a failure: the pipeline reads only what the
 manifest names, so it will not be ingested, but a scratch file does not fail the run.

--- a/nominal/experimental/extractor/_context.py
+++ b/nominal/experimental/extractor/_context.py
@@ -28,7 +28,12 @@ from nominal.experimental.extractor._env import (
     _ParamSpec,
     _spec_names,
 )
-from nominal.experimental.extractor._manifest import IngestType, _manifest_timestamp_metadata
+from nominal.experimental.extractor._manifest import (
+    _AVRO_TIMESTAMPS_FIELD,
+    IngestType,
+    _manifest_timestamp_metadata,
+    _optional_manifest_timestamp_metadata,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -314,6 +319,24 @@ class ManifestExtractorContext(ExtractorContext):
             )
         return resolved, relative
 
+    @overload
+    def add_tabular(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        tag_columns: Mapping[str, str] | None = ...,
+        channel_prefix: str | None = ...,
+    ) -> Path: ...
+    @overload
+    def add_tabular(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        tag_columns: Mapping[str, str] | None = ...,
+        channel_prefix: str | None = ...,
+        timestamp_column: str,
+        timestamp_type: ts._AnyNumericTimestampType,
+    ) -> Path: ...
     def add_tabular(
         self,
         path: str | os.PathLike[str],
@@ -321,7 +344,7 @@ class ManifestExtractorContext(ExtractorContext):
         tag_columns: Mapping[str, str] | None = None,
         channel_prefix: str | None = None,
         timestamp_column: str | None = None,
-        timestamp_type: ts._AnyTimestampType | None = None,
+        timestamp_type: ts._AnyNumericTimestampType | None = None,
     ) -> Path:
         """Declare a CSV or Parquet file you wrote; its columns become channels.
 
@@ -331,7 +354,7 @@ class ManifestExtractorContext(ExtractorContext):
         its own timestamp column; only numeric types work here -- absolute epochs
         (:class:`ts.Epoch`) or offsets from a starting time (:class:`ts.Relative`). Outputs needing
         ISO 8601 or custom formats omit the pair and inherit the job-level metadata, which supports
-        the full range.
+        the full range. The overloads make passing only one of the pair a type error.
         """
         resolved, relative = self._relative_declarable_path(path)
         FileType.from_path_dataset(resolved)
@@ -341,36 +364,70 @@ class ManifestExtractorContext(ExtractorContext):
             IngestType.TABULAR,
             tag_columns=tag_columns,
             channel_prefix=channel_prefix,
-            timestamp_column=timestamp_column,
-            timestamp_type=timestamp_type,
+            timestamp_metadata=_optional_manifest_timestamp_metadata(timestamp_column, timestamp_type),
         )
 
-    def add_avro_stream(self, path: str | os.PathLike[str], *, channel_prefix: str | None = None) -> Path:
+    def add_avro_stream(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        channel_prefix: str | None = None,
+        timestamp_type: ts._AnyNumericTimestampType | None = None,
+    ) -> Path:
         """Declare an avro-stream file you wrote (``.avro`` or ``.avro.gz``).
 
-        Avro records carry their own channel, timestamp, value, and tags, so this takes no tag
-        columns and no timestamp metadata -- the pipeline reads all of that from the records
-        themselves. ``channel_prefix`` is still prepended to every channel from this file.
+        Avro records carry their own channel, values, and tags, so this takes no tag columns and no
+        timestamp column. The schema fixes which field holds the timestamps; ``timestamp_type`` says how
+        to read the numbers in it, overriding the job-level timestamp metadata for this output. Only
+        numeric types work here: absolute epochs (:class:`ts.Epoch`) or offsets from a starting time
+        (:class:`ts.Relative`).
+
+        Omit ``timestamp_type`` to inherit the job-level metadata. That is only correct when the
+        job-level type is numeric too, since avro timestamps are integers and a string format cannot
+        read them.
+
+        ``channel_prefix`` is prepended to every channel from this file.
         """
         resolved, relative = self._relative_declarable_path(path)
         FileType.from_avro_stream(resolved)
-        return self._record_output(resolved, relative, IngestType.AVRO_STREAM, channel_prefix=channel_prefix)
+        return self._record_output(
+            resolved,
+            relative,
+            IngestType.AVRO_STREAM,
+            channel_prefix=channel_prefix,
+            timestamp_metadata=None
+            if timestamp_type is None
+            else _manifest_timestamp_metadata(_AVRO_TIMESTAMPS_FIELD, timestamp_type),
+        )
 
+    @overload
+    def add_journal_json(self, path: str | os.PathLike[str]) -> Path: ...
+    @overload
+    def add_journal_json(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        timestamp_column: str,
+        timestamp_type: ts._AnyNumericTimestampType,
+    ) -> Path: ...
     def add_journal_json(
         self,
         path: str | os.PathLike[str],
         *,
         timestamp_column: str | None = None,
-        timestamp_type: ts._AnyTimestampType | None = None,
+        timestamp_type: ts._AnyNumericTimestampType | None = None,
     ) -> Path:
         """Declare a journal JSONL file you wrote (``.jsonl`` or ``.jsonl.gz``); it is ingested as logs.
 
-        Each line must carry a ``MESSAGE`` field. ``timestamp_column``/``timestamp_type`` (provided
+        Each line must carry a ``MESSAGE`` field and a timestamp field; lines missing either are skipped.
+        Every other top-level field becomes a log arg, with its value converted to a string.
+        ``timestamp_column``/``timestamp_type`` (provided
         together) name the top-level JSON field holding each line's timestamp, overriding the
         job-level metadata; the same numeric-only restriction as :meth:`add_tabular` applies.
 
         Log samples carry no tags and every log point lands on one channel, so this takes neither
-        tag columns nor a channel prefix -- the ingest pipeline ignores both for log outputs.
+        tag columns nor a channel prefix -- the ingest pipeline ignores both for log outputs. The
+        overloads make passing only one of the pair a type error.
         """
         resolved, relative = self._relative_declarable_path(path)
         FileType.from_path_journal_json(resolved)
@@ -378,8 +435,7 @@ class ManifestExtractorContext(ExtractorContext):
             resolved,
             relative,
             IngestType.JSON_L,
-            timestamp_column=timestamp_column,
-            timestamp_type=timestamp_type,
+            timestamp_metadata=_optional_manifest_timestamp_metadata(timestamp_column, timestamp_type),
         )
 
     def _record_output(
@@ -390,19 +446,13 @@ class ManifestExtractorContext(ExtractorContext):
         *,
         tag_columns: Mapping[str, str] | None = None,
         channel_prefix: str | None = None,
-        timestamp_column: str | None = None,
-        timestamp_type: ts._AnyTimestampType | None = None,
+        timestamp_metadata: ingest_manifest.ManifestTimestampMetadata | None = None,
     ) -> Path:
         """Record one manifest entry, shared by the per-format declaration methods.
 
-        Each of those exposes only the fields its ingest type actually reads, so this takes the
-        union and trusts its callers not to pass one that would be silently dropped.
+        Each of those exposes only the fields its ingest type reads, and builds its own timestamp
+        metadata before calling here.
         """
-        if (timestamp_column is None) != (timestamp_type is None):
-            raise ExtractorError("timestamp_column and timestamp_type must be provided together")
-        timestamp_metadata = None
-        if timestamp_column is not None and timestamp_type is not None:
-            timestamp_metadata = _manifest_timestamp_metadata(timestamp_column, timestamp_type)
         logger.debug("declared output %s (%s)", relative, ingest_type.value)
         self._outputs.append(
             ingest_manifest.ManifestOutput(

--- a/nominal/experimental/extractor/_manifest.py
+++ b/nominal/experimental/extractor/_manifest.py
@@ -38,9 +38,14 @@ _MANIFEST_EPOCH_UNITS: dict[str, ingest_manifest.ManifestEpochTimeUnit] = {
     "nanoseconds": ingest_manifest.ManifestEpochTimeUnit.NANOSECONDS,
 }
 
+# The timestamp field in the canonical avro-stream schema. An avro output declares only how to read
+# its timestamps: the schema fixes which field holds them, and the pipeline reads that field by name.
+# This fills the series name the manifest type requires, and reaches only the file's own metadata.
+_AVRO_TIMESTAMPS_FIELD = "timestamps"
+
 
 def _manifest_timestamp_metadata(
-    series_name: str, timestamp_type: ts._AnyTimestampType
+    series_name: str, timestamp_type: ts._AnyNumericTimestampType
 ) -> ingest_manifest.ManifestTimestampMetadata:
     """Validate a per-output timestamp type against the manifest contract and convert it.
 
@@ -69,3 +74,20 @@ def _manifest_timestamp_metadata(
         if isinstance(typed, ts.Relative)
         else None,
     )
+
+
+def _optional_manifest_timestamp_metadata(
+    series_name: str | None, timestamp_type: ts._AnyNumericTimestampType | None
+) -> ingest_manifest.ManifestTimestampMetadata | None:
+    """Convert a timestamp column/type pair, which must be given together or not at all.
+
+    Formats that let the author name the timestamp field -- a tabular column, a journal JSON field --
+    take the pair. One without the other describes nothing, so it is rejected here.
+
+    A half-specified pair raises `ValueError`, like every other malformed argument in this client;
+    `ExtractorError` is for violations of the extractor's own contract.
+    """
+    ts._validate_timestamp_pair(series_name, timestamp_type)
+    if series_name is None or timestamp_type is None:
+        return None
+    return _manifest_timestamp_metadata(series_name, timestamp_type)

--- a/nominal/experimental/ingest/_ingest_builder.py
+++ b/nominal/experimental/ingest/_ingest_builder.py
@@ -45,9 +45,12 @@ from nominal.protos.ingest.v2 import (
 from nominal.ts import (
     Epoch,
     IntegralNanosecondsUTC,
+    Relative,
+    _AnyNumericTimestampType,
     _AnyTimestampType,
     _SecondsNanos,
     _to_typed_timestamp_type,
+    _validate_timestamp_pair,
 )
 
 logger = logging.getLogger(__name__)
@@ -398,19 +401,24 @@ class IngestBuilder:
         *,
         units: Mapping[str, str] | None = None,
         channel_prefix: str | None = None,
+        timestamp_type: _AnyNumericTimestampType | None = None,
         tags: Mapping[str, str] | None = None,
     ) -> Self:
         """Register an Avro stream (.avro) file.
 
         The file must conform to the canonical Avro stream schema (see `Dataset.add_avro_stream`
-        for the schema definition); its timestamps come from the epoch-nanosecond `timestamps`
-        field, so no timestamp column is passed here.
+        for the schema definition). The schema fixes which field holds the timestamps, so this takes
+        no timestamp column -- only how to read the numbers in that field.
 
         Args:
             path: Path to the .avro file on disk.
             units: Mapping of channel name to unit symbol.
             channel_prefix: Prefix prepended to every channel name ingested from this file.
-            tags: Key-value pairs applied as tags to all data from this file.
+            timestamp_type: How to read the file's numeric timestamps -- an absolute epoch
+                (`ts.Epoch`, or its string literal) or an offset from a start (`ts.Relative`).
+                Defaults to epoch nanoseconds, the canonical schema's reading.
+            tags: Key-value pairs applied as tags to all data from this file. Tags in the records
+                take precedence -- these only fill keys a record does not already set.
 
         Returns:
             This builder, for chaining.
@@ -425,13 +433,15 @@ class IngestBuilder:
         # Avro deliberately omits channel_name_overrides: the backend rejects it for avro
         # ("channel names come from record data").
         # TODO(drake): expose channel_name_overrides here once the backend accepts it for avro.
+
+        # The canonical avro stream schema fixes the timestamps to a `timestamps` field (see
+        # `Dataset.add_avro_stream` for the schema) and the multi-file endpoint requires
+        # timestamp_metadata on every file item, so the canonical epoch-nanosecond reading is sent
+        # whenever the caller declares none.
+        declared_type = Epoch(unit="nanoseconds") if timestamp_type is None else timestamp_type
         options = file_ingest_pb2.FileIngestOptions(
-            # The canonical avro stream schema fixes the timestamp to an epoch-nanosecond
-            # `timestamps` field (see `Dataset.add_avro_stream` for the schema), and the v2
-            # endpoint requires timestamp_metadata on every file item — so avro always sends
-            # this fixed definition.
             timestamp_metadata=common_pb2.TimestampMetadata(
-                column="timestamps", type=_to_typed_timestamp_type(Epoch(unit="nanoseconds"))._to_proto()
+                column="timestamps", type=_to_typed_timestamp_type(declared_type)._to_proto()
             ),
             units=units,
             channel_prefix=channel_prefix,
@@ -527,7 +537,7 @@ class IngestBuilder:
         *,
         channel: str | None = ...,
         timestamp_column: str,
-        timestamp_type: _AnyTimestampType,
+        timestamp_type: _AnyNumericTimestampType,
         tags: Mapping[str, str] | None = ...,
     ) -> Self: ...
     def add_journal_json(
@@ -536,7 +546,7 @@ class IngestBuilder:
         *,
         channel: str | None = None,
         timestamp_column: str | None = None,
-        timestamp_type: _AnyTimestampType | None = None,
+        timestamp_type: _AnyNumericTimestampType | None = None,
         tags: Mapping[str, str] | None = None,
     ) -> Self:
         """Register a journald-style .jsonl / .jsonl.gz log file.
@@ -550,26 +560,33 @@ class IngestBuilder:
             channel: Channel name to ingest the logs under. Defaults to 'logs' if omitted.
             timestamp_column: Field holding each record's timestamp. Omit to use the file's
                 default journald timestamp.
-            timestamp_type: Type of the timestamp data in `timestamp_column`, e.g. 'epoch_microseconds'.
+            timestamp_type: How to read the numbers in `timestamp_column` -- an absolute epoch
+                (`ts.Epoch`, or its string literal, e.g. 'epoch_microseconds') or an offset from a
+                start (`ts.Relative`). Log timestamps are read as numbers, so ISO 8601 and custom
+                string formats cannot be used here.
             tags: Key-value pairs applied as tags to all data from this file.
 
         Returns:
             This builder, for chaining.
 
         Raises:
-            ValueError: if only one of `timestamp_column` / `timestamp_type` is given.
+            ValueError: if only one of `timestamp_column` / `timestamp_type` is given, or if
+                `timestamp_type` is not numeric.
         """
-        if (timestamp_column is None) != (timestamp_type is None):
-            raise ValueError("pass both timestamp_column and timestamp_type, or neither")
+        _validate_timestamp_pair(timestamp_column, timestamp_type)
         file_path = Path(path)
         file_type = FileType.from_path_journal_json(file_path)
-        timestamp_meta = (
-            common_pb2.TimestampMetadata(
-                column=timestamp_column, type=_to_typed_timestamp_type(timestamp_type)._to_proto()
+        timestamp_meta = None
+        if timestamp_column is not None and timestamp_type is not None:
+            typed_timestamp_type = _to_typed_timestamp_type(timestamp_type)
+            if not isinstance(typed_timestamp_type, (Epoch, Relative)):
+                raise ValueError(
+                    f"journal json timestamps must be numeric (ts.Epoch or ts.Relative), "
+                    f"received {typed_timestamp_type!r}"
+                )
+            timestamp_meta = common_pb2.TimestampMetadata(
+                column=timestamp_column, type=typed_timestamp_type._to_proto()
             )
-            if timestamp_column is not None and timestamp_type is not None
-            else None
-        )
         self._pending.append(
             _LogItem(
                 file=_PendingFile(file_path, file_type),
@@ -729,8 +746,7 @@ class IngestBuilder:
             ValueError: if `sources` is empty, or if only one of `timestamp_column` /
                 `timestamp_type` is given.
         """
-        if (timestamp_column is None) != (timestamp_type is None):
-            raise ValueError("pass both timestamp_column and timestamp_type, or neither")
+        _validate_timestamp_pair(timestamp_column, timestamp_type)
         if not sources:
             raise ValueError("add_containerized requires at least one source")
         timestamp_meta = (

--- a/nominal/ts/__init__.py
+++ b/nominal/ts/__init__.py
@@ -249,6 +249,10 @@ class _ConjureTimestampType(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def _to_conjure_ingest_avro_api(self) -> ingest_api.AvroNumericTimestampType:
+        pass
+
+    @abc.abstractmethod
     def _to_proto(self) -> timestamp_parsers_pb2.TimestampType:
         """Convert to the proto nominal.types.time.TimestampType.
 
@@ -306,6 +310,9 @@ class Iso8601(_ConjureTimestampType):
     def _to_conjure_ingest_api(self) -> ingest_api.TimestampType:
         return ingest_api.TimestampType(absolute=ingest_api.AbsoluteTimestamp(iso8601=ingest_api.Iso8601Timestamp()))
 
+    def _to_conjure_ingest_avro_api(self) -> ingest_api.AvroNumericTimestampType:
+        raise ValueError("ISO 8601 timestamps are not supported with .avro files")
+
     def _to_proto(self) -> timestamp_parsers_pb2.TimestampType:
         return timestamp_parsers_pb2.TimestampType(
             absolute=timestamp_parsers_pb2.AbsoluteTimestamp(iso8601=timestamp_parsers_pb2.Iso8601Timestamp())
@@ -320,9 +327,16 @@ class Epoch(_ConjureTimestampType):
 
     unit: _LiteralTimeUnit
 
+    def _to_conjure_epoch_timestamp(self) -> ingest_api.EpochTimestamp:
+        return ingest_api.EpochTimestamp(time_unit=_time_unit_to_conjure(self.unit))
+
     def _to_conjure_ingest_api(self) -> ingest_api.TimestampType:
-        epoch = ingest_api.EpochTimestamp(time_unit=_time_unit_to_conjure(self.unit))
-        return ingest_api.TimestampType(absolute=ingest_api.AbsoluteTimestamp(epoch_of_time_unit=epoch))
+        return ingest_api.TimestampType(
+            absolute=ingest_api.AbsoluteTimestamp(epoch_of_time_unit=self._to_conjure_epoch_timestamp())
+        )
+
+    def _to_conjure_ingest_avro_api(self) -> ingest_api.AvroNumericTimestampType:
+        return ingest_api.AvroNumericTimestampType(epoch=self._to_conjure_epoch_timestamp())
 
     def _to_proto(self) -> timestamp_parsers_pb2.TimestampType:
         epoch = timestamp_parsers_pb2.EpochTimestamp(time_unit=_time_unit_to_conjure(self.unit).value)
@@ -346,6 +360,11 @@ class Relative(_ConjureTimestampType):
     start: datetime | IntegralNanosecondsUTC
     """The starting time to which all relatives times are relative to."""
 
+    def _to_conjure_relative_timestamp(self) -> ingest_api.RelativeTimestamp:
+        return ingest_api.RelativeTimestamp(
+            time_unit=_time_unit_to_conjure(self.unit), offset=_SecondsNanos.from_flexible(self.start).to_iso8601()
+        )
+
     def _to_conjure_ingest_api(self) -> ingest_api.TimestampType:
         """Note: The offset is a conjure datetime. They are serialized as ISO-8601 strings, with up-to nanosecond prec.
         The Python type for the field is just a str.
@@ -353,10 +372,10 @@ class Relative(_ConjureTimestampType):
         - https://github.com/palantir/conjure/blob/master/docs/concepts.md#built-in-types
         - https://github.com/palantir/conjure/pull/1643
         """
-        relative = ingest_api.RelativeTimestamp(
-            time_unit=_time_unit_to_conjure(self.unit), offset=_SecondsNanos.from_flexible(self.start).to_iso8601()
-        )
-        return ingest_api.TimestampType(relative=relative)
+        return ingest_api.TimestampType(relative=self._to_conjure_relative_timestamp())
+
+    def _to_conjure_ingest_avro_api(self) -> ingest_api.AvroNumericTimestampType:
+        return ingest_api.AvroNumericTimestampType(relative=self._to_conjure_relative_timestamp())
 
     def _to_proto(self) -> timestamp_parsers_pb2.TimestampType:
         sn = _SecondsNanos.from_flexible(self.start)
@@ -390,6 +409,9 @@ class Custom(_ConjureTimestampType):
         )
         return ingest_api.TimestampType(absolute=ingest_api.AbsoluteTimestamp(custom_format=fmt))
 
+    def _to_conjure_ingest_avro_api(self) -> ingest_api.AvroNumericTimestampType:
+        raise ValueError("Custom timestamps are not supported with .avro files")
+
     def _to_proto(self) -> timestamp_parsers_pb2.TimestampType:
         fmt = timestamp_parsers_pb2.CustomTimestamp(
             format=self.format,
@@ -421,8 +443,7 @@ _LiteralTimeUnit: TypeAlias = Literal[
     "days",
 ]
 
-_LiteralAbsolute: TypeAlias = Literal[
-    "iso_8601",
+_LiteralNumericAbsolute: TypeAlias = Literal[
     "epoch_picoseconds",
     "epoch_nanoseconds",
     "epoch_microseconds",
@@ -432,6 +453,7 @@ _LiteralAbsolute: TypeAlias = Literal[
     "epoch_hours",
     "epoch_days",
 ]
+_LiteralAbsolute: TypeAlias = Literal["iso_8601", _LiteralNumericAbsolute]
 
 _ExportableTypedTimestampType: TypeAlias = Iso8601 | Epoch | Relative
 """Type alias for all of the strongly typed timestamp types that can be converted to a native python datetime"""
@@ -444,6 +466,29 @@ _AnyExportableTimestampType: TypeAlias = _ExportableTypedTimestampType | _Litera
 
 _AnyTimestampType: TypeAlias = TypedTimestampType | _LiteralAbsolute
 """Type alias for all of the allowable timestamp types, including string representations."""
+
+_AnyNumericTimestampType: TypeAlias = Epoch | Relative | _LiteralNumericAbsolute
+"""Type alias for all of the allowable numeric timestamp types without string representations."""
+
+_AnyEpochTimestampType: TypeAlias = Epoch | _LiteralNumericAbsolute
+"""Type alias for absolute epoch timestamps, typed or as a string literal.
+
+`Relative` is excluded on purpose: the requests taking this alias carry a time unit and have nowhere to
+put a starting offset, so a relative type would lose its start.
+"""
+
+
+def _validate_timestamp_pair(timestamp_column: str | None, timestamp_type: _AnyTimestampType | None) -> None:
+    """Require a timestamp column and type together, or neither.
+
+    Naming a field without saying how to read it -- or the reverse -- describes nothing, so every
+    method taking the pair rejects a half-specified one. Shared so they all reject it the same way.
+
+    `timestamp_type` is typed to the widest alias, which every narrower one is a subset of, so callers
+    restricted to numeric or epoch types can pass theirs unchanged.
+    """
+    if (timestamp_column is None) != (timestamp_type is None):
+        raise ValueError("pass both timestamp_column and timestamp_type, or neither")
 
 
 def _to_typed_timestamp_type(type_: _AnyTimestampType) -> TypedTimestampType:

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -8,7 +8,8 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from nominal.core.dataset import Dataset, DatasetBounds
+from nominal import ts
+from nominal.core.dataset import Dataset, DatasetBounds, _DatasetWrapper
 from nominal.core.exceptions import NominalIngestError
 from nominal.core.log import LogPoint
 from nominal.core.unit import Unit
@@ -266,3 +267,172 @@ def test_add_avro_stream_uploads_with_the_resolved_file_type(
             mock_dataset.add_avro_stream(path)
 
     assert upload.call_args.kwargs["file_type"].extension == expected_extension
+
+
+def test_add_avro_stream_accepts_tags_and_an_epoch_string_literal(mock_dataset: Dataset, tmp_path) -> None:
+    """The avro request's options carry the merged tags and the converted numeric timestamp type."""
+    path = tmp_path / "records.avro"
+    path.write_bytes(b"avro")
+
+    with patch("nominal.core.dataset.upload_multipart_file", return_value="s3://path"):
+        with contextlib.suppress(ValueError):
+            mock_dataset.add_avro_stream(path, timestamp_type="epoch_microseconds", tags={"vehicle": "v1"})
+
+    # ingest() is called positionally as (auth_header, request).
+    (_, request) = mock_dataset._clients.ingest.ingest.call_args.args
+    avro_opts = request.options.avro_stream
+    assert avro_opts.additional_file_tags == {"vehicle": "v1"}
+    assert avro_opts.timestamp_type.epoch.time_unit.value == "MICROSECONDS"
+
+
+def test_add_journal_json_without_timestamp_arguments_ingests(mock_dataset: Dataset, tmp_path) -> None:
+    """Omitting both timestamp arguments is the default call, not a half-specified override."""
+    path = tmp_path / "logs.jsonl"
+    path.write_text('{"MESSAGE": "hello"}')
+
+    # The mocked client reports no real ingest status, so a ValueError escapes once the ingest is
+    # triggered. Reaching the upload at all is what is under test. (Verified: the escaping exception
+    # is ValueError("Unknown ingest status: ..."), so do not widen this to Exception.)
+    with patch("nominal.core.dataset.upload_multipart_file", return_value="s3://path") as upload:
+        with contextlib.suppress(ValueError):
+            mock_dataset.add_journal_json(path)
+
+    upload.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"timestamp_column": "ts"}, id="column-without-type"),
+        pytest.param({"timestamp_type": ts.Epoch("microseconds")}, id="type-without-column"),
+    ],
+)
+def test_add_journal_json_rejects_half_specified_timestamps(mock_dataset: Dataset, tmp_path, kwargs) -> None:
+    """One half of the timestamp pair is an error, and fails before any bytes are uploaded."""
+    path = tmp_path / "logs.jsonl"
+    path.write_text('{"MESSAGE": "hello"}')
+
+    with patch("nominal.core.dataset.upload_multipart_file") as upload:
+        with pytest.raises(ValueError, match="pass both"):
+            mock_dataset.add_journal_json(path, **kwargs)
+
+    upload.assert_not_called()
+
+
+def test_add_journal_json_accepts_an_epoch_string_literal(mock_dataset: Dataset, tmp_path) -> None:
+    """The string form of an epoch type works here as it does everywhere else in the client."""
+    path = tmp_path / "logs.jsonl"
+    path.write_text('{"ts": 1}')
+
+    with patch("nominal.core.dataset.upload_multipart_file", return_value="s3://path"):
+        with contextlib.suppress(ValueError):
+            mock_dataset.add_journal_json(path, timestamp_column="ts", timestamp_type="epoch_microseconds")
+
+    # ingest() is called positionally as (auth_header, request).
+    (_, request) = mock_dataset._clients.ingest.ingest.call_args.args
+    metadata = request.options.journal_json.timestamp_metadata
+    assert metadata.field_name == "ts"
+    assert metadata.epoch_of_time_unit.time_unit.value == "MICROSECONDS"
+
+
+@pytest.mark.parametrize(
+    "timestamp_type",
+    [
+        pytest.param("iso_8601", id="string-format-literal"),
+        pytest.param(ts.Relative("seconds", start=0), id="relative"),
+    ],
+)
+def test_add_journal_json_rejects_non_epoch_timestamps_before_uploading(
+    mock_dataset: Dataset, tmp_path, timestamp_type
+) -> None:
+    """A timestamp type journal ingest cannot express fails at the call, not after the file is uploaded."""
+    path = tmp_path / "logs.jsonl"
+    path.write_text('{"ts": 1}')
+
+    with patch("nominal.core.dataset.upload_multipart_file") as upload:
+        with pytest.raises(ValueError, match="epoch"):
+            mock_dataset.add_journal_json(path, timestamp_column="ts", timestamp_type=timestamp_type)
+
+    upload.assert_not_called()
+
+
+class _StubWrapper(_DatasetWrapper):
+    """The wrapper with scope resolution stubbed: what is under test is the delegation, not lookup."""
+
+    def _list_dataset_scopes(self):
+        return []
+
+
+def test_data_scope_avro_stream_merges_scope_tags() -> None:
+    """Avro ingest carries tags now, so a tagged scope no longer blocks the file; caller tags win on collision."""
+    dataset = MagicMock()
+    scope_tags = {"vehicle": "v1", "run": "scope-run"}
+    with patch.object(_StubWrapper, "_get_dataset_scope", return_value=(dataset, scope_tags)):
+        _StubWrapper().add_avro_stream("scope", "records.avro", tags={"run": "r1"})
+
+    dataset.add_avro_stream.assert_called_once_with(
+        "records.avro", timestamp_type=None, tags={"vehicle": "v1", "run": "r1"}
+    )
+
+
+def test_data_scope_avro_stream_forwards_the_timestamp_type() -> None:
+    """The scope wrapper is a passthrough for the timestamp type, not a second policy layer."""
+    dataset = MagicMock()
+    with patch.object(_StubWrapper, "_get_dataset_scope", return_value=(dataset, {})):
+        _StubWrapper().add_avro_stream("scope", "records.avro", timestamp_type="epoch_microseconds")
+
+    assert dataset.add_avro_stream.call_args.kwargs["timestamp_type"] == "epoch_microseconds"
+
+
+def test_data_scope_journal_json_forwards_the_timestamp_pair() -> None:
+    """The journal wrapper forwards both halves of the pair untouched."""
+    dataset = MagicMock()
+    with patch.object(_StubWrapper, "_get_dataset_scope", return_value=(dataset, {})):
+        _StubWrapper().add_journal_json(
+            "scope", "logs.jsonl", channel="events", timestamp_column="ts", timestamp_type="epoch_microseconds"
+        )
+
+    dataset.add_journal_json.assert_called_once_with(
+        "logs.jsonl", channel="events", timestamp_column="ts", timestamp_type="epoch_microseconds"
+    )
+
+
+def test_data_scope_journal_json_still_refuses_a_tagged_scope() -> None:
+    """Journal ingest carries no tags, so a tagged scope must keep failing rather than lose them."""
+    dataset = MagicMock()
+    with patch.object(_StubWrapper, "_get_dataset_scope", return_value=(dataset, {"vehicle": "v1"})):
+        with pytest.raises(RuntimeError, match="would not get"):
+            _StubWrapper().add_journal_json("scope", "logs.jsonl")
+
+    dataset.add_journal_json.assert_not_called()
+
+
+def test_data_scope_journal_json_default_call_forwards_an_explicit_none_pair() -> None:
+    """The default call shape forwards both halves as None, which is the shape the delegation suppresses.
+
+    The suppressed argument types are only sound while this holds: the delegate must accept a pair of
+    Nones as "no timestamp metadata". If that ever changes, this test is what fails.
+    """
+    dataset = MagicMock()
+    with patch.object(_StubWrapper, "_get_dataset_scope", return_value=(dataset, {})):
+        _StubWrapper().add_journal_json("scope", "logs.jsonl")
+
+    dataset.add_journal_json.assert_called_once_with(
+        "logs.jsonl", channel=None, timestamp_column=None, timestamp_type=None
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"timestamp_column": "ts"}, id="column-without-type"),
+        pytest.param({"timestamp_type": "epoch_microseconds"}, id="type-without-column"),
+    ],
+)
+def test_data_scope_journal_json_rejects_a_half_pair_before_resolving_the_scope(kwargs) -> None:
+    """A mispaired call fails on its own arguments, without a round trip to resolve the data scope."""
+    with patch.object(_StubWrapper, "_get_dataset_scope") as get_scope:
+        with pytest.raises(ValueError, match="pass both"):
+            _StubWrapper().add_journal_json("scope", "logs.jsonl", **kwargs)
+
+    get_scope.assert_not_called()

--- a/tests/experimental/ingest/test_ingest_builder.py
+++ b/tests/experimental/ingest/test_ingest_builder.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nominal import ts
 from nominal.core.exceptions import NominalIngestError, NominalIngestUploadFailed
 from nominal.core.filetype import FileType
 from nominal.experimental.ingest._ingest_builder import IngestBuilder, MultipartUploader
@@ -246,6 +247,78 @@ class TestSubmit:
                 builder.submit()
 
         client._clients.ingest_v2.Ingest.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"),
+        [
+            pytest.param({}, ts.Epoch("nanoseconds"), id="default-is-the-canonical-schema"),
+            pytest.param({"timestamp_type": "epoch_microseconds"}, ts.Epoch("microseconds"), id="epoch-literal"),
+            pytest.param(
+                {"timestamp_type": ts.Relative("seconds", start=0)},
+                ts.Relative("seconds", start=0),
+                id="relative",
+            ),
+        ],
+    )
+    def test_avro_item_carries_the_declared_timestamp_type(
+        self, write_file: WriteFile, kwargs: dict[str, Any], expected: ts.TypedTimestampType
+    ) -> None:
+        """An avro item always carries timestamp metadata, defaulting to the canonical schema's reading."""
+        client = MagicMock()
+        builder = IngestBuilder(client, "ri.catalog.test.dataset")
+        builder.add_avro_stream(write_file("records.avro", 1), **kwargs)
+
+        with patch.object(
+            MultipartUploader, "create", autospec=True, return_value=FakeUploader({"records.avro": "s3://bucket/a"})
+        ):
+            builder.submit()
+
+        (request,) = client._clients.ingest_v2.Ingest.call_args.args
+        metadata = request.items[0].file.ingest.timestamp_metadata
+        assert metadata.column == "timestamps"
+        assert ts._proto_timestamp_type_to_typed_timestamp_type(metadata.type) == expected
+
+    @pytest.mark.parametrize(
+        "timestamp_type",
+        [
+            pytest.param("epoch_microseconds", id="epoch-literal"),
+            pytest.param(ts.Epoch("nanoseconds"), id="epoch"),
+            pytest.param(ts.Relative("seconds", start=0), id="relative"),
+        ],
+    )
+    def test_log_item_accepts_any_numeric_timestamp_type(
+        self, write_file: WriteFile, timestamp_type: ts._AnyNumericTimestampType
+    ) -> None:
+        """Log timestamps are read as numbers, so every numeric type -- including relative -- works."""
+        client = MagicMock()
+        builder = IngestBuilder(client, "ri.catalog.test.dataset")
+        builder.add_journal_json(write_file("logs.jsonl", 1), timestamp_column="ts", timestamp_type=timestamp_type)
+
+        with patch.object(
+            MultipartUploader, "create", autospec=True, return_value=FakeUploader({"logs.jsonl": "s3://bucket/a"})
+        ):
+            builder.submit()
+
+        (request,) = client._clients.ingest_v2.Ingest.call_args.args
+        metadata = request.items[0].log.timestamp_metadata
+        assert metadata.column == "ts"
+        assert ts._proto_timestamp_type_to_typed_timestamp_type(metadata.type) == ts._to_typed_timestamp_type(
+            timestamp_type
+        )
+
+    @pytest.mark.parametrize(
+        "timestamp_type",
+        [
+            pytest.param("iso_8601", id="iso8601"),
+            pytest.param(ts.Custom("yyyy-DDD HH:mm:ss"), id="custom"),
+        ],
+    )
+    def test_log_item_rejects_string_format_timestamp_types(self, write_file: WriteFile, timestamp_type: Any) -> None:
+        """A string-format type cannot describe a numeric log timestamp, so it fails at the call."""
+        builder = IngestBuilder(MagicMock(), "ri.catalog.test.dataset")
+
+        with pytest.raises(ValueError, match="must be numeric"):
+            builder.add_journal_json(write_file("logs.jsonl", 1), timestamp_column="ts", timestamp_type=timestamp_type)
 
 
 class TestSubmitAllowPartial:

--- a/tests/experimental/test_extractor.py
+++ b/tests/experimental/test_extractor.py
@@ -513,8 +513,6 @@ def test_system_metadata_defaults_when_not_injected(
             "does not support time unit 'hours'",
             id="unit-outside-contract",
         ),
-        pytest.param({"timestamp_column": "ts"}, "together", id="column-without-type"),
-        pytest.param({"timestamp_type": "epoch_seconds"}, "together", id="type-without-column"),
     ],
 )
 def test_add_output_rejects_unexpressible_timestamp_metadata(
@@ -522,7 +520,7 @@ def test_add_output_rejects_unexpressible_timestamp_metadata(
     add_output_kwargs: dict[str, Any],
     expected_match: str,
 ) -> None:
-    """Per-output timestamp metadata only expresses what the manifest contract allows."""
+    """A timestamp type the manifest contract cannot express is an ExtractorError."""
 
     @manifest_extractor
     def emit(ctx: ManifestExtractorContext) -> None:
@@ -531,6 +529,32 @@ def test_add_output_rejects_unexpressible_timestamp_metadata(
         ctx.add_tabular(out, **add_output_kwargs)
 
     with pytest.raises(ExtractorError, match=expected_match):
+        run_extractor(emit)
+
+
+@pytest.mark.parametrize(
+    "add_output_kwargs",
+    [
+        pytest.param({"timestamp_column": "ts"}, id="column-without-type"),
+        pytest.param({"timestamp_type": "epoch_seconds"}, id="type-without-column"),
+    ],
+)
+def test_add_output_rejects_a_half_specified_timestamp_pair_as_a_value_error(
+    run_extractor: RunExtractor, add_output_kwargs: dict[str, Any]
+) -> None:
+    """A malformed argument is a ValueError, as everywhere else in the client.
+
+    ExtractorError is reserved for violations of the extractor's own contract -- a reserved file
+    name, a file outside the output directory -- not for a caller passing half of a pair.
+    """
+
+    @manifest_extractor
+    def emit(ctx: ManifestExtractorContext) -> None:
+        out = ctx.output_dir / "data.csv"
+        out.write_text("ts,x")
+        ctx.add_tabular(out, **add_output_kwargs)
+
+    with pytest.raises(ValueError, match="pass both"):
         run_extractor(emit)
 
 
@@ -1120,3 +1144,89 @@ def test_rejected_declaration_does_not_count_as_declared(
         run_extractor(emit)
 
     assert "notavideo.txt" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("timestamp_type", "expected_timestamp_metadata"),
+    [
+        pytest.param(
+            "epoch_microseconds",
+            {"seriesName": "timestamps", "epochTimeUnit": "MICROSECONDS", "relativeOffset": None},
+            id="epoch",
+        ),
+        pytest.param(
+            ts.Relative("milliseconds", start=datetime(2026, 1, 1, tzinfo=timezone.utc)),
+            {
+                "seriesName": "timestamps",
+                "epochTimeUnit": "MILLISECONDS",
+                "relativeOffset": "2026-01-01T00:00:00.000000000Z",
+            },
+            id="relative",
+        ),
+        pytest.param(None, None, id="omitted-defers-to-job-level"),
+    ],
+)
+def test_avro_output_declares_how_to_read_its_timestamps(
+    manifest_document: ReadManifest,
+    run_extractor: RunExtractor,
+    timestamp_type: Any,
+    expected_timestamp_metadata: dict[str, Any] | None,
+) -> None:
+    """An avro output declares a timestamp type and no column: the schema fixes which field holds them."""
+
+    @manifest_extractor
+    def emit(ctx: ManifestExtractorContext) -> None:
+        out = ctx.output_dir / "records.avro"
+        out.write_bytes(b"avro")
+        ctx.add_avro_stream(out, timestamp_type=timestamp_type)
+
+    run_extractor(emit)
+
+    [entry] = manifest_document()["outputs"]
+    assert entry["ingestType"] == "AVRO_STREAM"
+    assert entry["timestampMetadata"] == expected_timestamp_metadata
+
+
+@pytest.mark.parametrize(
+    ("timestamp_type", "expected_match"),
+    [
+        pytest.param("iso_8601", "numeric epoch", id="non-numeric-type"),
+        pytest.param(ts.Custom("yyyy-DDD HH:mm:ss"), "numeric epoch", id="custom-format"),
+        pytest.param(ts.Relative("hours", start=0), "does not support time unit 'hours'", id="unit-outside-contract"),
+    ],
+)
+def test_avro_output_rejects_unexpressible_timestamp_type(
+    run_extractor: RunExtractor, timestamp_type: Any, expected_match: str
+) -> None:
+    """A type the manifest cannot express is refused at the call, not silently narrowed.
+
+    The first two are also type errors under the numeric-only annotation; the runtime guard is what
+    protects callers without a type checker, so the test exercises it directly.
+    """
+
+    @manifest_extractor
+    def emit(ctx: ManifestExtractorContext) -> None:
+        out = ctx.output_dir / "records.avro"
+        out.write_bytes(b"avro")
+        ctx.add_avro_stream(out, timestamp_type=timestamp_type)
+
+    with pytest.raises(ExtractorError, match=expected_match):
+        run_extractor(emit)
+
+
+def test_avro_output_composes_channel_prefix_and_timestamp_type(
+    manifest_document: ReadManifest, run_extractor: RunExtractor
+) -> None:
+    """The two avro options are independent and both reach the entry."""
+
+    @manifest_extractor
+    def emit(ctx: ManifestExtractorContext) -> None:
+        out = ctx.output_dir / "records.avro.gz"
+        out.write_bytes(b"avro")
+        ctx.add_avro_stream(out, channel_prefix="sensors/", timestamp_type=ts.Epoch("seconds"))
+
+    run_extractor(emit)
+
+    [entry] = manifest_document()["outputs"]
+    assert entry["channelPrefix"] == "sensors/"
+    assert entry["timestampMetadata"]["epochTimeUnit"] == "SECONDS"

--- a/tests/test_ts.py
+++ b/tests/test_ts.py
@@ -68,3 +68,35 @@ def test_str_to_literal_time_unit_rejects_unknown_units() -> None:
 def test_timestamp_type_proto_round_trip(typed: ts.TypedTimestampType) -> None:
     """Every timestamp type survives a lossless round trip through the proto encoding."""
     assert ts._proto_timestamp_type_to_typed_timestamp_type(typed._to_proto()) == typed
+
+
+def test_epoch_converts_to_a_numeric_avro_timestamp_type() -> None:
+    """An epoch type reaches the avro request as an epoch union arm carrying its unit."""
+    converted = ts.Epoch("microseconds")._to_conjure_ingest_avro_api()
+
+    assert converted.relative is None
+    assert converted.epoch is not None
+    assert converted.epoch.time_unit.value == "MICROSECONDS"
+
+
+def test_relative_converts_to_a_numeric_avro_timestamp_type() -> None:
+    """A relative type reaches the avro request as a relative arm carrying its unit and start."""
+    converted = ts.Relative("seconds", start=1_700_000_000_000_000_000)._to_conjure_ingest_avro_api()
+
+    assert converted.epoch is None
+    assert converted.relative is not None
+    assert converted.relative.time_unit.value == "SECONDS"
+    assert converted.relative.offset == "2023-11-14T22:13:20.000000000Z"
+
+
+@pytest.mark.parametrize(
+    "typed",
+    [
+        pytest.param(ts.Iso8601(), id="iso8601"),
+        pytest.param(ts.Custom("yyyy-DDD HH:mm:ss"), id="custom"),
+    ],
+)
+def test_string_timestamp_types_cannot_describe_avro_timestamps(typed: ts.TypedTimestampType) -> None:
+    """Avro timestamps are integers, so a string-formatted type has no representation there."""
+    with pytest.raises(ValueError, match="not supported with .avro files"):
+        typed._to_conjure_ingest_avro_api()


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

Lets callers say how a file's numeric timestamps should be read, across every surface that ingests
avro or journal-json — including containerized extractor outputs, which previously could not say
anything at all.

## Why

An avro-stream file's timestamps are plain integers, and the schema does not record what unit they
are in. A manifest extractor that wrote an avro output had no way to declare that unit, so the output
inherited the *job-level* timestamp metadata. When the extractor's own input was a CSV, that
job-level type is commonly a string format — applied, silently, to a field holding integers.

## What changed

**Single-file ingest** — `Dataset.add_avro_stream` takes `timestamp_type` (numeric only: an absolute
epoch or an offset from a start) and `tags`. `Dataset.add_journal_json` takes
`timestamp_column`/`timestamp_type`, naming the field in each JSON payload that holds the timestamp
and the epoch unit it is in.

**Containerized extractors** — `ctx.add_avro_stream(timestamp_type=...)` declares the reading for one
output, overriding the job-level metadata for that file only. It takes a type and no column, because
the schema fixes which field holds the timestamps. Omit it to inherit the job-level metadata, which is
right only when that metadata already describes numeric timestamps.

`ctx.add_tabular` and `ctx.add_journal_json` gained `@overload` signatures, so passing one half of the
`timestamp_column`/`timestamp_type` pair is now a type error rather than a runtime one. That matters
more here than elsewhere in the client: the runtime error surfaces inside a container partway through
an ingest job, not at the call site. The runtime check stays for callers who do not type-check.

**Data scopes** — the wrapper forwards both option sets. See the behavior change below.

**Experimental ingest builder** — `IngestBuilder.add_avro_stream` takes `timestamp_type`. Unlike the
manifest there is no "absent" state here, since the multi-file endpoint wants timestamp metadata on
every file item, so omitting it still sends the canonical epoch-nanosecond reading as before.

**Typing** — a new `_AnyEpochTimestampType` alias lets journal-json accept `"epoch_microseconds"`-style
literals, not just `ts.Epoch` objects, matching every sibling method. Relative types are deliberately
excluded: the journal request carries a time unit with nowhere to record a starting offset, and the
alias documents that so nobody widens it later.

## Behavior change

`add_avro_stream` on a data scope used to raise `RuntimeError` when the selected scope required tags,
because avro ingest could not carry tags and ingesting untagged data was worse than failing. Avro
ingest applies additional file tags now, so those calls ingest, with the scope's tags merged in and
caller-provided tags winning on key collisions. The equivalent journal-json refusal stays — journal
ingest still has no tags field.

## Bug fixed along the way

The pairing guard introduced early in this branch rejected `add_journal_json` calls that passed
*neither* timestamp argument, which is the default call shape. Separately, the non-epoch guard ran
*after* the file upload, so a caller passing an inexpressible type uploaded the whole log file before
failing; it now runs before any I/O, matching the avro path.

## Typing note for reviewers

`ctx.add_tabular`'s `timestamp_type` narrowed from all timestamp types to the numeric-only set. Per-output
metadata never accepted anything else — the previous behavior was a runtime `ExtractorError` — so this
converts a runtime failure into a type error in an experimental module. Consequently, passing the pair
explicitly as `timestamp_column=None, timestamp_type=None` no longer type-checks; omit both instead.

## Testing

`just test` — 602 passed, 14 skipped. `just check` clean (ruff format, mypy strict over 161 source
files, ruff check).

New coverage: per-output avro metadata for epoch and relative types, plus the omitted case and the
rejection of types the manifest cannot express; the timestamp conversions this branch added at the
`ts` layer; the journal-json pairing guard in both directions and its pre-upload validation; the avro
options landing on the ingest request; data-scope tag merging with a colliding key; and the builder's
declared-versus-default reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
