### PR TITLE
fix: bump nominal-api & nominal-api-protos to 0.1371.0

### DIFF
--- a/nominal/experimental/compute/_buckets.py
+++ b/nominal/experimental/compute/_buckets.py
@@ -328,45 +328,35 @@ def _compute_buckets(
     yield from _numeric_buckets_from_compute_response(response)
 
 
+def _single_point_bucket(point: scout_compute_api.NumericPoint) -> scout_compute_api.NumericBucket:
+    """Wrap a single point as a bucket the client invented.
+
+    There are no server-computed aggregations to carry. Real buckets carry an empty map here too:
+    every `SummarizeSeries` the client builds requests `numeric_aggregations={}`.
+    """
+    return scout_compute_api.NumericBucket(
+        aggregations={},
+        count=1,
+        first_point=point,
+        last_point=point,
+        max=point.value,
+        mean=point.value,
+        min=point.value,
+        variance=0,
+    )
+
+
 def _numeric_buckets_from_compute_response(
     response: scout_compute_api.ComputeNodeResponse,
 ) -> Iterable[tuple[api.Timestamp, scout_compute_api.NumericBucket]]:
     if response.numeric_point is not None:
         # single point would be returned-- create a synthetic bucket
-        val = response.numeric_point.value
-        yield (
-            response.numeric_point.timestamp,
-            scout_compute_api.NumericBucket(
-                # synthetic bucket over a single point: no server-computed aggregations to carry
-                aggregations={},
-                count=1,
-                first_point=response.numeric_point,
-                max=val,
-                mean=val,
-                min=val,
-                variance=0,
-                last_point=response.numeric_point,
-            ),
-        )
+        yield (response.numeric_point.timestamp, _single_point_bucket(response.numeric_point))
     elif response.numeric is not None:
         # Not enough points to reach the number of requested bucket count, so
         # gets returned as all of the raw data.
         for timestamp, value in zip(response.numeric.timestamps, response.numeric.values):
-            point = scout_compute_api.NumericPoint(timestamp, value)
-            yield (
-                timestamp,
-                scout_compute_api.NumericBucket(
-                    # synthetic bucket over a single raw point: no server-computed aggregations
-                    aggregations={},
-                    count=1,
-                    first_point=point,
-                    max=value,
-                    min=value,
-                    mean=value,
-                    variance=0,
-                    last_point=point,
-                ),
-            )
+            yield (timestamp, _single_point_bucket(scout_compute_api.NumericPoint(timestamp, value)))
     elif response.bucketed_numeric is not None:
         # Actually bucketed data
         yield from zip(response.bucketed_numeric.timestamps, response.bucketed_numeric.buckets)

--- a/nominal/experimental/compute/_buckets.py
+++ b/nominal/experimental/compute/_buckets.py
@@ -337,6 +337,8 @@ def _numeric_buckets_from_compute_response(
         yield (
             response.numeric_point.timestamp,
             scout_compute_api.NumericBucket(
+                # synthetic bucket over a single point: no server-computed aggregations to carry
+                aggregations={},
                 count=1,
                 first_point=response.numeric_point,
                 max=val,
@@ -354,6 +356,8 @@ def _numeric_buckets_from_compute_response(
             yield (
                 timestamp,
                 scout_compute_api.NumericBucket(
+                    # synthetic bucket over a single raw point: no server-computed aggregations
+                    aggregations={},
                     count=1,
                     first_point=point,
                     max=value,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "conjure-python-client>=3.1.0,<4",
     "exceptiongroup>=1.3.0",
-    "nominal-api==0.1352.0",
-    "nominal-api-protos==0.1352.0",
+    "nominal-api==0.1371.0",
+    "nominal-api-protos==0.1371.0",
     "truststore>=0.10.4",
     "typing-extensions>=4,<5",
     "pandas>=2.0.0",

--- a/tests/thirdparty/polars/conftest.py
+++ b/tests/thirdparty/polars/conftest.py
@@ -24,6 +24,7 @@ def make_numeric_response():
         ]
         response.bucketed_numeric.buckets = [
             scout_compute_api.NumericBucket(
+                aggregations={},
                 count=c,
                 min=0.0,
                 max=1.0,

--- a/uv.lock
+++ b/uv.lock
@@ -798,8 +798,8 @@ requires-dist = [
     { name = "conjure-python-client", specifier = ">=3.1.0,<4" },
     { name = "exceptiongroup", specifier = ">=1.3.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
-    { name = "nominal-api", specifier = "==0.1352.0" },
-    { name = "nominal-api-protos", specifier = "==0.1352.0" },
+    { name = "nominal-api", specifier = "==0.1371.0" },
+    { name = "nominal-api-protos", specifier = "==0.1371.0" },
     { name = "nominal-compute", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin' and extra == 'compute') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'compute') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'compute') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32' and extra == 'compute')", specifier = "==0.1315.0" },
     { name = "nominal-streaming", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')", specifier = "==0.8.2" },
     { name = "nominal-tdms", marker = "extra == 'tdms'", editable = "packages/nominal-tdms" },
@@ -841,19 +841,19 @@ dev = [
 
 [[package]]
 name = "nominal-api"
-version = "0.1352.0"
+version = "0.1371.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "conjure-python-client" },
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/0b/7d46c864b843eed7dba7021d473ea84eac950ee7575c7118ac1cb6522a1f/nominal_api-0.1352.0-py3-none-any.whl", hash = "sha256:052fb5357638d7dd46779d70dd755fd7be52112f8f5e7b15d3a6032c0692a7bf", size = 937644, upload-time = "2026-07-30T14:46:55.284Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/11/c9b71d0501f14143cdf2787ab10bcf5e8a236027df447290a5a0f886e2d0/nominal_api-0.1371.0-py3-none-any.whl", hash = "sha256:12fb0d139529a63232560d5dc24604d2ddcc61b1e2cd7c9063571b2402d19fab", size = 943753, upload-time = "2026-08-07T15:22:36.757Z" },
 ]
 
 [[package]]
 name = "nominal-api-protos"
-version = "0.1352.0"
+version = "0.1371.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -861,7 +861,7 @@ dependencies = [
     { name = "protobuf" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/80/a4fe7c79727f10fc35fbb0e5f97ea8158a6c4c2505592dc3269a611d6eae/nominal_api_protos-0.1352.0-py3-none-any.whl", hash = "sha256:f58d6d84e5fee9c262c0875dab88ffac0819974cc15f0fb83db258673b81961b", size = 684277, upload-time = "2026-07-30T14:46:56.659Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3e/10d8ea215ad4b371dafa41a872459f82f74b8bb52976383f10207b297984/nominal_api_protos-0.1371.0-py3-none-any.whl", hash = "sha256:0eb2f736040b96775549cb561950845077734444ff509369e7473f4654279c6d", size = 671789, upload-time = "2026-08-07T15:22:38.144Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps both generated-binding pins from `0.1352.0` to `0.1371.0` (current latest) and regenerates `uv.lock`.

Prerequisite for migrating the data review service to gRPC: the v1 data review proto contract is not served by current backends, and its v2 replacement first ships in `0.1354.0`.

## The one breaking change that reaches us

`scout_compute_api.NumericBucket` gained a **required** `aggregations: Dict[str, float]`.

The client only ever constructs this type *synthetically*: when the compute backend returns a single point, or returns raw data because there weren't enough points to fill the requested bucket count, `_numeric_buckets_from_compute_response` fabricates a one-sample bucket locally. Both sites now pass `aggregations={}` — there are no server-computed aggregations for a bucket the client invented.

`{}` is the future-proof value, not merely a harmless one today: every `SummarizeSeries` the client builds requests `numeric_aggregations={}` (`channel.py`, `polars_export_handler.py`, `_buckets.py`), so buckets that come back from the server carry an empty map on this field too. Synthetic and real buckets stay indistinguishable on `aggregations` even if something starts reading it. (`Bucket._from_conjure` does not read it today.)

While here: the two synthetic-bucket literals were byte-identical except for the point they wrap, and this was the second bump in a row that had to edit both in lockstep for a new required field. They collapse into a single `_single_point_bucket` helper, so the next one is a one-line change.

## On the rest of the diff

The bump-scan report flags 16 "breaking changes touching the client", but its reference scan is substring-based and the rest are false positives — e.g. it attributes `ai.v1.DeleteRequest` to `secret.py` purely on the name `DeleteRequest`, and `KnowledgeBaseService.List` to 18 files on the word `List`. The real removals in that set are the `ai.v1` knowledge-base surface and the `datareview.v1` messages, neither of which the client references. mypy and the test suite are the load-bearing check here, and both are clean apart from the `NumericBucket` change above.

Note on that load-bearing claim: mypy is configured with `packages = ["nominal", "nominal.tdms"]`, so it does not cover `tests/`. Test-side constructors of generated types are caught by running the suite, not statically — which is why `tests/thirdparty/polars/conftest.py` surfaced at runtime. Anything constructed only inside a skipped test would not be caught at all.

## Testing

- `uv lock --check` clean.
- `just check` clean (ruff format, ruff check, mypy over all 159 source files).
- 609 unit tests pass, 14 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
