### PR TITLE
feat: persist derived dataset commits

### DIFF
--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -165,6 +165,7 @@ class ClientsBunch:
     storage: storage_datasource_api.NominalDataSourceService
     template: scout.TemplateService
     upload: upload_api.UploadService
+    versioning: scout.VersioningService
     video_file: scout_video.VideoFileService
     video: scout_video.VideoService
 
@@ -329,6 +330,7 @@ class ClientsBunch:
             storage=client_factory(storage_datasource_api.NominalDataSourceService),
             template=client_factory(scout.TemplateService),
             upload=client_factory(upload_api.UploadService),
+            versioning=client_factory(scout.VersioningService),
             video_file=client_factory(scout_video.VideoFileService),
             video=client_factory(scout_video.VideoService),
             # GRPC Service Stubs

--- a/nominal/core/exceptions.py
+++ b/nominal/core/exceptions.py
@@ -124,14 +124,6 @@ class NominalComputeError(NominalError):
     """An error occurred during a compute request."""
 
 
-class NominalCommitNotPersistedError(NominalError):
-    """A commit was created, but the follow-up call that persists it failed.
-
-    The commit itself landed, so retrying the write would duplicate it. Until it is persisted, it
-    stays hidden from commit history and may be removed by commit compaction.
-    """
-
-
 class NominalContainerImageError(NominalError):
     """A containerized extractor's container image is in a failed or unusable state."""
 

--- a/nominal/core/exceptions.py
+++ b/nominal/core/exceptions.py
@@ -124,6 +124,14 @@ class NominalComputeError(NominalError):
     """An error occurred during a compute request."""
 
 
+class NominalCommitNotPersistedError(NominalError):
+    """A commit was created, but the follow-up call that persists it failed.
+
+    The commit itself landed, so retrying the write would duplicate it. Until it is persisted, it
+    stays hidden from commit history and may be removed by commit compaction.
+    """
+
+
 class NominalContainerImageError(NominalError):
     """A containerized extractor's container image is in a failed or unusable state."""
 

--- a/nominal/experimental/compute_as_code/README.md
+++ b/nominal/experimental/compute_as_code/README.md
@@ -10,14 +10,14 @@ pip install 'nominal[compute]'
 
 A derived dataset is a regular dataset whose contents are computed from a `nominal_compute` graph instead of
 ingested files. Create one with `create_derived_dataset`, and manage its definition over time with
-`get_derived_definition` and `commit_derived_definition`:
+`get_derived_definition` and `commit_and_persist_derived_definition`:
 
 ```py
 import nominal_compute as nc
 
 from nominal.core import NominalClient
 from nominal.experimental.compute_as_code import (
-    commit_derived_definition,
+    commit_and_persist_derived_definition,
     create_derived_dataset,
     get_derived_definition,
 )
@@ -32,7 +32,9 @@ derived = create_derived_dataset(client, "my derived dataset", spec)
 # Later: replace the definition with a new commit.
 definition = get_derived_definition(client, derived)
 new_spec = nc.Dataset.Saved(dataset.rid).time_shift(nc.Duration.Seconds(10))
-commit_derived_definition(client, derived, new_spec, message="shift by 10s", latest_commit=definition.commit.id)
+commit_and_persist_derived_definition(
+    client, derived, new_spec, message="shift by 10s", latest_commit=definition.commit.id
+)
 ```
 
 ## Computing a series

