### PR TITLE
feat: migrate event service to gRPC

### DIFF
--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -9,7 +9,6 @@ from conjure_python_client import Service, ServiceConfiguration
 from nominal_api import (
     attachments_api,
     authentication_api,
-    event,
     ingest_api,
     scout,
     scout_assets,
@@ -39,6 +38,7 @@ from nominal.core._utils.networking import (
 from nominal.core.exceptions import NominalConfigError
 from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
+from nominal.protos.event.v2 import event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc, ingest_service_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2_grpc
 from nominal.protos.sandbox.v1 import sandbox_workspace_pb2_grpc
@@ -155,7 +155,6 @@ class ClientsBunch:
     dataexport: scout_dataexport_api.DataExportService
     datareview: scout_datareview_api.DataReviewService
     datasource: scout_datasource.DataSourceService
-    event: event.EventService
     ingest_jobs: ingest_api.IngestJobService
     ingest: ingest_api.IngestService
     notebook: scout.NotebookService
@@ -172,6 +171,7 @@ class ClientsBunch:
     # GRPC services
     comments: comments_pb2_grpc.CommentsServiceStub
     containerized_extractor: containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
+    event: event_pb2_grpc.EventServiceStub
     ingest_v2: ingest_service_pb2_grpc.IngestServiceStub
     registry: registry_pb2_grpc.RegistryServiceStub
     roles: roles_pb2_grpc.RoleServiceStub
@@ -319,7 +319,6 @@ class ClientsBunch:
             dataexport=client_factory(scout_dataexport_api.DataExportService),
             datareview=client_factory(scout_datareview_api.DataReviewService),
             datasource=client_factory(scout_datasource.DataSourceService),
-            event=client_factory(event.EventService),
             ingest_jobs=client_factory(ingest_api.IngestJobService),
             ingest=client_factory(ingest_api.IngestService),
             notebook=client_factory(scout.NotebookService),
@@ -335,6 +334,7 @@ class ClientsBunch:
             # GRPC Service Stubs
             comments=grpc_factory(comments_pb2_grpc.CommentsServiceStub),
             containerized_extractor=grpc_factory(containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub),
+            event=grpc_factory(event_pb2_grpc.EventServiceStub),
             ingest_v2=grpc_factory(ingest_service_pb2_grpc.IngestServiceStub),
             registry=grpc_factory(registry_pb2_grpc.RegistryServiceStub),
             roles=grpc_factory(roles_pb2_grpc.RoleServiceStub),

--- a/nominal/core/_event_types.py
+++ b/nominal/core/_event_types.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from enum import Enum
 from typing import Iterable, NamedTuple
 
-from nominal_api import event
+from typing_extensions import assert_never
+
+from nominal.protos.event.v2 import event_pb2
 
 
 class EventType(Enum):
@@ -24,30 +26,36 @@ class EventType(Enum):
     """
 
     @classmethod
-    def from_api_event_type(cls, event: event.EventType) -> EventType:
-        """Convert a `nominal-api` event type to a `nominal-core` event type."""
-        if event.name == "INFO":
-            return cls.INFO
-        elif event.name == "FLAG":
-            return cls.FLAG
-        elif event.name == "ERROR":
-            return cls.ERROR
-        elif event.name == "SUCCESS":
-            return cls.SUCCESS
-        else:
-            return cls.UNKNOWN
+    def _from_proto(cls, event: event_pb2.EventType.ValueType) -> EventType:
+        """Convert a proto event type to a `nominal-core` event type."""
+        match event:
+            case event_pb2.INFO:
+                result = cls.INFO
+            case event_pb2.FLAG:
+                result = cls.FLAG
+            case event_pb2.ERROR:
+                result = cls.ERROR
+            case event_pb2.SUCCESS:
+                result = cls.SUCCESS
+            case _:
+                result = cls.UNKNOWN
+        return result
 
-    def _to_api_event_type(self) -> event.EventType:
-        if self.name == "INFO":
-            return event.EventType.INFO
-        elif self.name == "FLAG":
-            return event.EventType.FLAG
-        elif self.name == "ERROR":
-            return event.EventType.ERROR
-        elif self.name == "SUCCESS":
-            return event.EventType.SUCCESS
-        else:
-            return event.EventType.UNKNOWN
+    def _to_proto(self) -> event_pb2.EventType.ValueType:
+        match self:
+            case EventType.INFO:
+                result = event_pb2.INFO
+            case EventType.FLAG:
+                result = event_pb2.FLAG
+            case EventType.ERROR:
+                result = event_pb2.ERROR
+            case EventType.SUCCESS:
+                result = event_pb2.SUCCESS
+            case EventType.UNKNOWN:
+                result = event_pb2.EVENT_TYPE_UNSPECIFIED
+            case _:
+                assert_never(self)
+        return result
 
 
 class EventCreationType(Enum):
@@ -59,38 +67,36 @@ class SearchEventOriginType(NamedTuple):
     name: str
     creation_type: EventCreationType
 
-    @classmethod
-    def from_api_origin_type(cls, event: event.SearchEventOriginType) -> SearchEventOriginType:
-        if event.name == "WORKBOOK":
-            return SearchEventOriginTypes.WORKBOOK
-        elif event.name == "TEMPLATE":
-            return SearchEventOriginTypes.TEMPLATE
-        elif event.name == "API":
-            return SearchEventOriginTypes.API
-        elif event.name == "DATA_REVIEW":
-            return SearchEventOriginTypes.DATA_REVIEW
-        elif event.name == "PROCEDURE":
-            return SearchEventOriginTypes.PROCEDURE
-        elif event.name == "STREAMING_CHECKLIST":
-            return SearchEventOriginTypes.STREAMING_CHECKLIST
-        else:
-            raise ValueError(f"Unexpected Event Origin {event.name}")
+    def _to_proto(self) -> event_pb2.SearchEventOriginType.ValueType:
+        """The proto value with this origin type's name.
 
-    def _to_api_search_event_origin_type(self) -> event.SearchEventOriginType:
-        if self.name == "WORKBOOK":
-            return event.SearchEventOriginType.WORKBOOK
-        elif self.name == "TEMPLATE":
-            return event.SearchEventOriginType.TEMPLATE
-        elif self.name == "API":
-            return event.SearchEventOriginType.API
-        elif self.name == "DATA_REVIEW":
-            return event.SearchEventOriginType.DATA_REVIEW
-        elif self.name == "PROCEDURE":
-            return event.SearchEventOriginType.PROCEDURE
-        elif self.name == "STREAMING_CHECKLIST":
-            return event.SearchEventOriginType.STREAMING_CHECKLIST
-        else:
-            raise ValueError(f"Unexpected Event Origin {self.name}")
+        Raises:
+            ValueError: If no proto value has this name.
+        """
+        return event_pb2.SearchEventOriginType.Value(self.name)
+
+    @classmethod
+    def _from_proto(cls, event: event_pb2.SearchEventOriginType.ValueType) -> SearchEventOriginType:
+        """The origin type named by a proto value.
+
+        Raises:
+            ValueError: If the value is unspecified or names an origin type this client does not know.
+        """
+        match event:
+            case event_pb2.WORKBOOK:
+                return SearchEventOriginTypes.WORKBOOK
+            case event_pb2.TEMPLATE:
+                return SearchEventOriginTypes.TEMPLATE
+            case event_pb2.API:
+                return SearchEventOriginTypes.API
+            case event_pb2.DATA_REVIEW:
+                return SearchEventOriginTypes.DATA_REVIEW
+            case event_pb2.PROCEDURE:
+                return SearchEventOriginTypes.PROCEDURE
+            case event_pb2.STREAMING_CHECKLIST:
+                return SearchEventOriginTypes.STREAMING_CHECKLIST
+            case _:
+                raise ValueError(f"Unexpected Event Origin {event}")
 
     @classmethod
     def get_manual_origin_types(cls) -> Iterable[SearchEventOriginType]:

--- a/nominal/core/_utils/pagination_tools.py
+++ b/nominal/core/_utils/pagination_tools.py
@@ -4,7 +4,6 @@ from typing import Any, Callable, Iterable, Protocol, Sequence, TypeVar, overloa
 
 from nominal_api import (
     authentication_api,
-    event,
     ingest_api,
     scout,
     scout_asset_api,
@@ -22,6 +21,7 @@ from nominal_api import (
 
 from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.query_tools import ArchiveStatusFilter
+from nominal.protos.event.v2 import event_pb2, event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2, containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2, registry_pb2_grpc
 from nominal.protos.secrets.v1 import secrets_pb2, secrets_pb2_grpc
@@ -34,24 +34,23 @@ T_contra = TypeVar("T_contra", contravariant=True)
 
 
 def search_events_paginated(
-    client: event.EventService,
-    auth_header: str,
-    query: event.SearchQuery,
+    client: event_pb2_grpc.EventServiceStub,
+    query: event_pb2.SearchQuery,
     archive_status: ArchiveStatusFilter = ArchiveStatusFilter.NOT_ARCHIVED,
-) -> Iterable[event.Event]:
-    def factory(page_token: str | None) -> event.SearchEventsRequest:
-        return event.SearchEventsRequest(
+) -> Iterable[event_pb2.Event]:
+    def factory(page_token: str | None) -> event_pb2.SearchEventsRequest:
+        return event_pb2.SearchEventsRequest(
             page_size=DEFAULT_PAGE_SIZE,
             query=query,
-            sort=event.SortOptions(
-                field=event.SortField.START_TIME,
+            sort=event_pb2.SortOptions(
+                field=event_pb2.START_TIME,
                 is_descending=True,
             ),
-            archived_statuses=archive_status.to_api_archived_statuses(),
+            archived_statuses=archive_status.to_proto_archived_statuses(),
             next_page_token=page_token,
         )
 
-    for response in paginate_rpc(client.search_events, auth_header, request_factory=factory):
+    for response in paginate_grpc(client.SearchEvents, request_factory=factory):
         yield from response.results
 
 

--- a/nominal/core/_utils/query_tools.py
+++ b/nominal/core/_utils/query_tools.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
 from nominal_api import (
     api,
     authentication_api,
-    event,
     ingest_api,
     scout_asset_api,
     scout_catalog,
@@ -19,7 +18,9 @@ from nominal_api import (
     scout_video_api,
 )
 
+from nominal.core._event_types import EventType, SearchEventOriginType
 from nominal.core._utils.api_tools import rid_from_instance_or_string
+from nominal.protos.event.v2 import event_pb2
 from nominal.protos.registry.v2 import registry_pb2
 from nominal.protos.secrets.v1 import secrets_pb2
 from nominal.protos.types import types_pb2
@@ -559,45 +560,52 @@ def create_search_events_query(  # noqa: PLR0912
     workbook_rid: str | None = None,
     data_review_rid: str | None = None,
     assignee_rid: str | None = None,
-    event_type: event.EventType | None = None,
-    origin_types: Iterable[event.SearchEventOriginType] | None = None,
+    event_type: EventType | None = None,
+    origin_types: Iterable[SearchEventOriginType] | None = None,
     workspace_rid: str | None = None,
-) -> event.SearchQuery:
+) -> event_pb2.SearchQuery:
     queries = []
     if search_text is not None:
-        queries.append(event.SearchQuery(search_text=search_text))
+        queries.append(event_pb2.SearchQuery(search_text=search_text))
     if after is not None:
-        queries.append(event.SearchQuery(after=_SecondsNanos.from_flexible(after).to_api()))
+        queries.append(event_pb2.SearchQuery(after=_SecondsNanos.from_flexible(after).to_proto()))
     if before is not None:
-        queries.append(event.SearchQuery(before=_SecondsNanos.from_flexible(before).to_api()))
+        queries.append(event_pb2.SearchQuery(before=_SecondsNanos.from_flexible(before).to_proto()))
     if asset_rids:
         if asset_match is AssetMatch.ANY:
             queries.append(
-                event.SearchQuery(assets=event.AssetsFilter(assets=list(asset_rids), operator=api.SetOperator.OR))
+                event_pb2.SearchQuery(
+                    assets=event_pb2.AssetsFilter(assets=list(asset_rids), operator=event_pb2.OR),
+                )
             )
         else:
             for asset in asset_rids:
-                queries.append(event.SearchQuery(asset=asset))
+                queries.append(event_pb2.SearchQuery(asset=asset))
     if labels:
         for label in labels:
-            queries.append(event.SearchQuery(label=label))
+            queries.append(event_pb2.SearchQuery(label=label))
     if properties:
         for name, value in properties.items():
-            queries.append(event.SearchQuery(property=api.Property(name=name, value=value)))
+            queries.append(event_pb2.SearchQuery(property=types_pb2.Property(name=name, value=value)))
     if created_by_rid:
-        queries.append(event.SearchQuery(created_by=created_by_rid))
+        queries.append(event_pb2.SearchQuery(created_by=created_by_rid))
     if workbook_rid is not None:
-        queries.append(event.SearchQuery(workbook=workbook_rid))
+        queries.append(event_pb2.SearchQuery(workbook=workbook_rid))
     if data_review_rid is not None:
-        queries.append(event.SearchQuery(data_review=data_review_rid))
+        queries.append(event_pb2.SearchQuery(data_review=data_review_rid))
     if assignee_rid is not None:
-        queries.append(event.SearchQuery(assignee=assignee_rid))
+        queries.append(event_pb2.SearchQuery(assignee=assignee_rid))
     if event_type is not None:
-        queries.append(event.SearchQuery(event_type=event_type))
-    if origin_types is not None:
-        origin_type_filter = event.OriginTypesFilter(api.SetOperator.OR, list(origin_types))
-        queries.append(event.SearchQuery(origin_types=origin_type_filter))
+        queries.append(event_pb2.SearchQuery(event_type=event_type._to_proto()))
+    if origin_types:
+        origin_type_filter = event_pb2.OriginTypesFilter(
+            operator=event_pb2.OR, origin_types=[origin_type._to_proto() for origin_type in origin_types]
+        )
+        queries.append(event_pb2.SearchQuery(origin_types=origin_type_filter))
     if workspace_rid is not None:
-        queries.append(event.SearchQuery(workspace=workspace_rid))
+        queries.append(event_pb2.SearchQuery(workspace=workspace_rid))
 
-    return event.SearchQuery(and_=queries)
+    # `and` is a Python keyword, and generated typing stubs cannot expose it as a named argument.
+    return event_pb2.SearchQuery(
+        **{"and": event_pb2.SearchQueryList(queries=queries)}  # type: ignore[arg-type]
+    )

--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -7,7 +7,6 @@ from types import MappingProxyType
 from typing import Iterable, Mapping, Protocol, Sequence, TypeAlias
 
 from nominal_api import (
-    event,
     scout,
     scout_asset_api,
     scout_assets,
@@ -77,8 +76,6 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
         def comments(self) -> comments_pb2_grpc.CommentsServiceStub: ...
         @property
         def run(self) -> scout.RunService: ...
-        @property
-        def event(self) -> event.EventService: ...
 
     @property
     def nominal_url(self) -> str:

--- a/nominal/core/checklist.py
+++ b/nominal/core/checklist.py
@@ -5,8 +5,6 @@ from datetime import timedelta
 from typing import Mapping, Protocol, Sequence
 
 from nominal_api import (
-    event,
-    scout,
     scout_checklistexecution_api,
     scout_checks_api,
     scout_datareview_api,
@@ -15,7 +13,6 @@ from nominal_api import (
 from typing_extensions import Self
 
 from nominal.core import run as core_run
-from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin, rid_from_instance_or_string
 from nominal.core._utils.frontend_urls import checklist_preview_url, checklist_url
 from nominal.core.asset import Asset
@@ -33,17 +30,13 @@ class Checklist(HasRid, RefreshableConjureMixin[scout_checks_api.VersionedCheckl
     _clients: _Clients = field(repr=False)
     author_rid: str | None = field(default=None, repr=False)
 
-    class _Clients(HasScoutParams, Protocol):
+    class _Clients(DataReview._Clients, Protocol):
         @property
         def checklist(self) -> scout_checks_api.ChecklistService: ...
         @property
         def checklist_execution(self) -> scout_checklistexecution_api.ChecklistExecutionService: ...
         @property
         def datareview(self) -> scout_datareview_api.DataReviewService: ...
-        @property
-        def event(self) -> event.EventService: ...
-        @property
-        def run(self) -> scout.RunService: ...
 
     @classmethod
     def _from_conjure(cls, clients: _Clients, checklist: scout_checks_api.VersionedChecklist) -> Self:

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -93,7 +93,7 @@ from nominal.core.dataset import (
 )
 from nominal.core.dataset_file import DatasetFile
 from nominal.core.datasource import DataSource
-from nominal.core.event import Event, _create_event, _search_events
+from nominal.core.event import Event, _create_event, _get_event, _get_events, _search_events
 from nominal.core.exceptions import (
     LegacyVideoDeprecationWarning,
     NominalConfigError,
@@ -1326,15 +1326,25 @@ class NominalClient:
         )
 
     def get_event(self, rid: str) -> Event:
-        events = self.get_events([rid])
-        if len(events) != 1:
-            raise RuntimeError(f"Expected to receive exactly one event, received {len(events)}")
+        """Retrieve an event by its RID.
 
-        return events[0]
+        Raises:
+            NominalNotFoundError: If no event has that rid.
+        """
+        return Event._from_proto(self._clients, _get_event(self._clients, rid))
 
     def get_events(self, rids: Sequence[str]) -> Sequence[Event]:
-        responses = self._clients.event.batch_get_events(self._clients.auth_header, list(rids))
-        return [Event._from_conjure(self._clients, response) for response in responses]
+        """Retrieve events by their RIDs.
+
+        Args:
+            rids: RIDs of the events to retrieve.
+
+        Returns:
+            The events that resolved, in the order the backend returned them. RIDs that do not resolve are
+            omitted rather than raising, so the result may be shorter than `rids`. Use `get_event` for a
+            single rid that must exist.
+        """
+        return [Event._from_proto(self._clients, raw_event) for raw_event in _get_events(self._clients, list(rids))]
 
     def search_data_reviews(
         self,

--- a/nominal/core/data_review.py
+++ b/nominal/core/data_review.py
@@ -6,9 +6,6 @@ from time import sleep
 from typing import TYPE_CHECKING, Iterable, Protocol, Sequence
 
 from nominal_api import (
-    event as event_api,
-)
-from nominal_api import (
     scout,
     scout_api,
     scout_checklistexecution_api,
@@ -24,7 +21,8 @@ from nominal.core._utils.api_tools import HasRid, rid_from_instance_or_string
 from nominal.core._utils.frontend_urls import data_review_events_url, data_review_url
 from nominal.core._utils.pagination_tools import search_data_reviews_paginated
 from nominal.core._utils.query_tools import ArchiveStatusFilter
-from nominal.core.event import Event
+from nominal.core.event import Event, _get_events
+from nominal.protos.event.v2 import event_pb2_grpc
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
 
 if TYPE_CHECKING:
@@ -53,7 +51,7 @@ class DataReview(HasRid):
         @property
         def checklist_execution(self) -> scout_checklistexecution_api.ChecklistExecutionService: ...
         @property
-        def event(self) -> event_api.EventService: ...
+        def event(self) -> event_pb2_grpc.EventServiceStub: ...
         @property
         def run(self) -> scout.RunService: ...
 
@@ -91,8 +89,10 @@ class DataReview(HasRid):
             if check.state._generated_alerts
             for event_rid in check.state._generated_alerts.event_rids
         ]
-        event_response = self._clients.event.batch_get_events(self._clients.auth_header, all_event_rids)
-        return [Event._from_conjure(self._clients, data_review_event) for data_review_event in event_response]
+        return [
+            Event._from_proto(self._clients, data_review_event)
+            for data_review_event in _get_events(self._clients, all_event_rids)
+        ]
 
     def reload(self) -> DataReview:
         """Reloads the data review from the server."""

--- a/nominal/core/event.py
+++ b/nominal/core/event.py
@@ -4,21 +4,30 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Iterable, Mapping, Protocol, Sequence
 
-from nominal_api import event
 from typing_extensions import Self
 
 from nominal.core import asset as core_asset
 from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._event_types import EventType as EventType  # noqa: PLC0414
 from nominal.core._event_types import SearchEventOriginType as SearchEventOriginType  # noqa: PLC0414
-from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin, rid_from_instance_or_string
+from nominal.core._utils.api_tools import HasRid, RefreshableGrpcMixin, rid_from_instance_or_string
+from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.pagination_tools import search_events_paginated
 from nominal.core._utils.query_tools import ArchiveStatusFilter, AssetMatch, create_search_events_query
-from nominal.ts import IntegralNanosecondsDuration, IntegralNanosecondsUTC, _SecondsNanos, _to_api_duration
+from nominal.core.exceptions import NominalNotFoundError
+from nominal.protos.event.v2 import event_pb2, event_pb2_grpc
+from nominal.protos.types import types_pb2
+from nominal.ts import (
+    IntegralNanosecondsDuration,
+    IntegralNanosecondsUTC,
+    _from_proto_duration,
+    _SecondsNanos,
+    _to_proto_duration,
+)
 
 
 @dataclass(frozen=True)
-class Event(HasRid, RefreshableConjureMixin[event.Event]):
+class Event(HasRid, RefreshableGrpcMixin[event_pb2.Event]):
     rid: str
     asset_rids: Sequence[str]
     name: str
@@ -39,14 +48,10 @@ class Event(HasRid, RefreshableConjureMixin[event.Event]):
 
     class _Clients(HasScoutParams, Protocol):
         @property
-        def event(self) -> event.EventService: ...
+        def event(self) -> event_pb2_grpc.EventServiceStub: ...
 
-    def _get_latest_api(self) -> event.Event:
-        resp = self._clients.event.batch_get_events(self._clients.auth_header, [self.rid])
-        if len(resp) != 1:
-            raise ValueError(f"Expected exactly one event with rid {self.rid}, received {len(resp)}")
-
-        return resp[0]
+    def _get_latest_api(self) -> event_pb2.Event:
+        return _get_event(self._clients, self.rid)
 
     def update(
         self,
@@ -60,34 +65,67 @@ class Event(HasRid, RefreshableConjureMixin[event.Event]):
         labels: Iterable[str] | None = None,
         type: EventType | None,
     ) -> Self:
-        """Replace event metadata.
-        Updates the current instance, and returns it.
-        Only the metadata passed in will be replaced, the rest will remain untouched.
+        """Replace event metadata, updating the current instance and returning it.
 
-        Note: This replaces the metadata rather than appending it. To append to labels or properties, merge them before
-        calling this method. E.g.:
+        Metadata is replaced rather than appended. To add to labels or properties, merge them before
+        calling. E.g.:
 
             new_labels = ["new-label-a", "new-label-b"]
             for old_label in event.labels:
                 new_labels.append(old_label)
             event = event.update(labels=new_labels)
+
+        Args:
+            name: New name for the event.
+            description: New description for the event.
+            assets: Assets or asset rids the event applies to. An empty sequence clears them.
+            start: New starting timestamp for the event.
+            duration: New duration for the event.
+            properties: Key-value properties replacing the existing ones. An empty mapping clears them.
+            labels: Labels replacing the existing ones. An empty sequence clears them.
+            type: New verbosity level for the event.
+
+        Returns:
+            This event, updated in place.
+
+        Note:
+            Every argument left as None is omitted from the request and the corresponding field is left
+            unchanged. That is distinct from passing an empty collection, which clears the field.
+
+        Raises:
+            ValueError: If the backend does not echo back exactly one updated event.
+            NominalError: If the update request fails.
         """
-        request = event.BatchUpdateEventRequest(
-            requests=[
-                event.UpdateEventRequest(
+        updated_asset_rids = (
+            None
+            if assets is None
+            else event_pb2.AssetRidSet(asset_rids=[rid_from_instance_or_string(asset) for asset in assets])
+        )
+        updated_timestamp = None if start is None else _SecondsNanos.from_flexible(start).to_proto()
+        updated_duration = None if duration is None else _to_proto_duration(duration)
+        updated_labels = None if labels is None else types_pb2.LabelUpdateWrapper(labels=list(labels))
+        updated_properties = (
+            None if properties is None else types_pb2.PropertyUpdateWrapper(properties=dict(properties))
+        )
+        updated_type = None if type is None else type._to_proto()
+
+        request = event_pb2.BatchUpdateEventRequest(
+            updates=[
+                event_pb2.EventUpdate(
                     rid=self.rid,
-                    asset_rids=None if assets is None else [rid_from_instance_or_string(asset) for asset in assets],
-                    duration=None if duration is None else _to_api_duration(duration),
-                    labels=None if labels is None else list(labels),
+                    asset_rids=updated_asset_rids,
+                    duration=updated_duration,
+                    labels=updated_labels,
                     name=name,
                     description=description,
-                    properties=None if properties is None else dict(properties),
-                    timestamp=None if start is None else _SecondsNanos.from_flexible(start).to_api(),
-                    type=None if type is None else type._to_api_event_type(),
+                    properties=updated_properties,
+                    timestamp=updated_timestamp,
+                    type=updated_type,
                 )
             ]
         )
-        batch_updated = self._clients.event.batch_update_event(self._clients.auth_header, request)
+        with translate_grpc_errors():
+            batch_updated = self._clients.event.BatchUpdateEvent(request)
         if len(batch_updated.events) != 1:
             raise ValueError(f"Expected exactly one updated rid, received {len(batch_updated.events)}")
 
@@ -98,32 +136,54 @@ class Event(HasRid, RefreshableConjureMixin[event.Event]):
 
         Note: this does not update the instance in place; call `refresh()` to see the change reflected.
         """
-        self._clients.event.batch_archive_event(self._clients.auth_header, [self.rid])
+        with translate_grpc_errors():
+            self._clients.event.BatchArchiveEvent(event_pb2.BatchArchiveEventRequest(event_rids=[self.rid]))
 
     def unarchive(self) -> None:
         """Unarchives the event, allowing it to show up in workbooks.
 
         Note: this does not update the instance in place; call `refresh()` to see the change reflected.
         """
-        self._clients.event.batch_unarchive_event(self._clients.auth_header, [self.rid])
+        with translate_grpc_errors():
+            self._clients.event.BatchUnarchiveEvent(event_pb2.BatchUnarchiveEventRequest(event_rids=[self.rid]))
 
     @classmethod
-    def _from_conjure(cls, clients: _Clients, event: event.Event) -> Self:
+    def _from_proto(cls, clients: _Clients, event: event_pb2.Event) -> Self:
         return cls(
             rid=event.rid,
             asset_rids=tuple(event.asset_rids),
             name=event.name,
             description=event.description,
-            start=_SecondsNanos.from_api(event.timestamp).to_nanoseconds(),
-            duration=event.duration.seconds * 1_000_000_000 + event.duration.nanos,
-            type=EventType.from_api_event_type(event.type),
+            start=_SecondsNanos.from_proto(event.timestamp).to_nanoseconds(),
+            duration=_from_proto_duration(event.duration),
+            type=EventType._from_proto(event.type),
             is_archived=event.is_archived,
-            properties=event.properties,
-            labels=event.labels,
-            created_by_rid=event.created_by,
+            properties=dict(event.properties),
+            labels=list(event.labels),
+            created_by_rid=event.created_by or None,
             _uuid=event.uuid,
             _clients=clients,
         )
+
+
+def _get_events(clients: Event._Clients, rids: Sequence[str]) -> Sequence[event_pb2.Event]:
+    with translate_grpc_errors():
+        return clients.event.BatchGetEvents(event_pb2.BatchGetEventsRequest(event_rids=list(rids))).events
+
+
+def _get_event(clients: Event._Clients, rid: str) -> event_pb2.Event:
+    """The event with the given rid.
+
+    Raises:
+        NominalNotFoundError: If no event has that rid.
+        ValueError: If more than one event is returned for it.
+    """
+    events = _get_events(clients, [rid])
+    if not events:
+        raise NominalNotFoundError(f"no event found with RID {rid!r}")
+    if len(events) != 1:
+        raise ValueError(f"Expected exactly one event with rid {rid!r}, received {len(events)}")
+    return events[0]
 
 
 def _create_event(
@@ -138,28 +198,28 @@ def _create_event(
     properties: Mapping[str, str] | None,
     labels: Iterable[str] | None,
 ) -> Event:
-    request = event.CreateEvent(
+    request = event_pb2.CreateEventRequest(
         name=name,
         description=description,
         asset_rids=[rid_from_instance_or_string(asset) for asset in (assets or [])],
-        timestamp=_SecondsNanos.from_flexible(start).to_api(),
-        duration=_to_api_duration(duration),
-        origins=[],
+        timestamp=_SecondsNanos.from_flexible(start).to_proto(),
+        duration=_to_proto_duration(duration),
         properties=dict(properties or {}),
         labels=list(labels or []),
-        type=type._to_api_event_type(),
+        type=type._to_proto(),
     )
-    response = clients.event.create_event(clients.auth_header, request)
-    return Event._from_conjure(clients, response)
+    with translate_grpc_errors():
+        response = clients.event.CreateEvent(request)
+    return Event._from_proto(clients, response.event)
 
 
 def _iter_search_events(
     clients: Event._Clients,
-    query: event.SearchQuery,
+    query: event_pb2.SearchQuery,
     archive_status: ArchiveStatusFilter = ArchiveStatusFilter.NOT_ARCHIVED,
 ) -> Iterable[Event]:
-    for e in search_events_paginated(clients.event, clients.auth_header, query, archive_status):
-        yield Event._from_conjure(clients, e)
+    for e in search_events_paginated(clients.event, query, archive_status):
+        yield Event._from_proto(clients, e)
 
 
 def _search_events(
@@ -193,10 +253,8 @@ def _search_events(
         workbook_rid=workbook_rid,
         data_review_rid=data_review_rid,
         assignee_rid=assignee_rid,
-        event_type=event_type._to_api_event_type() if event_type else None,
-        origin_types=[origin_type._to_api_search_event_origin_type() for origin_type in origin_types]
-        if origin_types
-        else None,
+        event_type=event_type,
+        origin_types=origin_types,
         workspace_rid=workspace_rid,
     )
     return list(_iter_search_events(clients, query, archive_status))

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -6,7 +6,6 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Iterable, Mapping, Protocol, Sequence, cast
 
 from nominal_api import (
-    event,
     scout,
     scout_asset_api,
     scout_assets,
@@ -64,6 +63,7 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
     class _Clients(
         Attachment._Clients,
         DataSource._Clients,
+        Event._Clients,
         Video._Clients,
         Workbook._Clients,
         Protocol,
@@ -72,8 +72,6 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
         def assets(self) -> scout_assets.AssetService: ...
         @property
         def comments(self) -> comments_pb2_grpc.CommentsServiceStub: ...
-        @property
-        def event(self) -> event.EventService: ...
         @property
         def run(self) -> scout.RunService: ...
 

--- a/nominal/ts/__init__.py
+++ b/nominal/ts/__init__.py
@@ -208,7 +208,8 @@ from google.protobuf import timestamp_pb2
 from nominal_api import api, ingest_api, scout_catalog, scout_dataexport_api, scout_run_api
 from typing_extensions import Self, assert_never
 
-from nominal.protos.types.time import timestamp_parsers_pb2
+from nominal.protos.event.v2 import event_pb2
+from nominal.protos.types.time import time_pb2, timestamp_parsers_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -630,6 +631,13 @@ class _SecondsNanos(NamedTuple):
     def to_api(self) -> api.Timestamp:
         return api.Timestamp(seconds=self.seconds, nanos=self.nanos)
 
+    def to_proto(self) -> time_pb2.Timestamp:
+        return time_pb2.Timestamp(seconds=self.seconds, nanos=self.nanos)
+
+    @classmethod
+    def from_proto(cls, timestamp: time_pb2.Timestamp) -> Self:
+        return cls(seconds=timestamp.seconds, nanos=timestamp.nanos)
+
     def to_iso8601(self) -> str:
         """To an iso8601 string with nanosecond precision.
 
@@ -692,12 +700,13 @@ _ONE_MICROSECOND = timedelta(microseconds=1)
 """timedelta's resolution, used to convert one losslessly to an integer without re-allocating it per call."""
 
 
-def _to_api_duration(duration: timedelta | IntegralNanosecondsDuration) -> scout_run_api.Duration:
-    """Encode a duration as the seconds/nanos pair the platform APIs carry.
+def _to_seconds_nanos_duration(duration: timedelta | IntegralNanosecondsDuration) -> tuple[int, int]:
+    """Split a duration into the seconds/nanos pair the platform APIs carry.
 
     The platform reconstructs the value as `seconds * 1e9 + nanos` using signed arithmetic and constrains
     neither field's sign, so the split is floored rather than truncated: `nanos` stays in [0, 1e9) and
-    `seconds` carries the sign. -1.5s therefore encodes as `(seconds=-2, nanos=500_000_000)`.
+    `seconds` carries the sign. -1.5s therefore splits as `(-2, 500_000_000)`, which looks like an overshoot
+    but is the same value. Both the conjure and proto duration messages take this pair as-is.
 
     A `timedelta` is an exact multiple of its microsecond resolution, so dividing by one microsecond
     converts it losslessly.
@@ -707,8 +716,21 @@ def _to_api_duration(duration: timedelta | IntegralNanosecondsDuration) -> scout
         and would reject a floored split. A duration bound for that type needs its own encoder.
     """
     total_nanos = duration // _ONE_MICROSECOND * 1_000 if isinstance(duration, timedelta) else duration
-    seconds, nanos = divmod(total_nanos, 1_000_000_000)
+    return divmod(total_nanos, 1_000_000_000)
+
+
+def _to_api_duration(duration: timedelta | IntegralNanosecondsDuration) -> scout_run_api.Duration:
+    seconds, nanos = _to_seconds_nanos_duration(duration)
     return scout_run_api.Duration(seconds=seconds, nanos=nanos)
+
+
+def _to_proto_duration(duration: timedelta | IntegralNanosecondsDuration) -> event_pb2.Duration:
+    seconds, nanos = _to_seconds_nanos_duration(duration)
+    return event_pb2.Duration(seconds=seconds, nanos=nanos)
+
+
+def _from_proto_duration(duration: event_pb2.Duration) -> IntegralNanosecondsDuration:
+    return duration.seconds * 1_000_000_000 + duration.nanos
 
 
 def _to_export_timestamp_format(type_: _AnyExportableTimestampType) -> scout_dataexport_api.TimestampFormat:

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -17,6 +17,7 @@ from nominal.core.exceptions import NominalConfigError
 from nominal.experimental import as_user
 from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
+from nominal.protos.event.v2 import event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2_grpc
 from nominal.protos.sandbox.v1 import sandbox_workspace_pb2_grpc
@@ -259,6 +260,7 @@ def test_from_config_wires_grpc_services_through_one_shared_channel(monkeypatch)
     assert isinstance(
         clients.containerized_extractor, containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
     )
+    assert isinstance(clients.event, event_pb2_grpc.EventServiceStub)
     assert isinstance(clients.registry, registry_pb2_grpc.RegistryServiceStub)
     assert isinstance(clients.sandbox_workspace, sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub)
     assert isinstance(clients.secrets, secrets_pb2_grpc.SecretServiceStub)

--- a/tests/core/test_event.py
+++ b/tests/core/test_event.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from typing import Sequence
+from unittest.mock import MagicMock
+
+import pytest
+
+from nominal.core._event_types import EventType, SearchEventOriginType, SearchEventOriginTypes
+from nominal.core.client import NominalClient
+from nominal.core.event import Event
+from nominal.core.exceptions import NominalNotFoundError
+from nominal.protos.event.v2 import event_pb2
+from nominal.protos.types.time import time_pb2
+
+
+def _proto_event(
+    rid: str = "ri.event.test",
+    *,
+    name: str = "original",
+    type: event_pb2.EventType.ValueType = event_pb2.INFO,
+    labels: Sequence[str] = (),
+    created_by: str | None = None,
+    seconds: int = 2,
+    nanos: int = 3,
+) -> event_pb2.Event:
+    return event_pb2.Event(
+        rid=rid,
+        uuid="uuid-1",
+        name=name,
+        type=type,
+        labels=list(labels),
+        created_by=created_by,
+        timestamp=time_pb2.Timestamp(seconds=seconds, nanos=nanos),
+        duration=event_pb2.Duration(seconds=1, nanos=500),
+    )
+
+
+def _event(clients: MagicMock) -> Event:
+    return Event._from_proto(clients, _proto_event(labels=["keep"]))
+
+
+def test_update_omits_absent_fields_so_the_backend_leaves_them_unchanged() -> None:
+    """None must not reach the wire: an omitted field is how a caller says "leave this alone"."""
+    clients = MagicMock()
+    event = _event(clients)
+    clients.event.BatchUpdateEvent.return_value = event_pb2.BatchUpdateEventResponse(
+        events=[_proto_event(name="renamed")]
+    )
+
+    event.update(name="renamed", type=None)
+
+    update = clients.event.BatchUpdateEvent.call_args.args[0].updates[0]
+    assert update.rid == event.rid
+    assert update.name == "renamed"
+    for field in ("description", "labels", "properties", "asset_rids", "timestamp", "duration", "type"):
+        assert not update.HasField(field), f"{field} should be absent when omitted"
+    assert event.name == "renamed"
+
+
+def test_update_sends_empty_collections_as_explicit_clears() -> None:
+    """An empty collection is a clear, which the update wrappers make distinguishable from omission."""
+    clients = MagicMock()
+    event = _event(clients)
+    clients.event.BatchUpdateEvent.return_value = event_pb2.BatchUpdateEventResponse(events=[_proto_event()])
+
+    event.update(assets=[], labels=[], properties={}, type=None)
+
+    update = clients.event.BatchUpdateEvent.call_args.args[0].updates[0]
+    assert (update.HasField("asset_rids"), list(update.asset_rids.asset_rids)) == (True, [])
+    assert (update.HasField("labels"), list(update.labels.labels)) == (True, [])
+    assert (update.HasField("properties"), dict(update.properties.properties)) == (True, {})
+
+
+def test_from_proto_decodes_seconds_and_nanos() -> None:
+    """Event carries Nominal's own seconds+nanos Timestamp and Duration, neither of which self-converts."""
+    event = Event._from_proto(MagicMock(), _proto_event(seconds=2, nanos=3))
+
+    assert event.start == 2_000_000_003
+    assert event.duration == 1_000_000_500
+
+
+@pytest.mark.parametrize("created_by", [None, "ri.user.1"])
+def test_from_proto_reads_optional_created_by(created_by: str | None) -> None:
+    """created_by is optional on the wire for legacy events; absent must not read as an empty rid."""
+    assert Event._from_proto(MagicMock(), _proto_event(created_by=created_by)).created_by_rid == created_by
+
+
+def test_from_proto_degrades_unknown_event_types() -> None:
+    """Event types are an open wire enum, so an unrecognized one must not raise on read."""
+    event = Event._from_proto(MagicMock(), _proto_event(type=event_pb2.EVENT_TYPE_UNSPECIFIED))
+
+    assert event.type is EventType.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    ("event_type", "wire_value"),
+    [
+        (EventType.INFO, event_pb2.INFO),
+        (EventType.FLAG, event_pb2.FLAG),
+        (EventType.ERROR, event_pb2.ERROR),
+        (EventType.SUCCESS, event_pb2.SUCCESS),
+        (EventType.UNKNOWN, event_pb2.EVENT_TYPE_UNSPECIFIED),
+    ],
+)
+def test_event_type_maps_to_and_from_the_wire(event_type: EventType, wire_value: int) -> None:
+    """Both directions are hand-written tables, so a transposed pair would otherwise go unnoticed."""
+    assert event_type._to_proto() == wire_value
+    if event_type is not EventType.UNKNOWN:
+        assert EventType._from_proto(wire_value) is event_type
+
+
+# Derived rather than listed so a newly declared origin type is round-tripped without editing this file.
+_DECLARED_ORIGIN_TYPES = [
+    origin_type
+    for origin_type in vars(SearchEventOriginTypes).values()
+    if isinstance(origin_type, SearchEventOriginType)
+]
+
+
+def test_every_declared_origin_type_is_discovered() -> None:
+    """Guards the reflection below: a broken derivation would silently parametrize nothing."""
+    assert len(_DECLARED_ORIGIN_TYPES) >= 6
+
+
+@pytest.mark.parametrize("origin_type", _DECLARED_ORIGIN_TYPES, ids=lambda o: o.name)
+def test_search_event_origin_type_round_trips(origin_type: SearchEventOriginType) -> None:
+    """_to_proto resolves by name while _from_proto is a hand-written table.
+
+    A member added to SearchEventOriginTypes but not to that table fails here, which is what keeps the
+    two sides from drifting now that no shared lookup derives one from the other.
+    """
+    assert SearchEventOriginType._from_proto(origin_type._to_proto()) is origin_type
+
+
+def test_create_event_puts_the_domain_values_on_the_wire() -> None:
+    """Creation is the only path that sends a caller-chosen type, timestamp and duration."""
+    clients = MagicMock()
+    client = NominalClient(_clients=clients)
+    clients.event.CreateEvent.return_value = event_pb2.CreateEventResponse(event=_proto_event())
+
+    client.create_event("launch", EventType.FLAG, start=1_000_000_002, duration=3_000_000_004, assets=["ri.asset.1"])
+
+    request = clients.event.CreateEvent.call_args.args[0]
+    assert request.name == "launch"
+    assert request.type == event_pb2.FLAG
+    assert (request.timestamp.seconds, request.timestamp.nanos) == (1, 2)
+    assert (request.duration.seconds, request.duration.nanos) == (3, 4)
+    assert list(request.asset_rids) == ["ri.asset.1"]
+    assert not request.HasField("description")
+
+
+@pytest.mark.parametrize(
+    ("returned", "expected_error"),
+    [
+        pytest.param(0, NominalNotFoundError, id="absent"),
+        pytest.param(2, ValueError, id="ambiguous"),
+    ],
+)
+def test_get_event_rejects_a_batch_that_is_not_exactly_one(returned: int, expected_error: type[Exception]) -> None:
+    """A rid that does not resolve comes back as an absent batch entry, never a NOT_FOUND status."""
+    clients = MagicMock()
+    client = NominalClient(_clients=clients)
+    clients.event.BatchGetEvents.return_value = event_pb2.BatchGetEventsResponse(
+        events=[_proto_event() for _ in range(returned)]
+    )
+
+    with pytest.raises(expected_error):
+        client.get_event("ri.event.test")

--- a/tests/core/test_query_tools.py
+++ b/tests/core/test_query_tools.py
@@ -1,18 +1,58 @@
-from nominal_api import api
-
+from nominal.core._event_types import EventType, SearchEventOriginTypes
 from nominal.core._utils.query_tools import AssetMatch, create_search_events_query
+from nominal.protos.event.v2 import event_pb2
 
 
 def test_create_search_events_query_asset_match_all_ands_per_asset_clauses():
     """AssetMatch.ALL (default) emits one ANDed asset clause per rid."""
     query = create_search_events_query(asset_rids=["a", "b"])
-    assert [sub.asset for sub in query.and_] == ["a", "b"]
+
+    assert query == event_pb2.SearchQuery(
+        **{
+            "and": event_pb2.SearchQueryList(
+                queries=[event_pb2.SearchQuery(asset="a"), event_pb2.SearchQuery(asset="b")]
+            )
+        }
+    )
 
 
 def test_create_search_events_query_asset_match_any_ors_assets():
     """AssetMatch.ANY emits a single OR AssetsFilter over all rids."""
     query = create_search_events_query(asset_rids=["a", "b", "c"], asset_match=AssetMatch.ANY)
-    assert len(query.and_) == 1
-    assets_filter = query.and_[0].assets
-    assert assets_filter.assets == ["a", "b", "c"]
-    assert assets_filter.operator == api.SetOperator.OR
+
+    assert query == event_pb2.SearchQuery(
+        **{
+            "and": event_pb2.SearchQueryList(
+                queries=[
+                    event_pb2.SearchQuery(assets=event_pb2.AssetsFilter(assets=["a", "b", "c"], operator=event_pb2.OR))
+                ]
+            )
+        }
+    )
+
+
+def test_create_search_events_query_converts_domain_enums() -> None:
+    """event_type and origin_types arrive as domain values and are converted here, not by the caller."""
+    query = create_search_events_query(event_type=EventType.FLAG, origin_types=[SearchEventOriginTypes.WORKBOOK])
+
+    assert query == event_pb2.SearchQuery(
+        **{
+            "and": event_pb2.SearchQueryList(
+                queries=[
+                    event_pb2.SearchQuery(event_type=event_pb2.FLAG),
+                    event_pb2.SearchQuery(
+                        origin_types=event_pb2.OriginTypesFilter(
+                            operator=event_pb2.OR, origin_types=[event_pb2.WORKBOOK]
+                        )
+                    ),
+                ]
+            )
+        }
+    )
+
+
+def test_create_search_events_query_drops_an_empty_origin_types() -> None:
+    """An empty sequence must drop the clause; an OR over no origin types would match nothing."""
+    assert create_search_events_query(origin_types=[]) == event_pb2.SearchQuery(
+        **{"and": event_pb2.SearchQueryList(queries=[])}
+    )

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from nominal_api import api
 
 from nominal.core.run import Run
+from nominal.protos.event.v2 import event_pb2
 
 
 @pytest.fixture
@@ -40,26 +40,26 @@ def mock_run(make_run):
     return make_run(["asset-rid-1", "asset-rid-2"])
 
 
-def _empty_search_response():
-    response = MagicMock()
-    response.results = []
-    response.next_page_token = None
-    return response
-
-
 def test_search_events_ors_run_assets(mock_run, mock_clients):
     """Run.search_events matches events on any of the run's assets (a single OR asset filter)."""
-    mock_clients.event.search_events.return_value = _empty_search_response()
+    mock_clients.event.SearchEvents.return_value = event_pb2.SearchEventsResponse()
 
     result = mock_run.search_events()
 
     assert result == []
-    mock_clients.event.search_events.assert_called_once()
-    _, request = mock_clients.event.search_events.call_args[0]
-    asset_filters = [sub.assets for sub in request.query.and_ if sub.assets is not None]
-    assert len(asset_filters) == 1
-    assert asset_filters[0].assets == ["asset-rid-1", "asset-rid-2"]
-    assert asset_filters[0].operator == api.SetOperator.OR
+    mock_clients.event.SearchEvents.assert_called_once()
+    request = mock_clients.event.SearchEvents.call_args.args[0]
+    assert request.query == event_pb2.SearchQuery(
+        **{
+            "and": event_pb2.SearchQueryList(
+                queries=[
+                    event_pb2.SearchQuery(
+                        assets=event_pb2.AssetsFilter(assets=["asset-rid-1", "asset-rid-2"], operator=event_pb2.OR)
+                    )
+                ]
+            )
+        }
+    )
 
 
 def test_search_events_empty_assets_returns_no_events(make_run, mock_clients):
@@ -69,7 +69,7 @@ def test_search_events_empty_assets_returns_no_events(make_run, mock_clients):
     result = run.search_events()
 
     assert result == []
-    mock_clients.event.search_events.assert_not_called()
+    mock_clients.event.SearchEvents.assert_not_called()
 
 
 def test_nominal_url_identifies_the_run_by_rid(mock_run, mock_clients):


### PR DESCRIPTION
Moves the client's event service from conjure to the v2 gRPC `EventService`, following the pattern used for comments, units, workspace, sandbox workspace, and secrets.

Public method signatures are unchanged. `Event` becomes a `RefreshableGrpcMixin` with `_from_proto`, event search moves to `paginate_grpc`, and every RPC is wrapped in `translate_grpc_errors()`.

Two behavior changes are worth a look:

- `get_event` and `Event.refresh` now raise `NominalNotFoundError` when a rid does not resolve. The batch endpoint answers with an absent entry rather than a `NOT_FOUND` status, so nothing translated that case before; they previously raised `RuntimeError` and `ValueError`.
- `EventType.from_api_event_type` and `SearchEventOriginType.from_api_origin_type` are removed. Both took conjure enums that the event service no longer uses and that callers cannot obtain from the SDK.

The event protos carry `nominal.types.time.Timestamp` and their own seconds/nanos `Duration` rather than the `google.protobuf` equivalents, so `_SecondsNanos` gains `to_proto`/`from_proto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
