### PR TITLE
refactor: build per-service proto durations in the service module

### DIFF
--- a/nominal/core/event.py
+++ b/nominal/core/event.py
@@ -20,9 +20,8 @@ from nominal.protos.types import types_pb2
 from nominal.ts import (
     IntegralNanosecondsDuration,
     IntegralNanosecondsUTC,
-    _from_proto_duration,
     _SecondsNanos,
-    _to_proto_duration,
+    _to_seconds_nanos_duration,
 )
 
 
@@ -164,6 +163,19 @@ class Event(HasRid, RefreshableGrpcMixin[event_pb2.Event]):
             _uuid=event.uuid,
             _clients=clients,
         )
+
+
+def _to_proto_duration(duration: timedelta | IntegralNanosecondsDuration) -> event_pb2.Duration:
+    """Encode a duration as `nominal.event.v2.Duration`.
+
+    See `nominal.ts._to_seconds_nanos_duration` for why the split floors.
+    """
+    seconds, nanos = _to_seconds_nanos_duration(duration)
+    return event_pb2.Duration(seconds=seconds, nanos=nanos)
+
+
+def _from_proto_duration(duration: event_pb2.Duration) -> IntegralNanosecondsDuration:
+    return duration.seconds * 1_000_000_000 + duration.nanos
 
 
 def _get_events(clients: Event._Clients, rids: Sequence[str]) -> Sequence[event_pb2.Event]:

--- a/nominal/ts/__init__.py
+++ b/nominal/ts/__init__.py
@@ -208,7 +208,6 @@ from google.protobuf import timestamp_pb2
 from nominal_api import api, ingest_api, scout_catalog, scout_dataexport_api, scout_run_api
 from typing_extensions import Self, assert_never
 
-from nominal.protos.event.v2 import event_pb2
 from nominal.protos.types.time import time_pb2, timestamp_parsers_pb2
 
 logger = logging.getLogger(__name__)
@@ -712,6 +711,12 @@ def _to_seconds_nanos_duration(duration: timedelta | IntegralNanosecondsDuration
     converts it losslessly.
 
     Note:
+        Each service declares its own `Duration` message (`nominal.event.v2.Duration`,
+        `nominal.asset.v2.Duration`, ...). They are structurally identical but not interchangeable, so the
+        message is built by the module that owns the service; only the shared `nominal.types.Duration`
+        would be built here.
+
+    Note:
         This is not valid for `google.protobuf.Duration`, which requires both fields to share a sign
         and would reject a floored split. A duration bound for that type needs its own encoder.
     """
@@ -722,15 +727,6 @@ def _to_seconds_nanos_duration(duration: timedelta | IntegralNanosecondsDuration
 def _to_api_duration(duration: timedelta | IntegralNanosecondsDuration) -> scout_run_api.Duration:
     seconds, nanos = _to_seconds_nanos_duration(duration)
     return scout_run_api.Duration(seconds=seconds, nanos=nanos)
-
-
-def _to_proto_duration(duration: timedelta | IntegralNanosecondsDuration) -> event_pb2.Duration:
-    seconds, nanos = _to_seconds_nanos_duration(duration)
-    return event_pb2.Duration(seconds=seconds, nanos=nanos)
-
-
-def _from_proto_duration(duration: event_pb2.Duration) -> IntegralNanosecondsDuration:
-    return duration.seconds * 1_000_000_000 + duration.nanos
 
 
 def _to_export_timestamp_format(type_: _AnyExportableTimestampType) -> scout_dataexport_api.TimestampFormat:


### PR DESCRIPTION
`nominal.ts` is the transport-agnostic time module, but it was importing `nominal.protos.event.v2` in order to build an `event_pb2.Duration`. This moves that construction to the module that owns the service.

Each service declares its **own** `Duration` message, and they are not interchangeable:

```
nominal.asset.v2.Duration     [seconds int64, nanos int64]
nominal.event.v2.Duration     [seconds int64, nanos int64]
nominal.types.Duration        [seconds int64, nanos int64]   <- shared, currently unused by any field
```

```
TypeError: Parameter to CopyFrom() must be instance of same class:
           expected asset_pb2.Duration, got event_pb2.Duration
```

protobuf types are nominal rather than structural, so identical shape buys nothing. A single generically-named `_to_proto_duration` in `nominal.ts` therefore cannot serve more than one service — assets would need a second, near-identical function beside it, and `nominal.ts` would import a second service's protos to host it.

## What changed

- `_to_proto_duration` and `_from_proto_duration` move to `nominal/core/event.py`, typed to `event_pb2.Duration`.
- `nominal.ts` keeps `_to_seconds_nanos_duration` — the genuinely shared part, which returns a plain `tuple[int, int]` and has no proto dependency — and `_to_api_duration` for the conjure type.
- Its docstring now records the rule: per-service `Duration` messages are built by the service's module; only the shared `nominal.types.Duration` would be built in `nominal.ts`.

`nominal.ts` now imports only shared `types/*` protos.

No behavior change. The split, the conjure encoder and the proto encoder all still produce the same pair — verified for a negative sub-second duration, including a proto round trip.

Follow-up to #913, where the encoder was introduced in `nominal.ts` and the layering question was deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)