### PR TITLE
feat: add helper for batch create or update channel

### DIFF
--- a/nominal/core/datasource.py
+++ b/nominal/core/datasource.py
@@ -374,7 +374,7 @@ class DataSource(HasRid):
         """
         return self._batch_write_channels(channels, self._clients.series_metadata.batch_create)
 
-    def batch_upsert_channels(
+    def batch_update_or_create_channels(
         self,
         channels: Sequence[CreateChannelRequest],
     ) -> BatchAddChannelsResult:

--- a/nominal/core/datasource.py
+++ b/nominal/core/datasource.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import Iterable, Literal, Mapping, Protocol, Sequence, overload
+from typing import Callable, Iterable, Literal, Mapping, Protocol, Sequence, overload
 
 from nominal_api import (
     api,
@@ -372,17 +372,7 @@ class DataSource(HasRid):
             single batch, the entire batch will fail. Callers are responsible for deduplicating
             channel names before passing them to this method.
         """
-        if not channels:
-            return BatchAddChannelsResult(channels=[], missing=[])
-        for batch in batched(channels, _DEFAULT_CHANNEL_BATCH_SIZE):
-            requests = [_build_series_metadata_request(self.rid, req) for req in batch]
-            batch_request = timeseries_metadata_api.BatchCreateSeriesMetadataRequest(requests=requests)
-            self._clients.series_metadata.batch_create(self._clients.auth_header, batch_request)
-        created = {ch.name: ch for ch in self.get_channels(names=[req.name for req in channels])}
-        return BatchAddChannelsResult(
-            channels=list(created.values()),
-            missing=[req for req in channels if req.name not in created],
-        )
+        return self._batch_write_channels(channels, self._clients.series_metadata.batch_create)
 
     def batch_upsert_channels(
         self,
@@ -406,12 +396,19 @@ class DataSource(HasRid):
             batch will fail. Callers are responsible for deduplicating channel names before
             passing them to this method.
         """
+        return self._batch_write_channels(channels, self._clients.series_metadata.batch_create_or_update)
+
+    def _batch_write_channels(
+        self,
+        channels: Sequence[CreateChannelRequest],
+        write_batch: Callable[[str, timeseries_metadata_api.BatchCreateSeriesMetadataRequest], None],
+    ) -> BatchAddChannelsResult:
         if not channels:
             return BatchAddChannelsResult(channels=[], missing=[])
         for batch in batched(channels, _DEFAULT_CHANNEL_BATCH_SIZE):
             requests = [_build_series_metadata_request(self.rid, req) for req in batch]
             batch_request = timeseries_metadata_api.BatchCreateSeriesMetadataRequest(requests=requests)
-            self._clients.series_metadata.batch_create_or_update(self._clients.auth_header, batch_request)
+            write_batch(self._clients.auth_header, batch_request)
         created = {ch.name: ch for ch in self.get_channels(names=[req.name for req in channels])}
         return BatchAddChannelsResult(
             channels=list(created.values()),

--- a/nominal/core/datasource.py
+++ b/nominal/core/datasource.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import Callable, Iterable, Literal, Mapping, Protocol, Sequence, overload
+from typing import Iterable, Literal, Mapping, Protocol, Sequence, overload
 
 from nominal_api import (
     api,
@@ -372,7 +372,7 @@ class DataSource(HasRid):
             single batch, the entire batch will fail. Callers are responsible for deduplicating
             channel names before passing them to this method.
         """
-        return self._batch_write_channels(channels, self._clients.series_metadata.batch_create)
+        return self._batch_write_channels(channels, update_existing=False)
 
     def batch_update_or_create_channels(
         self,
@@ -396,19 +396,23 @@ class DataSource(HasRid):
             batch will fail. Callers are responsible for deduplicating channel names before
             passing them to this method.
         """
-        return self._batch_write_channels(channels, self._clients.series_metadata.batch_create_or_update)
+        return self._batch_write_channels(channels, update_existing=True)
 
     def _batch_write_channels(
         self,
         channels: Sequence[CreateChannelRequest],
-        write_batch: Callable[[str, timeseries_metadata_api.BatchCreateSeriesMetadataRequest], None],
+        *,
+        update_existing: bool,
     ) -> BatchAddChannelsResult:
         if not channels:
             return BatchAddChannelsResult(channels=[], missing=[])
         for batch in batched(channels, _DEFAULT_CHANNEL_BATCH_SIZE):
             requests = [_build_series_metadata_request(self.rid, req) for req in batch]
             batch_request = timeseries_metadata_api.BatchCreateSeriesMetadataRequest(requests=requests)
-            write_batch(self._clients.auth_header, batch_request)
+            if update_existing:
+                self._clients.series_metadata.batch_create_or_update(self._clients.auth_header, batch_request)
+            else:
+                self._clients.series_metadata.batch_create(self._clients.auth_header, batch_request)
         created = {ch.name: ch for ch in self.get_channels(names=[req.name for req in channels])}
         return BatchAddChannelsResult(
             channels=list(created.values()),

--- a/nominal/core/datasource.py
+++ b/nominal/core/datasource.py
@@ -384,6 +384,40 @@ class DataSource(HasRid):
             missing=[req for req in channels if req.name not in created],
         )
 
+    def batch_upsert_channels(
+        self,
+        channels: Sequence[CreateChannelRequest],
+    ) -> BatchAddChannelsResult:
+        """Create or update multiple channels (series metadata) for this data source in batches.
+
+        For each request, creates the channel if it does not already exist. If it does exist,
+        updates the locator and any provided `unit` and `description` fields while preserving
+        existing values for fields left as None.
+
+        Args:
+            channels: Sequence of CreateChannelRequest objects.
+
+        Returns:
+            A BatchAddChannelsResult with the upserted channels and any requests that were
+            not found afterwards (i.e. silently dropped by the server).
+
+        Note:
+            If the same channel name appears more than once within a single batch, the entire
+            batch will fail. Callers are responsible for deduplicating channel names before
+            passing them to this method.
+        """
+        if not channels:
+            return BatchAddChannelsResult(channels=[], missing=[])
+        for batch in batched(channels, _DEFAULT_CHANNEL_BATCH_SIZE):
+            requests = [_build_series_metadata_request(self.rid, req) for req in batch]
+            batch_request = timeseries_metadata_api.BatchCreateSeriesMetadataRequest(requests=requests)
+            self._clients.series_metadata.batch_create_or_update(self._clients.auth_header, batch_request)
+        created = {ch.name: ch for ch in self.get_channels(names=[req.name for req in channels])}
+        return BatchAddChannelsResult(
+            channels=list(created.values()),
+            missing=[req for req in channels if req.name not in created],
+        )
+
 
 def _build_series_metadata_request(
     data_source_rid: str, req: CreateChannelRequest

--- a/tests/core/test_datasource.py
+++ b/tests/core/test_datasource.py
@@ -173,8 +173,10 @@ def test_batch_update_or_create_channels_returns_channels_and_no_missing(mock_da
         result = mock_datasource.batch_update_or_create_channels([req1, req2])
 
     assert isinstance(result, BatchAddChannelsResult)
-    assert result.channels == [mock_ch1, mock_ch2]
-    assert result.missing == []
+    assert len(result.channels) == 2
+    assert result.channels[0] == mock_ch1
+    assert result.channels[1] == mock_ch2
+    assert len(result.missing) == 0
 
 
 def test_batch_update_or_create_channels_returns_missing_when_server_drops_channel(mock_datasource: DataSource):
@@ -187,5 +189,7 @@ def test_batch_update_or_create_channels_returns_missing_when_server_drops_chann
     with patch.object(DataSource, "get_channels", return_value=[mock_ch1]):  # ch2 not returned
         result = mock_datasource.batch_update_or_create_channels([req1, req2])
 
-    assert result.channels == [mock_ch1]
-    assert result.missing == [req2]
+    assert len(result.channels) == 1
+    assert result.channels[0] == mock_ch1
+    assert len(result.missing) == 1
+    assert result.missing[0] == req2

--- a/tests/core/test_datasource.py
+++ b/tests/core/test_datasource.py
@@ -11,7 +11,7 @@ from nominal.core.datasource import BatchAddChannelsResult, CreateChannelRequest
 # so every test runs against both to guarantee they can't drift apart.
 BATCH_WRITE_METHODS = [
     ("batch_add_channels", "batch_create"),
-    ("batch_upsert_channels", "batch_create_or_update"),
+    ("batch_update_or_create_channels", "batch_create_or_update"),
 ]
 ENDPOINTS = [endpoint for _, endpoint in BATCH_WRITE_METHODS]
 

--- a/tests/core/test_datasource.py
+++ b/tests/core/test_datasource.py
@@ -7,6 +7,14 @@ import pytest
 from nominal.core.channel import ChannelDataType
 from nominal.core.datasource import BatchAddChannelsResult, CreateChannelRequest, DataSource
 
+# (public method, series_metadata endpoint it must hit) — both delegate to _batch_write_channels,
+# so every test runs against both to guarantee they can't drift apart.
+BATCH_WRITE_METHODS = [
+    ("batch_add_channels", "batch_create"),
+    ("batch_upsert_channels", "batch_create_or_update"),
+]
+ENDPOINTS = [endpoint for _, endpoint in BATCH_WRITE_METHODS]
+
 
 def _make_channels(n: int) -> list[CreateChannelRequest]:
     return [CreateChannelRequest(name=f"ch{i}", data_type=ChannelDataType.DOUBLE) for i in range(n)]
@@ -26,34 +34,46 @@ def mock_datasource(mock_clients):
     return DataSource(rid="test-datasource-rid", _clients=mock_clients)
 
 
-def test_batch_add_channels_single_batch(mock_datasource: DataSource, mock_clients: MagicMock):
-    """All channels fit in one batch, so batch_create is called exactly once."""
+@pytest.mark.parametrize(("method", "endpoint"), BATCH_WRITE_METHODS)
+def test_batch_write_channels_single_batch(
+    mock_datasource: DataSource, mock_clients: MagicMock, method: str, endpoint: str
+):
+    """All channels fit in one batch, so the endpoint is called exactly once (and no other endpoint at all)."""
     channels = [
         CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE),
         CreateChannelRequest(name="ch2", data_type=ChannelDataType.STRING, description="a string"),
         CreateChannelRequest(name="ch3", data_type=ChannelDataType.INT, unit="m/s"),
     ]
-    mock_datasource.batch_add_channels(channels)
+    getattr(mock_datasource, method)(channels)
 
-    assert mock_clients.series_metadata.batch_create.call_count == 1
-    _, batch_req = mock_clients.series_metadata.batch_create.call_args[0]
+    endpoint_mock = getattr(mock_clients.series_metadata, endpoint)
+    assert endpoint_mock.call_count == 1
+    for other in ENDPOINTS:
+        if other != endpoint:
+            getattr(mock_clients.series_metadata, other).assert_not_called()
+    _, batch_req = endpoint_mock.call_args[0]
     assert [r.channel for r in batch_req.requests] == ["ch1", "ch2", "ch3"]
 
 
-def test_batch_add_channels_empty(mock_datasource: DataSource, mock_clients: MagicMock):
+@pytest.mark.parametrize("method", [method for method, _ in BATCH_WRITE_METHODS])
+def test_batch_write_channels_empty(mock_datasource: DataSource, mock_clients: MagicMock, method: str):
     """An empty channel list results in no API calls."""
-    mock_datasource.batch_add_channels([])
-    mock_clients.series_metadata.batch_create.assert_not_called()
+    getattr(mock_datasource, method)([])
+    for endpoint in ENDPOINTS:
+        getattr(mock_clients.series_metadata, endpoint).assert_not_called()
 
 
-def test_batch_add_channels_request_fields(mock_datasource: DataSource, mock_clients: MagicMock):
+@pytest.mark.parametrize(("method", "endpoint"), BATCH_WRITE_METHODS)
+def test_batch_write_channels_request_fields(
+    mock_datasource: DataSource, mock_clients: MagicMock, method: str, endpoint: str
+):
     """Channel name, datasource RID, description, and unit are correctly propagated to the API request."""
     channels = [
         CreateChannelRequest(name="velocity", data_type=ChannelDataType.DOUBLE, description="speed", unit="m/s"),
     ]
-    mock_datasource.batch_add_channels(channels)
+    getattr(mock_datasource, method)(channels)
 
-    _, batch_req = mock_clients.series_metadata.batch_create.call_args[0]
+    _, batch_req = getattr(mock_clients.series_metadata, endpoint).call_args[0]
     req = batch_req.requests[0]
     assert req.channel == "velocity"
     assert req.data_source_rid == "test-datasource-rid"
@@ -61,15 +81,19 @@ def test_batch_add_channels_request_fields(mock_datasource: DataSource, mock_cli
     assert req.unit == "m/s"
 
 
-def test_batch_add_channels_api_failure_propagates(mock_datasource: DataSource, mock_clients: MagicMock):
+@pytest.mark.parametrize(("method", "endpoint"), BATCH_WRITE_METHODS)
+def test_batch_write_channels_api_failure_propagates(
+    mock_datasource: DataSource, mock_clients: MagicMock, method: str, endpoint: str
+):
     """An exception raised by the API propagates to the caller unchanged."""
-    mock_clients.series_metadata.batch_create.side_effect = RuntimeError("API error")
+    getattr(mock_clients.series_metadata, endpoint).side_effect = RuntimeError("API error")
     with pytest.raises(RuntimeError, match="API error"):
-        mock_datasource.batch_add_channels(_make_channels(1))
+        getattr(mock_datasource, method)(_make_channels(1))
 
 
-def test_batch_add_channels_returns_channels_and_no_missing(mock_datasource: DataSource):
-    """When all requested channels are created, result.channels is populated and result.missing is empty."""
+@pytest.mark.parametrize("method", [method for method, _ in BATCH_WRITE_METHODS])
+def test_batch_write_channels_returns_channels_and_no_missing(mock_datasource: DataSource, method: str):
+    """When all requested channels are written, result.channels is populated and result.missing is empty."""
     req1 = CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE)
     req2 = CreateChannelRequest(name="ch2", data_type=ChannelDataType.STRING)
     mock_ch1, mock_ch2 = MagicMock(), MagicMock()
@@ -77,95 +101,23 @@ def test_batch_add_channels_returns_channels_and_no_missing(mock_datasource: Dat
     mock_ch2.name = "ch2"
 
     with patch.object(DataSource, "get_channels", return_value=[mock_ch1, mock_ch2]):
-        result = mock_datasource.batch_add_channels([req1, req2])
+        result = getattr(mock_datasource, method)([req1, req2])
 
     assert isinstance(result, BatchAddChannelsResult)
     assert result.channels == [mock_ch1, mock_ch2]
     assert result.missing == []
 
 
-def test_batch_add_channels_returns_missing_when_server_drops_channel(mock_datasource: DataSource):
-    """Channels not returned by get_channels after creation appear in result.missing."""
+@pytest.mark.parametrize("method", [method for method, _ in BATCH_WRITE_METHODS])
+def test_batch_write_channels_returns_missing_when_server_drops_channel(mock_datasource: DataSource, method: str):
+    """Channels not returned by get_channels after the write appear in result.missing."""
     req1 = CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE)
     req2 = CreateChannelRequest(name="ch2", data_type=ChannelDataType.DOUBLE)
     mock_ch1 = MagicMock()
     mock_ch1.name = "ch1"
 
     with patch.object(DataSource, "get_channels", return_value=[mock_ch1]):  # ch2 not returned
-        result = mock_datasource.batch_add_channels([req1, req2])
-
-    assert result.channels == [mock_ch1]
-    assert result.missing == [req2]
-
-
-def test_batch_upsert_channels_single_batch(mock_datasource: DataSource, mock_clients: MagicMock):
-    """All channels fit in one batch, so batch_create_or_update is called exactly once (and batch_create never)."""
-    channels = [
-        CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE),
-        CreateChannelRequest(name="ch2", data_type=ChannelDataType.STRING, description="a string"),
-        CreateChannelRequest(name="ch3", data_type=ChannelDataType.INT, unit="m/s"),
-    ]
-    mock_datasource.batch_upsert_channels(channels)
-
-    assert mock_clients.series_metadata.batch_create_or_update.call_count == 1
-    mock_clients.series_metadata.batch_create.assert_not_called()
-    _, batch_req = mock_clients.series_metadata.batch_create_or_update.call_args[0]
-    assert [r.channel for r in batch_req.requests] == ["ch1", "ch2", "ch3"]
-
-
-def test_batch_upsert_channels_empty(mock_datasource: DataSource, mock_clients: MagicMock):
-    """An empty channel list results in no API calls."""
-    mock_datasource.batch_upsert_channels([])
-    mock_clients.series_metadata.batch_create_or_update.assert_not_called()
-
-
-def test_batch_upsert_channels_request_fields(mock_datasource: DataSource, mock_clients: MagicMock):
-    """Channel name, datasource RID, description, and unit are correctly propagated to the API request."""
-    channels = [
-        CreateChannelRequest(name="velocity", data_type=ChannelDataType.DOUBLE, description="speed", unit="m/s"),
-    ]
-    mock_datasource.batch_upsert_channels(channels)
-
-    _, batch_req = mock_clients.series_metadata.batch_create_or_update.call_args[0]
-    req = batch_req.requests[0]
-    assert req.channel == "velocity"
-    assert req.data_source_rid == "test-datasource-rid"
-    assert req.description == "speed"
-    assert req.unit == "m/s"
-
-
-def test_batch_upsert_channels_api_failure_propagates(mock_datasource: DataSource, mock_clients: MagicMock):
-    """An exception raised by the API propagates to the caller unchanged."""
-    mock_clients.series_metadata.batch_create_or_update.side_effect = RuntimeError("API error")
-    with pytest.raises(RuntimeError, match="API error"):
-        mock_datasource.batch_upsert_channels(_make_channels(1))
-
-
-def test_batch_upsert_channels_returns_channels_and_no_missing(mock_datasource: DataSource):
-    """When all requested channels are upserted, result.channels is populated and result.missing is empty."""
-    req1 = CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE)
-    req2 = CreateChannelRequest(name="ch2", data_type=ChannelDataType.STRING)
-    mock_ch1, mock_ch2 = MagicMock(), MagicMock()
-    mock_ch1.name = "ch1"
-    mock_ch2.name = "ch2"
-
-    with patch.object(DataSource, "get_channels", return_value=[mock_ch1, mock_ch2]):
-        result = mock_datasource.batch_upsert_channels([req1, req2])
-
-    assert isinstance(result, BatchAddChannelsResult)
-    assert result.channels == [mock_ch1, mock_ch2]
-    assert result.missing == []
-
-
-def test_batch_upsert_channels_returns_missing_when_server_drops_channel(mock_datasource: DataSource):
-    """Channels not returned by get_channels after upsert appear in result.missing."""
-    req1 = CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE)
-    req2 = CreateChannelRequest(name="ch2", data_type=ChannelDataType.DOUBLE)
-    mock_ch1 = MagicMock()
-    mock_ch1.name = "ch1"
-
-    with patch.object(DataSource, "get_channels", return_value=[mock_ch1]):  # ch2 not returned
-        result = mock_datasource.batch_upsert_channels([req1, req2])
+        result = getattr(mock_datasource, method)([req1, req2])
 
     assert result.channels == [mock_ch1]
     assert result.missing == [req2]

--- a/tests/core/test_datasource.py
+++ b/tests/core/test_datasource.py
@@ -96,3 +96,76 @@ def test_batch_add_channels_returns_missing_when_server_drops_channel(mock_datas
 
     assert result.channels == [mock_ch1]
     assert result.missing == [req2]
+
+
+def test_batch_upsert_channels_single_batch(mock_datasource: DataSource, mock_clients: MagicMock):
+    """All channels fit in one batch, so batch_create_or_update is called exactly once (and batch_create never)."""
+    channels = [
+        CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE),
+        CreateChannelRequest(name="ch2", data_type=ChannelDataType.STRING, description="a string"),
+        CreateChannelRequest(name="ch3", data_type=ChannelDataType.INT, unit="m/s"),
+    ]
+    mock_datasource.batch_upsert_channels(channels)
+
+    assert mock_clients.series_metadata.batch_create_or_update.call_count == 1
+    mock_clients.series_metadata.batch_create.assert_not_called()
+    _, batch_req = mock_clients.series_metadata.batch_create_or_update.call_args[0]
+    assert [r.channel for r in batch_req.requests] == ["ch1", "ch2", "ch3"]
+
+
+def test_batch_upsert_channels_empty(mock_datasource: DataSource, mock_clients: MagicMock):
+    """An empty channel list results in no API calls."""
+    mock_datasource.batch_upsert_channels([])
+    mock_clients.series_metadata.batch_create_or_update.assert_not_called()
+
+
+def test_batch_upsert_channels_request_fields(mock_datasource: DataSource, mock_clients: MagicMock):
+    """Channel name, datasource RID, description, and unit are correctly propagated to the API request."""
+    channels = [
+        CreateChannelRequest(name="velocity", data_type=ChannelDataType.DOUBLE, description="speed", unit="m/s"),
+    ]
+    mock_datasource.batch_upsert_channels(channels)
+
+    _, batch_req = mock_clients.series_metadata.batch_create_or_update.call_args[0]
+    req = batch_req.requests[0]
+    assert req.channel == "velocity"
+    assert req.data_source_rid == "test-datasource-rid"
+    assert req.description == "speed"
+    assert req.unit == "m/s"
+
+
+def test_batch_upsert_channels_api_failure_propagates(mock_datasource: DataSource, mock_clients: MagicMock):
+    """An exception raised by the API propagates to the caller unchanged."""
+    mock_clients.series_metadata.batch_create_or_update.side_effect = RuntimeError("API error")
+    with pytest.raises(RuntimeError, match="API error"):
+        mock_datasource.batch_upsert_channels(_make_channels(1))
+
+
+def test_batch_upsert_channels_returns_channels_and_no_missing(mock_datasource: DataSource):
+    """When all requested channels are upserted, result.channels is populated and result.missing is empty."""
+    req1 = CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE)
+    req2 = CreateChannelRequest(name="ch2", data_type=ChannelDataType.STRING)
+    mock_ch1, mock_ch2 = MagicMock(), MagicMock()
+    mock_ch1.name = "ch1"
+    mock_ch2.name = "ch2"
+
+    with patch.object(DataSource, "get_channels", return_value=[mock_ch1, mock_ch2]):
+        result = mock_datasource.batch_upsert_channels([req1, req2])
+
+    assert isinstance(result, BatchAddChannelsResult)
+    assert result.channels == [mock_ch1, mock_ch2]
+    assert result.missing == []
+
+
+def test_batch_upsert_channels_returns_missing_when_server_drops_channel(mock_datasource: DataSource):
+    """Channels not returned by get_channels after upsert appear in result.missing."""
+    req1 = CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE)
+    req2 = CreateChannelRequest(name="ch2", data_type=ChannelDataType.DOUBLE)
+    mock_ch1 = MagicMock()
+    mock_ch1.name = "ch1"
+
+    with patch.object(DataSource, "get_channels", return_value=[mock_ch1]):  # ch2 not returned
+        result = mock_datasource.batch_upsert_channels([req1, req2])
+
+    assert result.channels == [mock_ch1]
+    assert result.missing == [req2]

--- a/tests/core/test_datasource.py
+++ b/tests/core/test_datasource.py
@@ -7,14 +7,6 @@ import pytest
 from nominal.core.channel import ChannelDataType
 from nominal.core.datasource import BatchAddChannelsResult, CreateChannelRequest, DataSource
 
-# (public method, series_metadata endpoint it must hit) — both delegate to _batch_write_channels,
-# so every test runs against both to guarantee they can't drift apart.
-BATCH_WRITE_METHODS = [
-    ("batch_add_channels", "batch_create"),
-    ("batch_update_or_create_channels", "batch_create_or_update"),
-]
-ENDPOINTS = [endpoint for _, endpoint in BATCH_WRITE_METHODS]
-
 
 def _make_channels(n: int) -> list[CreateChannelRequest]:
     return [CreateChannelRequest(name=f"ch{i}", data_type=ChannelDataType.DOUBLE) for i in range(n)]
@@ -34,46 +26,34 @@ def mock_datasource(mock_clients):
     return DataSource(rid="test-datasource-rid", _clients=mock_clients)
 
 
-@pytest.mark.parametrize(("method", "endpoint"), BATCH_WRITE_METHODS)
-def test_batch_write_channels_single_batch(
-    mock_datasource: DataSource, mock_clients: MagicMock, method: str, endpoint: str
-):
-    """All channels fit in one batch, so the endpoint is called exactly once (and no other endpoint at all)."""
+def test_batch_add_channels_single_batch(mock_datasource: DataSource, mock_clients: MagicMock):
+    """All channels fit in one batch, so batch_create is called exactly once."""
     channels = [
         CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE),
         CreateChannelRequest(name="ch2", data_type=ChannelDataType.STRING, description="a string"),
         CreateChannelRequest(name="ch3", data_type=ChannelDataType.INT, unit="m/s"),
     ]
-    getattr(mock_datasource, method)(channels)
+    mock_datasource.batch_add_channels(channels)
 
-    endpoint_mock = getattr(mock_clients.series_metadata, endpoint)
-    assert endpoint_mock.call_count == 1
-    for other in ENDPOINTS:
-        if other != endpoint:
-            getattr(mock_clients.series_metadata, other).assert_not_called()
-    _, batch_req = endpoint_mock.call_args[0]
+    assert mock_clients.series_metadata.batch_create.call_count == 1
+    _, batch_req = mock_clients.series_metadata.batch_create.call_args[0]
     assert [r.channel for r in batch_req.requests] == ["ch1", "ch2", "ch3"]
 
 
-@pytest.mark.parametrize("method", [method for method, _ in BATCH_WRITE_METHODS])
-def test_batch_write_channels_empty(mock_datasource: DataSource, mock_clients: MagicMock, method: str):
+def test_batch_add_channels_empty(mock_datasource: DataSource, mock_clients: MagicMock):
     """An empty channel list results in no API calls."""
-    getattr(mock_datasource, method)([])
-    for endpoint in ENDPOINTS:
-        getattr(mock_clients.series_metadata, endpoint).assert_not_called()
+    mock_datasource.batch_add_channels([])
+    mock_clients.series_metadata.batch_create.assert_not_called()
 
 
-@pytest.mark.parametrize(("method", "endpoint"), BATCH_WRITE_METHODS)
-def test_batch_write_channels_request_fields(
-    mock_datasource: DataSource, mock_clients: MagicMock, method: str, endpoint: str
-):
+def test_batch_add_channels_request_fields(mock_datasource: DataSource, mock_clients: MagicMock):
     """Channel name, datasource RID, description, and unit are correctly propagated to the API request."""
     channels = [
         CreateChannelRequest(name="velocity", data_type=ChannelDataType.DOUBLE, description="speed", unit="m/s"),
     ]
-    getattr(mock_datasource, method)(channels)
+    mock_datasource.batch_add_channels(channels)
 
-    _, batch_req = getattr(mock_clients.series_metadata, endpoint).call_args[0]
+    _, batch_req = mock_clients.series_metadata.batch_create.call_args[0]
     req = batch_req.requests[0]
     assert req.channel == "velocity"
     assert req.data_source_rid == "test-datasource-rid"
@@ -81,19 +61,15 @@ def test_batch_write_channels_request_fields(
     assert req.unit == "m/s"
 
 
-@pytest.mark.parametrize(("method", "endpoint"), BATCH_WRITE_METHODS)
-def test_batch_write_channels_api_failure_propagates(
-    mock_datasource: DataSource, mock_clients: MagicMock, method: str, endpoint: str
-):
+def test_batch_add_channels_api_failure_propagates(mock_datasource: DataSource, mock_clients: MagicMock):
     """An exception raised by the API propagates to the caller unchanged."""
-    getattr(mock_clients.series_metadata, endpoint).side_effect = RuntimeError("API error")
+    mock_clients.series_metadata.batch_create.side_effect = RuntimeError("API error")
     with pytest.raises(RuntimeError, match="API error"):
-        getattr(mock_datasource, method)(_make_channels(1))
+        mock_datasource.batch_add_channels(_make_channels(1))
 
 
-@pytest.mark.parametrize("method", [method for method, _ in BATCH_WRITE_METHODS])
-def test_batch_write_channels_returns_channels_and_no_missing(mock_datasource: DataSource, method: str):
-    """When all requested channels are written, result.channels is populated and result.missing is empty."""
+def test_batch_add_channels_returns_channels_and_no_missing(mock_datasource: DataSource):
+    """When all requested channels are created, result.channels is populated and result.missing is empty."""
     req1 = CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE)
     req2 = CreateChannelRequest(name="ch2", data_type=ChannelDataType.STRING)
     mock_ch1, mock_ch2 = MagicMock(), MagicMock()
@@ -101,23 +77,115 @@ def test_batch_write_channels_returns_channels_and_no_missing(mock_datasource: D
     mock_ch2.name = "ch2"
 
     with patch.object(DataSource, "get_channels", return_value=[mock_ch1, mock_ch2]):
-        result = getattr(mock_datasource, method)([req1, req2])
+        result = mock_datasource.batch_add_channels([req1, req2])
 
     assert isinstance(result, BatchAddChannelsResult)
     assert result.channels == [mock_ch1, mock_ch2]
     assert result.missing == []
 
 
-@pytest.mark.parametrize("method", [method for method, _ in BATCH_WRITE_METHODS])
-def test_batch_write_channels_returns_missing_when_server_drops_channel(mock_datasource: DataSource, method: str):
-    """Channels not returned by get_channels after the write appear in result.missing."""
+def test_batch_add_channels_returns_missing_when_server_drops_channel(mock_datasource: DataSource):
+    """Channels not returned by get_channels after creation appear in result.missing."""
     req1 = CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE)
     req2 = CreateChannelRequest(name="ch2", data_type=ChannelDataType.DOUBLE)
     mock_ch1 = MagicMock()
     mock_ch1.name = "ch1"
 
     with patch.object(DataSource, "get_channels", return_value=[mock_ch1]):  # ch2 not returned
-        result = getattr(mock_datasource, method)([req1, req2])
+        result = mock_datasource.batch_add_channels([req1, req2])
+
+    assert result.channels == [mock_ch1]
+    assert result.missing == [req2]
+
+
+def test_batch_update_or_create_channels_single_batch(mock_datasource: DataSource, mock_clients: MagicMock):
+    """All channels fit in one batch, so batch_create_or_update is called exactly once."""
+    channels = [
+        CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE),
+        CreateChannelRequest(name="ch2", data_type=ChannelDataType.STRING, description="a string"),
+        CreateChannelRequest(name="ch3", data_type=ChannelDataType.INT, unit="m/s"),
+    ]
+    mock_datasource.batch_update_or_create_channels(channels)
+
+    assert mock_clients.series_metadata.batch_create_or_update.call_count == 1
+    _, batch_req = mock_clients.series_metadata.batch_create_or_update.call_args[0]
+    assert [r.channel for r in batch_req.requests] == ["ch1", "ch2", "ch3"]
+
+
+def test_batch_update_or_create_channels_does_not_use_create_endpoint(
+    mock_datasource: DataSource, mock_clients: MagicMock
+):
+    """Upserts go through the create-or-update endpoint, so pre-existing channels are not an error."""
+    mock_datasource.batch_update_or_create_channels(_make_channels(1))
+    mock_clients.series_metadata.batch_create.assert_not_called()
+
+
+def test_batch_update_or_create_channels_empty(mock_datasource: DataSource, mock_clients: MagicMock):
+    """An empty channel list results in no API calls."""
+    mock_datasource.batch_update_or_create_channels([])
+    mock_clients.series_metadata.batch_create_or_update.assert_not_called()
+
+
+def test_batch_update_or_create_channels_request_fields(mock_datasource: DataSource, mock_clients: MagicMock):
+    """Channel name, datasource RID, description, and unit are correctly propagated to the API request."""
+    channels = [
+        CreateChannelRequest(name="velocity", data_type=ChannelDataType.DOUBLE, description="speed", unit="m/s"),
+    ]
+    mock_datasource.batch_update_or_create_channels(channels)
+
+    _, batch_req = mock_clients.series_metadata.batch_create_or_update.call_args[0]
+    req = batch_req.requests[0]
+    assert req.channel == "velocity"
+    assert req.data_source_rid == "test-datasource-rid"
+    assert req.description == "speed"
+    assert req.unit == "m/s"
+
+
+def test_batch_update_or_create_channels_sends_none_for_unset_fields(
+    mock_datasource: DataSource, mock_clients: MagicMock
+):
+    """Unset description and unit are sent as None so the server preserves the existing values."""
+    channels = [CreateChannelRequest(name="velocity", data_type=ChannelDataType.DOUBLE)]
+    mock_datasource.batch_update_or_create_channels(channels)
+
+    _, batch_req = mock_clients.series_metadata.batch_create_or_update.call_args[0]
+    req = batch_req.requests[0]
+    assert req.description is None
+    assert req.unit is None
+
+
+def test_batch_update_or_create_channels_api_failure_propagates(mock_datasource: DataSource, mock_clients: MagicMock):
+    """An exception raised by the API propagates to the caller unchanged."""
+    mock_clients.series_metadata.batch_create_or_update.side_effect = RuntimeError("API error")
+    with pytest.raises(RuntimeError, match="API error"):
+        mock_datasource.batch_update_or_create_channels(_make_channels(1))
+
+
+def test_batch_update_or_create_channels_returns_channels_and_no_missing(mock_datasource: DataSource):
+    """When all requested channels are upserted, result.channels is populated and result.missing is empty."""
+    req1 = CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE)
+    req2 = CreateChannelRequest(name="ch2", data_type=ChannelDataType.STRING)
+    mock_ch1, mock_ch2 = MagicMock(), MagicMock()
+    mock_ch1.name = "ch1"
+    mock_ch2.name = "ch2"
+
+    with patch.object(DataSource, "get_channels", return_value=[mock_ch1, mock_ch2]):
+        result = mock_datasource.batch_update_or_create_channels([req1, req2])
+
+    assert isinstance(result, BatchAddChannelsResult)
+    assert result.channels == [mock_ch1, mock_ch2]
+    assert result.missing == []
+
+
+def test_batch_update_or_create_channels_returns_missing_when_server_drops_channel(mock_datasource: DataSource):
+    """Channels not returned by get_channels after the upsert appear in result.missing."""
+    req1 = CreateChannelRequest(name="ch1", data_type=ChannelDataType.DOUBLE)
+    req2 = CreateChannelRequest(name="ch2", data_type=ChannelDataType.DOUBLE)
+    mock_ch1 = MagicMock()
+    mock_ch1.name = "ch1"
+
+    with patch.object(DataSource, "get_channels", return_value=[mock_ch1]):  # ch2 not returned
+        result = mock_datasource.batch_update_or_create_channels([req1, req2])
 
     assert result.channels == [mock_ch1]
     assert result.missing == [req2]

--- a/tests/e2e/test_core.py
+++ b/tests/e2e/test_core.py
@@ -474,8 +474,8 @@ def test_batch_update_or_create_channels(client: NominalClient, archive: Archive
 
     seed = ds.batch_add_channels(
         [
-            CreateChannelRequest(name="velocity", data_type=ChannelDataType.DOUBLE, unit="m/s"),
-            CreateChannelRequest(name="status", data_type=ChannelDataType.STRING, description="system status"),
+            CreateChannelRequest(name="velocity", data_type=ChannelDataType.UINT, unit="m/s"),
+            CreateChannelRequest(name="gyro", data_type=ChannelDataType.DOUBLE_ARRAY, description="gyro xyz"),
         ]
     )
     assert seed.missing == []
@@ -483,9 +483,9 @@ def test_batch_update_or_create_channels(client: NominalClient, archive: Archive
     result = ds.batch_update_or_create_channels(
         [
             # Existing channel: unit changed in place
-            CreateChannelRequest(name="velocity", data_type=ChannelDataType.DOUBLE, unit="km/h"),
+            CreateChannelRequest(name="velocity", data_type=ChannelDataType.UINT, unit="km/h"),
             # Existing channel: description not supplied, so the existing value is preserved
-            CreateChannelRequest(name="status", data_type=ChannelDataType.STRING),
+            CreateChannelRequest(name="gyro", data_type=ChannelDataType.DOUBLE_ARRAY),
             # New channel: created fresh
             CreateChannelRequest(name="temperature", data_type=ChannelDataType.DOUBLE, unit="degC"),
         ]
@@ -493,9 +493,11 @@ def test_batch_update_or_create_channels(client: NominalClient, archive: Archive
 
     assert result.missing == []
     channels = {ch.name: ch for ch in result.channels}
-    assert set(channels) == {"velocity", "status", "temperature"}
+    assert set(channels) == {"velocity", "gyro", "temperature"}
     assert channels["velocity"].unit == "km/h"
-    assert channels["status"].description == "system status"
+    assert channels["velocity"].data_type == ChannelDataType.UINT
+    assert channels["gyro"].description == "gyro xyz"
+    assert channels["gyro"].data_type == ChannelDataType.DOUBLE_ARRAY
     assert channels["temperature"].unit == "degC"
 
 

--- a/tests/e2e/test_core.py
+++ b/tests/e2e/test_core.py
@@ -8,7 +8,7 @@ Covers:
   - Reading channel data via the pandas integration (single-channel and full-dataset retrieval)
   - Downloading a dataset file to disk via MultipartFileDownloader and verifying byte-identical content
   - Creating channels on a datasource via add_channel and batch_add_channels
-  - Upserting channels on a datasource via batch_upsert_channels
+  - Upserting channels on a datasource via batch_update_or_create_channels
 
 The `ingested_dataset` fixture is session-scoped (defined in conftest.py): one shared dataset is
 created at the start of the session and reused by all read-only channel/pandas tests, avoiding
@@ -465,8 +465,8 @@ def test_batch_add_channels(client: NominalClient, archive: ArchiveFn) -> None:
     assert channels["status"].description == "system status"
 
 
-def test_batch_upsert_channels(client: NominalClient, archive: ArchiveFn) -> None:
-    """batch_upsert_channels updates existing channels in place, preserves unsupplied fields,
+def test_batch_update_or_create_channels(client: NominalClient, archive: ArchiveFn) -> None:
+    """batch_update_or_create_channels updates existing channels in place, preserves unsupplied fields,
     and creates new channels in the same call.
     """
     ds = client.create_dataset(f"dataset-{uuid4()}")
@@ -480,7 +480,7 @@ def test_batch_upsert_channels(client: NominalClient, archive: ArchiveFn) -> Non
     )
     assert seed.missing == []
 
-    result = ds.batch_upsert_channels(
+    result = ds.batch_update_or_create_channels(
         [
             # Existing channel: unit changed in place
             CreateChannelRequest(name="velocity", data_type=ChannelDataType.DOUBLE, unit="km/h"),

--- a/tests/e2e/test_core.py
+++ b/tests/e2e/test_core.py
@@ -8,6 +8,7 @@ Covers:
   - Reading channel data via the pandas integration (single-channel and full-dataset retrieval)
   - Downloading a dataset file to disk via MultipartFileDownloader and verifying byte-identical content
   - Creating channels on a datasource via add_channel and batch_add_channels
+  - Upserting channels on a datasource via batch_upsert_channels
 
 The `ingested_dataset` fixture is session-scoped (defined in conftest.py): one shared dataset is
 created at the start of the session and reused by all read-only channel/pandas tests, avoiding
@@ -462,6 +463,40 @@ def test_batch_add_channels(client: NominalClient, archive: ArchiveFn) -> None:
     assert channels["velocity"].unit == "m/s"
     assert channels["temperature"].unit == "degC"
     assert channels["status"].description == "system status"
+
+
+def test_batch_upsert_channels(client: NominalClient, archive: ArchiveFn) -> None:
+    """batch_upsert_channels updates existing channels in place, preserves unsupplied fields,
+    and creates new channels in the same call.
+    """
+    ds = client.create_dataset(f"dataset-{uuid4()}")
+    archive(ds)
+
+    seed = ds.batch_add_channels(
+        [
+            CreateChannelRequest(name="velocity", data_type=ChannelDataType.DOUBLE, unit="m/s"),
+            CreateChannelRequest(name="status", data_type=ChannelDataType.STRING, description="system status"),
+        ]
+    )
+    assert seed.missing == []
+
+    result = ds.batch_upsert_channels(
+        [
+            # Existing channel: unit changed in place
+            CreateChannelRequest(name="velocity", data_type=ChannelDataType.DOUBLE, unit="km/h"),
+            # Existing channel: description not supplied, so the existing value is preserved
+            CreateChannelRequest(name="status", data_type=ChannelDataType.STRING),
+            # New channel: created fresh
+            CreateChannelRequest(name="temperature", data_type=ChannelDataType.DOUBLE, unit="degC"),
+        ]
+    )
+
+    assert result.missing == []
+    channels = {ch.name: ch for ch in result.channels}
+    assert set(channels) == {"velocity", "status", "temperature"}
+    assert channels["velocity"].unit == "km/h"
+    assert channels["status"].description == "system status"
+    assert channels["temperature"].unit == "degC"
 
 
 @pytest.mark.parametrize(

--- a/tests/e2e/test_core.py
+++ b/tests/e2e/test_core.py
@@ -495,7 +495,6 @@ def test_batch_update_or_create_channels(client: NominalClient, archive: Archive
     channels = {ch.name: ch for ch in result.channels}
     assert set(channels) == {"velocity", "gyro", "temperature"}
     assert channels["velocity"].unit == "km/h"
-    assert channels["velocity"].data_type == ChannelDataType.UINT
     assert channels["gyro"].description == "gyro xyz"
     assert channels["gyro"].data_type == ChannelDataType.DOUBLE_ARRAY
     assert channels["temperature"].unit == "degC"


### PR DESCRIPTION
**Changes** 
- Add helper function `batch_update_or_create_channels` around the batch create or update endpoint
- Consolidate duplicate between batch_create and batch_add across client + tests