### PR TITLE
fix: stop truncating negative timedelta durations

### DIFF
--- a/nominal/ts/__init__.py
+++ b/nominal/ts/__init__.py
@@ -697,16 +697,14 @@ def _to_api_duration(duration: timedelta | IntegralNanosecondsDuration) -> scout
 
     The platform reconstructs the value as `seconds * 1e9 + nanos` using signed arithmetic and constrains
     neither field's sign, so the split is floored rather than truncated: `nanos` stays in [0, 1e9) and
-    `seconds` carries the sign. -1.5s therefore encodes as `(seconds=-2, nanos=500_000_000)`, which looks
-    like an overshoot but is the same value. Flooring is also what `divmod` gives, which the
-    integral-nanosecond path has always used, and what the platform's own duration type produces.
+    `seconds` carries the sign. -1.5s therefore encodes as `(seconds=-2, nanos=500_000_000)`.
 
     A `timedelta` is an exact multiple of its microsecond resolution, so dividing by one microsecond
     converts it losslessly.
 
     Note:
-        This is not `google.protobuf.Duration`, which requires both fields to share a sign and would
-        reject a floored split. A duration bound for that type needs its own encoder.
+        This is not valid for `google.protobuf.Duration`, which requires both fields to share a sign
+        and would reject a floored split. A duration bound for that type needs its own encoder.
     """
     total_nanos = duration // _ONE_MICROSECOND * 1_000 if isinstance(duration, timedelta) else duration
     seconds, nanos = divmod(total_nanos, 1_000_000_000)

--- a/nominal/ts/__init__.py
+++ b/nominal/ts/__init__.py
@@ -688,12 +688,29 @@ The backend converts to long nanoseconds, and the maximum long (int64) value is 
 """
 
 
+_ONE_MICROSECOND = timedelta(microseconds=1)
+"""timedelta's resolution, used to convert one losslessly to an integer without re-allocating it per call."""
+
+
 def _to_api_duration(duration: timedelta | IntegralNanosecondsDuration) -> scout_run_api.Duration:
-    if isinstance(duration, timedelta):
-        return scout_run_api.Duration(seconds=int(duration.total_seconds()), nanos=duration.microseconds * 1000)
-    else:
-        seconds, nanos = divmod(duration, 1_000_000_000)
-        return scout_run_api.Duration(seconds=seconds, nanos=nanos)
+    """Encode a duration as the seconds/nanos pair the platform APIs carry.
+
+    The platform reconstructs the value as `seconds * 1e9 + nanos` using signed arithmetic and constrains
+    neither field's sign, so the split is floored rather than truncated: `nanos` stays in [0, 1e9) and
+    `seconds` carries the sign. -1.5s therefore encodes as `(seconds=-2, nanos=500_000_000)`, which looks
+    like an overshoot but is the same value. Flooring is also what `divmod` gives, which the
+    integral-nanosecond path has always used, and what the platform's own duration type produces.
+
+    A `timedelta` is an exact multiple of its microsecond resolution, so dividing by one microsecond
+    converts it losslessly.
+
+    Note:
+        This is not `google.protobuf.Duration`, which requires both fields to share a sign and would
+        reject a floored split. A duration bound for that type needs its own encoder.
+    """
+    total_nanos = duration // _ONE_MICROSECOND * 1_000 if isinstance(duration, timedelta) else duration
+    seconds, nanos = divmod(total_nanos, 1_000_000_000)
+    return scout_run_api.Duration(seconds=seconds, nanos=nanos)
 
 
 def _to_export_timestamp_format(type_: _AnyExportableTimestampType) -> scout_dataexport_api.TimestampFormat:

--- a/tests/test_ts.py
+++ b/tests/test_ts.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import dateutil.parser
 import pytest
 
 from nominal import ts
+from nominal.ts import _to_api_duration
 
 
 @pytest.mark.parametrize(
@@ -100,3 +101,27 @@ def test_string_timestamp_types_cannot_describe_avro_timestamps(typed: ts.TypedT
     """Avro timestamps are integers, so a string-formatted type has no representation there."""
     with pytest.raises(ValueError, match="not supported with .avro files"):
         typed._to_conjure_ingest_avro_api()
+
+
+@pytest.mark.parametrize(
+    ("duration", "expected"),
+    [
+        pytest.param(timedelta(seconds=1, microseconds=500_000), (1, 500_000_000), id="timedelta-positive"),
+        pytest.param(1_500_000_000, (1, 500_000_000), id="int-positive"),
+        pytest.param(timedelta(seconds=-1, microseconds=-500_000), (-2, 500_000_000), id="timedelta-negative"),
+        pytest.param(-1_500_000_000, (-2, 500_000_000), id="int-negative"),
+        pytest.param(timedelta(microseconds=-1), (-1, 999_999_000), id="timedelta-negative-sub-second"),
+        pytest.param(-1_000, (-1, 999_999_000), id="int-negative-sub-second"),
+        pytest.param(timedelta(days=-1), (-86_400, 0), id="timedelta-negative-whole-day"),
+        pytest.param(timedelta(0), (0, 0), id="zero"),
+    ],
+)
+def test_to_api_duration_encodes_the_same_split_for_both_input_types(duration, expected: tuple[int, int]) -> None:
+    """The same duration must encode to the same (seconds, nanos) split however it is spelled.
+
+    nanos stays in [0, 1e9) and seconds carries the sign, so a negative duration borrows a whole second
+    rather than pairing a negative nanos with it.
+    """
+    api_duration = _to_api_duration(duration)
+
+    assert (api_duration.seconds, api_duration.nanos) == expected


### PR DESCRIPTION
`_to_api_duration` split a `timedelta` with `int(total_seconds())`, which truncates toward zero, and then took `microseconds` as the remainder. For a negative duration that is not a whole number of seconds those two disagree, so `timedelta(seconds=-1.5)` produced `(seconds=-1, nanos=500_000_000)`, or -0.5s. The integral-nanoseconds branch used `divmod`, which floors, and was already correct.

Normalizing to nanoseconds before the split makes both input types agree and removes the branch.

Measured before and after, for the same duration expressed both ways:

| input | before | after |
|---|---|---|
| `timedelta(seconds=-1.5)` | -0.500s | -1.500s |
| `-1_500_000_000` | -1.500s | -1.500s |
| `timedelta(seconds=1.5)` | +1.500s | +1.500s |

Whole-second negatives such as `timedelta(days=-1)` were already correct, because there is no sub-second remainder to lose.

The callers that can receive a negative duration from a user are `Run.add_dataset_scope` and `Run.add_connection_scope`, where `offset` being negative is the point, and `Event` durations. `Checklist.execute_streaming`'s delays and matlab's `forward_fill_lookback` also route through this but are not meaningfully negative.

Split out of #913, which hit this while extracting the seconds/nanos logic for the event protos. Fixing it here keeps the event migration free of an unrelated behavior change.

Testing: a parametrized case over timedelta and integral-nanosecond spellings of the same positive, negative, whole-day and zero durations, asserting they agree. I confirmed the negative-timedelta case fails against the old implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)