### PR TITLE
test(e2e): pin search field surface, set semantics, and time-range boundaries

### DIFF
--- a/tests/e2e/test_search_field_surface.py
+++ b/tests/e2e/test_search_field_surface.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import itertools
 import time
-import warnings
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Callable, Iterator, Protocol, Sequence
@@ -67,12 +66,22 @@ class Probe:
 
 
 def _archive_all(resources: Sequence[Archivable]) -> None:
-    """Archive every resource, continuing past failures so one bad archive can't orphan the rest."""
+    """Archive every resource, continuing past failures so one bad archive can't orphan the rest.
+
+    Failures are collected and reported once, after the loop. Reporting from inside the `except`
+    would let the reporting call itself abort the loop -- `pyproject.toml` sets
+    `filterwarnings = ["error"]`, so a `warnings.warn` there raises and orphans every resource
+    that had not been reached yet. An orphaned probe is harmless (unique tokens, no collision),
+    so this must never fail the run either.
+    """
+    failures = []
     for resource in resources:
         try:
             resource.archive()
         except Exception as e:
-            warnings.warn(f"failed to archive probe resource {resource!r}: {e!r}")
+            failures.append(f"{resource!r}: {e!r}")
+    if failures:
+        print(f"WARNING: failed to archive {len(failures)} of {len(resources)} probe resources: {'; '.join(failures)}")
 
 
 def test_field_tokens_share_no_substring() -> None:

--- a/tests/e2e/test_search_field_surface.py
+++ b/tests/e2e/test_search_field_surface.py
@@ -14,12 +14,13 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import Callable, Iterator, Protocol, Sequence, cast
 from uuid import uuid4
 
 import pytest
 
-from nominal.core import NominalClient
+from nominal.core import EventType, NominalClient
 from nominal.core._utils.api_tools import HasRid
 
 FIELDS = ("name", "description", "label", "property")
@@ -132,7 +133,6 @@ def _make_asset(client: NominalClient, tokens: dict[str, str]) -> HasRid:
 
 
 def _make_event(client: NominalClient, tokens: dict[str, str]) -> HasRid:
-    from nominal.core import EventType
     from tests.e2e import _create_random_start_end
 
     # The backend rejects event creation without an asset (Scout:MissingAssetRid), even though
