### PR TITLE
feat: migrate asset service to gRPC

### DIFF
--- a/nominal/cli/download.py
+++ b/nominal/cli/download.py
@@ -95,10 +95,7 @@ class DataDownloader(abc.ABC):
                 return None
 
         # Sort by last updated timestamps
-        raw_assets = self._client._clients.assets.get_assets(
-            self._client._clients.auth_header, [asset.rid for asset in assets]
-        )
-        sorted_assets = sorted(assets, key=lambda asset: pd.to_datetime(raw_assets[asset.rid].updated_at), reverse=True)
+        sorted_assets = sorted(assets, key=lambda asset: asset.updated_at, reverse=True)
         table = Table(
             Column("#", style=Style(color="white", bold=True), ratio=1, overflow="fold"),
             Column("Name", style=Style(color="white", bold=True), ratio=2, overflow="fold"),
@@ -418,15 +415,11 @@ class DataDownloader(abc.ABC):
             return
 
         # get tags from dataset & asset combo
-        scope_tags = None
-        raw_asset = self._client._clients.assets.get_assets(self._client._clients.auth_header, [asset.rid])[asset.rid]
-        for raw_datascope in raw_asset.data_scopes:
-            if raw_datascope.data_scope_name == refname:
-                scope_tags = raw_datascope.series_tags
-                break
-        if scope_tags is None:
+        data_scope = asset._lookup_dataset_scope(refname)
+        if data_scope is None:
             logger.error("Failed to retrieve datascope details for refname %s", refname)
             return
+        _, scope_tags = data_scope
 
         # Select channels (exact-name matching with iterative queries) to download
         channels = self._select_channels(dataset)

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -11,7 +11,6 @@ from nominal_api import (
     authentication_api,
     ingest_api,
     scout,
-    scout_assets,
     scout_catalog,
     scout_checklistexecution_api,
     scout_checks_api,
@@ -36,6 +35,7 @@ from nominal.core._utils.networking import (
     create_conjure_client_factory,
 )
 from nominal.core.exceptions import NominalConfigError
+from nominal.protos.asset.v2 import asset_pb2_grpc
 from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
 from nominal.protos.event.v2 import event_pb2_grpc
@@ -143,7 +143,6 @@ class ClientsBunch:
     )
 
     # Conjure services
-    assets: scout_assets.AssetService
     attachment: attachments_api.AttachmentService
     authentication: authentication_api.AuthenticationServiceV2
     catalog: scout_catalog.CatalogService
@@ -169,6 +168,7 @@ class ClientsBunch:
     video: scout_video.VideoService
 
     # GRPC services
+    assets: asset_pb2_grpc.AssetServiceStub
     comments: comments_pb2_grpc.CommentsServiceStub
     containerized_extractor: containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
     event: event_pb2_grpc.EventServiceStub
@@ -307,7 +307,6 @@ class ClientsBunch:
             _token=token,
             _service_config=cfg,
             # Conjure Service Stubs
-            assets=client_factory(scout_assets.AssetService),
             attachment=client_factory(attachments_api.AttachmentService),
             authentication=client_factory(authentication_api.AuthenticationServiceV2),
             catalog=client_factory(scout_catalog.CatalogService),
@@ -332,6 +331,7 @@ class ClientsBunch:
             video_file=client_factory(scout_video.VideoFileService),
             video=client_factory(scout_video.VideoService),
             # GRPC Service Stubs
+            assets=grpc_factory(asset_pb2_grpc.AssetServiceStub),
             comments=grpc_factory(comments_pb2_grpc.CommentsServiceStub),
             containerized_extractor=grpc_factory(containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub),
             event=grpc_factory(event_pb2_grpc.EventServiceStub),

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -11,7 +11,6 @@ from nominal_api import (
     authentication_api,
     ingest_api,
     scout,
-    scout_assets,
     scout_catalog,
     scout_checklistexecution_api,
     scout_checks_api,
@@ -37,6 +36,7 @@ from nominal.core._utils.networking import (
     validate_api_base_url,
 )
 from nominal.core.exceptions import NominalConfigError
+from nominal.protos.asset.v2 import asset_pb2_grpc
 from nominal.protos.authorization.markings.v1 import markings_pb2_grpc
 from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
@@ -145,7 +145,6 @@ class ClientsBunch:
     )
 
     # Conjure services
-    assets: scout_assets.AssetService
     attachment: attachments_api.AttachmentService
     authentication: authentication_api.AuthenticationServiceV2
     catalog: scout_catalog.CatalogService
@@ -171,6 +170,7 @@ class ClientsBunch:
     video: scout_video.VideoService
 
     # GRPC services
+    assets: asset_pb2_grpc.AssetServiceStub
     comments: comments_pb2_grpc.CommentsServiceStub
     containerized_extractor: containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
     event: event_pb2_grpc.EventServiceStub
@@ -311,7 +311,6 @@ class ClientsBunch:
             _token=token,
             _service_config=cfg,
             # Conjure Service Stubs
-            assets=client_factory(scout_assets.AssetService),
             attachment=client_factory(attachments_api.AttachmentService),
             authentication=client_factory(authentication_api.AuthenticationServiceV2),
             catalog=client_factory(scout_catalog.CatalogService),
@@ -336,6 +335,7 @@ class ClientsBunch:
             video_file=client_factory(scout_video.VideoFileService),
             video=client_factory(scout_video.VideoService),
             # GRPC Service Stubs
+            assets=grpc_factory(asset_pb2_grpc.AssetServiceStub),
             comments=grpc_factory(comments_pb2_grpc.CommentsServiceStub),
             containerized_extractor=grpc_factory(containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub),
             event=grpc_factory(event_pb2_grpc.EventServiceStub),

--- a/nominal/core/_utils/api_tools.py
+++ b/nominal/core/_utils/api_tools.py
@@ -5,12 +5,24 @@ import importlib.metadata
 import logging
 import platform
 import sys
-from typing import Any, Generic, Literal, Mapping, Protocol, Sequence, TypeAlias, TypedDict, TypeVar, runtime_checkable
+from typing import (
+    Any,
+    Generic,
+    Literal,
+    Mapping,
+    Protocol,
+    Sequence,
+    TypeAlias,
+    TypedDict,
+    TypeVar,
+    runtime_checkable,
+)
 
 from nominal_api import scout_asset_api, scout_compute_api, scout_run_api
 from typing_extensions import NotRequired, Self
 
 from nominal._utils.dataclass_tools import update_dataclass
+from nominal.protos.asset.v2 import asset_pb2
 
 ScopeTypeSpecifier: TypeAlias = Literal["connection", "dataset", "video"]
 
@@ -108,17 +120,31 @@ class LinkDict(TypedDict):
     title: NotRequired[str]
 
 
-def create_links(links: Sequence[str | Link | LinkDict]) -> list[scout_run_api.Link]:
-    links_conjure = []
+def normalize_links(links: Sequence[str | Link | LinkDict]) -> list[tuple[str, str | None]]:
+    """Reduce every accepted link spelling -- url, (url, title), or dict -- to (url, title) pairs."""
+    normalized: list[tuple[str, str | None]] = []
     for link in links:
         if isinstance(link, tuple):
             url, title = link
-            links_conjure.append(scout_run_api.Link(url=url, title=title))
+            normalized.append((url, title))
         elif isinstance(link, dict):
-            links_conjure.append(scout_run_api.Link(url=link["url"], title=link.get("title")))
+            normalized.append((link["url"], link.get("title")))
         else:
-            links_conjure.append(scout_run_api.Link(url=link))
-    return links_conjure
+            normalized.append((link, None))
+    return normalized
+
+
+def create_links(links: Sequence[str | Link | LinkDict]) -> list[scout_run_api.Link]:
+    return [scout_run_api.Link(url=url, title=title) for url, title in normalize_links(links)]
+
+
+def create_proto_links(links: Sequence[str | Link | LinkDict]) -> list[asset_pb2.Link]:
+    """The proto peer of `create_links`.
+
+    `Link` is currently declared per service and only the asset service has migrated, so this builds the
+    asset spelling. It collapses into `create_links` once `Link` becomes a shared type.
+    """
+    return [asset_pb2.Link(url=url, title=title) for url, title in normalize_links(links)]
 
 
 def create_api_tags(tags: Mapping[str, str] | None = None) -> dict[str, scout_compute_api.StringConstant]:
@@ -157,9 +183,3 @@ def filter_scopes(
     scopes: Sequence[scout_asset_api.DataScope], scope_type: ScopeTypeSpecifier
 ) -> Sequence[scout_asset_api.DataScope]:
     return [scope for scope in scopes if scope.data_source.type.lower() == scope_type]
-
-
-def filter_scope_rids(scopes: Sequence[scout_asset_api.DataScope], scope_type: ScopeTypeSpecifier) -> Mapping[str, str]:
-    return {
-        scope.data_scope_name: getattr(scope.data_source, scope_type) for scope in filter_scopes(scopes, scope_type)
-    }

--- a/nominal/core/_utils/pagination_tools.py
+++ b/nominal/core/_utils/pagination_tools.py
@@ -6,8 +6,6 @@ from nominal_api import (
     authentication_api,
     ingest_api,
     scout,
-    scout_asset_api,
-    scout_assets,
     scout_catalog,
     scout_checklistexecution_api,
     scout_checks_api,
@@ -21,6 +19,7 @@ from nominal_api import (
 
 from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.query_tools import ArchiveStatusFilter
+from nominal.protos.asset.v2 import asset_pb2, asset_pb2_grpc
 from nominal.protos.event.v2 import event_pb2, event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2, containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2, registry_pb2_grpc
@@ -97,24 +96,25 @@ def search_dataset_files_paginated(
 
 
 def search_assets_paginated(
-    client: scout_assets.AssetService,
-    auth_header: str,
-    query: scout_asset_api.SearchAssetsQuery,
+    client: asset_pb2_grpc.AssetServiceStub,
+    query: asset_pb2.SearchAssetsQuery,
     archive_status: ArchiveStatusFilter = ArchiveStatusFilter.NOT_ARCHIVED,
-) -> Iterable[scout_asset_api.Asset]:
-    def factory(page_token: str | None) -> scout_asset_api.SearchAssetsRequest:
-        return scout_asset_api.SearchAssetsRequest(
+) -> Iterable[asset_pb2.Asset]:
+    def factory(page_token: str | None) -> asset_pb2.SearchAssetsRequest:
+        return asset_pb2.SearchAssetsRequest(
             page_size=DEFAULT_PAGE_SIZE,
             query=query,
-            sort=scout_asset_api.AssetSortOptions(
-                field=scout_asset_api.AssetSortField.CREATED_AT,
+            sort=asset_pb2.AssetSortOptions(
+                field=asset_pb2.AssetSortField.CREATED_AT,
                 is_descending=True,
             ),
-            archived_statuses=archive_status.to_api_archived_statuses(),
+            archived_statuses=asset_pb2.ArchivedStatusSet(
+                archived_statuses=archive_status.to_proto_archived_statuses()
+            ),
             next_page_token=page_token,
         )
 
-    for response in paginate_rpc(client.search_assets, auth_header, request_factory=factory):
+    for response in paginate_grpc(client.SearchAssets, request_factory=factory):
         yield from response.results
 
 

--- a/nominal/core/_utils/pagination_tools.py
+++ b/nominal/core/_utils/pagination_tools.py
@@ -6,8 +6,6 @@ from nominal_api import (
     authentication_api,
     ingest_api,
     scout,
-    scout_asset_api,
-    scout_assets,
     scout_catalog,
     scout_checklistexecution_api,
     scout_checks_api,
@@ -21,6 +19,7 @@ from nominal_api import (
 
 from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.query_tools import ArchiveStatusFilter
+from nominal.protos.asset.v2 import asset_pb2, asset_pb2_grpc
 from nominal.protos.authorization.markings.v1 import markings_pb2, markings_pb2_grpc
 from nominal.protos.event.v2 import event_pb2, event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2, containerized_extractor_pb2_grpc
@@ -98,24 +97,25 @@ def search_dataset_files_paginated(
 
 
 def search_assets_paginated(
-    client: scout_assets.AssetService,
-    auth_header: str,
-    query: scout_asset_api.SearchAssetsQuery,
+    client: asset_pb2_grpc.AssetServiceStub,
+    query: asset_pb2.SearchAssetsQuery,
     archive_status: ArchiveStatusFilter = ArchiveStatusFilter.NOT_ARCHIVED,
-) -> Iterable[scout_asset_api.Asset]:
-    def factory(page_token: str | None) -> scout_asset_api.SearchAssetsRequest:
-        return scout_asset_api.SearchAssetsRequest(
+) -> Iterable[asset_pb2.Asset]:
+    def factory(page_token: str | None) -> asset_pb2.SearchAssetsRequest:
+        return asset_pb2.SearchAssetsRequest(
             page_size=DEFAULT_PAGE_SIZE,
             query=query,
-            sort=scout_asset_api.AssetSortOptions(
-                field=scout_asset_api.AssetSortField.CREATED_AT,
+            sort=asset_pb2.AssetSortOptions(
+                field=asset_pb2.AssetSortField.CREATED_AT,
                 is_descending=True,
             ),
-            archived_statuses=archive_status.to_api_archived_statuses(),
+            archived_statuses=asset_pb2.ArchivedStatusSet(
+                archived_statuses=archive_status.to_proto_archived_statuses()
+            ),
             next_page_token=page_token,
         )
 
-    for response in paginate_rpc(client.search_assets, auth_header, request_factory=factory):
+    for response in paginate_grpc(client.SearchAssets, request_factory=factory):
         yield from response.results
 
 

--- a/nominal/core/_utils/query_tools.py
+++ b/nominal/core/_utils/query_tools.py
@@ -8,7 +8,6 @@ from nominal_api import (
     api,
     authentication_api,
     ingest_api,
-    scout_asset_api,
     scout_catalog,
     scout_checks_api,
     scout_notebook_api,
@@ -20,6 +19,7 @@ from nominal_api import (
 
 from nominal.core._event_types import EventType, SearchEventOriginType
 from nominal.core._utils.api_tools import rid_from_instance_or_string
+from nominal.protos.asset.v2 import asset_pb2
 from nominal.protos.event.v2 import event_pb2
 from nominal.protos.registry.v2 import registry_pb2
 from nominal.protos.secrets.v1 import secrets_pb2
@@ -237,22 +237,25 @@ def create_search_assets_query(
     properties: Mapping[str, str] | None = None,
     exact_substring: str | None = None,
     workspace_rid: str | None = None,
-) -> scout_asset_api.SearchAssetsQuery:
+) -> asset_pb2.SearchAssetsQuery:
     queries = []
     if search_text is not None:
-        queries.append(scout_asset_api.SearchAssetsQuery(search_text=search_text))
+        queries.append(asset_pb2.SearchAssetsQuery(search_text=search_text))
     if exact_substring is not None:
-        queries.append(scout_asset_api.SearchAssetsQuery(exact_substring=exact_substring))
+        queries.append(asset_pb2.SearchAssetsQuery(exact_substring=exact_substring))
     if labels is not None:
         for label in labels:
-            queries.append(scout_asset_api.SearchAssetsQuery(label=label))
+            queries.append(asset_pb2.SearchAssetsQuery(label=label))
     if properties:
         for name, value in properties.items():
-            queries.append(scout_asset_api.SearchAssetsQuery(property=api.Property(name=name, value=value)))
+            queries.append(asset_pb2.SearchAssetsQuery(property=types_pb2.Property(name=name, value=value)))
     if workspace_rid is not None:
-        queries.append(scout_asset_api.SearchAssetsQuery(workspace=workspace_rid))
+        queries.append(asset_pb2.SearchAssetsQuery(workspace=workspace_rid))
 
-    return scout_asset_api.SearchAssetsQuery(and_=queries)
+    # `and` is a Python keyword, and generated typing stubs cannot expose it as a named argument.
+    return asset_pb2.SearchAssetsQuery(
+        **{"and": asset_pb2.SearchAssetsQueryList(queries=queries)}  # type: ignore[arg-type]
+    )
 
 
 def create_search_ingest_jobs_query(

--- a/nominal/core/_utils/query_tools.py
+++ b/nominal/core/_utils/query_tools.py
@@ -8,7 +8,6 @@ from nominal_api import (
     api,
     authentication_api,
     ingest_api,
-    scout_asset_api,
     scout_catalog,
     scout_checks_api,
     scout_notebook_api,
@@ -20,6 +19,7 @@ from nominal_api import (
 
 from nominal.core._event_types import EventType, SearchEventOriginType
 from nominal.core._utils.api_tools import rid_from_instance_or_string
+from nominal.protos.asset.v2 import asset_pb2
 from nominal.protos.authorization.markings.v1 import markings_pb2
 from nominal.protos.event.v2 import event_pb2
 from nominal.protos.registry.v2 import registry_pb2
@@ -250,22 +250,25 @@ def create_search_assets_query(
     properties: Mapping[str, str] | None = None,
     exact_substring: str | None = None,
     workspace_rid: str | None = None,
-) -> scout_asset_api.SearchAssetsQuery:
+) -> asset_pb2.SearchAssetsQuery:
     queries = []
     if search_text is not None:
-        queries.append(scout_asset_api.SearchAssetsQuery(search_text=search_text))
+        queries.append(asset_pb2.SearchAssetsQuery(search_text=search_text))
     if exact_substring is not None:
-        queries.append(scout_asset_api.SearchAssetsQuery(exact_substring=exact_substring))
+        queries.append(asset_pb2.SearchAssetsQuery(exact_substring=exact_substring))
     if labels is not None:
         for label in labels:
-            queries.append(scout_asset_api.SearchAssetsQuery(label=label))
+            queries.append(asset_pb2.SearchAssetsQuery(label=label))
     if properties:
         for name, value in properties.items():
-            queries.append(scout_asset_api.SearchAssetsQuery(property=api.Property(name=name, value=value)))
+            queries.append(asset_pb2.SearchAssetsQuery(property=types_pb2.Property(name=name, value=value)))
     if workspace_rid is not None:
-        queries.append(scout_asset_api.SearchAssetsQuery(workspace=workspace_rid))
+        queries.append(asset_pb2.SearchAssetsQuery(workspace=workspace_rid))
 
-    return scout_asset_api.SearchAssetsQuery(and_=queries)
+    # `and` is a Python keyword, and generated typing stubs cannot expose it as a named argument.
+    return asset_pb2.SearchAssetsQuery(
+        **{"and": asset_pb2.SearchAssetsQueryList(queries=queries)}  # type: ignore[arg-type]
+    )
 
 
 def create_search_ingest_jobs_query(

--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -8,9 +8,6 @@ from typing import Iterable, Mapping, Protocol, Sequence, TypeAlias
 
 from nominal_api import (
     scout,
-    scout_asset_api,
-    scout_assets,
-    scout_run_api,
 )
 from typing_extensions import Self, deprecated
 
@@ -21,14 +18,13 @@ from nominal.core._utils.api_tools import (
     HasRid,
     Link,
     LinkDict,
-    RefreshableConjureMixin,
+    RefreshableGrpcMixin,
     ScopeTypeSpecifier,
-    create_links,
-    filter_scope_rids,
-    filter_scopes,
+    create_proto_links,
     rid_from_instance_or_string,
 )
 from nominal.core._utils.frontend_urls import asset_url
+from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.pagination_tools import search_runs_by_asset_paginated
 from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.core.attachment import Attachment, _iter_get_attachments
@@ -36,11 +32,13 @@ from nominal.core.connection import Connection, _get_connection, _get_connection
 from nominal.core.dataset import Dataset, _create_dataset, _DatasetWrapper, _get_dataset, _get_datasets
 from nominal.core.datasource import DataSource
 from nominal.core.event import Event, _create_event, _search_events
-from nominal.core.exceptions import LegacyVideoDeprecationWarning
+from nominal.core.exceptions import LegacyVideoDeprecationWarning, NominalNotFoundError
 from nominal.core.video import Video, _create_video, _get_video
 from nominal.core.workbook import Workbook, _search_workbooks
+from nominal.protos.asset.v2 import asset_pb2, asset_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
-from nominal.ts import IntegralNanosecondsDuration, IntegralNanosecondsUTC, _SecondsNanos
+from nominal.protos.types import types_pb2
+from nominal.ts import IntegralNanosecondsDuration, IntegralNanosecondsUTC
 
 ScopeType: TypeAlias = Connection | Dataset | Video
 
@@ -48,13 +46,14 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Asset]):
+class Asset(_DatasetWrapper, HasRid, RefreshableGrpcMixin[asset_pb2.Asset]):
     rid: str
     name: str
     description: str | None
     properties: Mapping[str, str]
     labels: Sequence[str]
     created_at: IntegralNanosecondsUTC
+    updated_at: IntegralNanosecondsUTC
     is_archived: bool
 
     _clients: _Clients = field(repr=False)
@@ -71,7 +70,7 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
         Protocol,
     ):
         @property
-        def assets(self) -> scout_assets.AssetService: ...
+        def assets(self) -> asset_pb2_grpc.AssetServiceStub: ...
         @property
         def comments(self) -> comments_pb2_grpc.CommentsServiceStub: ...
         @property
@@ -82,20 +81,30 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
         """Returns a link to the page for this Asset in the Nominal app"""
         return asset_url(self._clients, self.rid)
 
-    def _get_latest_api(self) -> scout_asset_api.Asset:
-        response = self._clients.assets.get_assets(self._clients.auth_header, [self.rid])
-        if len(response) == 0 or self.rid not in response:
-            raise ValueError(f"no asset found with RID {self.rid!r}: {response!r}")
-        if len(response) > 1:
-            raise ValueError(f"multiple assets found with RID {self.rid!r}: {response!r}")
-        return response[self.rid]
+    def _get_latest_api(self) -> asset_pb2.Asset:
+        return _get_asset(self._clients, self.rid)
 
-    def _list_dataset_scopes(self) -> Sequence[scout_asset_api.DataScope]:
-        return filter_scopes(self._get_latest_api().data_scopes, "dataset")
+    def _apply_update(self, request: asset_pb2.UpdateAssetRequest) -> Self:
+        """Send an update and refresh this instance from the returned asset."""
+        with translate_grpc_errors():
+            response = self._clients.assets.UpdateAsset(request)
+        return self._refresh_from_api(response.asset)
+
+    def _dataset_scopes(self) -> Sequence[asset_pb2.DataScope]:
+        return _filter_proto_scopes(self._get_latest_api().data_scopes, "dataset")
+
+    def _lookup_dataset_scope(self, data_scope_name: str) -> tuple[str, Mapping[str, str]] | None:
+        for scope in self._dataset_scopes():
+            if scope.data_scope_name == data_scope_name:
+                return scope.data_source.dataset, scope.series_tags
+        return None
 
     def _scope_rids(self, scope_type: ScopeTypeSpecifier) -> Mapping[str, str]:
         asset = self._get_latest_api()
-        return filter_scope_rids(asset.data_scopes, scope_type)
+        return {
+            scope.data_scope_name: getattr(scope.data_source, scope_type)
+            for scope in _filter_proto_scopes(asset.data_scopes, scope_type)
+        }
 
     def update(
         self,
@@ -120,15 +129,22 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
                 new_labels.append(old_label)
             asset = asset.update(labels=new_labels)
         """
-        request = scout_asset_api.UpdateAssetRequest(
-            description=description,
-            labels=None if labels is None else list(labels),
-            properties=None if properties is None else dict(properties),
-            title=name,
-            links=None if links is None else create_links(links),
+        # None omits a field, leaving it unchanged; an empty wrapper clears it.
+        updated_labels = None if labels is None else types_pb2.LabelUpdateWrapper(labels=list(labels))
+        updated_properties = (
+            None if properties is None else types_pb2.PropertyUpdateWrapper(properties=dict(properties))
         )
-        api_asset = self._clients.assets.update_asset(self._clients.auth_header, request, self.rid)
-        return self._refresh_from_api(api_asset)
+        updated_links = None if links is None else asset_pb2.LinkList(links=create_proto_links(links))
+
+        request = asset_pb2.UpdateAssetRequest(
+            asset_rid=self.rid,
+            description=description,
+            labels=updated_labels,
+            properties=updated_properties,
+            title=name,
+            links=updated_links,
+        )
+        return self._apply_update(request)
 
     def promote(self) -> Self:
         """Promote this asset to be a standard, searchable, and displayable asset.
@@ -138,9 +154,7 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
         asset (e.g. an asset created by create_asset, or an asset that's already been promoted).
         """
         if self._get_latest_api().is_staged:
-            request = scout_asset_api.UpdateAssetRequest(is_staged=False)
-            updated_asset = self._clients.assets.update_asset(self._clients.auth_header, request, self.rid)
-            self._refresh_from_api(updated_asset)
+            self._apply_update(asset_pb2.UpdateAssetRequest(asset_rid=self.rid, is_staged=False))
         else:
             logger.warning("Not promoting asset %s-- already promoted!", self.rid)
 
@@ -178,16 +192,16 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
         data_scopes_to_remove = scopes or []
 
         scope_rids_to_remove = {rid_from_instance_or_string(ds) for ds in data_scopes_to_remove}
-        conjure_asset = self._get_latest_api()
+        latest_asset = self._get_latest_api()
 
         data_scopes_to_keep = [
-            scout_asset_api.CreateAssetDataScope(
+            asset_pb2.CreateAssetDataScope(
                 data_scope_name=ds.data_scope_name,
-                data_source=ds.data_source,
+                data_source=ds.data_source if ds.HasField("data_source") else None,
                 series_tags=ds.series_tags,
-                offset=ds.offset,
+                offset=ds.offset if ds.HasField("offset") else None,
             )
-            for ds in conjure_asset.data_scopes
+            for ds in latest_asset.data_scopes
             if ds.data_scope_name not in scope_names_to_remove
             and all(
                 rid not in scope_rids_to_remove
@@ -195,14 +209,11 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
             )
         ]
 
-        updated_asset = self._clients.assets.update_asset(
-            self._clients.auth_header,
-            scout_asset_api.UpdateAssetRequest(
-                data_scopes=data_scopes_to_keep,
-            ),
-            self.rid,
+        request = asset_pb2.UpdateAssetRequest(
+            asset_rid=self.rid,
+            data_scopes=asset_pb2.CreateAssetDataScopeList(data_scopes=data_scopes_to_keep),
         )
-        self._refresh_from_api(updated_asset)
+        self._apply_update(request)
 
     def add_dataset(
         self,
@@ -222,16 +233,18 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
             dataset: dataset to add to the asset
             series_tags: Key-value tags to pre-filter the dataset with before adding to the asset.
         """
-        request = scout_asset_api.AddDataScopesToAssetRequest(
+        request = asset_pb2.AddDataScopesToAssetRequest(
+            asset_rid=self.rid,
             data_scopes=[
-                scout_asset_api.CreateAssetDataScope(
+                asset_pb2.CreateAssetDataScope(
                     data_scope_name=data_scope_name,
-                    data_source=scout_run_api.DataSource(dataset=rid_from_instance_or_string(dataset)),
+                    data_source=asset_pb2.DataSource(dataset=rid_from_instance_or_string(dataset)),
                     series_tags={**series_tags} if series_tags else {},
                 )
             ],
         )
-        self._clients.assets.add_data_scopes_to_asset(self.rid, self._clients.auth_header, request)
+        with translate_grpc_errors():
+            self._clients.assets.AddDataScopesToAsset(request)
 
     @deprecated(
         "Attaching a standalone `Video` to an asset is deprecated in favor of video channels on a dataset. Attach the "
@@ -245,16 +258,18 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
         videos (e.g., files from a given camera) should use the same data scope name across assets, since checklists and
         templates use data scope names to reference videos.
         """
-        request = scout_asset_api.AddDataScopesToAssetRequest(
+        request = asset_pb2.AddDataScopesToAssetRequest(
+            asset_rid=self.rid,
             data_scopes=[
-                scout_asset_api.CreateAssetDataScope(
+                asset_pb2.CreateAssetDataScope(
                     data_scope_name=data_scope_name,
-                    data_source=scout_run_api.DataSource(video=rid_from_instance_or_string(video)),
+                    data_source=asset_pb2.DataSource(video=rid_from_instance_or_string(video)),
                     series_tags={},
-                ),
-            ]
+                )
+            ],
         )
-        self._clients.assets.add_data_scopes_to_asset(self.rid, self._clients.auth_header, request)
+        with translate_grpc_errors():
+            self._clients.assets.AddDataScopesToAsset(request)
 
     def add_connection(
         self,
@@ -274,16 +289,18 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
             connection: connection to add to the asset
             series_tags: Key-value tags to pre-filter the connection with before adding to the asset.
         """
-        request = scout_asset_api.AddDataScopesToAssetRequest(
+        request = asset_pb2.AddDataScopesToAssetRequest(
+            asset_rid=self.rid,
             data_scopes=[
-                scout_asset_api.CreateAssetDataScope(
+                asset_pb2.CreateAssetDataScope(
                     data_scope_name=data_scope_name,
-                    data_source=scout_run_api.DataSource(connection=rid_from_instance_or_string(connection)),
+                    data_source=asset_pb2.DataSource(connection=rid_from_instance_or_string(connection)),
                     series_tags={**series_tags} if series_tags else {},
                 )
-            ]
+            ],
         )
-        self._clients.assets.add_data_scopes_to_asset(self.rid, self._clients.auth_header, request)
+        with translate_grpc_errors():
+            self._clients.assets.AddDataScopesToAsset(request)
 
     def add_attachments(self, attachments: Iterable[Attachment] | Iterable[str]) -> None:
         """Add attachments that have already been uploaded to this asset.
@@ -291,8 +308,11 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
         `attachments` can be `Attachment` instances, or attachment RIDs.
         """
         rids = [rid_from_instance_or_string(a) for a in attachments]
-        request = scout_asset_api.UpdateAttachmentsRequest(attachments_to_add=rids, attachments_to_remove=[])
-        self._clients.assets.update_asset_attachments(self._clients.auth_header, request, self.rid)
+        request = asset_pb2.UpdateAssetAttachmentsRequest(
+            asset_rid=self.rid, attachments_to_add=rids, attachments_to_remove=[]
+        )
+        with translate_grpc_errors():
+            self._clients.assets.UpdateAssetAttachments(request)
 
     def get_or_create_dataset(
         self,
@@ -695,8 +715,11 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
         `attachments` can be `Attachment` instances, or attachment RIDs.
         """
         rids = [rid_from_instance_or_string(a) for a in attachments]
-        request = scout_asset_api.UpdateAttachmentsRequest(attachments_to_add=[], attachments_to_remove=rids)
-        self._clients.assets.update_asset_attachments(self._clients.auth_header, request, self.rid)
+        request = asset_pb2.UpdateAssetAttachmentsRequest(
+            asset_rid=self.rid, attachments_to_add=[], attachments_to_remove=rids
+        )
+        with translate_grpc_errors():
+            self._clients.assets.UpdateAssetAttachments(request)
 
     def archive(self) -> None:
         """Archive this asset.
@@ -704,28 +727,57 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
 
         Note: this does not update the instance in place; call `refresh()` to see the change reflected.
         """
-        self._clients.assets.archive(self._clients.auth_header, self.rid)
+        with translate_grpc_errors():
+            self._clients.assets.Archive(asset_pb2.ArchiveRequest(asset_rid=self.rid))
 
     def unarchive(self) -> None:
         """Unarchive this asset, allowing it to be viewed in the UI.
 
         Note: this does not update the instance in place; call `refresh()` to see the change reflected.
         """
-        self._clients.assets.unarchive(self._clients.auth_header, self.rid)
+        with translate_grpc_errors():
+            self._clients.assets.Unarchive(asset_pb2.UnarchiveRequest(asset_rid=self.rid))
 
     @classmethod
-    def _from_conjure(cls, clients: _Clients, asset: scout_asset_api.Asset) -> Self:
+    def _from_proto(cls, clients: _Clients, asset: asset_pb2.Asset) -> Self:
         return cls(
             rid=asset.rid,
             name=asset.title,
-            description=asset.description,
-            properties=MappingProxyType(asset.properties),
+            description=asset.description or None,
+            properties=MappingProxyType(dict(asset.properties)),
             labels=tuple(asset.labels),
-            created_at=_SecondsNanos.from_flexible(asset.created_at).to_nanoseconds(),
+            created_at=asset.created_at.ToNanoseconds(),
+            updated_at=asset.updated_at.ToNanoseconds(),
             is_archived=asset.is_archived,
             _clients=clients,
-            created_by_rid=asset.created_by,
+            created_by_rid=asset.created_by or None,
         )
+
+
+def _filter_proto_scopes(
+    scopes: Iterable[asset_pb2.DataScope], scope_type: ScopeTypeSpecifier
+) -> Sequence[asset_pb2.DataScope]:
+    """The data scopes whose `data_source` is set to `scope_type`."""
+    return [scope for scope in scopes if scope.data_source.WhichOneof("data_source") == scope_type]
+
+
+def _get_assets(clients: Asset._Clients, rids: Sequence[str]) -> Mapping[str, asset_pb2.Asset]:
+    """The assets with the given rids, keyed by rid. Rids that do not resolve are absent from the result."""
+    with translate_grpc_errors():
+        response = clients.assets.GetAssets(asset_pb2.GetAssetsRequest(rids=list(rids)))
+    return response.responses
+
+
+def _get_asset(clients: Asset._Clients, rid: str) -> asset_pb2.Asset:
+    """The asset with the given rid.
+
+    Raises:
+        NominalNotFoundError: If no asset has that rid.
+    """
+    assets = _get_assets(clients, [rid])
+    if rid not in assets:
+        raise NominalNotFoundError(f"no asset found with RID {rid!r}")
+    return assets[rid]
 
 
 # Moving to bottom to deal with circular dependencies

--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -187,27 +187,33 @@ class Asset(_DatasetWrapper, HasRid, RefreshableGrpcMixin[asset_pb2.Asset]):
         Args:
             names: Names of datascopes to remove
             scopes: Rids or instances of scope types (dataset, video, connection) to remove.
+
+        Raises:
+            ValueError: If any scope RID is empty.
         """
         scope_names_to_remove = names or []
         data_scopes_to_remove = scopes or []
 
         scope_rids_to_remove = {rid_from_instance_or_string(ds) for ds in data_scopes_to_remove}
+        if "" in scope_rids_to_remove:
+            raise ValueError("Data scope RIDs must not be empty")
         latest_asset = self._get_latest_api()
 
-        data_scopes_to_keep = [
-            asset_pb2.CreateAssetDataScope(
-                data_scope_name=ds.data_scope_name,
-                data_source=ds.data_source if ds.HasField("data_source") else None,
-                series_tags=ds.series_tags,
-                offset=ds.offset if ds.HasField("offset") else None,
+        data_scopes_to_keep = []
+        for ds in latest_asset.data_scopes:
+            if ds.data_scope_name in scope_names_to_remove:
+                continue
+            source_type = ds.data_source.WhichOneof("data_source")
+            if source_type is not None and getattr(ds.data_source, source_type) in scope_rids_to_remove:
+                continue
+            data_scopes_to_keep.append(
+                asset_pb2.CreateAssetDataScope(
+                    data_scope_name=ds.data_scope_name,
+                    data_source=ds.data_source if ds.HasField("data_source") else None,
+                    series_tags=ds.series_tags,
+                    offset=ds.offset if ds.HasField("offset") else None,
+                )
             )
-            for ds in latest_asset.data_scopes
-            if ds.data_scope_name not in scope_names_to_remove
-            and all(
-                rid not in scope_rids_to_remove
-                for rid in (ds.data_source.dataset, ds.data_source.connection, ds.data_source.video)
-            )
-        ]
 
         request = asset_pb2.UpdateAssetRequest(
             asset_rid=self.rid,
@@ -743,7 +749,7 @@ class Asset(_DatasetWrapper, HasRid, RefreshableGrpcMixin[asset_pb2.Asset]):
         return cls(
             rid=asset.rid,
             name=asset.title,
-            description=asset.description or None,
+            description=asset.description if asset.HasField("description") else None,
             properties=MappingProxyType(dict(asset.properties)),
             labels=tuple(asset.labels),
             created_at=asset.created_at.ToNanoseconds(),

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -16,7 +16,6 @@ from nominal_api import (
     attachments_api,
     authentication_api,
     ingest_api,
-    scout_asset_api,
     scout_catalog,
     scout_checks_api,
     scout_datasource_connection_api,
@@ -67,7 +66,7 @@ from nominal.core._utils.query_tools import (
     create_search_videos_query,
     create_search_workbook_templates_query,
 )
-from nominal.core.asset import Asset
+from nominal.core.asset import Asset, _get_asset
 from nominal.core.attachment import Attachment, _iter_get_attachments
 from nominal.core.checklist import Checklist
 from nominal.core.connection import Connection, StreamingConnection
@@ -112,6 +111,7 @@ from nominal.core.video import Video, _create_video
 from nominal.core.workbook import Workbook, _search_workbooks
 from nominal.core.workbook_template import WorkbookTemplate
 from nominal.core.workspace import Workspace
+from nominal.protos.asset.v2 import asset_pb2
 from nominal.protos.secrets.v1 import secrets_pb2
 from nominal.protos.units.v1 import units_pb2
 from nominal.protos.workspaces.v1 import workspaces_pb2
@@ -1126,28 +1126,26 @@ class NominalClient:
         labels: Sequence[str] = (),
     ) -> Asset:
         """Create an asset."""
-        request = scout_asset_api.CreateAssetRequest(
+        request = asset_pb2.CreateAssetRequest(
             description=description,
             labels=list(labels),
             properties={} if properties is None else dict(properties),
             typed_properties={},
             title=name,
-            attachments=[],
-            data_scopes=[],
-            links=[],
             workspace=self._clients.resolve_default_workspace_rid(),
         )
-        response = self._clients.assets.create_asset(self._clients.auth_header, request)
-        return Asset._from_conjure(self._clients, response)
+        with translate_grpc_errors():
+            response = self._clients.assets.CreateAsset(request)
+        return Asset._from_proto(self._clients, response.asset)
 
     def get_asset(self, rid: str) -> Asset:
-        """Retrieve an asset by its RID."""
-        response = self._clients.assets.get_assets(self._clients.auth_header, [rid])
-        if len(response) == 0 or rid not in response:
-            raise ValueError(f"no asset found with RID {rid!r}: {response!r}")
-        if len(response) > 1:
-            raise ValueError(f"multiple assets found with RID {rid!r}: {response!r}")
-        return Asset._from_conjure(self._clients, response[rid])
+        """Retrieve an asset by its RID.
+
+        Raises:
+            NominalNotFoundError: If no asset has that rid. `GetAssets` is a batch endpoint, so an
+                unresolvable rid comes back as an absent map entry rather than a NOT_FOUND status.
+        """
+        return Asset._from_proto(self._clients, _get_asset(self._clients, rid))
 
     def get_or_create_asset_by_properties(
         self, properties: Mapping[str, str], *, name: str, description: str | None = None, labels: Sequence[str] = ()
@@ -1181,11 +1179,11 @@ class NominalClient:
 
     def _iter_search_assets(
         self,
-        query: scout_asset_api.SearchAssetsQuery,
+        query: asset_pb2.SearchAssetsQuery,
         archive_status: ArchiveStatusFilter,
     ) -> Iterable[Asset]:
-        for asset in search_assets_paginated(self._clients.assets, self._clients.auth_header, query, archive_status):
-            yield Asset._from_conjure(self._clients, asset)
+        for asset in search_assets_paginated(self._clients.assets, query, archive_status):
+            yield Asset._from_proto(self._clients, asset)
 
     def search_assets(
         self,

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -16,7 +16,6 @@ from nominal_api import (
     attachments_api,
     authentication_api,
     ingest_api,
-    scout_asset_api,
     scout_catalog,
     scout_checks_api,
     scout_datasource_connection_api,
@@ -67,7 +66,7 @@ from nominal.core._utils.query_tools import (
     create_search_videos_query,
     create_search_workbook_templates_query,
 )
-from nominal.core.asset import Asset
+from nominal.core.asset import Asset, _get_asset
 from nominal.core.attachment import Attachment, _iter_get_attachments
 from nominal.core.checklist import Checklist
 from nominal.core.connection import Connection, StreamingConnection
@@ -121,6 +120,7 @@ from nominal.core.video import Video, _create_video
 from nominal.core.workbook import Workbook, _search_workbooks
 from nominal.core.workbook_template import WorkbookTemplate
 from nominal.core.workspace import Workspace
+from nominal.protos.asset.v2 import asset_pb2
 from nominal.protos.secrets.v1 import secrets_pb2
 from nominal.protos.units.v1 import units_pb2
 from nominal.protos.workspaces.v1 import workspaces_pb2
@@ -1227,28 +1227,26 @@ class NominalClient:
         labels: Sequence[str] = (),
     ) -> Asset:
         """Create an asset."""
-        request = scout_asset_api.CreateAssetRequest(
+        request = asset_pb2.CreateAssetRequest(
             description=description,
             labels=list(labels),
             properties={} if properties is None else dict(properties),
             typed_properties={},
             title=name,
-            attachments=[],
-            data_scopes=[],
-            links=[],
             workspace=self._clients.resolve_default_workspace_rid(),
         )
-        response = self._clients.assets.create_asset(self._clients.auth_header, request)
-        return Asset._from_conjure(self._clients, response)
+        with translate_grpc_errors():
+            response = self._clients.assets.CreateAsset(request)
+        return Asset._from_proto(self._clients, response.asset)
 
     def get_asset(self, rid: str) -> Asset:
-        """Retrieve an asset by its RID."""
-        response = self._clients.assets.get_assets(self._clients.auth_header, [rid])
-        if len(response) == 0 or rid not in response:
-            raise ValueError(f"no asset found with RID {rid!r}: {response!r}")
-        if len(response) > 1:
-            raise ValueError(f"multiple assets found with RID {rid!r}: {response!r}")
-        return Asset._from_conjure(self._clients, response[rid])
+        """Retrieve an asset by its RID.
+
+        Raises:
+            NominalNotFoundError: If no asset has that rid. `GetAssets` is a batch endpoint, so an
+                unresolvable rid comes back as an absent map entry rather than a NOT_FOUND status.
+        """
+        return Asset._from_proto(self._clients, _get_asset(self._clients, rid))
 
     def get_or_create_asset_by_properties(
         self, properties: Mapping[str, str], *, name: str, description: str | None = None, labels: Sequence[str] = ()
@@ -1282,11 +1280,11 @@ class NominalClient:
 
     def _iter_search_assets(
         self,
-        query: scout_asset_api.SearchAssetsQuery,
+        query: asset_pb2.SearchAssetsQuery,
         archive_status: ArchiveStatusFilter,
     ) -> Iterable[Asset]:
-        for asset in search_assets_paginated(self._clients.assets, self._clients.auth_header, query, archive_status):
-            yield Asset._from_conjure(self._clients, asset)
+        for asset in search_assets_paginated(self._clients.assets, query, archive_status):
+            yield Asset._from_proto(self._clients, asset)
 
     def search_assets(
         self,

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import BinaryIO, Iterable, Mapping, Sequence, TypeAlias, overload
 
-from nominal_api import api, ingest_api, scout_asset_api, scout_catalog, scout_video_api
+from nominal_api import api, ingest_api, scout_catalog, scout_video_api
 from typing_extensions import Self
 
 from nominal.core._stream.batch_processor import process_log_batch
@@ -1226,18 +1226,18 @@ class _DatasetWrapper(abc.ABC):
     - Some formats cannot be safely tagged with scope tags; those wrapper methods raise `RuntimeError` when the selected
       scope requires tags.
 
-    Subclasses must implement `_list_dataset_scopes`, which is used to resolve scopes.
+    Subclasses must implement `_lookup_dataset_scope`, which is used to resolve scopes.
     """
 
     # static typing for required field
     _clients: Dataset._Clients
 
     @abc.abstractmethod
-    def _list_dataset_scopes(self) -> Sequence[scout_asset_api.DataScope]:
-        """Return the data scopes available to this wrapper.
+    def _lookup_dataset_scope(self, data_scope_name: str) -> tuple[str, Mapping[str, str]] | None:
+        """The backing dataset rid and required series tags of the named scope, or None if there is none.
 
-        Subclasses provide the authoritative list of `scout_asset_api.DataScope` objects used to
-        resolve `data_scope_name` in wrapper methods.
+        Each subclass resolves the name against the data scopes its own transport returns, so this wrapper
+        never sees a wire type.
         """
 
     def _get_dataset_scope(self, data_scope_name: str) -> tuple[Dataset, Mapping[str, str]]:
@@ -1247,20 +1247,18 @@ class _DatasetWrapper(abc.ABC):
             A tuple of the resolved `Dataset` and the scope's required `series_tags`.
 
         Raises:
-            ValueError: If no scope exists with the given `data_scope_name`, or if the scope is not backed by a dataset.
+            ValueError: If no dataset-backed scope exists with the given `data_scope_name`.
         """
-        dataset_scopes = {scope.data_scope_name: scope for scope in self._list_dataset_scopes()}
-        data_scope = dataset_scopes.get(data_scope_name)
+        data_scope = self._lookup_dataset_scope(data_scope_name)
         if data_scope is None:
             raise ValueError(f"No such data scope found with data_scope_name {data_scope_name}")
-        elif data_scope.data_source.dataset is None:
-            raise ValueError(f"Datascope {data_scope_name} is not a dataset!")
 
+        dataset_rid, series_tags = data_scope
         dataset = Dataset._from_conjure(
             self._clients,
-            _get_dataset(self._clients.auth_header, self._clients.catalog, data_scope.data_source.dataset),
+            _get_dataset(self._clients.auth_header, self._clients.catalog, dataset_rid),
         )
-        return dataset, data_scope.series_tags
+        return dataset, series_tags
 
     ################
     # Add Data API #

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import BinaryIO, Iterable, Mapping, Sequence, TypeAlias, overload
 
-from nominal_api import api, ingest_api, scout_asset_api, scout_catalog, scout_video_api
+from nominal_api import api, ingest_api, scout_catalog, scout_video_api
 from typing_extensions import Self
 
 from nominal.core._stream.batch_processor import process_log_batch
@@ -1232,18 +1232,18 @@ class _DatasetWrapper(abc.ABC):
     - Some formats cannot be safely tagged with scope tags; those wrapper methods raise `RuntimeError` when the selected
       scope requires tags.
 
-    Subclasses must implement `_list_dataset_scopes`, which is used to resolve scopes.
+    Subclasses must implement `_lookup_dataset_scope`, which is used to resolve scopes.
     """
 
     # static typing for required field
     _clients: Dataset._Clients
 
     @abc.abstractmethod
-    def _list_dataset_scopes(self) -> Sequence[scout_asset_api.DataScope]:
-        """Return the data scopes available to this wrapper.
+    def _lookup_dataset_scope(self, data_scope_name: str) -> tuple[str, Mapping[str, str]] | None:
+        """The backing dataset rid and required series tags of the named scope, or None if there is none.
 
-        Subclasses provide the authoritative list of `scout_asset_api.DataScope` objects used to
-        resolve `data_scope_name` in wrapper methods.
+        Each subclass resolves the name against the data scopes its own transport returns, so this wrapper
+        never sees a wire type.
         """
 
     def _get_dataset_scope(self, data_scope_name: str) -> tuple[Dataset, Mapping[str, str]]:
@@ -1253,20 +1253,18 @@ class _DatasetWrapper(abc.ABC):
             A tuple of the resolved `Dataset` and the scope's required `series_tags`.
 
         Raises:
-            ValueError: If no scope exists with the given `data_scope_name`, or if the scope is not backed by a dataset.
+            ValueError: If no dataset-backed scope exists with the given `data_scope_name`.
         """
-        dataset_scopes = {scope.data_scope_name: scope for scope in self._list_dataset_scopes()}
-        data_scope = dataset_scopes.get(data_scope_name)
+        data_scope = self._lookup_dataset_scope(data_scope_name)
         if data_scope is None:
             raise ValueError(f"No such data scope found with data_scope_name {data_scope_name}")
-        elif data_scope.data_source.dataset is None:
-            raise ValueError(f"Datascope {data_scope_name} is not a dataset!")
 
+        dataset_rid, series_tags = data_scope
         dataset = Dataset._from_conjure(
             self._clients,
-            _get_dataset(self._clients.auth_header, self._clients.catalog, data_scope.data_source.dataset),
+            _get_dataset(self._clients.auth_header, self._clients.catalog, dataset_rid),
         )
-        return dataset, data_scope.series_tags
+        return dataset, series_tags
 
     ################
     # Add Data API #

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING, Iterable, Mapping, Protocol, Sequence, cast
 
 from nominal_api import (
     scout,
-    scout_asset_api,
-    scout_assets,
     scout_run_api,
 )
 from typing_extensions import Self, deprecated
@@ -35,6 +33,7 @@ from nominal.core.event import Event, _create_event, _search_events
 from nominal.core.exceptions import LegacyVideoDeprecationWarning
 from nominal.core.video import Video, _get_video
 from nominal.core.workbook import Workbook, _search_workbooks
+from nominal.protos.asset.v2 import asset_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2, comments_pb2_grpc
 from nominal.ts import IntegralNanosecondsDuration, IntegralNanosecondsUTC, _SecondsNanos, _to_api_duration
 
@@ -69,7 +68,7 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
         Protocol,
     ):
         @property
-        def assets(self) -> scout_assets.AssetService: ...
+        def assets(self) -> asset_pb2_grpc.AssetServiceStub: ...
         @property
         def comments(self) -> comments_pb2_grpc.CommentsServiceStub: ...
         @property
@@ -153,12 +152,18 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
             response = self._clients.comments.CreateComment(request)
         return Comment._from_proto(response.comment)
 
-    def _list_dataset_scopes(self) -> Sequence[scout_asset_api.DataScope]:
+    def _lookup_dataset_scope(self, data_scope_name: str) -> tuple[str, Mapping[str, str]] | None:
         api_run = self._get_latest_api()
         if len(api_run.assets) > 1:
             raise RuntimeError("Can't retrieve dataset scopes on multi-asset runs")
 
-        return filter_scopes(api_run.asset_data_scopes, "dataset")
+        for scope in filter_scopes(api_run.asset_data_scopes, "dataset"):
+            if scope.data_scope_name != data_scope_name:
+                continue
+            if scope.data_source.dataset is None:
+                raise ValueError(f"data scope {data_scope_name!r} is typed as a dataset but carries no dataset rid")
+            return scope.data_source.dataset, scope.series_tags
+        return None
 
     def _list_datasource_rids(
         self, datasource_type: str | None = None, property_name: str | None = None
@@ -534,13 +539,12 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
         return list(self._iter_list_attachments())
 
     def _iter_list_assets(self) -> Iterable["Asset"]:
-        from nominal.core.asset import Asset
+        from nominal.core.asset import Asset, _get_assets
 
         clients = cast(Asset._Clients, self._clients)
         run = self._get_latest_api()
-        assets = self._clients.assets.get_assets(self._clients.auth_header, run.assets)
-        for a in assets.values():
-            yield Asset._from_conjure(clients, a)
+        for a in _get_assets(clients, run.assets).values():
+            yield Asset._from_proto(clients, a)
 
     def list_assets(self) -> Sequence["Asset"]:
         """List assets associated with this run."""

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -4,10 +4,9 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Sequence
 
-from nominal_api import scout_asset_api
-
 from nominal.core import NominalClient
 from nominal.core._event_types import SearchEventOriginType
+from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core.asset import Asset
 from nominal.core.exceptions import NominalChecklistNotPublishedError
 from nominal.core.run import Run
@@ -23,6 +22,7 @@ from nominal.experimental.migration.migrator.run_migrator import RunCopyOptions,
 from nominal.experimental.migration.migrator.video_migrator import VideoCopyOptions, VideoMigrator
 from nominal.experimental.migration.migrator.workbook_migrator import WorkbookCopyOptions, WorkbookMigrator
 from nominal.experimental.migration.resource_type import ResourceType
+from nominal.protos.asset.v2 import asset_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -126,11 +126,10 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
         )
 
         if source_asset._get_latest_api().is_staged:
-            new_asset._clients.assets.update_asset(
-                new_asset._clients.auth_header,
-                scout_asset_api.UpdateAssetRequest(is_staged=True),
-                new_asset.rid,
-            )
+            with translate_grpc_errors():
+                new_asset._clients.assets.UpdateAsset(
+                    asset_pb2.UpdateAssetRequest(asset_rid=new_asset.rid, is_staged=True)
+                )
 
         return new_asset
 
@@ -140,15 +139,16 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
 
         dataset_migrator = DatasetMigrator(self.ctx)
 
-        source_data_scopes = source_asset._list_dataset_scopes()
         source_datasets = {ds.rid: ds for _, ds in source_asset.list_datasets()}
 
-        for source_data_scope in source_data_scopes:
+        for source_data_scope in source_asset._dataset_scopes():
             source_data_scope_name = source_data_scope.data_scope_name
             source_dataset_rid = source_data_scope.data_source.dataset
-            if source_dataset_rid is None or source_dataset_rid not in source_datasets:
+            source_series_tags = source_data_scope.series_tags
+            if source_dataset_rid not in source_datasets:
                 raise ValueError(
-                    f"Data scope {source_data_scope_name} on asset {source_asset.rid} does not have a dataset"
+                    f"Data scope {source_data_scope_name} on asset {source_asset.rid} references dataset "
+                    f"{source_dataset_rid}, which could not be resolved"
                 )
 
             source_dataset = source_datasets[source_dataset_rid]
@@ -161,7 +161,6 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                     source_data_scope_name,
                 )
                 continue
-            source_series_tags = source_data_scope.series_tags
             # Always delegate to dataset_migrator.copy_from so that file migrations are
             # never skipped on resume. DatasetMigrator._copy_from_impl handles fetch-or-create
             # internally and always proceeds to file copies regardless.

--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -4,10 +4,9 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Sequence
 
-from nominal_api import scout_asset_api
-
 from nominal.core import NominalClient
 from nominal.core._event_types import SearchEventOriginType
+from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core.asset import Asset
 from nominal.core.exceptions import NominalChecklistNotPublishedError
 from nominal.core.run import Run
@@ -24,6 +23,7 @@ from nominal.experimental.migration.migrator.video_migrator import VideoCopyOpti
 from nominal.experimental.migration.migrator.workbook_migrator import WorkbookCopyOptions, WorkbookMigrator
 from nominal.experimental.migration.resource_type import ResourceType
 from nominal.experimental.migration.utils.retry_utils import is_transient_error
+from nominal.protos.asset.v2 import asset_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -127,11 +127,10 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
         )
 
         if source_asset._get_latest_api().is_staged:
-            new_asset._clients.assets.update_asset(
-                new_asset._clients.auth_header,
-                scout_asset_api.UpdateAssetRequest(is_staged=True),
-                new_asset.rid,
-            )
+            with translate_grpc_errors():
+                new_asset._clients.assets.UpdateAsset(
+                    asset_pb2.UpdateAssetRequest(asset_rid=new_asset.rid, is_staged=True)
+                )
 
         return new_asset
 
@@ -141,15 +140,16 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
 
         dataset_migrator = DatasetMigrator(self.ctx)
 
-        source_data_scopes = source_asset._list_dataset_scopes()
         source_datasets = {ds.rid: ds for _, ds in source_asset.list_datasets()}
 
-        for source_data_scope in source_data_scopes:
+        for source_data_scope in source_asset._dataset_scopes():
             source_data_scope_name = source_data_scope.data_scope_name
             source_dataset_rid = source_data_scope.data_source.dataset
-            if source_dataset_rid is None or source_dataset_rid not in source_datasets:
+            source_series_tags = source_data_scope.series_tags
+            if source_dataset_rid not in source_datasets:
                 raise ValueError(
-                    f"Data scope {source_data_scope_name} on asset {source_asset.rid} does not have a dataset"
+                    f"Data scope {source_data_scope_name} on asset {source_asset.rid} references dataset "
+                    f"{source_dataset_rid}, which could not be resolved"
                 )
 
             source_dataset = source_datasets[source_dataset_rid]
@@ -162,7 +162,6 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                     source_data_scope_name,
                 )
                 continue
-            source_series_tags = source_data_scope.series_tags
             # Always delegate to dataset_migrator.copy_from so that file migrations are
             # never skipped on resume. DatasetMigrator._copy_from_impl handles fetch-or-create
             # internally and always proceeds to file copies regardless.

--- a/tests/core/test_api_tools.py
+++ b/tests/core/test_api_tools.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from nominal.core._utils.api_tools import create_links, create_proto_links
+
+EVERY_SPELLING = ["https://a", ("https://b", "B"), {"url": "https://c", "title": "C"}, {"url": "https://d"}]
+
+
+def test_create_proto_links_accepts_every_link_spelling() -> None:
+    """A link may be a url, a (url, title) tuple, or a dict with an optional title."""
+    links = create_proto_links(EVERY_SPELLING)
+
+    assert [(link.url, link.title) for link in links] == [
+        ("https://a", ""),
+        ("https://b", "B"),
+        ("https://c", "C"),
+        ("https://d", ""),
+    ]
+
+
+def test_create_links_agrees_with_the_proto_builder() -> None:
+    """Both builders share one dispatch; only the absent title differs, since proto has no null string."""
+    links = create_links(EVERY_SPELLING)
+
+    assert [(link.url, link.title) for link in links] == [
+        ("https://a", None),
+        ("https://b", "B"),
+        ("https://c", "C"),
+        ("https://d", None),
+    ]

--- a/tests/core/test_asset.py
+++ b/tests/core/test_asset.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+from typing import Sequence
 from unittest.mock import MagicMock, patch
 
 import pytest
+from google.protobuf import timestamp_pb2
 
 from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.core.asset import Asset
+from nominal.core.client import NominalClient
 from nominal.core.dataset import Dataset, DatasetBounds
+from nominal.core.exceptions import NominalNotFoundError
+from nominal.protos.asset.v2 import asset_pb2
 
 SCOPE_NAME = "test-scope"
 
@@ -25,6 +30,7 @@ def mock_asset(mock_clients):
         properties={},
         labels=[],
         created_at=0,
+        updated_at=0,
         is_archived=False,
         _clients=mock_clients,
     )
@@ -140,3 +146,118 @@ def test_search_data_reviews_passes_archive_status(mock_asset):
     mock_reviews.assert_called_once()
     assert mock_reviews.call_args.kwargs["assets"] == [mock_asset.rid]
     assert mock_reviews.call_args.kwargs["archive_status"] == ArchiveStatusFilter.ARCHIVED
+
+
+def _proto_asset(
+    rid: str = "ri.asset.test",
+    *,
+    title: str = "original",
+    description: str | None = None,
+    created_by: str | None = None,
+    data_scopes: Sequence[asset_pb2.DataScope] = (),
+) -> asset_pb2.Asset:
+    return asset_pb2.Asset(
+        rid=rid,
+        title=title,
+        description=description,
+        created_by=created_by,
+        created_at=timestamp_pb2.Timestamp(seconds=1),
+        updated_at=timestamp_pb2.Timestamp(seconds=2),
+        data_scopes=list(data_scopes),
+    )
+
+
+@pytest.fixture
+def update_asset(mock_clients, mock_asset):
+    """The stubbed UpdateAsset, echoing the same asset back for `update()` to refresh from."""
+    mock_clients.assets.UpdateAsset.return_value = asset_pb2.UpdateAssetResponse(asset=_proto_asset(mock_asset.rid))
+    return mock_clients.assets.UpdateAsset
+
+
+@pytest.fixture
+def asset_with_scopes(mock_asset, mock_clients):
+    """An asset resolving to one dataset-backed scope and one video-backed scope."""
+    mock_clients.assets.GetAssets.return_value = asset_pb2.GetAssetsResponse(
+        responses={
+            mock_asset.rid: _proto_asset(
+                mock_asset.rid,
+                data_scopes=[
+                    asset_pb2.DataScope(
+                        data_scope_name="ds",
+                        data_source=asset_pb2.DataSource(dataset="ri.dataset.1"),
+                        series_tags={"vehicle": "a"},
+                    ),
+                    asset_pb2.DataScope(data_scope_name="vid", data_source=asset_pb2.DataSource(video="ri.video.1")),
+                ],
+            )
+        }
+    )
+    return mock_asset
+
+
+def test_update_omits_absent_fields_so_the_backend_leaves_them_unchanged(mock_asset, update_asset) -> None:
+    """None must not reach the wire: an omitted field is how a caller says "leave this alone"."""
+    mock_asset.update(description="only the description")
+
+    request = update_asset.call_args.args[0]
+    assert request.asset_rid == mock_asset.rid
+    assert request.description == "only the description"
+    for field in ("title", "labels", "properties", "links", "data_scopes"):
+        assert not request.HasField(field), f"{field} should be absent when omitted"
+
+
+def test_update_sends_empty_collections_as_explicit_clears(mock_asset, update_asset) -> None:
+    """An empty collection is a clear, which the update wrappers make distinguishable from omission."""
+    mock_asset.update(labels=[], properties={}, links=[])
+
+    request = update_asset.call_args.args[0]
+    assert (request.HasField("labels"), list(request.labels.labels)) == (True, [])
+    assert (request.HasField("properties"), dict(request.properties.properties)) == (True, {})
+    assert (request.HasField("links"), list(request.links.links)) == (True, [])
+
+
+def test_remove_data_scopes_drops_by_rid_and_keeps_survivors_intact(asset_with_scopes, update_asset) -> None:
+    """Survivors must round-trip without gaining an offset they never had."""
+    asset_with_scopes.remove_data_scopes(scopes=["ri.video.1"])
+
+    kept = update_asset.call_args.args[0].data_scopes.data_scopes
+    assert [scope.data_scope_name for scope in kept] == ["ds"]
+    assert kept[0].data_source.dataset == "ri.dataset.1"
+    assert dict(kept[0].series_tags) == {"vehicle": "a"}
+    assert not kept[0].HasField("offset"), "an unset offset must not be re-sent as an explicit zero"
+
+
+def test_scopes_are_selected_by_the_oneof_discriminator(asset_with_scopes) -> None:
+    """The proto data_source is a oneof, so scope kind comes from which field is set."""
+    assert asset_with_scopes._scope_rids("dataset") == {"ds": "ri.dataset.1"}
+    assert asset_with_scopes._scope_rids("video") == {"vid": "ri.video.1"}
+    assert [
+        (scope.data_scope_name, scope.data_source.dataset, dict(scope.series_tags))
+        for scope in asset_with_scopes._dataset_scopes()
+    ] == [("ds", "ri.dataset.1", {"vehicle": "a"})]
+
+
+def test_lookup_dataset_scope_resolves_a_name_to_its_dataset_and_tags(asset_with_scopes) -> None:
+    """`_DatasetWrapper` resolves scope names through this, and only dataset-backed scopes can answer."""
+    dataset_rid, series_tags = asset_with_scopes._lookup_dataset_scope("ds")
+    assert (dataset_rid, dict(series_tags)) == ("ri.dataset.1", {"vehicle": "a"})
+
+    assert asset_with_scopes._lookup_dataset_scope("vid") is None
+    assert asset_with_scopes._lookup_dataset_scope("absent") is None
+
+
+def test_from_proto_reads_optional_fields() -> None:
+    """Description and created_by are optional on the wire; absent must read as None, not empty string."""
+    absent = Asset._from_proto(MagicMock(), _proto_asset())
+    assert (absent.description, absent.created_by_rid) == (None, None)
+
+    present = Asset._from_proto(MagicMock(), _proto_asset(description="d", created_by="ri.user.1"))
+    assert (present.description, present.created_by_rid) == ("d", "ri.user.1")
+
+
+def test_get_asset_raises_not_found_when_the_rid_is_absent(mock_clients) -> None:
+    """GetAssets answers a missing rid with an absent map entry, never a NOT_FOUND status."""
+    mock_clients.assets.GetAssets.return_value = asset_pb2.GetAssetsResponse()
+
+    with pytest.raises(NominalNotFoundError, match="no asset found with RID"):
+        NominalClient(_clients=mock_clients).get_asset("ri.asset.missing")

--- a/tests/core/test_asset.py
+++ b/tests/core/test_asset.py
@@ -227,6 +227,40 @@ def test_remove_data_scopes_drops_by_rid_and_keeps_survivors_intact(asset_with_s
     assert not kept[0].HasField("offset"), "an unset offset must not be re-sent as an explicit zero"
 
 
+@pytest.mark.parametrize("scopes", [[""], ["ri.video.1", ""]])
+def test_remove_data_scopes_rejects_empty_rids_before_calling_the_service(
+    asset_with_scopes, mock_clients, scopes
+) -> None:
+    with pytest.raises(ValueError, match="RIDs must not be empty"):
+        asset_with_scopes.remove_data_scopes(scopes=scopes)
+
+    mock_clients.assets.GetAssets.assert_not_called()
+    mock_clients.assets.UpdateAsset.assert_not_called()
+
+
+@pytest.mark.parametrize("source_type", ["dataset", "connection", "video", "log_set", "spatial"])
+def test_remove_data_scopes_matches_the_active_source_rid(mock_asset, mock_clients, update_asset, source_type) -> None:
+    mock_clients.assets.GetAssets.return_value = asset_pb2.GetAssetsResponse(
+        responses={
+            mock_asset.rid: _proto_asset(
+                mock_asset.rid,
+                data_scopes=[
+                    asset_pb2.DataScope(
+                        data_scope_name="remove", data_source=asset_pb2.DataSource(**{source_type: "ri.source.1"})
+                    ),
+                    asset_pb2.DataScope(data_scope_name="keep"),
+                ],
+            )
+        }
+    )
+
+    mock_asset.remove_data_scopes(scopes=["ri.source.1"])
+
+    kept = update_asset.call_args.args[0].data_scopes.data_scopes
+    assert [scope.data_scope_name for scope in kept] == ["keep"]
+    assert not kept[0].HasField("data_source")
+
+
 def test_scopes_are_selected_by_the_oneof_discriminator(asset_with_scopes) -> None:
     """The proto data_source is a oneof, so scope kind comes from which field is set."""
     assert asset_with_scopes._scope_rids("dataset") == {"ds": "ri.dataset.1"}
@@ -253,6 +287,12 @@ def test_from_proto_reads_optional_fields() -> None:
 
     present = Asset._from_proto(MagicMock(), _proto_asset(description="d", created_by="ri.user.1"))
     assert (present.description, present.created_by_rid) == ("d", "ri.user.1")
+
+
+def test_from_proto_preserves_an_explicitly_empty_description() -> None:
+    asset = Asset._from_proto(MagicMock(), _proto_asset(description=""))
+
+    assert asset.description == ""
 
 
 def test_get_asset_raises_not_found_when_the_rid_is_absent(mock_clients) -> None:

--- a/tests/core/test_asset_migrator.py
+++ b/tests/core/test_asset_migrator.py
@@ -16,6 +16,7 @@ from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.migrator.asset_migrator import AssetCopyOptions, AssetMigrator
 from nominal.experimental.migration.migrator.context import MigrationContext
 from nominal.experimental.migration.resource_type import ResourceType
+from nominal.protos.asset.v2 import asset_pb2
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -225,15 +226,15 @@ class TestAssetMigratorDatasets:
 
         scope_active = MagicMock()
         scope_active.data_scope_name = "scope-active"
-        scope_active.data_source.dataset = active_ds.rid
-        scope_active.series_tags = {}
-        scope_archived = MagicMock()
-        scope_archived.data_scope_name = "scope-archived"
-        scope_archived.data_source.dataset = archived_ds.rid
-        scope_archived.series_tags = {}
-
         source_asset = _make_source_asset()
-        source_asset._list_dataset_scopes.return_value = [scope_active, scope_archived]
+        source_asset._dataset_scopes.return_value = [
+            asset_pb2.DataScope(
+                data_scope_name="scope-active", data_source=asset_pb2.DataSource(dataset=active_ds.rid)
+            ),
+            asset_pb2.DataScope(
+                data_scope_name="scope-archived", data_source=asset_pb2.DataSource(dataset=archived_ds.rid)
+            ),
+        ]
         source_asset.list_datasets.return_value = [("scope-active", active_ds), ("scope-archived", archived_ds)]
 
         dest_asset = _make_dest_asset()

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -15,6 +15,7 @@ from nominal.core._clientsbunch import (
 from nominal.core.client import NominalClient
 from nominal.core.exceptions import NominalConfigError
 from nominal.experimental import as_user
+from nominal.protos.asset.v2 import asset_pb2_grpc
 from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
 from nominal.protos.event.v2 import event_pb2_grpc
@@ -260,6 +261,7 @@ def test_from_config_wires_grpc_services_through_one_shared_channel(monkeypatch)
     assert isinstance(
         clients.containerized_extractor, containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
     )
+    assert isinstance(clients.assets, asset_pb2_grpc.AssetServiceStub)
     assert isinstance(clients.event, event_pb2_grpc.EventServiceStub)
     assert isinstance(clients.registry, registry_pb2_grpc.RegistryServiceStub)
     assert isinstance(clients.sandbox_workspace, sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub)
@@ -295,7 +297,7 @@ def test_experimental_as_user_returns_derived_nominal_client(monkeypatch):
     assert impersonated._clients.catalog._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
         "ri.authn.dev.user.target"
     )
-    assert impersonated._clients.assets._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
+    assert impersonated._clients.run._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
         "ri.authn.dev.user.target"
     )
     # The impersonation header_provider must also reach the gRPC channel; the most

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -15,6 +15,7 @@ from nominal.core._clientsbunch import (
 from nominal.core.client import NominalClient
 from nominal.core.exceptions import NominalConfigError
 from nominal.experimental import as_user
+from nominal.protos.asset.v2 import asset_pb2_grpc
 from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
 from nominal.protos.event.v2 import event_pb2_grpc
@@ -280,6 +281,7 @@ def test_from_config_wires_grpc_services_through_one_shared_channel(monkeypatch)
     assert isinstance(
         clients.containerized_extractor, containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
     )
+    assert isinstance(clients.assets, asset_pb2_grpc.AssetServiceStub)
     assert isinstance(clients.event, event_pb2_grpc.EventServiceStub)
     assert isinstance(clients.registry, registry_pb2_grpc.RegistryServiceStub)
     assert isinstance(clients.sandbox_workspace, sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub)
@@ -315,7 +317,7 @@ def test_experimental_as_user_returns_derived_nominal_client(monkeypatch):
     assert impersonated._clients.catalog._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
         "ri.authn.dev.user.target"
     )
-    assert impersonated._clients.assets._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
+    assert impersonated._clients.run._requests_session.headers[ON_BEHALF_OF_USER_RID_HEADER] == (
         "ri.authn.dev.user.target"
     )
     # The impersonation header_provider must also reach the gRPC channel; the most

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -360,8 +360,8 @@ def test_add_journal_json_rejects_non_epoch_timestamps_before_uploading(
 class _StubWrapper(_DatasetWrapper):
     """The wrapper with scope resolution stubbed: what is under test is the delegation, not lookup."""
 
-    def _list_dataset_scopes(self):
-        return []
+    def _lookup_dataset_scope(self, data_scope_name):
+        return None
 
 
 def test_data_scope_avro_stream_merges_scope_tags() -> None:

--- a/tests/core/test_migration_destination_client_resolution.py
+++ b/tests/core/test_migration_destination_client_resolution.py
@@ -50,7 +50,7 @@ def _make_asset(rid: str) -> MagicMock:
     asset.labels = [rid]
     asset.list_runs.return_value = []
     asset.search_workbooks.return_value = []
-    asset._list_dataset_scopes.return_value = []
+    asset._dataset_scopes.return_value = []
     asset.list_datasets.return_value = []
     asset.list_videos.return_value = []
     asset.search_events.return_value = []

--- a/tests/core/test_query_tools.py
+++ b/tests/core/test_query_tools.py
@@ -1,6 +1,8 @@
 from nominal.core._event_types import EventType, SearchEventOriginTypes
-from nominal.core._utils.query_tools import AssetMatch, create_search_events_query
+from nominal.core._utils.query_tools import AssetMatch, create_search_assets_query, create_search_events_query
+from nominal.protos.asset.v2 import asset_pb2
 from nominal.protos.event.v2 import event_pb2
+from nominal.protos.types import types_pb2
 
 
 def test_create_search_events_query_asset_match_all_ands_per_asset_clauses():
@@ -55,4 +57,32 @@ def test_create_search_events_query_drops_an_empty_origin_types() -> None:
     """An empty sequence must drop the clause; an OR over no origin types would match nothing."""
     assert create_search_events_query(origin_types=[]) == event_pb2.SearchQuery(
         **{"and": event_pb2.SearchQueryList(queries=[])}
+    )
+
+
+def test_create_search_assets_query_ands_one_clause_per_filter() -> None:
+    """`and` is a Python keyword, so this query is built by keyword expansion rather than a named argument."""
+    query = create_search_assets_query(
+        search_text="rocket", labels=["flight", "prod"], properties={"vehicle": "v1"}, workspace_rid="ri.workspace.1"
+    )
+
+    assert query == asset_pb2.SearchAssetsQuery(
+        **{
+            "and": asset_pb2.SearchAssetsQueryList(
+                queries=[
+                    asset_pb2.SearchAssetsQuery(search_text="rocket"),
+                    asset_pb2.SearchAssetsQuery(label="flight"),
+                    asset_pb2.SearchAssetsQuery(label="prod"),
+                    asset_pb2.SearchAssetsQuery(property=types_pb2.Property(name="vehicle", value="v1")),
+                    asset_pb2.SearchAssetsQuery(workspace="ri.workspace.1"),
+                ]
+            )
+        }
+    )
+
+
+def test_create_search_assets_query_ands_nothing_when_unfiltered() -> None:
+    """An unfiltered search still wraps in `and`: the empty clause list matches every asset."""
+    assert create_search_assets_query() == asset_pb2.SearchAssetsQuery(
+        **{"and": asset_pb2.SearchAssetsQueryList(queries=[])}
     )

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from typing import Mapping
+from unittest.mock import MagicMock, patch
 
 import pytest
+from nominal_api import scout_run_api
 
 from nominal.core.run import Run
 from nominal.protos.event.v2 import event_pb2
+
+
+def _conjure_scope(name: str, data_source: scout_run_api.DataSource, series_tags: Mapping[str, str]) -> MagicMock:
+    return MagicMock(data_scope_name=name, data_source=data_source, series_tags=series_tags)
 
 
 @pytest.fixture
@@ -70,6 +76,30 @@ def test_search_events_empty_assets_returns_no_events(make_run, mock_clients):
 
     assert result == []
     mock_clients.event.SearchEvents.assert_not_called()
+
+
+def test_lookup_dataset_scope_resolves_conjure_scopes_by_name(make_run):
+    """Runs still read conjure scopes, where the scope kind is a string on the data source."""
+    run = make_run(["asset-rid-1"])
+    enriched_run = MagicMock(
+        assets=["asset-rid-1"],
+        asset_data_scopes=[
+            _conjure_scope("ds", scout_run_api.DataSource(dataset="ri.dataset.1"), {"vehicle": "a"}),
+            _conjure_scope("vid", scout_run_api.DataSource(video="ri.video.1"), {}),
+        ],
+    )
+
+    with patch.object(Run, "_get_latest_api", return_value=enriched_run):
+        assert run._lookup_dataset_scope("ds") == ("ri.dataset.1", {"vehicle": "a"})
+        assert run._lookup_dataset_scope("vid") is None
+        assert run._lookup_dataset_scope("absent") is None
+
+
+def test_lookup_dataset_scope_rejects_multi_asset_runs(mock_run):
+    """A scope name is only unambiguous within one asset, so a multi-asset run cannot resolve one."""
+    with patch.object(Run, "_get_latest_api", return_value=MagicMock(assets=["a", "b"])):
+        with pytest.raises(RuntimeError, match="multi-asset runs"):
+            mock_run._lookup_dataset_scope("ds")
 
 
 def test_nominal_url_identifies_the_run_by_rid(mock_run, mock_clients):


### PR DESCRIPTION
Migrates the SDK's asset operations from Conjure to the v2 gRPC `AssetService`. Client method signatures remain unchanged, asset RPCs use `translate_grpc_errors()`, and search uses the shared gRPC paginator. `Asset` uses `RefreshableGrpcMixin` and exposes `updated_at`, allowing the download CLI to sort assets without another fetch.

`Asset` and `Run` each resolve dataset scope names through `_lookup_dataset_scope()`, returning only a dataset RID and series tags. `_DatasetWrapper` therefore stays independent of both wire formats; `Run` continues to read its Conjure scopes directly. Link normalization is shared by the Conjure and asset-proto builders.

Presence and error behavior:

- Missing assets raise `NominalNotFoundError`, including absent entries in a successful batch response.
- Updates distinguish omitted collections from explicit empty collections. Asset descriptions preserve the distinction between an absent value and an explicitly empty string.
- Scope removal compares only the active data-source oneof arm and rejects empty RIDs before making an RPC. Surviving scopes retain field presence, including absent offsets and data sources.

Validation on Python 3.13 after merging current `main`: 1,001 unit tests passed; mypy and Ruff lint/format checks passed. One optional video-stream test module was skipped because the local GStreamer WebRTC library is unavailable. Live-backend tests were not run.