--- a/nominal/experimental/compute_as_code/__init__.py
+++ b/nominal/experimental/compute_as_code/__init__.py
@@ -1,4 +1,5 @@
 from nominal.experimental.compute_as_code._derived_datasets import (
+    commit_and_persist_derived_definition,
     commit_derived_definition,
     create_derived_dataset,
     get_derived_definition,
@@ -6,6 +7,7 @@ from nominal.experimental.compute_as_code._derived_datasets import (
 from nominal.experimental.compute_as_code._series import compute_series
 
 __all__ = [
+    "commit_and_persist_derived_definition",
     "commit_derived_definition",
     "compute_series",
     "create_derived_dataset",

--- a/nominal/experimental/compute_as_code/_derived_datasets.py
+++ b/nominal/experimental/compute_as_code/_derived_datasets.py
@@ -5,11 +5,12 @@ from typing import Mapping, Sequence
 
 import nominal_compute
 from conjure_python_client import ConjureDecoder
-from nominal_api import scout_catalog, scout_compute_api
+from nominal_api import scout_catalog, scout_compute_api, scout_versioning_api
 
 from nominal.core import NominalClient
 from nominal.core._utils.api_tools import rid_from_instance_or_string
 from nominal.core.dataset import Dataset
+from nominal.core.exceptions import NominalCommitNotPersistedError
 
 
 def _to_conjure_dataset(spec: nominal_compute.Dataset) -> scout_compute_api.Dataset:
@@ -17,6 +18,14 @@ def _to_conjure_dataset(spec: nominal_compute.Dataset) -> scout_compute_api.Data
     wire_json = spec.to_json()  # type: ignore[attr-defined]
     dataset: scout_compute_api.Dataset = ConjureDecoder().decode(json.loads(wire_json), scout_compute_api.Dataset)
     return dataset
+
+
+def _persist_commit(client: NominalClient, rid: str, commit_id: str) -> None:
+    """Persist a commit so it survives commit compaction and appears in commit history."""
+    client._clients.versioning.persist_commits(
+        client._clients.auth_header,
+        [scout_versioning_api.ResourceAndCommitId(commit_id=commit_id, resource_rid=rid)],
+    )
 
 
 def create_derived_dataset(
@@ -94,6 +103,9 @@ def commit_derived_definition(
 ) -> scout_catalog.DerivedDefinition:
     """Replace a derived dataset's definition by creating a new commit.
 
+    The new commit is persisted, without which it would be hidden from commit history and could be
+    removed by commit compaction.
+
     Args:
         client: The NominalClient to use for the commit.
         dataset: The derived dataset, or its RID, whose definition to replace.
@@ -104,6 +116,9 @@ def commit_derived_definition(
 
     Returns:
         The newly committed derived definition.
+
+    Raises:
+        NominalCommitNotPersistedError: If the commit was created but persisting it failed.
     """
     rid = rid_from_instance_or_string(dataset)
     request = scout_catalog.CommitDerivedDefinitionRequest(
@@ -111,4 +126,12 @@ def commit_derived_definition(
         message=message,
         latest_commit=latest_commit,
     )
-    return client._clients.catalog.commit_derived_definition(client._clients.auth_header, rid, request)
+    definition = client._clients.catalog.commit_derived_definition(client._clients.auth_header, rid, request)
+    if definition.commit.is_working_state:
+        try:
+            _persist_commit(client, rid, definition.commit.id)
+        except Exception as e:
+            raise NominalCommitNotPersistedError(
+                f"committed {definition.commit.id} to {rid}, but failed to persist it"
+            ) from e
+    return definition

--- a/nominal/experimental/compute_as_code/_derived_datasets.py
+++ b/nominal/experimental/compute_as_code/_derived_datasets.py
@@ -105,9 +105,8 @@ def commit_and_persist_derived_definition(
         message: Commit message describing the change.
         latest_commit: If provided, the dataset's expected current commit, used for optimistic
             concurrency control.
-        persist: Whether to persist the new commit, at the cost of one extra request. When False,
-            the commit is saved as a working commit, which is hidden from commit history and may be
-            lost to compaction.
+        persist: Whether to persist the new commit. When False, the commit is saved as a working commit, 
+            which is hidden from commit history and may be lost to compaction.
 
     Returns:
         The newly committed derived definition.

--- a/nominal/experimental/compute_as_code/_derived_datasets.py
+++ b/nominal/experimental/compute_as_code/_derived_datasets.py
@@ -6,6 +6,7 @@ from typing import Mapping, Sequence
 import nominal_compute
 from conjure_python_client import ConjureDecoder
 from nominal_api import scout_catalog, scout_compute_api, scout_versioning_api
+from typing_extensions import deprecated
 
 from nominal.core import NominalClient
 from nominal.core._utils.api_tools import rid_from_instance_or_string
@@ -84,6 +85,58 @@ def get_derived_definition(
     return client._clients.catalog.get_dataset_derived_definition(client._clients.auth_header, rid, commit)
 
 
+def commit_and_persist_derived_definition(
+    client: NominalClient,
+    dataset: Dataset | str,
+    spec: nominal_compute.Dataset,
+    *,
+    message: str,
+    latest_commit: str | None = None,
+    persist: bool = True,
+) -> scout_catalog.DerivedDefinition:
+    """Replace a derived dataset's definition by creating a new commit, then persist that commit.
+    Persisting calls the versioning API so that the new commit appears in commit history and is not
+    lost to compaction.
+
+    Args:
+        client: The NominalClient to use for the commit.
+        dataset: The derived dataset, or its RID, whose definition to replace.
+        spec: ``nominal_compute`` graph defining the new derived definition.
+        message: Commit message describing the change.
+        latest_commit: If provided, the dataset's expected current commit, used for optimistic
+            concurrency control.
+        persist: Whether to persist the new commit, at the cost of one extra request. When False,
+            the commit is saved as a working commit, which is hidden from commit history and may be
+            lost to compaction.
+
+    Returns:
+        The newly committed derived definition.
+
+    Raises:
+        Exception: If the commit landed but persisting it failed. The two are separate requests, so
+            the commit still exists and is the dataset's current definition, but stays hidden from
+            history and eligible for compaction until persisted. Retrying this call creates a second
+            commit, so persist the existing one via the versioning API instead.
+    """
+    rid = rid_from_instance_or_string(dataset)
+    request = scout_catalog.CommitDerivedDefinitionRequest(
+        spec=_to_conjure_dataset(spec),
+        message=message,
+        latest_commit=latest_commit,
+    )
+    definition = client._clients.catalog.commit_derived_definition(client._clients.auth_header, rid, request)
+    if persist and definition.commit.is_working_state:
+        client._clients.versioning.persist_commits(
+            client._clients.auth_header,
+            [scout_versioning_api.ResourceAndCommitId(commit_id=definition.commit.id, resource_rid=rid)],
+        )
+    return definition
+
+
+@deprecated(
+    "`commit_derived_definition` is deprecated in favor of `commit_and_persist_derived_definition`, which persists "
+    "the new commit so that it appears in commit history and is not lost to compaction."
+)
 def commit_derived_definition(
     client: NominalClient,
     dataset: Dataset | str,
@@ -92,10 +145,10 @@ def commit_derived_definition(
     message: str,
     latest_commit: str | None = None,
 ) -> scout_catalog.DerivedDefinition:
-    """Replace a derived dataset's definition by creating a new commit. Note that this does not persist
-    the new commit, it simply saves it as a working commit. This means that commits created with this may
-    be lost to compaction. To prevent this, either call :func:`commit_and_persist_derived_definition` instead
-    or use the versioning API directly afterwards to persist the new commit.
+    """Replace a derived dataset's definition by creating a new commit, without persisting it.
+
+    Deprecated in favor of :func:`commit_and_persist_derived_definition`. This saves the new commit
+    as a working commit, which is hidden from commit history and may be lost to compaction.
 
     Args:
         client: The NominalClient to use for the commit.
@@ -108,46 +161,6 @@ def commit_derived_definition(
     Returns:
         The newly committed derived definition.
     """
-    rid = rid_from_instance_or_string(dataset)
-    request = scout_catalog.CommitDerivedDefinitionRequest(
-        spec=_to_conjure_dataset(spec),
-        message=message,
-        latest_commit=latest_commit,
+    return commit_and_persist_derived_definition(
+        client, dataset, spec, message=message, latest_commit=latest_commit, persist=False
     )
-    return client._clients.catalog.commit_derived_definition(client._clients.auth_header, rid, request)
-
-
-def commit_and_persist_derived_definition(
-    client: NominalClient,
-    dataset: Dataset | str,
-    spec: nominal_compute.Dataset,
-    *,
-    message: str,
-    latest_commit: str | None = None,
-) -> scout_catalog.DerivedDefinition:
-    """Replace a derived dataset's definition by creating a new commit, then persist that commit.
-    Similar to :func:`commit_derived_definition`, but also calls the versioning API to persist the new
-    commit so that it is not lost to compaction.
-
-    Args:
-        client: The NominalClient to use for the commit.
-        dataset: The derived dataset, or its RID, whose definition to replace.
-        spec: ``nominal_compute`` graph defining the new derived definition.
-        message: Commit message describing the change.
-        latest_commit: If provided, the dataset's expected current commit, used for optimistic
-            concurrency control.
-
-    Returns:
-        The newly committed derived definition.
-    """
-    definition = commit_derived_definition(client, dataset, spec, message=message, latest_commit=latest_commit)
-    if definition.commit.is_working_state:
-        client._clients.versioning.persist_commits(
-            client._clients.auth_header,
-            [
-                scout_versioning_api.ResourceAndCommitId(
-                    commit_id=definition.commit.id, resource_rid=rid_from_instance_or_string(dataset)
-                )
-            ],
-        )
-    return definition

--- a/nominal/experimental/compute_as_code/_derived_datasets.py
+++ b/nominal/experimental/compute_as_code/_derived_datasets.py
@@ -105,7 +105,7 @@ def commit_and_persist_derived_definition(
         message: Commit message describing the change.
         latest_commit: If provided, the dataset's expected current commit, used for optimistic
             concurrency control.
-        persist: Whether to persist the new commit. When False, the commit is saved as a working commit, 
+        persist: Whether to persist the new commit. When False, the commit is saved as a working commit,
             which is hidden from commit history and may be lost to compaction.
 
     Returns:

--- a/nominal/experimental/compute_as_code/_derived_datasets.py
+++ b/nominal/experimental/compute_as_code/_derived_datasets.py
@@ -10,7 +10,6 @@ from nominal_api import scout_catalog, scout_compute_api, scout_versioning_api
 from nominal.core import NominalClient
 from nominal.core._utils.api_tools import rid_from_instance_or_string
 from nominal.core.dataset import Dataset
-from nominal.core.exceptions import NominalCommitNotPersistedError
 
 
 def _to_conjure_dataset(spec: nominal_compute.Dataset) -> scout_compute_api.Dataset:
@@ -18,14 +17,6 @@ def _to_conjure_dataset(spec: nominal_compute.Dataset) -> scout_compute_api.Data
     wire_json = spec.to_json()  # type: ignore[attr-defined]
     dataset: scout_compute_api.Dataset = ConjureDecoder().decode(json.loads(wire_json), scout_compute_api.Dataset)
     return dataset
-
-
-def _persist_commit(client: NominalClient, rid: str, commit_id: str) -> None:
-    """Persist a commit so it survives commit compaction and appears in commit history."""
-    client._clients.versioning.persist_commits(
-        client._clients.auth_header,
-        [scout_versioning_api.ResourceAndCommitId(commit_id=commit_id, resource_rid=rid)],
-    )
 
 
 def create_derived_dataset(
@@ -116,9 +107,6 @@ def commit_derived_definition(
 
     Returns:
         The newly committed derived definition.
-
-    Raises:
-        NominalCommitNotPersistedError: If the commit was created but persisting it failed.
     """
     rid = rid_from_instance_or_string(dataset)
     request = scout_catalog.CommitDerivedDefinitionRequest(
@@ -128,10 +116,8 @@ def commit_derived_definition(
     )
     definition = client._clients.catalog.commit_derived_definition(client._clients.auth_header, rid, request)
     if definition.commit.is_working_state:
-        try:
-            _persist_commit(client, rid, definition.commit.id)
-        except Exception as e:
-            raise NominalCommitNotPersistedError(
-                f"committed {definition.commit.id} to {rid}, but failed to persist it"
-            ) from e
+        client._clients.versioning.persist_commits(
+            client._clients.auth_header,
+            [scout_versioning_api.ResourceAndCommitId(commit_id=definition.commit.id, resource_rid=rid)],
+        )
     return definition

--- a/nominal/experimental/compute_as_code/_derived_datasets.py
+++ b/nominal/experimental/compute_as_code/_derived_datasets.py
@@ -92,7 +92,10 @@ def commit_derived_definition(
     message: str,
     latest_commit: str | None = None,
 ) -> scout_catalog.DerivedDefinition:
-    """Replace a derived dataset's definition by creating a new commit.
+    """Replace a derived dataset's definition by creating a new commit. Note that this does not persist
+    the new commit, it simply saves it as a working commit. This means that commits created with this may
+    be lost to compaction. To prevent this, either call :func:`commit_and_persist_derived_definition` instead
+    or use the versioning API directly afterwards to persist the new commit.
 
     Args:
         client: The NominalClient to use for the commit.
@@ -123,9 +126,8 @@ def commit_and_persist_derived_definition(
     latest_commit: str | None = None,
 ) -> scout_catalog.DerivedDefinition:
     """Replace a derived dataset's definition by creating a new commit, then persist that commit.
-
-    Like :func:`commit_derived_definition`, at the cost of one extra request: an unpersisted commit
-    is hidden from commit history and may be removed by commit compaction.
+    Similar to :func:`commit_derived_definition`, but also calls the versioning API to persist the new
+    commit so that it is not lost to compaction.
 
     Args:
         client: The NominalClient to use for the commit.

--- a/nominal/experimental/compute_as_code/_derived_datasets.py
+++ b/nominal/experimental/compute_as_code/_derived_datasets.py
@@ -94,9 +94,6 @@ def commit_derived_definition(
 ) -> scout_catalog.DerivedDefinition:
     """Replace a derived dataset's definition by creating a new commit.
 
-    The new commit is persisted, without which it would be hidden from commit history and could be
-    removed by commit compaction.
-
     Args:
         client: The NominalClient to use for the commit.
         dataset: The derived dataset, or its RID, whose definition to replace.
@@ -114,10 +111,41 @@ def commit_derived_definition(
         message=message,
         latest_commit=latest_commit,
     )
-    definition = client._clients.catalog.commit_derived_definition(client._clients.auth_header, rid, request)
+    return client._clients.catalog.commit_derived_definition(client._clients.auth_header, rid, request)
+
+
+def commit_and_persist_derived_definition(
+    client: NominalClient,
+    dataset: Dataset | str,
+    spec: nominal_compute.Dataset,
+    *,
+    message: str,
+    latest_commit: str | None = None,
+) -> scout_catalog.DerivedDefinition:
+    """Replace a derived dataset's definition by creating a new commit, then persist that commit.
+
+    Like :func:`commit_derived_definition`, at the cost of one extra request: an unpersisted commit
+    is hidden from commit history and may be removed by commit compaction.
+
+    Args:
+        client: The NominalClient to use for the commit.
+        dataset: The derived dataset, or its RID, whose definition to replace.
+        spec: ``nominal_compute`` graph defining the new derived definition.
+        message: Commit message describing the change.
+        latest_commit: If provided, the dataset's expected current commit, used for optimistic
+            concurrency control.
+
+    Returns:
+        The newly committed derived definition.
+    """
+    definition = commit_derived_definition(client, dataset, spec, message=message, latest_commit=latest_commit)
     if definition.commit.is_working_state:
         client._clients.versioning.persist_commits(
             client._clients.auth_header,
-            [scout_versioning_api.ResourceAndCommitId(commit_id=definition.commit.id, resource_rid=rid)],
+            [
+                scout_versioning_api.ResourceAndCommitId(
+                    commit_id=definition.commit.id, resource_rid=rid_from_instance_or_string(dataset)
+                )
+            ],
         )
     return definition

--- a/tests/experimental/test_derived_datasets.py
+++ b/tests/experimental/test_derived_datasets.py
@@ -6,6 +6,7 @@ import pytest
 from nominal_api import scout_catalog, scout_compute_api, scout_versioning_api
 
 from nominal.experimental.compute_as_code import (
+    commit_and_persist_derived_definition,
     commit_derived_definition,
     create_derived_dataset,
     get_derived_definition,
@@ -146,11 +147,11 @@ def _commit_spec() -> object:
     return nc.Dataset.Saved(DATASET_RID)
 
 
-def test_commit_persists_working_state_commit(client: MagicMock) -> None:
-    """A commit that lands in working state is persisted."""
+def test_commit_and_persist_persists_working_state_commit(client: MagicMock) -> None:
+    """The new commit is persisted, and the definition returned unchanged."""
     definition = _stub_commit_response(client, _commit("ri.commit.new"))
 
-    result = commit_derived_definition(client, DATASET_RID, _commit_spec(), message="update")
+    result = commit_and_persist_derived_definition(client, DATASET_RID, _commit_spec(), message="update")
 
     assert result is definition
     auth, _ = client._clients.versioning.persist_commits.call_args[0]
@@ -158,9 +159,32 @@ def test_commit_persists_working_state_commit(client: MagicMock) -> None:
     assert _persisted_ids(client) == ["ri.commit.new"]
 
 
-def test_commit_skips_persist_when_commit_already_permanent(client: MagicMock) -> None:
+def test_commit_and_persist_forwards_the_commit_request(client: MagicMock) -> None:
+    """The commit itself goes through commit_derived_definition, latest_commit and all."""
+    _stub_commit_response(client, _commit("ri.commit.new"))
+
+    commit_and_persist_derived_definition(
+        client, DATASET_RID, _commit_spec(), message="update", latest_commit="ri.commit.1"
+    )
+
+    _, rid, request = client._clients.catalog.commit_derived_definition.call_args[0]
+    assert rid == DATASET_RID
+    assert request.message == "update"
+    assert request.latest_commit == "ri.commit.1"
+
+
+def test_commit_and_persist_skips_persist_when_commit_already_permanent(client: MagicMock) -> None:
     """A commit that is already permanent is not persisted again."""
     _stub_commit_response(client, _commit("ri.commit.new", working_state=False))
+
+    commit_and_persist_derived_definition(client, DATASET_RID, _commit_spec(), message="update")
+
+    client._clients.versioning.persist_commits.assert_not_called()
+
+
+def test_commit_derived_definition_does_not_persist(client: MagicMock) -> None:
+    """The plain commit function is unchanged: it makes no versioning request."""
+    _stub_commit_response(client, _commit("ri.commit.new"))
 
     commit_derived_definition(client, DATASET_RID, _commit_spec(), message="update")
 

--- a/tests/experimental/test_derived_datasets.py
+++ b/tests/experimental/test_derived_datasets.py
@@ -126,9 +126,10 @@ def test_commit_derived_definition_builds_request(client: MagicMock) -> None:
     """commit_derived_definition builds the request with the bridged spec, message, and latest commit."""
     nc = pytest.importorskip("nominal_compute")
     spec = nc.Dataset.Saved("ri.catalog.ws.dataset.abc").time_shift(nc.Duration.Seconds(5))
-    result = commit_derived_definition(
-        client, "ri.catalog.ws.dataset.abc", spec, message="update", latest_commit="ri.commit.1"
-    )
+    with pytest.warns(DeprecationWarning):
+        result = commit_derived_definition(
+            client, "ri.catalog.ws.dataset.abc", spec, message="update", latest_commit="ri.commit.1"
+        )
     assert result is client._clients.catalog.commit_derived_definition.return_value
     auth, rid, request = client._clients.catalog.commit_derived_definition.call_args[0]
     assert auth == "Bearer test-token"
@@ -159,18 +160,16 @@ def test_commit_and_persist_persists_working_state_commit(client: MagicMock) -> 
     assert _persisted_ids(client) == ["ri.commit.new"]
 
 
-def test_commit_and_persist_forwards_the_commit_request(client: MagicMock) -> None:
-    """The commit itself goes through commit_derived_definition, latest_commit and all."""
+def test_commit_and_persist_persists_against_the_resolved_rid(client: MagicMock) -> None:
+    """A Dataset instance resolves to its RID, which is what the commit is persisted against."""
+    dataset = MagicMock()
+    dataset.rid = DATASET_RID
     _stub_commit_response(client, _commit("ri.commit.new"))
 
-    commit_and_persist_derived_definition(
-        client, DATASET_RID, _commit_spec(), message="update", latest_commit="ri.commit.1"
-    )
+    commit_and_persist_derived_definition(client, dataset, _commit_spec(), message="update")
 
-    _, rid, request = client._clients.catalog.commit_derived_definition.call_args[0]
-    assert rid == DATASET_RID
-    assert request.message == "update"
-    assert request.latest_commit == "ri.commit.1"
+    # _persisted_ids asserts the resource_rid of every entry.
+    assert _persisted_ids(client) == ["ri.commit.new"]
 
 
 def test_commit_and_persist_skips_persist_when_commit_already_permanent(client: MagicMock) -> None:
@@ -182,10 +181,32 @@ def test_commit_and_persist_skips_persist_when_commit_already_permanent(client: 
     client._clients.versioning.persist_commits.assert_not_called()
 
 
-def test_commit_derived_definition_does_not_persist(client: MagicMock) -> None:
-    """The plain commit function is unchanged: it makes no versioning request."""
+def test_commit_and_persist_skips_persist_when_opted_out(client: MagicMock) -> None:
+    """persist=False commits without the extra versioning request."""
     _stub_commit_response(client, _commit("ri.commit.new"))
 
-    commit_derived_definition(client, DATASET_RID, _commit_spec(), message="update")
+    commit_and_persist_derived_definition(client, DATASET_RID, _commit_spec(), message="update", persist=False)
+
+    client._clients.catalog.commit_derived_definition.assert_called_once()
+    client._clients.versioning.persist_commits.assert_not_called()
+
+
+def test_commit_and_persist_propagates_a_failed_persist(client: MagicMock) -> None:
+    """A failed persist surfaces to the caller, with the commit already landed."""
+    _stub_commit_response(client, _commit("ri.commit.new"))
+    client._clients.versioning.persist_commits.side_effect = RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        commit_and_persist_derived_definition(client, DATASET_RID, _commit_spec(), message="update")
+
+    client._clients.catalog.commit_derived_definition.assert_called_once()
+
+
+def test_commit_derived_definition_is_deprecated_and_does_not_persist(client: MagicMock) -> None:
+    """The old function warns, and delegates with persistence off, so it makes no versioning request."""
+    _stub_commit_response(client, _commit("ri.commit.new"))
+
+    with pytest.warns(DeprecationWarning, match="commit_and_persist_derived_definition"):
+        commit_derived_definition(client, DATASET_RID, _commit_spec(), message="update")
 
     client._clients.versioning.persist_commits.assert_not_called()

--- a/tests/experimental/test_derived_datasets.py
+++ b/tests/experimental/test_derived_datasets.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from nominal_api import scout_compute_api
+from nominal_api import scout_catalog, scout_compute_api, scout_versioning_api
 
+from nominal.core.exceptions import NominalCommitNotPersistedError
 from nominal.experimental.compute_as_code import (
     commit_derived_definition,
     create_derived_dataset,
@@ -21,10 +22,38 @@ def client(mock_clients: MagicMock) -> MagicMock:
     return client
 
 
+DATASET_RID = "ri.catalog.ws.dataset.abc"
+
+
 def _conjure_saved(rid: str) -> scout_compute_api.Dataset:
     return scout_compute_api.Dataset(
         saved=scout_compute_api.SavedDataset(rid=scout_compute_api.StringConstant(literal=rid))
     )
+
+
+def _commit(commit_id: str, *, working_state: bool = True) -> scout_versioning_api.Commit:
+    return scout_versioning_api.Commit(
+        committed_at="2026-01-01T00:00:00Z",
+        committed_by="ri.authn.ws.user.1",
+        id=commit_id,
+        is_working_state=working_state,
+        message=f"commit {commit_id}",
+        resource_rid=DATASET_RID,
+    )
+
+
+def _stub_commit_response(client: MagicMock, commit: scout_versioning_api.Commit) -> scout_catalog.DerivedDefinition:
+    """Make the catalog's commit call return a definition carrying `commit`."""
+    definition = scout_catalog.DerivedDefinition(commit=commit, spec=_conjure_saved(DATASET_RID))
+    client._clients.catalog.commit_derived_definition.return_value = definition
+    return definition
+
+
+def _persisted_ids(client: MagicMock) -> list[str]:
+    """The commit IDs the client passed to persist_commits."""
+    _, request = client._clients.versioning.persist_commits.call_args[0]
+    assert [entry.resource_rid for entry in request] == [DATASET_RID] * len(request)
+    return [entry.commit_id for entry in request]
 
 
 # --- bridge: nominal_compute -> scout_compute_api ---
@@ -108,3 +137,44 @@ def test_commit_derived_definition_builds_request(client: MagicMock) -> None:
     assert request.spec.type == "timeShift"
     assert request.message == "update"
     assert request.latest_commit == "ri.commit.1"
+
+
+# --- commit persistence ---
+
+
+def _commit_spec() -> object:
+    nc = pytest.importorskip("nominal_compute")
+    return nc.Dataset.Saved(DATASET_RID)
+
+
+def test_commit_persists_working_state_commit(client: MagicMock) -> None:
+    """A commit that lands in working state is persisted."""
+    definition = _stub_commit_response(client, _commit("ri.commit.new"))
+
+    result = commit_derived_definition(client, DATASET_RID, _commit_spec(), message="update")
+
+    assert result is definition
+    auth, _ = client._clients.versioning.persist_commits.call_args[0]
+    assert auth == "Bearer test-token"
+    assert _persisted_ids(client) == ["ri.commit.new"]
+
+
+def test_commit_skips_persist_when_commit_already_permanent(client: MagicMock) -> None:
+    """A commit that is already permanent is not persisted again."""
+    _stub_commit_response(client, _commit("ri.commit.new", working_state=False))
+
+    commit_derived_definition(client, DATASET_RID, _commit_spec(), message="update")
+
+    client._clients.versioning.persist_commits.assert_not_called()
+
+
+def test_commit_raises_naming_the_commit_when_persist_fails(client: MagicMock) -> None:
+    """A failed persist raises an error naming the commit that landed."""
+    _stub_commit_response(client, _commit("ri.commit.new"))
+    cause = RuntimeError("boom")
+    client._clients.versioning.persist_commits.side_effect = cause
+
+    with pytest.raises(NominalCommitNotPersistedError, match="ri.commit.new") as excinfo:
+        commit_derived_definition(client, DATASET_RID, _commit_spec(), message="update")
+
+    assert excinfo.value.__cause__ is cause

--- a/tests/experimental/test_derived_datasets.py
+++ b/tests/experimental/test_derived_datasets.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from nominal_api import scout_catalog, scout_compute_api, scout_versioning_api
 
-from nominal.core.exceptions import NominalCommitNotPersistedError
 from nominal.experimental.compute_as_code import (
     commit_derived_definition,
     create_derived_dataset,
@@ -166,15 +165,3 @@ def test_commit_skips_persist_when_commit_already_permanent(client: MagicMock) -
     commit_derived_definition(client, DATASET_RID, _commit_spec(), message="update")
 
     client._clients.versioning.persist_commits.assert_not_called()
-
-
-def test_commit_raises_naming_the_commit_when_persist_fails(client: MagicMock) -> None:
-    """A failed persist raises an error naming the commit that landed."""
-    _stub_commit_response(client, _commit("ri.commit.new"))
-    cause = RuntimeError("boom")
-    client._clients.versioning.persist_commits.side_effect = cause
-
-    with pytest.raises(NominalCommitNotPersistedError, match="ri.commit.new") as excinfo:
-        commit_derived_definition(client, DATASET_RID, _commit_spec(), message="update")
-
-    assert excinfo.value.__cause__ is cause


### PR DESCRIPTION
Editing a derived dataset's definition through the SDK doesn't show up in the dataset's history. The edit itself saves correctly, and the dataset always reflects the latest definition, but the backend records it as a temporary "working state" commit rather than a permanent one. Those commits are hidden from history and are eligible for automatic cleanup, so a dataset edited a few times still shows only its original creation in the API and UI, and older versions can disappear entirely, along with the ability to see what the definition used to be or roll back to it. 

This PR adds `commit_and_persist_derived_definition`, which commits and then marks the commit permanent so the edit shows up in history and persist. `commit_derived_definition` is unchanged.