@@ -309,3 +309,103 @@ def test_properties_filter_matches_key_and_value(
 
     assert probe.rid in _rids(search_props(client, {"probe": value}))
     assert probe.rid not in _rids(search_props(client, {"probe": f"dates{uuid4().hex}"}))
+
+
+_T1 = datetime(2023, 3, 1, 12, 0, 0)
+_T2 = _T1 + timedelta(hours=1)
+_ONE_MICRO = timedelta(microseconds=1)
+
+
+@dataclass(frozen=True)
+class TimeProbes:
+    """A run and an event both spanning exactly [_T1, _T2]."""
+
+    run_rid: str
+    event_rid: str
+
+
+@pytest.fixture(scope="session")
+def time_probes(client: NominalClient) -> Iterator[TimeProbes]:
+    """A run and an event spanning exactly [_T1, _T2], archived on every exit path."""
+    run_tokens = _field_tokens()
+    event_tokens = _field_tokens()
+    resources: list[HasArchive] = []
+    try:
+        run = client.create_run(run_tokens["name"], _T1, _T2, properties={"probe": run_tokens["property"]})
+        resources.append(run)
+        # Event creation requires an asset even though `assets` is optional client-side.
+        event_asset = client.create_asset(f"event-asset-{uuid4().hex}")
+        resources.append(event_asset)
+        event = client.create_event(
+            event_tokens["name"],
+            EventType.INFO,
+            _T1,
+            _T2 - _T1,
+            assets=[event_asset],
+            properties={"probe": event_tokens["property"]},
+        )
+        resources.append(event)
+        _wait_for_indexed(lambda c, t: c.search_runs(search_text=t), client, run_tokens["name"], run.rid)
+        _wait_for_indexed(lambda c, t: c.search_events(search_text=t), client, event_tokens["name"], event.rid)
+
+        yield TimeProbes(run_rid=run.rid, event_rid=event.rid)
+    finally:
+        for archivable in resources:
+            archivable.archive()
+
+
+@pytest.mark.parametrize(
+    ("kwargs_name", "offset", "expected"),
+    (
+        ("start", timedelta(0), True),
+        ("start", _ONE_MICRO, False),
+        ("end", timedelta(0), True),
+        ("end", -_ONE_MICRO, False),
+    ),
+    ids=["start-at-boundary", "start-past-boundary", "end-at-boundary", "end-past-boundary"],
+)
+def test_search_runs_time_bounds_are_inclusive(
+    client: NominalClient,
+    time_probes: TimeProbes,
+    kwargs_name: str,
+    offset: timedelta,
+    expected: bool,
+) -> None:
+    """Run start and end bounds include a run sitting exactly on the boundary."""
+    anchor = _T1 if kwargs_name == "start" else _T2
+    results = client.search_runs(**{kwargs_name: anchor + offset})  # type: ignore[arg-type]
+    assert (time_probes.run_rid in _rids(results)) == expected
+
+
+def test_search_runs_time_bounds_select_contained_runs(client: NominalClient, time_probes: TimeProbes) -> None:
+    """A window strictly inside the run excludes it, so the bounds are containment not overlap."""
+    results = client.search_runs(start=_T1 + _ONE_MICRO, end=_T2 - _ONE_MICRO)
+    assert time_probes.run_rid not in _rids(results)
+
+
+def test_search_runs_exact_window_matches(client: NominalClient, time_probes: TimeProbes) -> None:
+    """A window exactly equal to the run's span contains it."""
+    results = client.search_runs(start=_T1, end=_T2)
+    assert time_probes.run_rid in _rids(results)
+
+
+@pytest.mark.parametrize(
+    ("kwargs_name", "anchor", "expected"),
+    (
+        ("after", _T1, True),
+        ("after", _T2, False),
+        ("before", _T2, True),
+        ("before", _T1, False),
+    ),
+    ids=["after-overlaps", "after-at-end", "before-overlaps", "before-at-start"],
+)
+def test_search_events_time_bounds_are_exclusive(
+    client: NominalClient,
+    time_probes: TimeProbes,
+    kwargs_name: str,
+    anchor: datetime,
+    expected: bool,
+) -> None:
+    """Event bounds are exclusive and overlap based, unlike the containment bounds on runs."""
+    results = client.search_events(**{kwargs_name: anchor})  # type: ignore[arg-type]
+    assert (time_probes.event_rid in _rids(results)) == expected

--- a/tests/e2e/test_search_field_surface.py
+++ b/tests/e2e/test_search_field_surface.py
@@ -137,17 +137,19 @@ def _make_event(client: NominalClient, tokens: dict[str, str]) -> HasRid:
     # `assets` is optional in the client signature. This throwaway asset exists only to satisfy
     # that requirement; it carries none of the probe's tokens and is archived immediately.
     asset = client.create_asset(f"event-asset-{uuid4().hex}")
-    start, _ = _create_random_start_end()
-    event = client.create_event(
-        tokens["name"],
-        EventType.INFO,
-        start,
-        description=tokens["description"],
-        assets=[asset],
-        labels=[tokens["label"]],
-        properties={"probe": tokens["property"]},
-    )
-    asset.archive()
+    try:
+        start, _ = _create_random_start_end()
+        event = client.create_event(
+            tokens["name"],
+            EventType.INFO,
+            start,
+            description=tokens["description"],
+            assets=[asset],
+            labels=[tokens["label"]],
+            properties={"probe": tokens["property"]},
+        )
+    finally:
+        asset.archive()
     return event
 
 
@@ -175,17 +177,21 @@ TARGETS = (
 def probes(client: NominalClient) -> Iterator[dict[str, Probe]]:
     """One probe resource per target, archived on teardown."""
     created: dict[str, Probe] = {}
-    resources: list[object] = []
-    for target in TARGETS:
-        tokens = _field_tokens()
-        resource = target.make(client, tokens)
-        resources.append(resource)
-        created[target.name] = Probe(tokens=tokens, rid=resource.rid)
-
-    yield created
-
-    for archivable in resources:
-        cast("HasArchive", archivable).archive()
+    resources: list[HasArchive] = []
+    try:
+        for target in TARGETS:
+            tokens = _field_tokens()
+            resource = target.make(client, tokens)
+            resources.append(cast("HasArchive", resource))
+            created[target.name] = Probe(tokens=tokens, rid=resource.rid)
+        yield created
+    finally:
+        for archivable in resources:
+            try:
+                archivable.archive()
+            except Exception as e:
+                # A failed archive must not orphan the rest; the failure is surfaced, not swallowed.
+                print(f"WARNING: failed to archive probe resource {archivable!r}: {e!r}")
 
 
 def test_probes_fixture_builds(probes: dict[str, Probe]) -> None:

--- a/tests/e2e/test_search_field_surface.py
+++ b/tests/e2e/test_search_field_surface.py
@@ -12,19 +12,23 @@ the other -- which would make every negative assertion unreliable.
 
 from __future__ import annotations
 
+import itertools
 import time
+import warnings
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Callable, Iterator, Protocol, Sequence, cast
+from typing import Callable, Iterator, Protocol, Sequence
 from uuid import uuid4
 
 import pytest
 
 from nominal.core import EventType, NominalClient
-from nominal.core._utils.api_tools import HasRid
 from tests.e2e import _create_random_start_end
 
-FIELDS = ("name", "description", "label", "property")
+_PROPERTY_KEY = "probe"
+
+_FIELD_WORDS = {"name": "apples", "description": "bananas", "label": "cherries", "property": "dates"}
+FIELDS = tuple(_FIELD_WORDS)
 
 
 def _field_tokens() -> dict[str, str]:
@@ -33,16 +37,20 @@ def _field_tokens() -> dict[str, str]:
     The words are for readability in failure output; the independent random tails are what make a
     match attributable, since no token shares a substring with any other.
     """
-    return {
-        "name": f"apples{uuid4().hex}",
-        "description": f"bananas{uuid4().hex}",
-        "label": f"cherries{uuid4().hex}",
-        "property": f"dates{uuid4().hex}",
-    }
+    return {field: f"{word}{uuid4().hex}" for field, word in _FIELD_WORDS.items()}
 
 
-def _rids(items: Sequence[object]) -> set[str]:
-    return {cast(HasRid, item).rid for item in items}
+class Archivable(Protocol):
+    """A created resource: readable rid, archivable on teardown."""
+
+    @property
+    def rid(self) -> str: ...
+
+    def archive(self) -> None: ...
+
+
+def _rids(items: Sequence[Archivable]) -> set[str]:
+    return {item.rid for item in items}
 
 
 def _kgrams(value: str, k: int = 8) -> set[str]:
@@ -58,17 +66,13 @@ class Probe:
     rid: str
 
 
-class HasArchive(Protocol):
-    def archive(self) -> None: ...
-
-
-def _archive_all(resources: Sequence[HasArchive]) -> None:
+def _archive_all(resources: Sequence[Archivable]) -> None:
     """Archive every resource, continuing past failures so one bad archive can't orphan the rest."""
     for resource in resources:
         try:
             resource.archive()
         except Exception as e:
-            print(f"WARNING: failed to archive probe resource {resource!r}: {e!r}")
+            warnings.warn(f"failed to archive probe resource {resource!r}: {e!r}")
 
 
 def test_field_tokens_share_no_substring() -> None:
@@ -76,30 +80,28 @@ def test_field_tokens_share_no_substring() -> None:
     tokens = _field_tokens()
     assert set(tokens) == set(FIELDS)
     kgrams = {field: _kgrams(token) for field, token in tokens.items()}
-    for field, grams in kgrams.items():
-        others = [other for name, other in kgrams.items() if name != field]
-        assert all(grams.isdisjoint(other) for other in others)
+    for field_a, field_b in itertools.combinations(kgrams, 2):
+        assert kgrams[field_a].isdisjoint(kgrams[field_b]), f"{field_a!r} and {field_b!r} tokens share a substring"
 
 
 @dataclass(frozen=True)
 class Target:
-    """A searchable type: how to create a probe for it, and how to search it."""
+    """A searchable type: how to create a probe for it."""
 
     name: str
-    make: Callable[[NominalClient, dict[str, str]], HasRid]
-    warm: Callable[[NominalClient, str], Sequence[object]]
+    make: Callable[[NominalClient, dict[str, str]], Archivable]
 
 
-def _make_dataset(client: NominalClient, tokens: dict[str, str]) -> HasRid:
+def _make_dataset(client: NominalClient, tokens: dict[str, str]) -> Archivable:
     return client.create_dataset(
         tokens["name"],
         description=tokens["description"],
         labels=[tokens["label"]],
-        properties={"probe": tokens["property"]},
+        properties={_PROPERTY_KEY: tokens["property"]},
     )
 
 
-def _make_run(client: NominalClient, tokens: dict[str, str]) -> HasRid:
+def _make_run(client: NominalClient, tokens: dict[str, str]) -> Archivable:
     start, end = _create_random_start_end()
     return client.create_run(
         tokens["name"],
@@ -107,39 +109,39 @@ def _make_run(client: NominalClient, tokens: dict[str, str]) -> HasRid:
         end,
         tokens["description"],
         labels=[tokens["label"]],
-        properties={"probe": tokens["property"]},
+        properties={_PROPERTY_KEY: tokens["property"]},
     )
 
 
-def _make_secret(client: NominalClient, tokens: dict[str, str]) -> HasRid:
+def _make_secret(client: NominalClient, tokens: dict[str, str]) -> Archivable:
     return client.create_secret(
         tokens["name"],
         "probe-value",
         tokens["description"],
         labels=[tokens["label"]],
-        properties={"probe": tokens["property"]},
+        properties={_PROPERTY_KEY: tokens["property"]},
     )
 
 
-def _make_video(client: NominalClient, tokens: dict[str, str]) -> HasRid:
+def _make_video(client: NominalClient, tokens: dict[str, str]) -> Archivable:
     return client.create_video(
         tokens["name"],
         description=tokens["description"],
         labels=[tokens["label"]],
-        properties={"probe": tokens["property"]},
+        properties={_PROPERTY_KEY: tokens["property"]},
     )
 
 
-def _make_asset(client: NominalClient, tokens: dict[str, str]) -> HasRid:
+def _make_asset(client: NominalClient, tokens: dict[str, str]) -> Archivable:
     return client.create_asset(
         tokens["name"],
         tokens["description"],
         labels=[tokens["label"]],
-        properties={"probe": tokens["property"]},
+        properties={_PROPERTY_KEY: tokens["property"]},
     )
 
 
-def _make_event(client: NominalClient, tokens: dict[str, str]) -> HasRid:
+def _make_event(client: NominalClient, tokens: dict[str, str]) -> Archivable:
     # Event creation requires an asset even though `assets` is optional client-side. This
     # throwaway asset carries none of the probe's tokens and is archived immediately.
     asset = client.create_asset(f"event-asset-{uuid4().hex}")
@@ -152,43 +154,81 @@ def _make_event(client: NominalClient, tokens: dict[str, str]) -> HasRid:
             description=tokens["description"],
             assets=[asset],
             labels=[tokens["label"]],
-            properties={"probe": tokens["property"]},
+            properties={_PROPERTY_KEY: tokens["property"]},
         )
     finally:
         asset.archive()
     return event
 
 
-def _make_template(client: NominalClient, tokens: dict[str, str]) -> HasRid:
+def _make_template(client: NominalClient, tokens: dict[str, str]) -> Archivable:
     return client.create_workbook_template(
         title=tokens["name"],
         description=tokens["description"],
         labels=[tokens["label"]],
-        properties={"probe": tokens["property"]},
+        properties={_PROPERTY_KEY: tokens["property"]},
     )
 
 
 TARGETS = (
-    Target("datasets", _make_dataset, lambda c, t: c.search_datasets(search_text=t)),
-    Target("runs", _make_run, lambda c, t: c.search_runs(search_text=t)),
-    Target("secrets", _make_secret, lambda c, t: c.search_secrets(search_text=t)),
-    Target("videos", _make_video, lambda c, t: c.search_videos(search_text=t)),
-    Target("assets", _make_asset, lambda c, t: c.search_assets(search_text=t)),
-    Target("events", _make_event, lambda c, t: c.search_events(search_text=t)),
-    Target("templates", _make_template, lambda c, t: c.search_workbook_templates(search_text=t)),
+    Target("datasets", _make_dataset),
+    Target("runs", _make_run),
+    Target("secrets", _make_secret),
+    Target("videos", _make_video),
+    Target("assets", _make_asset),
+    Target("events", _make_event),
+    Target("templates", _make_template),
 )
+
+
+SearchFn = Callable[[NominalClient, str], Sequence[Archivable]]
+
+
+@dataclass(frozen=True)
+class SurfaceCase:
+    """One filter's expected field surface on one target type."""
+
+    target: str
+    filter_name: str
+    search: SearchFn
+    matching_fields: tuple[str, ...]
+
+    @property
+    def id(self) -> str:
+        return f"{self.target}-{self.filter_name}"
+
+
+SURFACE_CASES = (
+    SurfaceCase("datasets", "search_text", lambda c, t: c.search_datasets(search_text=t), FIELDS),
+    SurfaceCase("runs", "search_text", lambda c, t: c.search_runs(search_text=t), FIELDS),
+    SurfaceCase("secrets", "search_text", lambda c, t: c.search_secrets(search_text=t), FIELDS),
+    SurfaceCase("videos", "search_text", lambda c, t: c.search_videos(search_text=t), FIELDS),
+    SurfaceCase("assets", "search_text", lambda c, t: c.search_assets(search_text=t), FIELDS),
+    SurfaceCase("events", "search_text", lambda c, t: c.search_events(search_text=t), FIELDS),
+    SurfaceCase("datasets", "exact_match", lambda c, t: c.search_datasets(exact_match=t), FIELDS),
+    SurfaceCase("runs", "exact_match", lambda c, t: c.search_runs(exact_match=t), FIELDS),
+    SurfaceCase("runs", "name_substring", lambda c, t: c.search_runs(name_substring=t), FIELDS),
+    SurfaceCase("assets", "exact_substring", lambda c, t: c.search_assets(exact_substring=t), FIELDS),
+    SurfaceCase("templates", "exact_match", lambda c, t: c.search_workbook_templates(exact_match=t), ("name",)),
+    SurfaceCase(
+        "templates",
+        "search_text",
+        lambda c, t: c.search_workbook_templates(search_text=t),
+        ("name", "description"),
+    ),
+)
+
+# Every target must be searchable by search_text so the fixture below can warm the index on it;
+# this derives the warm-up search from SURFACE_CASES instead of duplicating a second list of lambdas.
+_WARM_SEARCHES = {case.target: case.search for case in SURFACE_CASES if case.filter_name == "search_text"}
+assert set(_WARM_SEARCHES) == {t.name for t in TARGETS}, "every target needs a search_text case to warm with"
 
 
 _INDEX_POLL_SECONDS = 5.0
 _INDEX_POLL_ATTEMPTS = 12  # up to a minute
 
 
-def _wait_for_indexed(
-    search: Callable[[NominalClient, str], Sequence[object]],
-    client: NominalClient,
-    token: str,
-    rid: str,
-) -> None:
+def _wait_for_indexed(search: SearchFn, client: NominalClient, token: str, rid: str) -> None:
     """Block until `rid` is findable by `token`, so later negative assertions are trustworthy."""
     for attempt in range(_INDEX_POLL_ATTEMPTS):
         if rid in _rids(search(client, token)):
@@ -202,90 +242,56 @@ def _wait_for_indexed(
 def probes(client: NominalClient) -> Iterator[dict[str, Probe]]:
     """One probe resource per target, archived on teardown."""
     created: dict[str, Probe] = {}
-    resources: list[HasArchive] = []
+    resources: list[Archivable] = []
     try:
         for target in TARGETS:
             tokens = _field_tokens()
             resource = target.make(client, tokens)
-            resources.append(cast("HasArchive", resource))
+            resources.append(resource)
             created[target.name] = Probe(tokens=tokens, rid=resource.rid)
         for target in TARGETS:
             probe = created[target.name]
             # Warming on the name token alone is enough: "name" is in matching_fields for every
             # SURFACE_CASES case, so each filter still gets its own positive-control cell below.
-            _wait_for_indexed(target.warm, client, probe.tokens["name"], probe.rid)
+            _wait_for_indexed(_WARM_SEARCHES[target.name], client, probe.tokens["name"], probe.rid)
         yield created
     finally:
         _archive_all(resources)
 
 
-# (target name, filter name, search callable, fields the filter is expected to match)
-SURFACE_CASES = (
-    ("datasets", "search_text", lambda c, t: c.search_datasets(search_text=t), FIELDS),
-    ("runs", "search_text", lambda c, t: c.search_runs(search_text=t), FIELDS),
-    ("secrets", "search_text", lambda c, t: c.search_secrets(search_text=t), FIELDS),
-    ("videos", "search_text", lambda c, t: c.search_videos(search_text=t), FIELDS),
-    ("assets", "search_text", lambda c, t: c.search_assets(search_text=t), FIELDS),
-    ("events", "search_text", lambda c, t: c.search_events(search_text=t), FIELDS),
-    ("datasets", "exact_match", lambda c, t: c.search_datasets(exact_match=t), FIELDS),
-    ("runs", "exact_match", lambda c, t: c.search_runs(exact_match=t), FIELDS),
-    ("runs", "name_substring", lambda c, t: c.search_runs(name_substring=t), FIELDS),
-    ("assets", "exact_substring", lambda c, t: c.search_assets(exact_substring=t), FIELDS),
-    ("templates", "exact_match", lambda c, t: c.search_workbook_templates(exact_match=t), ("name",)),
-    ("templates", "search_text", lambda c, t: c.search_workbook_templates(search_text=t), ("name", "description")),
-)
-
-
-@pytest.mark.parametrize(
-    ("target_name", "filter_name", "search", "matching_fields"),
-    SURFACE_CASES,
-    ids=[f"{target}-{filter_name}" for target, filter_name, _, _ in SURFACE_CASES],
-)
+@pytest.mark.parametrize("case", SURFACE_CASES, ids=lambda c: c.id)
 @pytest.mark.parametrize("field", FIELDS)
 def test_field_surface(
     client: NominalClient,
     probes: dict[str, Probe],
-    target_name: str,
-    filter_name: str,
-    search: Callable[[NominalClient, str], Sequence[object]],
-    matching_fields: tuple[str, ...],
+    case: SurfaceCase,
     field: str,
 ) -> None:
     """The filter matches a token living only in `field` exactly when `field` is in its surface."""
-    probe = probes[target_name]
-    found = probe.rid in _rids(search(client, probe.tokens[field]))
-    assert found == (field in matching_fields)
+    probe = probes[case.target]
+    found = probe.rid in _rids(case.search(client, probe.tokens[field]))
+    assert found == (field in case.matching_fields)
 
 
-# (target name, labels search, properties search) -- one per distinct query construction
-SET_SEMANTICS_CASES = (
-    (
-        "runs",
-        lambda c, labels: c.search_runs(labels=labels),
-        lambda c, props: c.search_runs(properties=props),
-    ),
-    (
-        "datasets",
-        lambda c, labels: c.search_datasets(labels=labels),
-        lambda c, props: c.search_datasets(properties=props),
-    ),
-    (
-        "templates",
-        lambda c, labels: c.search_workbook_templates(labels=labels),
-        lambda c, props: c.search_workbook_templates(properties=props),
-    ),
+LABELS_CASES = (
+    ("runs", lambda c, labels: c.search_runs(labels=labels)),
+    ("datasets", lambda c, labels: c.search_datasets(labels=labels)),
+    ("templates", lambda c, labels: c.search_workbook_templates(labels=labels)),
 )
 
-_SET_IDS = [name for name, _, _ in SET_SEMANTICS_CASES]
+PROPERTIES_CASES = (
+    ("runs", lambda c, props: c.search_runs(properties=props)),
+    ("datasets", lambda c, props: c.search_datasets(properties=props)),
+    ("templates", lambda c, props: c.search_workbook_templates(properties=props)),
+)
 
 
-@pytest.mark.parametrize(("target_name", "search_labels", "_search_props"), SET_SEMANTICS_CASES, ids=_SET_IDS)
+@pytest.mark.parametrize(("target_name", "search_labels"), LABELS_CASES, ids=[name for name, _ in LABELS_CASES])
 def test_labels_filter_requires_all_labels(
     client: NominalClient,
     probes: dict[str, Probe],
     target_name: str,
-    search_labels: Callable[[NominalClient, list[str]], Sequence[object]],
-    _search_props: Callable[[NominalClient, dict[str, str]], Sequence[object]],
+    search_labels: Callable[[NominalClient, list[str]], Sequence[Archivable]],
 ) -> None:
     """A labels filter requires every given label, so adding an absent one excludes the resource."""
     probe = probes[target_name]
@@ -296,21 +302,20 @@ def test_labels_filter_requires_all_labels(
     assert probe.rid not in _rids(search_labels(client, [present, absent]))
 
 
-@pytest.mark.parametrize(("target_name", "_search_labels", "search_props"), SET_SEMANTICS_CASES, ids=_SET_IDS)
+@pytest.mark.parametrize(("target_name", "search_props"), PROPERTIES_CASES, ids=[name for name, _ in PROPERTIES_CASES])
 def test_properties_filter_matches_key_and_value(
     client: NominalClient,
     probes: dict[str, Probe],
     target_name: str,
-    _search_labels: Callable[[NominalClient, list[str]], Sequence[object]],
-    search_props: Callable[[NominalClient, dict[str, str]], Sequence[object]],
+    search_props: Callable[[NominalClient, dict[str, str]], Sequence[Archivable]],
 ) -> None:
     """A properties filter matches on key and value, so a wrong key or a wrong value excludes it."""
     probe = probes[target_name]
     value = probe.tokens["property"]
 
-    assert probe.rid in _rids(search_props(client, {"probe": value}))
-    assert probe.rid not in _rids(search_props(client, {"probe": f"dates{uuid4().hex}"}))
-    assert probe.rid not in _rids(search_props(client, {f"probe{uuid4().hex}": value}))
+    assert probe.rid in _rids(search_props(client, {_PROPERTY_KEY: value}))
+    assert probe.rid not in _rids(search_props(client, {_PROPERTY_KEY: f"dates{uuid4().hex}"}))
+    assert probe.rid not in _rids(search_props(client, {f"{_PROPERTY_KEY}{uuid4().hex}": value}))
 
 
 _T1 = datetime(2023, 3, 1, 12, 0, 0)
@@ -322,10 +327,8 @@ _ONE_MICRO = timedelta(microseconds=1)
 class TimeProbes:
     """A run and an event both spanning exactly [_T1, _T2], each carrying its own probe token."""
 
-    run_rid: str
-    run_token: str
-    event_rid: str
-    event_token: str
+    run: Probe
+    event: Probe
 
 
 @pytest.fixture(scope="session")
@@ -333,9 +336,9 @@ def time_probes(client: NominalClient) -> Iterator[TimeProbes]:
     """A run and an event spanning exactly [_T1, _T2], archived on every exit path."""
     run_tokens = _field_tokens()
     event_tokens = _field_tokens()
-    resources: list[HasArchive] = []
+    resources: list[Archivable] = []
     try:
-        run = client.create_run(run_tokens["name"], _T1, _T2, properties={"probe": run_tokens["property"]})
+        run = client.create_run(run_tokens["name"], _T1, _T2, properties={_PROPERTY_KEY: run_tokens["property"]})
         resources.append(run)
         # Event creation requires an asset even though `assets` is optional client-side.
         event_asset = client.create_asset(f"event-asset-{uuid4().hex}")
@@ -346,31 +349,29 @@ def time_probes(client: NominalClient) -> Iterator[TimeProbes]:
             _T1,
             _T2 - _T1,
             assets=[event_asset],
-            properties={"probe": event_tokens["property"]},
+            properties={_PROPERTY_KEY: event_tokens["property"]},
         )
         resources.append(event)
         _wait_for_indexed(lambda c, t: c.search_runs(search_text=t), client, run_tokens["name"], run.rid)
         _wait_for_indexed(lambda c, t: c.search_events(search_text=t), client, event_tokens["name"], event.rid)
 
         yield TimeProbes(
-            run_rid=run.rid,
-            run_token=run_tokens["property"],
-            event_rid=event.rid,
-            event_token=event_tokens["property"],
+            run=Probe(tokens=run_tokens, rid=run.rid),
+            event=Probe(tokens=event_tokens, rid=event.rid),
         )
     finally:
         _archive_all(resources)
 
 
-# Every case below also filters on properties={"probe": <token>}, narrowing the search to the probe
+# Every case below also filters on properties={_PROPERTY_KEY: <token>}, narrowing the search to the probe
 # resource instead of scanning the whole corpus. Filters are ANDed, and the expected=True cases are
 # same-shape positive controls proving the property conjunct alone doesn't exclude the probe -- so an
 # expected=False result here is attributable solely to the time bound.
 RUN_TIME_BOUND_CASES = (
-    (lambda c, t: c.search_runs(start=_T1, properties={"probe": t}), True),
-    (lambda c, t: c.search_runs(start=_T1 + _ONE_MICRO, properties={"probe": t}), False),
-    (lambda c, t: c.search_runs(end=_T2, properties={"probe": t}), True),
-    (lambda c, t: c.search_runs(end=_T2 - _ONE_MICRO, properties={"probe": t}), False),
+    (lambda c, t: c.search_runs(start=_T1, properties={_PROPERTY_KEY: t}), True),
+    (lambda c, t: c.search_runs(start=_T1 + _ONE_MICRO, properties={_PROPERTY_KEY: t}), False),
+    (lambda c, t: c.search_runs(end=_T2, properties={_PROPERTY_KEY: t}), True),
+    (lambda c, t: c.search_runs(end=_T2 - _ONE_MICRO, properties={_PROPERTY_KEY: t}), False),
 )
 
 
@@ -382,33 +383,33 @@ RUN_TIME_BOUND_CASES = (
 def test_search_runs_time_bounds_are_inclusive(
     client: NominalClient,
     time_probes: TimeProbes,
-    search: Callable[[NominalClient, str], Sequence[object]],
+    search: SearchFn,
     expected: bool,
 ) -> None:
     """Run start and end bounds include a run sitting exactly on the boundary."""
-    results = search(client, time_probes.run_token)
-    assert (time_probes.run_rid in _rids(results)) == expected
+    results = search(client, time_probes.run.tokens["property"])
+    assert (time_probes.run.rid in _rids(results)) == expected
 
 
 def test_search_runs_time_bounds_select_contained_runs(client: NominalClient, time_probes: TimeProbes) -> None:
     """A window strictly inside the run excludes it, so the bounds are containment not overlap."""
     results = client.search_runs(
-        start=_T1 + _ONE_MICRO, end=_T2 - _ONE_MICRO, properties={"probe": time_probes.run_token}
+        start=_T1 + _ONE_MICRO, end=_T2 - _ONE_MICRO, properties={_PROPERTY_KEY: time_probes.run.tokens["property"]}
     )
-    assert time_probes.run_rid not in _rids(results)
+    assert time_probes.run.rid not in _rids(results)
 
 
 def test_search_runs_exact_window_matches(client: NominalClient, time_probes: TimeProbes) -> None:
     """A window exactly equal to the run's span contains it."""
-    results = client.search_runs(start=_T1, end=_T2, properties={"probe": time_probes.run_token})
-    assert time_probes.run_rid in _rids(results)
+    results = client.search_runs(start=_T1, end=_T2, properties={_PROPERTY_KEY: time_probes.run.tokens["property"]})
+    assert time_probes.run.rid in _rids(results)
 
 
 EVENT_TIME_BOUND_CASES = (
-    (lambda c, t: c.search_events(after=_T1, properties={"probe": t}), True),
-    (lambda c, t: c.search_events(after=_T2, properties={"probe": t}), False),
-    (lambda c, t: c.search_events(before=_T2, properties={"probe": t}), True),
-    (lambda c, t: c.search_events(before=_T1, properties={"probe": t}), False),
+    (lambda c, t: c.search_events(after=_T1, properties={_PROPERTY_KEY: t}), True),
+    (lambda c, t: c.search_events(after=_T2, properties={_PROPERTY_KEY: t}), False),
+    (lambda c, t: c.search_events(before=_T2, properties={_PROPERTY_KEY: t}), True),
+    (lambda c, t: c.search_events(before=_T1, properties={_PROPERTY_KEY: t}), False),
 )
 
 
@@ -420,9 +421,9 @@ EVENT_TIME_BOUND_CASES = (
 def test_search_events_time_bounds_are_exclusive(
     client: NominalClient,
     time_probes: TimeProbes,
-    search: Callable[[NominalClient, str], Sequence[object]],
+    search: SearchFn,
     expected: bool,
 ) -> None:
     """Event bounds are exclusive and overlap based, unlike the containment bounds on runs."""
-    results = search(client, time_probes.event_token)
-    assert (time_probes.event_rid in _rids(results)) == expected
+    results = search(client, time_probes.event.tokens["property"])
+    assert (time_probes.event.rid in _rids(results)) == expected

--- a/tests/e2e/test_search_field_surface.py
+++ b/tests/e2e/test_search_field_surface.py
@@ -254,3 +254,58 @@ def test_field_surface(
     probe = probes[target_name]
     found = probe.rid in _rids(search(client, probe.tokens[field]))
     assert found == (field in matching_fields)
+
+
+# (target name, labels search, properties search) -- one per distinct query construction
+SET_SEMANTICS_CASES = (
+    (
+        "runs",
+        lambda c, labels: c.search_runs(labels=labels),
+        lambda c, props: c.search_runs(properties=props),
+    ),
+    (
+        "datasets",
+        lambda c, labels: c.search_datasets(labels=labels),
+        lambda c, props: c.search_datasets(properties=props),
+    ),
+    (
+        "templates",
+        lambda c, labels: c.search_workbook_templates(labels=labels),
+        lambda c, props: c.search_workbook_templates(properties=props),
+    ),
+)
+
+_SET_IDS = [name for name, _, _ in SET_SEMANTICS_CASES]
+
+
+@pytest.mark.parametrize(("target_name", "search_labels", "_search_props"), SET_SEMANTICS_CASES, ids=_SET_IDS)
+def test_labels_filter_requires_all_labels(
+    client: NominalClient,
+    probes: dict[str, Probe],
+    target_name: str,
+    search_labels: Callable[[NominalClient, list[str]], Sequence[object]],
+    _search_props: Callable[[NominalClient, dict[str, str]], Sequence[object]],
+) -> None:
+    """A labels filter requires every given label, so adding an absent one excludes the resource."""
+    probe = probes[target_name]
+    present = probe.tokens["label"]
+    absent = f"cherries{uuid4().hex}"
+
+    assert probe.rid in _rids(search_labels(client, [present]))
+    assert probe.rid not in _rids(search_labels(client, [present, absent]))
+
+
+@pytest.mark.parametrize(("target_name", "_search_labels", "search_props"), SET_SEMANTICS_CASES, ids=_SET_IDS)
+def test_properties_filter_matches_key_and_value(
+    client: NominalClient,
+    probes: dict[str, Probe],
+    target_name: str,
+    _search_labels: Callable[[NominalClient, list[str]], Sequence[object]],
+    search_props: Callable[[NominalClient, dict[str, str]], Sequence[object]],
+) -> None:
+    """A properties filter matches on key and value, so a wrong value excludes the resource."""
+    probe = probes[target_name]
+    value = probe.tokens["property"]
+
+    assert probe.rid in _rids(search_props(client, {"probe": value}))
+    assert probe.rid not in _rids(search_props(client, {"probe": f"dates{uuid4().hex}"}))

--- a/tests/e2e/test_search_field_surface.py
+++ b/tests/e2e/test_search_field_surface.py
@@ -42,6 +42,11 @@ def _rids(items: Sequence[object]) -> set[str]:
     return {cast(HasRid, item).rid for item in items}
 
 
+def _kgrams(value: str, k: int = 8) -> set[str]:
+    """Every length-k slice of `value`, for detecting shared substrings between tokens."""
+    return {value[i : i + k] for i in range(len(value) - k + 1)}
+
+
 @dataclass(frozen=True)
 class Probe:
     """A resource whose four fields each carry a distinct, unrelated token."""
@@ -55,12 +60,13 @@ class HasArchive(Protocol):
 
 
 def test_field_tokens_share_no_substring() -> None:
-    """Each field's token is unrelated to every other, so a match names exactly one field."""
+    """Each field's token shares no 8-character substring with any other, so a match names exactly one field."""
     tokens = _field_tokens()
     assert len(set(tokens)) == len(FIELDS)
-    for field, token in tokens.items():
-        others = [other for name, other in tokens.items() if name != field]
-        assert all(token not in other and other not in token for other in others)
+    kgrams = {field: _kgrams(token) for field, token in tokens.items()}
+    for field, grams in kgrams.items():
+        others = [other for name, other in kgrams.items() if name != field]
+        assert all(grams.isdisjoint(other) for other in others)
 
 
 @dataclass(frozen=True)

--- a/tests/e2e/test_search_field_surface.py
+++ b/tests/e2e/test_search_field_surface.py
@@ -1,0 +1,188 @@
+"""End-to-end tests for which fields each search filter matches.
+
+`test_search.py` cannot detect a change in field surface: its fixture puts the session tag in
+several fields of the same resource, so an assertion passes regardless of which field matched.
+This module creates one probe resource per type, each field carrying its own token, so a match is
+attributable to exactly one field.
+
+Tokens must not share substrings across fields. `search_text` matches name and description by
+similarity, so two strings sharing a long substring match each other even when neither contains
+the other -- which would make every negative assertion unreliable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterator, Protocol, Sequence, cast
+from uuid import uuid4
+
+import pytest
+
+from nominal.core import NominalClient
+from nominal.core._utils.api_tools import HasRid
+
+FIELDS = ("name", "description", "label", "property")
+
+
+def _field_tokens() -> dict[str, str]:
+    """One token per field.
+
+    The words are for readability in failure output; the independent random tails are what make a
+    match attributable, since no token shares a substring with any other.
+    """
+    return {
+        "name": f"apples{uuid4().hex}",
+        "description": f"bananas{uuid4().hex}",
+        "label": f"cherries{uuid4().hex}",
+        "property": f"dates{uuid4().hex}",
+    }
+
+
+def _rids(items: Sequence[object]) -> set[str]:
+    return {cast(HasRid, item).rid for item in items}
+
+
+@dataclass(frozen=True)
+class Probe:
+    """A resource whose four fields each carry a distinct, unrelated token."""
+
+    tokens: dict[str, str]
+    rid: str
+
+
+class HasArchive(Protocol):
+    def archive(self) -> None: ...
+
+
+def test_field_tokens_share_no_substring() -> None:
+    """Each field's token is unrelated to every other, so a match names exactly one field."""
+    tokens = _field_tokens()
+    assert len(set(tokens)) == len(FIELDS)
+    for field, token in tokens.items():
+        others = [other for name, other in tokens.items() if name != field]
+        assert all(token not in other and other not in token for other in others)
+
+
+@dataclass(frozen=True)
+class Target:
+    """A searchable type: how to create a probe for it, and how to search it."""
+
+    name: str
+    make: Callable[[NominalClient, dict[str, str]], HasRid]
+    fields: tuple[str, ...] = FIELDS
+
+
+def _make_dataset(client: NominalClient, tokens: dict[str, str]) -> HasRid:
+    return client.create_dataset(
+        tokens["name"],
+        description=tokens["description"],
+        labels=[tokens["label"]],
+        properties={"probe": tokens["property"]},
+    )
+
+
+def _make_run(client: NominalClient, tokens: dict[str, str]) -> HasRid:
+    from tests.e2e import _create_random_start_end
+
+    start, end = _create_random_start_end()
+    return client.create_run(
+        tokens["name"],
+        start,
+        end,
+        tokens["description"],
+        labels=[tokens["label"]],
+        properties={"probe": tokens["property"]},
+    )
+
+
+def _make_secret(client: NominalClient, tokens: dict[str, str]) -> HasRid:
+    return client.create_secret(
+        tokens["name"],
+        "probe-value",
+        tokens["description"],
+        labels=[tokens["label"]],
+        properties={"probe": tokens["property"]},
+    )
+
+
+def _make_video(client: NominalClient, tokens: dict[str, str]) -> HasRid:
+    return client.create_video(
+        tokens["name"],
+        description=tokens["description"],
+        labels=[tokens["label"]],
+        properties={"probe": tokens["property"]},
+    )
+
+
+def _make_asset(client: NominalClient, tokens: dict[str, str]) -> HasRid:
+    return client.create_asset(
+        tokens["name"],
+        tokens["description"],
+        labels=[tokens["label"]],
+        properties={"probe": tokens["property"]},
+    )
+
+
+def _make_event(client: NominalClient, tokens: dict[str, str]) -> HasRid:
+    from nominal.core import EventType
+    from tests.e2e import _create_random_start_end
+
+    # The backend rejects event creation without an asset (Scout:MissingAssetRid), even though
+    # `assets` is optional in the client signature. This throwaway asset exists only to satisfy
+    # that requirement; it carries none of the probe's tokens and is archived immediately.
+    asset = client.create_asset(f"event-asset-{uuid4().hex}")
+    start, _ = _create_random_start_end()
+    event = client.create_event(
+        tokens["name"],
+        EventType.INFO,
+        start,
+        description=tokens["description"],
+        assets=[asset],
+        labels=[tokens["label"]],
+        properties={"probe": tokens["property"]},
+    )
+    asset.archive()
+    return event
+
+
+def _make_template(client: NominalClient, tokens: dict[str, str]) -> HasRid:
+    return client.create_workbook_template(
+        title=tokens["name"],
+        description=tokens["description"],
+        labels=[tokens["label"]],
+        properties={"probe": tokens["property"]},
+    )
+
+
+TARGETS = (
+    Target("datasets", _make_dataset),
+    Target("runs", _make_run),
+    Target("secrets", _make_secret),
+    Target("videos", _make_video),
+    Target("assets", _make_asset),
+    Target("events", _make_event),
+    Target("templates", _make_template),
+)
+
+
+@pytest.fixture(scope="session")
+def probes(client: NominalClient) -> Iterator[dict[str, Probe]]:
+    """One probe resource per target, archived on teardown."""
+    created: dict[str, Probe] = {}
+    resources: list[object] = []
+    for target in TARGETS:
+        tokens = _field_tokens()
+        resource = target.make(client, tokens)
+        resources.append(resource)
+        created[target.name] = Probe(tokens=tokens, rid=resource.rid)
+
+    yield created
+
+    for archivable in resources:
+        cast("HasArchive", archivable).archive()
+
+
+def test_probes_fixture_builds(probes: dict[str, Probe]) -> None:
+    """Every target creates a probe resource with a rid."""
+    assert set(probes) == {t.name for t in TARGETS}
+    assert all(p.rid for p in probes.values())

--- a/tests/e2e/test_search_field_surface.py
+++ b/tests/e2e/test_search_field_surface.py
@@ -218,7 +218,39 @@ def probes(client: NominalClient) -> Iterator[dict[str, Probe]]:
                 print(f"WARNING: failed to archive probe resource {archivable!r}: {e!r}")
 
 
-def test_probes_fixture_builds(probes: dict[str, Probe]) -> None:
-    """Every target creates a probe resource with a rid."""
-    assert set(probes) == {t.name for t in TARGETS}
-    assert all(p.rid for p in probes.values())
+# (target name, filter name, search callable, fields the filter is expected to match)
+SURFACE_CASES = (
+    ("datasets", "search_text", lambda c, t: c.search_datasets(search_text=t), FIELDS),
+    ("runs", "search_text", lambda c, t: c.search_runs(search_text=t), FIELDS),
+    ("secrets", "search_text", lambda c, t: c.search_secrets(search_text=t), FIELDS),
+    ("videos", "search_text", lambda c, t: c.search_videos(search_text=t), FIELDS),
+    ("assets", "search_text", lambda c, t: c.search_assets(search_text=t), FIELDS),
+    ("events", "search_text", lambda c, t: c.search_events(search_text=t), FIELDS),
+    ("datasets", "exact_match", lambda c, t: c.search_datasets(exact_match=t), FIELDS),
+    ("runs", "exact_match", lambda c, t: c.search_runs(exact_match=t), FIELDS),
+    ("runs", "name_substring", lambda c, t: c.search_runs(name_substring=t), FIELDS),
+    ("assets", "exact_substring", lambda c, t: c.search_assets(exact_substring=t), FIELDS),
+    ("templates", "exact_match", lambda c, t: c.search_workbook_templates(exact_match=t), ("name",)),
+    ("templates", "search_text", lambda c, t: c.search_workbook_templates(search_text=t), ("name", "description")),
+)
+
+
+@pytest.mark.parametrize(
+    ("target_name", "filter_name", "search", "matching_fields"),
+    SURFACE_CASES,
+    ids=[f"{target}-{filter_name}" for target, filter_name, _, _ in SURFACE_CASES],
+)
+@pytest.mark.parametrize("field", FIELDS)
+def test_field_surface(
+    client: NominalClient,
+    probes: dict[str, Probe],
+    target_name: str,
+    filter_name: str,
+    search: Callable[[NominalClient, str], Sequence[object]],
+    matching_fields: tuple[str, ...],
+    field: str,
+) -> None:
+    """The filter matches a token living only in `field` exactly when `field` is in its surface."""
+    probe = probes[target_name]
+    found = probe.rid in _rids(search(client, probe.tokens[field]))
+    assert found == (field in matching_fields)

--- a/tests/e2e/test_search_field_surface.py
+++ b/tests/e2e/test_search_field_surface.py
@@ -12,6 +12,7 @@ the other -- which would make every negative assertion unreliable.
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import Callable, Iterator, Protocol, Sequence, cast
 from uuid import uuid4
@@ -75,6 +76,7 @@ class Target:
 
     name: str
     make: Callable[[NominalClient, dict[str, str]], HasRid]
+    warm: Callable[[NominalClient, str], Sequence[object]]
     fields: tuple[str, ...] = FIELDS
 
 
@@ -163,14 +165,33 @@ def _make_template(client: NominalClient, tokens: dict[str, str]) -> HasRid:
 
 
 TARGETS = (
-    Target("datasets", _make_dataset),
-    Target("runs", _make_run),
-    Target("secrets", _make_secret),
-    Target("videos", _make_video),
-    Target("assets", _make_asset),
-    Target("events", _make_event),
-    Target("templates", _make_template),
+    Target("datasets", _make_dataset, lambda c, t: c.search_datasets(search_text=t)),
+    Target("runs", _make_run, lambda c, t: c.search_runs(search_text=t)),
+    Target("secrets", _make_secret, lambda c, t: c.search_secrets(search_text=t)),
+    Target("videos", _make_video, lambda c, t: c.search_videos(search_text=t)),
+    Target("assets", _make_asset, lambda c, t: c.search_assets(search_text=t)),
+    Target("events", _make_event, lambda c, t: c.search_events(search_text=t)),
+    Target("templates", _make_template, lambda c, t: c.search_workbook_templates(search_text=t)),
 )
+
+
+_INDEX_POLL_SECONDS = 5.0
+_INDEX_POLL_ATTEMPTS = 12  # up to a minute
+
+
+def _wait_for_indexed(
+    search: Callable[[NominalClient, str], Sequence[object]],
+    client: NominalClient,
+    token: str,
+    rid: str,
+) -> None:
+    """Block until `rid` is findable by `token`, so later negative assertions are trustworthy."""
+    for attempt in range(_INDEX_POLL_ATTEMPTS):
+        if rid in _rids(search(client, token)):
+            return
+        if attempt < _INDEX_POLL_ATTEMPTS - 1:
+            time.sleep(_INDEX_POLL_SECONDS)
+    raise AssertionError(f"probe {rid} never became searchable by {token!r}")
 
 
 @pytest.fixture(scope="session")
@@ -184,6 +205,9 @@ def probes(client: NominalClient) -> Iterator[dict[str, Probe]]:
             resource = target.make(client, tokens)
             resources.append(cast("HasArchive", resource))
             created[target.name] = Probe(tokens=tokens, rid=resource.rid)
+        for target in TARGETS:
+            probe = created[target.name]
+            _wait_for_indexed(target.warm, client, probe.tokens["name"], probe.rid)
         yield created
     finally:
         for archivable in resources:

--- a/tests/e2e/test_search_field_surface.py
+++ b/tests/e2e/test_search_field_surface.py
@@ -22,6 +22,7 @@ import pytest
 
 from nominal.core import EventType, NominalClient
 from nominal.core._utils.api_tools import HasRid
+from tests.e2e import _create_random_start_end
 
 FIELDS = ("name", "description", "label", "property")
 
@@ -61,10 +62,19 @@ class HasArchive(Protocol):
     def archive(self) -> None: ...
 
 
+def _archive_all(resources: Sequence[HasArchive]) -> None:
+    """Archive every resource, continuing past failures so one bad archive can't orphan the rest."""
+    for resource in resources:
+        try:
+            resource.archive()
+        except Exception as e:
+            print(f"WARNING: failed to archive probe resource {resource!r}: {e!r}")
+
+
 def test_field_tokens_share_no_substring() -> None:
     """Each field's token shares no 8-character substring with any other, so a match names exactly one field."""
     tokens = _field_tokens()
-    assert len(set(tokens)) == len(FIELDS)
+    assert set(tokens) == set(FIELDS)
     kgrams = {field: _kgrams(token) for field, token in tokens.items()}
     for field, grams in kgrams.items():
         others = [other for name, other in kgrams.items() if name != field]
@@ -78,7 +88,6 @@ class Target:
     name: str
     make: Callable[[NominalClient, dict[str, str]], HasRid]
     warm: Callable[[NominalClient, str], Sequence[object]]
-    fields: tuple[str, ...] = FIELDS
 
 
 def _make_dataset(client: NominalClient, tokens: dict[str, str]) -> HasRid:
@@ -91,8 +100,6 @@ def _make_dataset(client: NominalClient, tokens: dict[str, str]) -> HasRid:
 
 
 def _make_run(client: NominalClient, tokens: dict[str, str]) -> HasRid:
-    from tests.e2e import _create_random_start_end
-
     start, end = _create_random_start_end()
     return client.create_run(
         tokens["name"],
@@ -133,11 +140,8 @@ def _make_asset(client: NominalClient, tokens: dict[str, str]) -> HasRid:
 
 
 def _make_event(client: NominalClient, tokens: dict[str, str]) -> HasRid:
-    from tests.e2e import _create_random_start_end
-
-    # The backend rejects event creation without an asset (Scout:MissingAssetRid), even though
-    # `assets` is optional in the client signature. This throwaway asset exists only to satisfy
-    # that requirement; it carries none of the probe's tokens and is archived immediately.
+    # Event creation requires an asset even though `assets` is optional client-side. This
+    # throwaway asset carries none of the probe's tokens and is archived immediately.
     asset = client.create_asset(f"event-asset-{uuid4().hex}")
     try:
         start, _ = _create_random_start_end()
@@ -207,15 +211,12 @@ def probes(client: NominalClient) -> Iterator[dict[str, Probe]]:
             created[target.name] = Probe(tokens=tokens, rid=resource.rid)
         for target in TARGETS:
             probe = created[target.name]
+            # Warming on the name token alone is enough: "name" is in matching_fields for every
+            # SURFACE_CASES case, so each filter still gets its own positive-control cell below.
             _wait_for_indexed(target.warm, client, probe.tokens["name"], probe.rid)
         yield created
     finally:
-        for archivable in resources:
-            try:
-                archivable.archive()
-            except Exception as e:
-                # A failed archive must not orphan the rest; the failure is surfaced, not swallowed.
-                print(f"WARNING: failed to archive probe resource {archivable!r}: {e!r}")
+        _archive_all(resources)
 
 
 # (target name, filter name, search callable, fields the filter is expected to match)
@@ -303,12 +304,13 @@ def test_properties_filter_matches_key_and_value(
     _search_labels: Callable[[NominalClient, list[str]], Sequence[object]],
     search_props: Callable[[NominalClient, dict[str, str]], Sequence[object]],
 ) -> None:
-    """A properties filter matches on key and value, so a wrong value excludes the resource."""
+    """A properties filter matches on key and value, so a wrong key or a wrong value excludes it."""
     probe = probes[target_name]
     value = probe.tokens["property"]
 
     assert probe.rid in _rids(search_props(client, {"probe": value}))
     assert probe.rid not in _rids(search_props(client, {"probe": f"dates{uuid4().hex}"}))
+    assert probe.rid not in _rids(search_props(client, {f"probe{uuid4().hex}": value}))
 
 
 _T1 = datetime(2023, 3, 1, 12, 0, 0)
@@ -318,10 +320,12 @@ _ONE_MICRO = timedelta(microseconds=1)
 
 @dataclass(frozen=True)
 class TimeProbes:
-    """A run and an event both spanning exactly [_T1, _T2]."""
+    """A run and an event both spanning exactly [_T1, _T2], each carrying its own probe token."""
 
     run_rid: str
+    run_token: str
     event_rid: str
+    event_token: str
 
 
 @pytest.fixture(scope="session")
@@ -348,64 +352,77 @@ def time_probes(client: NominalClient) -> Iterator[TimeProbes]:
         _wait_for_indexed(lambda c, t: c.search_runs(search_text=t), client, run_tokens["name"], run.rid)
         _wait_for_indexed(lambda c, t: c.search_events(search_text=t), client, event_tokens["name"], event.rid)
 
-        yield TimeProbes(run_rid=run.rid, event_rid=event.rid)
+        yield TimeProbes(
+            run_rid=run.rid,
+            run_token=run_tokens["property"],
+            event_rid=event.rid,
+            event_token=event_tokens["property"],
+        )
     finally:
-        for archivable in resources:
-            archivable.archive()
+        _archive_all(resources)
+
+
+# Every case below also filters on properties={"probe": <token>}, narrowing the search to the probe
+# resource instead of scanning the whole corpus. Filters are ANDed, and the expected=True cases are
+# same-shape positive controls proving the property conjunct alone doesn't exclude the probe -- so an
+# expected=False result here is attributable solely to the time bound.
+RUN_TIME_BOUND_CASES = (
+    (lambda c, t: c.search_runs(start=_T1, properties={"probe": t}), True),
+    (lambda c, t: c.search_runs(start=_T1 + _ONE_MICRO, properties={"probe": t}), False),
+    (lambda c, t: c.search_runs(end=_T2, properties={"probe": t}), True),
+    (lambda c, t: c.search_runs(end=_T2 - _ONE_MICRO, properties={"probe": t}), False),
+)
 
 
 @pytest.mark.parametrize(
-    ("kwargs_name", "offset", "expected"),
-    (
-        ("start", timedelta(0), True),
-        ("start", _ONE_MICRO, False),
-        ("end", timedelta(0), True),
-        ("end", -_ONE_MICRO, False),
-    ),
+    ("search", "expected"),
+    RUN_TIME_BOUND_CASES,
     ids=["start-at-boundary", "start-past-boundary", "end-at-boundary", "end-past-boundary"],
 )
 def test_search_runs_time_bounds_are_inclusive(
     client: NominalClient,
     time_probes: TimeProbes,
-    kwargs_name: str,
-    offset: timedelta,
+    search: Callable[[NominalClient, str], Sequence[object]],
     expected: bool,
 ) -> None:
     """Run start and end bounds include a run sitting exactly on the boundary."""
-    anchor = _T1 if kwargs_name == "start" else _T2
-    results = client.search_runs(**{kwargs_name: anchor + offset})  # type: ignore[arg-type]
+    results = search(client, time_probes.run_token)
     assert (time_probes.run_rid in _rids(results)) == expected
 
 
 def test_search_runs_time_bounds_select_contained_runs(client: NominalClient, time_probes: TimeProbes) -> None:
     """A window strictly inside the run excludes it, so the bounds are containment not overlap."""
-    results = client.search_runs(start=_T1 + _ONE_MICRO, end=_T2 - _ONE_MICRO)
+    results = client.search_runs(
+        start=_T1 + _ONE_MICRO, end=_T2 - _ONE_MICRO, properties={"probe": time_probes.run_token}
+    )
     assert time_probes.run_rid not in _rids(results)
 
 
 def test_search_runs_exact_window_matches(client: NominalClient, time_probes: TimeProbes) -> None:
     """A window exactly equal to the run's span contains it."""
-    results = client.search_runs(start=_T1, end=_T2)
+    results = client.search_runs(start=_T1, end=_T2, properties={"probe": time_probes.run_token})
     assert time_probes.run_rid in _rids(results)
 
 
+EVENT_TIME_BOUND_CASES = (
+    (lambda c, t: c.search_events(after=_T1, properties={"probe": t}), True),
+    (lambda c, t: c.search_events(after=_T2, properties={"probe": t}), False),
+    (lambda c, t: c.search_events(before=_T2, properties={"probe": t}), True),
+    (lambda c, t: c.search_events(before=_T1, properties={"probe": t}), False),
+)
+
+
 @pytest.mark.parametrize(
-    ("kwargs_name", "anchor", "expected"),
-    (
-        ("after", _T1, True),
-        ("after", _T2, False),
-        ("before", _T2, True),
-        ("before", _T1, False),
-    ),
+    ("search", "expected"),
+    EVENT_TIME_BOUND_CASES,
     ids=["after-overlaps", "after-at-end", "before-overlaps", "before-at-start"],
 )
 def test_search_events_time_bounds_are_exclusive(
     client: NominalClient,
     time_probes: TimeProbes,
-    kwargs_name: str,
-    anchor: datetime,
+    search: Callable[[NominalClient, str], Sequence[object]],
     expected: bool,
 ) -> None:
     """Event bounds are exclusive and overlap based, unlike the containment bounds on runs."""
-    results = client.search_events(**{kwargs_name: anchor})  # type: ignore[arg-type]
+    results = search(client, time_probes.event_token)
     assert (time_probes.event_rid in _rids(results)) == expected


### PR DESCRIPTION
## Why

Follow-up to #900. Those six docstrings misdescribed search semantics for a long time with the e2e suite green throughout, and the reason is structural: `test_search.py` cannot tell *which field* a filter matched. Its fixture puts the session tag into several fields of the same resource, so `search_runs(name_substring=tag)` passes whether the backend matched the run's name, its properties, or both — and would keep passing if the field surface silently narrowed.

That is not hypothetical. `test_search_runs_by_name_substring` asserted name-scoped behaviour in its docstring that its assertion could not verify, which is what #900 had to correct.

Coverage was also lopsided. Runs and assets had filter-level tests; datasets, secrets, videos, workbooks and templates had only `archive_status`. The filters most likely to drift were the least covered.

## What this adds

`tests/e2e/test_search_field_surface.py` — 65 tests. One probe resource per searchable type, with a **distinct token in each field**, so a match is attributable to exactly one field.

Three families:

| family | tests | what it pins |
| --- | --- | --- |
| Field surface | 48 | which fields each free-text filter matches, in both directions |
| Set semantics | 6 | the "must ALL be present" claim on `labels` / `properties` |
| Time boundaries | 10 | inclusive-vs-exclusive and containment-vs-overlap |
| Token guard | 1 | the property the other 64 depend on (offline) |

Failures name the cell: `test_field_surface[label-secrets-search_text]`.

`SURFACE_CASES` is an executable transcription of the docstrings #900 corrected. If the backend's field surface changes, a specific cell goes red and names the parameter whose documentation just became wrong.

## Design notes worth knowing

**Tokens carry independent random tails, not a shared id.** `search_text` matches name and description by similarity, so two strings sharing a long substring match each other *even when neither contains the other*. Measured: a dataset named `apples-name-<uuid>` was returned by a search for `bananas-description-<same uuid>`, a string that existed nowhere. A shared-id scheme would have made every negative assertion unreliable. `test_field_tokens_share_no_substring` guards this with k-gram disjointness — containment checking does not catch it.

**Assertions are membership, never set equality or result position.** These searches are not relevance-ranked and each type sorts on a different field — secrets and videos by creation time, datasets by ingest date, runs by data start time (which the existing fixture randomises). Exclusivity is already the job of `test_search.py`'s narrowing tests, and it has a legitimate exception: videos are dual-written as datasets, so a dataset search for a video's token returns a second row that is not a bug.

**Set semantics run against three targets, not eight**, because there are only three distinct query constructions — `search_runs` sends one filter carrying an AND operator, datasets/secrets/videos send a clause per label, templates build their own. The other five would re-test a covered path.

**Time boundaries cover client-set timestamps only.** `created_at` and ingest date are server-assigned, so no resource can be placed on those boundaries from the SDK; a test there would be a relative-ordering assertion that passes under an off-by-one while looking as strong as a real boundary test. Runs and events turn out to be *opposite* — runs inclusive/containment, events exclusive/overlap — which is the reason both are worth pinning. `search_dataset_files` is a third variant already covered.

## Results

All 65 pass against a `staging` profile. Every expectation was independently measured before being written down, and the suite reproduced all of them — no expected value was ever adjusted to match observed behaviour.

Two claims verified for the first time:
- `labels` / `properties` really are AND across all three constructions. Nine docstrings say so; nothing checked it, because every existing `labels=` call site passes exactly one label.
- Run and event time bounds behave exactly as documented.

Each family was also verified to *fail* when it should — inverting one `SURFACE_CASES` expectation produces exactly the predicted 3 failures and no others. A matrix that passes vacuously is worse than no matrix.

## Runtime

28 seconds.

Time-bounded queries carry a `properties=` conjunct so they do not scan the whole corpus. Unfiltered, the four `search_events` time-only calls took **62-168 seconds each** and one died with a transport-level `ChunkedEncodingError` — roughly 8 minutes added to a job with a 15-minute cap that finishes in ~4 today, plus a 1-in-2 flake. The equivalent `search_runs` queries take under 10 seconds, so this looks worth a backend look independently of this PR.

The conjunct preserves what the tests prove: filters are ANDed, and every absence assertion has a same-shape positive control with the identical conjunct and token, differing only in the time bound. Adding it changed no expected value.

## Testing

- `pytest tests/e2e/test_search_field_surface.py --profile staging` — 65 passed in 28.09s, twice.
- `pytest tests/e2e/test_search.py --profile staging` — 31 passed, no regression and no fixture leakage.
- `pytest tests/core` — 337 passed, 12 skipped. The new module is correctly excluded from bare runs by `norecursedirs`.
- `ruff check`, `ruff format --check`, `mypy -p nominal` — clean.

## Docs impact

- [ ] **Is this a user-facing change?** No — tests only, no library code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
