### PR TITLE
feat: migrate data review service to gRPC

### DIFF
--- a/nominal/core/_checklist_types.py
+++ b/nominal/core/_checklist_types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import IntEnum
 
-from nominal_api import scout_api
+from nominal.protos.types import common_pb2
 
 
 class Priority(IntEnum):
@@ -13,36 +13,26 @@ class Priority(IntEnum):
     P4 = 4
 
     @classmethod
-    def _from_conjure(cls, priority: scout_api.Priority) -> Priority:
-        match priority.name:
-            case "P0":
+    def _from_proto(cls, priority: common_pb2.Priority.ValueType) -> Priority | None:
+        """The SDK priority for a proto priority, or None if it does not name one.
+
+        Proto enums are open, so a level added after this client was built arrives as an integer with no
+        name here. That degrades to None rather than raising, which is what the conjure transport did too:
+        its decoder collapsed unrecognized values into `Priority.UNKNOWN`, which callers read as absence.
+
+        The unordered enum wrappers instead degrade to an `UNSPECIFIED` member. This scale is ordered, so
+        such a member would take a position on it -- below P4 or above P0 -- and None takes none.
+        """
+        match priority:
+            case common_pb2.P0:
                 return cls.P0
-            case "P1":
+            case common_pb2.P1:
                 return cls.P1
-            case "P2":
+            case common_pb2.P2:
                 return cls.P2
-            case "P3":
+            case common_pb2.P3:
                 return cls.P3
-            case "P4":
+            case common_pb2.P4:
                 return cls.P4
             case _:
-                raise ValueError(f"unknown priority '{priority}', expected one of {list(cls)}")
-
-    def _to_conjure(self) -> scout_api.Priority:
-        match self:
-            case Priority.P0:
-                return scout_api.Priority.P0
-            case Priority.P1:
-                return scout_api.Priority.P1
-            case Priority.P2:
-                return scout_api.Priority.P2
-            case Priority.P3:
-                return scout_api.Priority.P3
-            case Priority.P4:
-                return scout_api.Priority.P4
-            case _:
-                raise ValueError(f"unknown priority '{self}', expected one of {list(Priority)}")
-
-
-def _conjure_priority_to_priority(priority: scout_api.Priority) -> Priority:
-    return Priority._from_conjure(priority)
+                return None

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -17,7 +17,6 @@ from nominal_api import (
     scout_checks_api,
     scout_compute_api,
     scout_dataexport_api,
-    scout_datareview_api,
     scout_datasource,
     scout_datasource_connection,
     scout_video,
@@ -38,6 +37,7 @@ from nominal.core._utils.networking import (
 from nominal.core.exceptions import NominalConfigError
 from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
+from nominal.protos.datareview.v2 import data_review_pb2_grpc
 from nominal.protos.event.v2 import event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc, ingest_service_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2_grpc
@@ -153,7 +153,6 @@ class ClientsBunch:
     compute: scout_compute_api.ComputeService
     connection: scout_datasource_connection.ConnectionService
     dataexport: scout_dataexport_api.DataExportService
-    datareview: scout_datareview_api.DataReviewService
     datasource: scout_datasource.DataSourceService
     ingest_jobs: ingest_api.IngestJobService
     ingest: ingest_api.IngestService
@@ -171,6 +170,7 @@ class ClientsBunch:
     # GRPC services
     comments: comments_pb2_grpc.CommentsServiceStub
     containerized_extractor: containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
+    datareview: data_review_pb2_grpc.DataReviewServiceStub
     event: event_pb2_grpc.EventServiceStub
     ingest_v2: ingest_service_pb2_grpc.IngestServiceStub
     registry: registry_pb2_grpc.RegistryServiceStub
@@ -317,7 +317,6 @@ class ClientsBunch:
             compute=client_factory(scout_compute_api.ComputeService),
             connection=client_factory(scout_datasource_connection.ConnectionService),
             dataexport=client_factory(scout_dataexport_api.DataExportService),
-            datareview=client_factory(scout_datareview_api.DataReviewService),
             datasource=client_factory(scout_datasource.DataSourceService),
             ingest_jobs=client_factory(ingest_api.IngestJobService),
             ingest=client_factory(ingest_api.IngestService),
@@ -334,6 +333,7 @@ class ClientsBunch:
             # GRPC Service Stubs
             comments=grpc_factory(comments_pb2_grpc.CommentsServiceStub),
             containerized_extractor=grpc_factory(containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub),
+            datareview=grpc_factory(data_review_pb2_grpc.DataReviewServiceStub),
             event=grpc_factory(event_pb2_grpc.EventServiceStub),
             ingest_v2=grpc_factory(ingest_service_pb2_grpc.IngestServiceStub),
             registry=grpc_factory(registry_pb2_grpc.RegistryServiceStub),

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -17,7 +17,6 @@ from nominal_api import (
     scout_checks_api,
     scout_compute_api,
     scout_dataexport_api,
-    scout_datareview_api,
     scout_datasource,
     scout_datasource_connection,
     scout_video,
@@ -40,6 +39,7 @@ from nominal.core.exceptions import NominalConfigError
 from nominal.protos.authorization.markings.v1 import markings_pb2_grpc
 from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
+from nominal.protos.datareview.v2 import data_review_pb2_grpc
 from nominal.protos.event.v2 import event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc, ingest_service_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2_grpc
@@ -155,7 +155,6 @@ class ClientsBunch:
     compute: scout_compute_api.ComputeService
     connection: scout_datasource_connection.ConnectionService
     dataexport: scout_dataexport_api.DataExportService
-    datareview: scout_datareview_api.DataReviewService
     datasource: scout_datasource.DataSourceService
     ingest_jobs: ingest_api.IngestJobService
     ingest: ingest_api.IngestService
@@ -173,6 +172,7 @@ class ClientsBunch:
     # GRPC services
     comments: comments_pb2_grpc.CommentsServiceStub
     containerized_extractor: containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
+    datareview: data_review_pb2_grpc.DataReviewServiceStub
     event: event_pb2_grpc.EventServiceStub
     ingest_v2: ingest_service_pb2_grpc.IngestServiceStub
     markings: markings_pb2_grpc.MarkingServiceStub
@@ -321,7 +321,6 @@ class ClientsBunch:
             compute=client_factory(scout_compute_api.ComputeService),
             connection=client_factory(scout_datasource_connection.ConnectionService),
             dataexport=client_factory(scout_dataexport_api.DataExportService),
-            datareview=client_factory(scout_datareview_api.DataReviewService),
             datasource=client_factory(scout_datasource.DataSourceService),
             ingest_jobs=client_factory(ingest_api.IngestJobService),
             ingest=client_factory(ingest_api.IngestService),
@@ -338,6 +337,7 @@ class ClientsBunch:
             # GRPC Service Stubs
             comments=grpc_factory(comments_pb2_grpc.CommentsServiceStub),
             containerized_extractor=grpc_factory(containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub),
+            datareview=grpc_factory(data_review_pb2_grpc.DataReviewServiceStub),
             event=grpc_factory(event_pb2_grpc.EventServiceStub),
             ingest_v2=grpc_factory(ingest_service_pb2_grpc.IngestServiceStub),
             markings=grpc_factory(markings_pb2_grpc.MarkingServiceStub),

--- a/nominal/core/_utils/pagination_tools.py
+++ b/nominal/core/_utils/pagination_tools.py
@@ -11,7 +11,6 @@ from nominal_api import (
     scout_catalog,
     scout_checklistexecution_api,
     scout_checks_api,
-    scout_datareview_api,
     scout_notebook_api,
     scout_run_api,
     scout_template_api,
@@ -21,6 +20,7 @@ from nominal_api import (
 
 from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.query_tools import ArchiveStatusFilter
+from nominal.protos.datareview.v2 import data_review_pb2, data_review_pb2_grpc
 from nominal.protos.event.v2 import event_pb2, event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2, containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2, registry_pb2_grpc
@@ -139,25 +139,23 @@ def search_ingest_jobs_paginated(
 
 
 def search_data_reviews_paginated(
-    datareview: scout_datareview_api.DataReviewService,
-    auth_header: str,
+    datareview: data_review_pb2_grpc.DataReviewServiceStub,
     assets: Sequence[str] | None = None,
     runs: Sequence[str] | None = None,
     archive_status: ArchiveStatusFilter = ArchiveStatusFilter.NOT_ARCHIVED,
-) -> Iterable[scout_datareview_api.DataReview]:
+) -> Iterable[data_review_pb2.DataReview]:
     """Search for any data reviews present within a collection of runs and assets."""
 
-    def factory(page_token: str | None) -> scout_datareview_api.FindDataReviewsRequest:
-        return scout_datareview_api.FindDataReviewsRequest(
-            asset_rids=[] if assets is None else list(assets),
-            checklist_refs=[],
-            run_rids=[] if runs is None else list(runs),
-            archived_statuses=archive_status.to_api_archived_statuses(),
+    def factory(page_token: str | None) -> data_review_pb2.FindDataReviewsRequest:
+        return data_review_pb2.FindDataReviewsRequest(
+            asset_rids=list(assets or ()),
+            run_rids=list(runs or ()),
+            archived_statuses=data_review_pb2.ArchivedStatusSet(values=archive_status.to_proto_archived_statuses()),
             page_size=DEFAULT_PAGE_SIZE,
             next_page_token=page_token,
         )
 
-    for response in paginate_rpc(datareview.find_data_reviews, auth_header, request_factory=factory):
+    for response in paginate_grpc(datareview.FindDataReviews, request_factory=factory):
         yield from response.data_reviews
 
 

--- a/nominal/core/_utils/pagination_tools.py
+++ b/nominal/core/_utils/pagination_tools.py
@@ -11,7 +11,6 @@ from nominal_api import (
     scout_catalog,
     scout_checklistexecution_api,
     scout_checks_api,
-    scout_datareview_api,
     scout_notebook_api,
     scout_run_api,
     scout_template_api,
@@ -22,6 +21,7 @@ from nominal_api import (
 from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.protos.authorization.markings.v1 import markings_pb2, markings_pb2_grpc
+from nominal.protos.datareview.v2 import data_review_pb2, data_review_pb2_grpc
 from nominal.protos.event.v2 import event_pb2, event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2, containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2, registry_pb2_grpc
@@ -140,25 +140,23 @@ def search_ingest_jobs_paginated(
 
 
 def search_data_reviews_paginated(
-    datareview: scout_datareview_api.DataReviewService,
-    auth_header: str,
+    datareview: data_review_pb2_grpc.DataReviewServiceStub,
     assets: Sequence[str] | None = None,
     runs: Sequence[str] | None = None,
     archive_status: ArchiveStatusFilter = ArchiveStatusFilter.NOT_ARCHIVED,
-) -> Iterable[scout_datareview_api.DataReview]:
+) -> Iterable[data_review_pb2.DataReview]:
     """Search for any data reviews present within a collection of runs and assets."""
 
-    def factory(page_token: str | None) -> scout_datareview_api.FindDataReviewsRequest:
-        return scout_datareview_api.FindDataReviewsRequest(
-            asset_rids=[] if assets is None else list(assets),
-            checklist_refs=[],
-            run_rids=[] if runs is None else list(runs),
-            archived_statuses=archive_status.to_api_archived_statuses(),
+    def factory(page_token: str | None) -> data_review_pb2.FindDataReviewsRequest:
+        return data_review_pb2.FindDataReviewsRequest(
+            asset_rids=list(assets or ()),
+            run_rids=list(runs or ()),
+            archived_statuses=data_review_pb2.ArchivedStatusSet(values=archive_status.to_proto_archived_statuses()),
             page_size=DEFAULT_PAGE_SIZE,
             next_page_token=page_token,
         )
 
-    for response in paginate_rpc(datareview.find_data_reviews, auth_header, request_factory=factory):
+    for response in paginate_grpc(datareview.FindDataReviews, request_factory=factory):
         yield from response.data_reviews
 
 

--- a/nominal/core/checklist.py
+++ b/nominal/core/checklist.py
@@ -7,7 +7,6 @@ from typing import Mapping, Protocol, Sequence
 from nominal_api import (
     scout_checklistexecution_api,
     scout_checks_api,
-    scout_datareview_api,
     scout_integrations_api,
 )
 from typing_extensions import Self
@@ -16,8 +15,9 @@ from nominal.core import run as core_run
 from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin, rid_from_instance_or_string
 from nominal.core._utils.frontend_urls import checklist_preview_url, checklist_url
 from nominal.core.asset import Asset
-from nominal.core.data_review import DataReview
+from nominal.core.data_review import DataReview, _initiate_data_reviews
 from nominal.core.exceptions import NominalChecklistNotPublishedError
+from nominal.protos.datareview.v2 import data_review_pb2
 from nominal.ts import _to_api_duration
 
 
@@ -36,8 +36,6 @@ class Checklist(HasRid, RefreshableConjureMixin[scout_checks_api.VersionedCheckl
         def checklist(self) -> scout_checks_api.ChecklistService: ...
         @property
         def checklist_execution(self) -> scout_checklistexecution_api.ChecklistExecutionService: ...
-        @property
-        def datareview(self) -> scout_datareview_api.DataReviewService: ...
 
     @classmethod
     def _from_conjure(cls, clients: _Clients, checklist: scout_checks_api.VersionedChecklist) -> Self:
@@ -72,26 +70,13 @@ class Checklist(HasRid, RefreshableConjureMixin[scout_checks_api.VersionedCheckl
         """
         run_rid = rid_from_instance_or_string(run)
 
-        response = self._clients.datareview.batch_initiate(
-            self._clients.auth_header,
-            scout_datareview_api.BatchInitiateDataReviewRequest(
-                notification_configurations=[],
-                requests=[
-                    scout_datareview_api.CreateDataReviewRequest(
-                        checklist_rid=self.rid,
-                        run_rid=run_rid,
-                        commit=commit,
-                    )
-                ],
-            ),
-        )
-        if len(response.rids) != 1:
-            raise RuntimeError(f"Expected exactly one response from batch_initiate, received {len(response.rids)}")
-
-        return DataReview._from_conjure(
+        reviews = _initiate_data_reviews(
             self._clients,
-            self._clients.datareview.get(self._clients.auth_header, response.rids[0]),
+            [data_review_pb2.CreateDataReviewRequest(checklist_rid=self.rid, run_rid=run_rid, commit=commit)],
         )
+        if len(reviews) != 1:
+            raise RuntimeError(f"Expected exactly one response from BatchInitiate, received {len(reviews)}")
+        return reviews[0]
 
     def execute_streaming(
         self,

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -83,7 +83,7 @@ from nominal.core.containerized_extractor import (
     _get_containerized_extractor,
     _search_containerized_extractors,
 )
-from nominal.core.data_review import DataReview, DataReviewBuilder, _iter_search_data_reviews
+from nominal.core.data_review import DataReview, DataReviewBuilder, _get_data_review, _iter_search_data_reviews
 from nominal.core.dataset import (
     Dataset,
     _create_dataset,
@@ -1299,8 +1299,7 @@ class NominalClient:
         return DataReviewBuilder([], [], [], _clients=self._clients)
 
     def get_data_review(self, rid: str) -> DataReview:
-        response = self._clients.datareview.get(self._clients.auth_header, rid)
-        return DataReview._from_conjure(self._clients, response)
+        return DataReview._from_proto(self._clients, _get_data_review(self._clients, rid))
 
     def create_event(
         self,

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -1400,7 +1400,7 @@ class NominalClient:
         return DataReviewBuilder([], [], [], _clients=self._clients)
 
     def get_data_review(self, rid: str) -> DataReview:
-        return DataReview._from_proto(self._clients, _get_data_review(self._clients, rid))
+        return _get_data_review(self._clients, rid)
 
     def create_event(
         self,

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -83,7 +83,7 @@ from nominal.core.containerized_extractor import (
     _get_containerized_extractor,
     _search_containerized_extractors,
 )
-from nominal.core.data_review import DataReview, DataReviewBuilder, _iter_search_data_reviews
+from nominal.core.data_review import DataReview, DataReviewBuilder, _get_data_review, _iter_search_data_reviews
 from nominal.core.dataset import (
     Dataset,
     _create_dataset,
@@ -1400,8 +1400,7 @@ class NominalClient:
         return DataReviewBuilder([], [], [], _clients=self._clients)
 
     def get_data_review(self, rid: str) -> DataReview:
-        response = self._clients.datareview.get(self._clients.auth_header, rid)
-        return DataReview._from_conjure(self._clients, response)
+        return DataReview._from_proto(self._clients, _get_data_review(self._clients, rid))
 
     def create_event(
         self,

--- a/nominal/core/data_review.py
+++ b/nominal/core/data_review.py
@@ -7,23 +7,22 @@ from typing import TYPE_CHECKING, Iterable, Protocol, Sequence
 
 from nominal_api import (
     scout,
-    scout_api,
     scout_checklistexecution_api,
     scout_checks_api,
-    scout_datareview_api,
-    scout_integrations_api,
 )
 from typing_extensions import Self
 
-from nominal.core._checklist_types import Priority, _conjure_priority_to_priority
+from nominal.core._checklist_types import Priority
 from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils.api_tools import HasRid, rid_from_instance_or_string
 from nominal.core._utils.frontend_urls import data_review_events_url, data_review_url
+from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.pagination_tools import search_data_reviews_paginated
 from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.core.event import Event, _get_events
+from nominal.protos.datareview.v2 import data_review_pb2, data_review_pb2_grpc
 from nominal.protos.event.v2 import event_pb2_grpc
-from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
+from nominal.ts import IntegralNanosecondsUTC
 
 if TYPE_CHECKING:
     from nominal.core.asset import Asset
@@ -45,7 +44,7 @@ class DataReview(HasRid):
 
     class _Clients(HasScoutParams, Protocol):
         @property
-        def datareview(self) -> scout_datareview_api.DataReviewService: ...
+        def datareview(self) -> data_review_pb2_grpc.DataReviewServiceStub: ...
         @property
         def checklist(self) -> scout_checks_api.ChecklistService: ...
         @property
@@ -56,20 +55,16 @@ class DataReview(HasRid):
         def run(self) -> scout.RunService: ...
 
     @classmethod
-    def _from_conjure(cls, clients: _Clients, data_review: scout_datareview_api.DataReview) -> Self:
-        executing_states = [
-            check.state._pending_execution or check.state._executing for check in data_review.check_evaluations
-        ]
-        completed = not any(executing_states)
+    def _from_proto(cls, clients: _Clients, data_review: data_review_pb2.DataReview) -> Self:
         return cls(
             rid=data_review.rid,
             run_rid=data_review.run_rid,
             checklist_rid=data_review.checklist_ref.rid,
             checklist_commit=data_review.checklist_ref.commit,
-            completed=completed,
-            created_at=_SecondsNanos.from_flexible(data_review.created_at).to_nanoseconds(),
+            completed=all(_check_has_settled(check.state) for check in data_review.check_evaluations),
+            created_at=data_review.created_at.ToNanoseconds(),
             _clients=clients,
-            created_by_rid=data_review.created_by,
+            created_by_rid=data_review.created_by or None,
         )
 
     def get_checklist(self) -> "Checklist":
@@ -82,12 +77,11 @@ class DataReview(HasRid):
 
     def get_events(self) -> Sequence[Event]:
         """Retrieves the list of events for the data review."""
-        data_review_response = self._clients.datareview.get(self._clients.auth_header, self.rid).check_evaluations
         all_event_rids = [
             event_rid
-            for check in data_review_response
-            if check.state._generated_alerts
-            for event_rid in check.state._generated_alerts.event_rids
+            for check in _get_data_review(self._clients, self.rid).check_evaluations
+            if check.state.HasField("generated_alerts")
+            for event_rid in check.state.generated_alerts.event_rids
         ]
         return [
             Event._from_proto(self._clients, data_review_event)
@@ -96,9 +90,7 @@ class DataReview(HasRid):
 
     def reload(self) -> DataReview:
         """Reloads the data review from the server."""
-        return DataReview._from_conjure(
-            self._clients, self._clients.datareview.get(self._clients.auth_header, self.rid)
-        )
+        return DataReview._from_proto(self._clients, _get_data_review(self._clients, self.rid))
 
     def poll_for_completion(self, interval: timedelta = timedelta(seconds=2)) -> DataReview:
         """Polls the data review until it is completed."""
@@ -114,7 +106,10 @@ class DataReview(HasRid):
 
         NOTE: currently, it is not possible (yet) to unarchive a data review once archived.
         """
-        self._clients.datareview.archive_data_review(self._clients.auth_header, self.rid)
+        with translate_grpc_errors():
+            self._clients.datareview.ArchiveDataReview(
+                data_review_pb2.ArchiveDataReviewRequest(data_review_rid=self.rid)
+            )
 
     @property
     def nominal_url(self) -> str:
@@ -137,23 +132,21 @@ class CheckViolation:
     priority: Priority | None
 
     @classmethod
-    def _from_conjure(cls, check_alert: scout_datareview_api.CheckAlert) -> CheckViolation:
+    def _from_proto(cls, check_alert: data_review_pb2.CheckAlert) -> CheckViolation:
         return cls(
             rid=check_alert.rid,
             check_rid=check_alert.check_rid,
             name=check_alert.name,
-            start=_SecondsNanos.from_api(check_alert.start).to_nanoseconds(),
-            end=_SecondsNanos.from_api(check_alert.end).to_nanoseconds() if check_alert.end is not None else None,
-            priority=_conjure_priority_to_priority(check_alert.priority)
-            if check_alert.priority is not scout_api.Priority.UNKNOWN
-            else None,
+            start=check_alert.start.ToNanoseconds(),
+            end=check_alert.end.ToNanoseconds() if check_alert.HasField("end") else None,
+            priority=Priority._from_proto(check_alert.priority),
         )
 
 
 @dataclass(frozen=True)
 class DataReviewBuilder:
     _integration_rids: list[str]
-    _requests: list[scout_datareview_api.CreateDataReviewRequest]
+    _requests: list[data_review_pb2.CreateDataReviewRequest]
     _tags: list[str]
     _clients: DataReview._Clients = field(repr=False)
 
@@ -204,7 +197,7 @@ class DataReviewBuilder:
                 )
 
         self._requests.append(
-            scout_datareview_api.CreateDataReviewRequest(
+            data_review_pb2.CreateDataReviewRequest(
                 checklist_rid=checklist_rid,
                 run_rid=run_rid,
                 asset_rid=asset_rid,
@@ -223,18 +216,14 @@ class DataReviewBuilder:
         Args:
             wait_for_completion: If True, waits for the data review process to complete before returning.
         """
-        request = scout_datareview_api.BatchInitiateDataReviewRequest(
-            notification_configurations=[
-                scout_integrations_api.NotificationConfiguration(c, tags=self._tags) for c in self._integration_rids
+        data_reviews = _initiate_data_reviews(
+            self._clients,
+            self._requests,
+            [
+                data_review_pb2.NotificationConfiguration(integration_rid=c, tags=self._tags)
+                for c in self._integration_rids
             ],
-            requests=self._requests,
         )
-        response = self._clients.datareview.batch_initiate(self._clients.auth_header, request)
-
-        data_reviews = [
-            DataReview._from_conjure(self._clients, self._clients.datareview.get(self._clients.auth_header, rid))
-            for rid in response.rids
-        ]
         if wait_for_completion:
             return poll_until_completed(data_reviews)
         else:
@@ -255,9 +244,49 @@ def _iter_search_data_reviews(
 ) -> Iterable[DataReview]:
     for review in search_data_reviews_paginated(
         clients.datareview,
-        clients.auth_header,
         assets=assets,
         runs=runs,
         archive_status=archive_status,
     ):
-        yield DataReview._from_conjure(clients, review)
+        yield DataReview._from_proto(clients, review)
+
+
+def _check_has_settled(state: data_review_pb2.AutomaticCheckEvaluationState) -> bool:
+    """Whether a check evaluation has reached a terminal state.
+
+    Matching on the oneof rather than testing individual arms means a state added to the proto has to be
+    classified here instead of silently counting as settled.
+    """
+    match state.WhichOneof("automatic_check_evaluation_state"):
+        case "pending_execution" | "executing":
+            return False
+        case "failed_to_execute" | "passing" | "generated_alerts" | "too_many_alerts":
+            return True
+        case None:
+            return True
+
+
+def _initiate_data_reviews(
+    clients: DataReview._Clients,
+    requests: Sequence[data_review_pb2.CreateDataReviewRequest],
+    notification_configurations: Sequence[data_review_pb2.NotificationConfiguration] = (),
+) -> Sequence[DataReview]:
+    """Initiate the requested data reviews and return them hydrated."""
+    request = data_review_pb2.BatchInitiateRequest(
+        requests=list(requests),
+        notification_configurations=list(notification_configurations),
+    )
+    with translate_grpc_errors():
+        rids = clients.datareview.BatchInitiate(request).rids
+    return [DataReview._from_proto(clients, _get_data_review(clients, rid)) for rid in rids]
+
+
+def _get_data_review(clients: DataReview._Clients, rid: str) -> data_review_pb2.DataReview:
+    """The data review with the given rid.
+
+    Raises:
+        NominalNotFoundError: If no data review has that rid.
+    """
+    with translate_grpc_errors():
+        response = clients.datareview.GetDataReview(data_review_pb2.GetDataReviewRequest(data_review_rid=rid))
+    return response.data_review

--- a/nominal/core/data_review.py
+++ b/nominal/core/data_review.py
@@ -79,7 +79,7 @@ class DataReview(HasRid):
         """Retrieves the list of events for the data review."""
         all_event_rids = [
             event_rid
-            for check in _get_data_review(self._clients, self.rid).check_evaluations
+            for check in _get_data_review_proto(self._clients, self.rid).check_evaluations
             if check.state.HasField("generated_alerts")
             for event_rid in check.state.generated_alerts.event_rids
         ]
@@ -90,7 +90,7 @@ class DataReview(HasRid):
 
     def reload(self) -> DataReview:
         """Reloads the data review from the server."""
-        return DataReview._from_proto(self._clients, _get_data_review(self._clients, self.rid))
+        return _get_data_review(self._clients, self.rid)
 
     def poll_for_completion(self, interval: timedelta = timedelta(seconds=2)) -> DataReview:
         """Polls the data review until it is completed."""
@@ -215,6 +215,9 @@ class DataReviewBuilder:
 
         Args:
             wait_for_completion: If True, waits for the data review process to complete before returning.
+
+        Returns:
+            The initiated reviews, which may still be running unless wait_for_completion is True.
         """
         data_reviews = _initiate_data_reviews(
             self._clients,
@@ -254,8 +257,9 @@ def _iter_search_data_reviews(
 def _check_has_settled(state: data_review_pb2.AutomaticCheckEvaluationState) -> bool:
     """Whether a check evaluation has reached a terminal state.
 
-    Matching on the oneof rather than testing individual arms means a state added to the proto has to be
-    classified here instead of silently counting as settled.
+    The generated oneof types make this match exhaustive when the client updates its proto dependency.
+    Unknown states received from a newer server appear as an unset oneof and count as settled, preserving
+    the legacy behavior.
     """
     match state.WhichOneof("automatic_check_evaluation_state"):
         case "pending_execution" | "executing":
@@ -273,20 +277,24 @@ def _initiate_data_reviews(
 ) -> Sequence[DataReview]:
     """Initiate the requested data reviews and return them hydrated."""
     request = data_review_pb2.BatchInitiateRequest(
-        requests=list(requests),
-        notification_configurations=list(notification_configurations),
+        requests=requests,
+        notification_configurations=notification_configurations,
     )
     with translate_grpc_errors():
         rids = clients.datareview.BatchInitiate(request).rids
-    return [DataReview._from_proto(clients, _get_data_review(clients, rid)) for rid in rids]
+    return [_get_data_review(clients, rid) for rid in rids]
 
 
-def _get_data_review(clients: DataReview._Clients, rid: str) -> data_review_pb2.DataReview:
+def _get_data_review(clients: DataReview._Clients, rid: str) -> DataReview:
     """The data review with the given rid.
 
     Raises:
         NominalNotFoundError: If no data review has that rid.
     """
+    return DataReview._from_proto(clients, _get_data_review_proto(clients, rid))
+
+
+def _get_data_review_proto(clients: DataReview._Clients, rid: str) -> data_review_pb2.DataReview:
     with translate_grpc_errors():
         response = clients.datareview.GetDataReview(data_review_pb2.GetDataReviewRequest(data_review_rid=rid))
     return response.data_review

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -17,6 +17,7 @@ from nominal.core.exceptions import NominalConfigError
 from nominal.experimental import as_user
 from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
+from nominal.protos.datareview.v2 import data_review_pb2_grpc
 from nominal.protos.event.v2 import event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2_grpc
@@ -260,6 +261,7 @@ def test_from_config_wires_grpc_services_through_one_shared_channel(monkeypatch)
     assert isinstance(
         clients.containerized_extractor, containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
     )
+    assert isinstance(clients.datareview, data_review_pb2_grpc.DataReviewServiceStub)
     assert isinstance(clients.event, event_pb2_grpc.EventServiceStub)
     assert isinstance(clients.registry, registry_pb2_grpc.RegistryServiceStub)
     assert isinstance(clients.sandbox_workspace, sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub)

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -17,6 +17,7 @@ from nominal.core.exceptions import NominalConfigError
 from nominal.experimental import as_user
 from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
+from nominal.protos.datareview.v2 import data_review_pb2_grpc
 from nominal.protos.event.v2 import event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2_grpc
@@ -280,6 +281,7 @@ def test_from_config_wires_grpc_services_through_one_shared_channel(monkeypatch)
     assert isinstance(
         clients.containerized_extractor, containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
     )
+    assert isinstance(clients.datareview, data_review_pb2_grpc.DataReviewServiceStub)
     assert isinstance(clients.event, event_pb2_grpc.EventServiceStub)
     assert isinstance(clients.registry, registry_pb2_grpc.RegistryServiceStub)
     assert isinstance(clients.sandbox_workspace, sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub)

--- a/tests/core/test_data_review.py
+++ b/tests/core/test_data_review.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from typing import Sequence
+from unittest.mock import MagicMock
+
+import pytest
+from google.protobuf import timestamp_pb2
+
+from nominal.core._checklist_types import Priority
+from nominal.core._utils.query_tools import ArchiveStatusFilter
+from nominal.core.checklist import Checklist
+from nominal.core.client import NominalClient
+from nominal.core.data_review import CheckViolation, DataReview, DataReviewBuilder, _iter_search_data_reviews
+from nominal.protos.datareview.v2 import data_review_pb2
+from nominal.protos.event.v2 import event_pb2
+from nominal.protos.types import common_pb2, types_pb2
+
+PENDING = data_review_pb2.AutomaticCheckEvaluationState(pending_execution=data_review_pb2.PendingExecutionState())
+EXECUTING = data_review_pb2.AutomaticCheckEvaluationState(executing=data_review_pb2.ExecutingState())
+PASSING = data_review_pb2.AutomaticCheckEvaluationState(passing=data_review_pb2.PassingExecutionState())
+ALERTED = data_review_pb2.AutomaticCheckEvaluationState(
+    generated_alerts=data_review_pb2.GeneratedAlertsState(event_rids=["ri.event.1"])
+)
+
+
+def _evaluation(state: data_review_pb2.AutomaticCheckEvaluationState) -> data_review_pb2.AutomaticCheckEvaluation:
+    return data_review_pb2.AutomaticCheckEvaluation(
+        rid="ri.eval.1", check_rid="ri.check.1", data_review_rid="ri.datareview.1", state=state
+    )
+
+
+def _proto_review(
+    rid: str = "ri.datareview.1",
+    *,
+    created_by: str = "",
+    states: Sequence[data_review_pb2.AutomaticCheckEvaluationState] = (),
+) -> data_review_pb2.DataReview:
+    return data_review_pb2.DataReview(
+        rid=rid,
+        run_rid="ri.run.1",
+        created_by=created_by,
+        created_at=timestamp_pb2.Timestamp(seconds=1),
+        checklist_ref=data_review_pb2.PinnedChecklistRef(rid="ri.checklist.1", commit="abc"),
+        check_evaluations=[_evaluation(state) for state in states],
+    )
+
+
+def _get_response(rid: str = "ri.datareview.1") -> data_review_pb2.GetDataReviewResponse:
+    return data_review_pb2.GetDataReviewResponse(data_review=_proto_review(rid))
+
+
+@pytest.fixture
+def clients():
+    return MagicMock()
+
+
+@pytest.fixture
+def review(clients):
+    return DataReview._from_proto(clients, _proto_review())
+
+
+@pytest.fixture
+def checklist(clients):
+    return Checklist(rid="ri.checklist.1", name="checks", description="", properties={}, labels=[], _clients=clients)
+
+
+@pytest.fixture
+def initiate(clients):
+    """BatchInitiate returning one rid, with GetDataReview stubbed for the hydration that follows."""
+    clients.datareview.BatchInitiate.return_value = data_review_pb2.BatchInitiateResponse(rids=["ri.datareview.1"])
+    clients.datareview.GetDataReview.return_value = _get_response()
+    return clients.datareview.BatchInitiate
+
+
+@pytest.mark.parametrize(
+    ("states", "completed"),
+    [
+        pytest.param((), True, id="no-checks"),
+        pytest.param((PASSING, ALERTED), True, id="all-settled"),
+        pytest.param((PENDING,), False, id="pending"),
+        pytest.param((EXECUTING,), False, id="executing"),
+    ],
+)
+def test_completed_tracks_unsettled_check_evaluations(states, completed: bool) -> None:
+    """Completion reads the evaluation-state oneof, so a check still running must keep the review incomplete."""
+    assert DataReview._from_proto(MagicMock(), _proto_review(states=states)).completed is completed
+
+
+@pytest.mark.parametrize(("created_by", "expected"), [("", None), ("ri.user.1", "ri.user.1")])
+def test_from_proto_normalizes_empty_created_by(created_by: str, expected: str | None) -> None:
+    """created_by is a plain proto string, so an unset value arrives as "" and must read as None."""
+    assert DataReview._from_proto(MagicMock(), _proto_review(created_by=created_by)).created_by_rid == expected
+
+
+def test_get_events_collects_rids_from_alerting_checks_only(clients, review) -> None:
+    """Only checks in the generated-alerts state carry event rids; other states contribute none."""
+    clients.datareview.GetDataReview.return_value = data_review_pb2.GetDataReviewResponse(
+        data_review=_proto_review(states=(PASSING, ALERTED))
+    )
+    clients.event.BatchGetEvents.return_value = event_pb2.BatchGetEventsResponse(events=[])
+
+    review.get_events()
+
+    assert list(clients.event.BatchGetEvents.call_args.args[0].event_rids) == ["ri.event.1"]
+
+
+def test_initiate_fans_tags_across_every_integration(clients) -> None:
+    """Each integration rid becomes its own NotificationConfiguration carrying the full tag list."""
+    builder = DataReviewBuilder(["ri.integration.1", "ri.integration.2"], [], ["tag-a", "tag-b"], _clients=clients)
+    clients.datareview.BatchInitiate.return_value = data_review_pb2.BatchInitiateResponse(rids=[])
+
+    builder.initiate(wait_for_completion=False)
+
+    request = clients.datareview.BatchInitiate.call_args.args[0]
+    assert [(c.integration_rid, list(c.tags)) for c in request.notification_configurations] == [
+        ("ri.integration.1", ["tag-a", "tag-b"]),
+        ("ri.integration.2", ["tag-a", "tag-b"]),
+    ]
+
+
+def test_search_wraps_archived_statuses_in_a_set_message(clients) -> None:
+    """Unlike the other gRPC searches, find takes archived statuses wrapped in ArchivedStatusSet."""
+    clients.datareview.FindDataReviews.return_value = data_review_pb2.FindDataReviewsResponse()
+
+    list(_iter_search_data_reviews(clients, assets=["ri.asset.1"], archive_status=ArchiveStatusFilter.ARCHIVED))
+
+    request = clients.datareview.FindDataReviews.call_args.args[0]
+    assert list(request.archived_statuses.values) == [types_pb2.ArchivedStatus.ARCHIVED]
+    assert list(request.asset_rids) == ["ri.asset.1"]
+
+
+def test_checklist_execute_pins_the_checklist_run_and_commit(checklist, initiate) -> None:
+    """execute() initiates exactly one review, and an unpinned commit stays absent rather than empty."""
+    assert checklist.execute("ri.run.1", commit="abc").rid == "ri.datareview.1"
+
+    request = initiate.call_args.args[0].requests[0]
+    assert (request.checklist_rid, request.run_rid, request.commit) == ("ri.checklist.1", "ri.run.1", "abc")
+
+    checklist.execute("ri.run.1")
+    assert not initiate.call_args.args[0].requests[0].HasField("commit")
+
+
+def test_checklist_execute_rejects_a_batch_that_is_not_exactly_one(clients, checklist, initiate) -> None:
+    """A batch that does not yield one review is a protocol violation, not a silent pick-first."""
+    clients.datareview.BatchInitiate.return_value = data_review_pb2.BatchInitiateResponse(rids=["a", "b"])
+
+    with pytest.raises(RuntimeError, match="Expected exactly one response from BatchInitiate"):
+        checklist.execute("ri.run.1")
+
+
+@pytest.mark.parametrize(
+    ("wire_value", "expected"),
+    [
+        pytest.param(common_pb2.P0, Priority.P0, id="P0"),
+        pytest.param(common_pb2.P1, Priority.P1, id="P1"),
+        pytest.param(common_pb2.P2, Priority.P2, id="P2"),
+        pytest.param(common_pb2.P3, Priority.P3, id="P3"),
+        pytest.param(common_pb2.P4, Priority.P4, id="P4"),
+        pytest.param(common_pb2.PRIORITY_UNSPECIFIED, None, id="unspecified"),
+        pytest.param(99, None, id="a-level-added-after-this-client-was-built"),
+    ],
+)
+def test_priority_maps_from_the_wire(wire_value: common_pb2.Priority.ValueType, expected: Priority | None) -> None:
+    """Inbound conversion has no exhaustiveness check, so every level is pinned here.
+
+    A value this client cannot name degrades to None rather than raising, matching the conjure transport,
+    whose decoder collapsed unrecognized values into `Priority.UNKNOWN`.
+    """
+    assert Priority._from_proto(wire_value) is expected
+
+
+def test_check_violation_reads_optional_end_and_priority() -> None:
+    """An open violation has no end timestamp, and an unspecified priority is absence rather than a level."""
+    open_alert = data_review_pb2.CheckAlert(
+        rid="ri.alert.1", check_rid="ri.check.1", name="n", start=timestamp_pb2.Timestamp(seconds=5)
+    )
+
+    violation = CheckViolation._from_proto(open_alert)
+
+    assert violation.start == 5_000_000_000
+    assert violation.end is None
+    assert violation.priority is None
+
+
+def test_get_data_review_returns_a_hydrated_review(clients) -> None:
+    """The getter hydrates, so callers do not repeat _from_proto at every site."""
+    clients.datareview.GetDataReview.return_value = _get_response()
+
+    assert isinstance(NominalClient(_clients=clients).get_data_review("ri.datareview.1"), DataReview)
+    assert clients.datareview.GetDataReview.call_args.args[0].data_review_rid == "ri.datareview.1"

--- a/tests/core/test_data_review.py
+++ b/tests/core/test_data_review.py
@@ -10,7 +10,13 @@ from nominal.core._checklist_types import Priority
 from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.core.checklist import Checklist
 from nominal.core.client import NominalClient
-from nominal.core.data_review import CheckViolation, DataReview, DataReviewBuilder, _iter_search_data_reviews
+from nominal.core.data_review import (
+    CheckViolation,
+    DataReview,
+    DataReviewBuilder,
+    _get_data_review,
+    _iter_search_data_reviews,
+)
 from nominal.protos.datareview.v2 import data_review_pb2
 from nominal.protos.event.v2 import event_pb2
 from nominal.protos.types import common_pb2, types_pb2
@@ -186,5 +192,39 @@ def test_get_data_review_returns_a_hydrated_review(clients) -> None:
     """The getter hydrates, so callers do not repeat _from_proto at every site."""
     clients.datareview.GetDataReview.return_value = _get_response()
 
-    assert isinstance(NominalClient(_clients=clients).get_data_review("ri.datareview.1"), DataReview)
+    assert isinstance(_get_data_review(clients, "ri.datareview.1"), DataReview)
     assert clients.datareview.GetDataReview.call_args.args[0].data_review_rid == "ri.datareview.1"
+
+
+def test_client_get_data_review_and_reload_return_hydrated_reviews(clients) -> None:
+    clients.datareview.GetDataReview.return_value = _get_response()
+    review = NominalClient(_clients=clients).get_data_review("ri.datareview.1")
+    clients.datareview.GetDataReview.return_value = data_review_pb2.GetDataReviewResponse(
+        data_review=_proto_review(states=(PENDING,))
+    )
+
+    reloaded = review.reload()
+
+    assert isinstance(reloaded, DataReview)
+    assert reloaded.rid == review.rid
+    assert reloaded.completed is False
+    assert review.completed is True
+
+
+@pytest.mark.parametrize(("asset", "commit"), [(None, None), ("ri.asset.1", "abc")])
+def test_builder_preserves_optional_request_fields(clients, initiate, asset: str | None, commit: str | None) -> None:
+    clients.run.get_run.return_value.assets = ["ri.asset.1"]
+    builder = NominalClient(_clients=clients).data_review_builder()
+
+    reviews = builder.execute_checklist("ri.run.1", "ri.checklist.1", asset=asset, commit=commit).initiate(
+        wait_for_completion=False
+    )
+
+    request = initiate.call_args.args[0].requests[0]
+    assert (request.run_rid, request.checklist_rid) == ("ri.run.1", "ri.checklist.1")
+    for field, value in (("asset_rid", asset), ("commit", commit)):
+        assert request.HasField(field) is (value is not None)
+        if value is not None:
+            assert getattr(request, field) == value
+    assert len(reviews) == 1
+    assert isinstance(reviews[0], DataReview)


### PR DESCRIPTION
Migrates the SDK's data-review operations from Conjure to the v2 gRPC `DataReviewService`, preserving public method signatures. RPCs use `translate_grpc_errors()`, and searches use the shared gRPC paginator.

`_get_data_review()` returns a hydrated SDK `DataReview` for the client getter, reload, and batch initiation paths. `_get_data_review_proto()` supplies the raw check evaluations needed by event lookup. `_initiate_data_reviews()` owns the batch request and hydration shared by `Checklist.execute()` and `DataReviewBuilder.initiate()`.

Completion uses an explicit match on the evaluation-state oneof. Generated types make the match exhaustive when the proto dependency is updated; unknown states arriving from a newer server still appear unset and count as settled, preserving legacy behavior. Unspecified and unrecognized priorities both become `None`, matching the legacy decoder's treatment of unknown values.

Tests cover builder request field presence for omitted and explicit asset/commit values, SDK-object hydration and reload behavior, event lookup, completion states, archive filters, notification tags, and priority conversion.

Validation on Python 3.13 after merging current `main`: 1,003 unit tests passed; mypy and Ruff lint/format checks passed. One optional video-stream test module was skipped because the local GStreamer WebRTC library is unavailable. Live-backend tests were not run.
