### PR TITLE
feat: add markings support for datasets, connections, and videos

### DIFF
--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -29,6 +29,7 @@ from nominal.core.event import Event
 from nominal.core.filetype import FileType, FileTypes
 from nominal.core.ingestion_job import IngestionJob, IngestionJobStatus, IngestType
 from nominal.core.log import LogPoint
+from nominal.core.marking import Marking
 from nominal.core.run import Run
 from nominal.core.secret import Secret
 from nominal.core.unit import Unit, UnitLike
@@ -77,6 +78,7 @@ __all__ = [
     "LinkDict",
     "LogPoint",
     "LogStream",
+    "Marking",
     "Comment",
     "NominalClient",
     "Run",

--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -24,7 +24,7 @@ from nominal.core.data_review import CheckViolation, DataReview, DataReviewBuild
 from nominal.core.dataset import Dataset
 from nominal.core.dataset_file import DatasetFile, IngestWaitType, as_files_ingested, wait_for_files_to_ingest
 from nominal.core.datasource import DataSource
-from nominal.core.elements import Color, Symbol, SymbolKind
+from nominal.core.elements import Symbol, SymbolKind
 from nominal.core.event import Event
 from nominal.core.filetype import FileType, FileTypes
 from nominal.core.ingestion_job import IngestionJob, IngestionJobStatus, IngestType
@@ -52,7 +52,6 @@ __all__ = [
     "filter_channels_with_data",
     "Checklist",
     "CheckViolation",
-    "Color",
     "Connection",
     "ContainerImage",
     "ContainerImageStatus",

--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -24,6 +24,7 @@ from nominal.core.data_review import CheckViolation, DataReview, DataReviewBuild
 from nominal.core.dataset import Dataset
 from nominal.core.dataset_file import DatasetFile, IngestWaitType, as_files_ingested, wait_for_files_to_ingest
 from nominal.core.datasource import DataSource
+from nominal.core.elements import Color, Symbol, SymbolKind
 from nominal.core.event import Event
 from nominal.core.filetype import FileType, FileTypes
 from nominal.core.ingestion_job import IngestionJob, IngestionJobStatus, IngestType
@@ -50,6 +51,7 @@ __all__ = [
     "filter_channels_with_data",
     "Checklist",
     "CheckViolation",
+    "Color",
     "Connection",
     "ContainerImage",
     "ContainerImageStatus",
@@ -80,6 +82,8 @@ __all__ = [
     "Run",
     "SearchEventOriginType",
     "Secret",
+    "Symbol",
+    "SymbolKind",
     "TimestampMetadata",
     "Unit",
     "UnitLike",

--- a/nominal/core/__init__.py
+++ b/nominal/core/__init__.py
@@ -24,10 +24,12 @@ from nominal.core.data_review import CheckViolation, DataReview, DataReviewBuild
 from nominal.core.dataset import Dataset
 from nominal.core.dataset_file import DatasetFile, IngestWaitType, as_files_ingested, wait_for_files_to_ingest
 from nominal.core.datasource import DataSource
+from nominal.core.elements import Symbol, SymbolKind
 from nominal.core.event import Event
 from nominal.core.filetype import FileType, FileTypes
 from nominal.core.ingestion_job import IngestionJob, IngestionJobStatus, IngestType
 from nominal.core.log import LogPoint
+from nominal.core.marking import Marking
 from nominal.core.run import Run
 from nominal.core.secret import Secret
 from nominal.core.unit import Unit, UnitLike
@@ -75,11 +77,14 @@ __all__ = [
     "LinkDict",
     "LogPoint",
     "LogStream",
+    "Marking",
     "Comment",
     "NominalClient",
     "Run",
     "SearchEventOriginType",
     "Secret",
+    "Symbol",
+    "SymbolKind",
     "TimestampMetadata",
     "Unit",
     "UnitLike",

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -36,6 +36,7 @@ from nominal.core._utils.networking import (
     create_conjure_client_factory,
 )
 from nominal.core.exceptions import NominalConfigError
+from nominal.protos.authorization.markings.v1 import markings_pb2_grpc
 from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
 from nominal.protos.event.v2 import event_pb2_grpc
@@ -173,6 +174,7 @@ class ClientsBunch:
     containerized_extractor: containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
     event: event_pb2_grpc.EventServiceStub
     ingest_v2: ingest_service_pb2_grpc.IngestServiceStub
+    markings: markings_pb2_grpc.MarkingServiceStub
     registry: registry_pb2_grpc.RegistryServiceStub
     roles: roles_pb2_grpc.RoleServiceStub
     sandbox_workspace: sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub
@@ -336,6 +338,7 @@ class ClientsBunch:
             containerized_extractor=grpc_factory(containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub),
             event=grpc_factory(event_pb2_grpc.EventServiceStub),
             ingest_v2=grpc_factory(ingest_service_pb2_grpc.IngestServiceStub),
+            markings=grpc_factory(markings_pb2_grpc.MarkingServiceStub),
             registry=grpc_factory(registry_pb2_grpc.RegistryServiceStub),
             roles=grpc_factory(roles_pb2_grpc.RoleServiceStub),
             sandbox_workspace=grpc_factory(sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub),

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -37,6 +37,7 @@ from nominal.core._utils.networking import (
     validate_api_base_url,
 )
 from nominal.core.exceptions import NominalConfigError
+from nominal.protos.authorization.markings.v1 import markings_pb2_grpc
 from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.comments.v1 import comments_pb2_grpc
 from nominal.protos.event.v2 import event_pb2_grpc
@@ -174,6 +175,7 @@ class ClientsBunch:
     containerized_extractor: containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
     event: event_pb2_grpc.EventServiceStub
     ingest_v2: ingest_service_pb2_grpc.IngestServiceStub
+    markings: markings_pb2_grpc.MarkingServiceStub
     registry: registry_pb2_grpc.RegistryServiceStub
     roles: roles_pb2_grpc.RoleServiceStub
     sandbox_workspace: sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub
@@ -338,6 +340,7 @@ class ClientsBunch:
             containerized_extractor=grpc_factory(containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub),
             event=grpc_factory(event_pb2_grpc.EventServiceStub),
             ingest_v2=grpc_factory(ingest_service_pb2_grpc.IngestServiceStub),
+            markings=grpc_factory(markings_pb2_grpc.MarkingServiceStub),
             registry=grpc_factory(registry_pb2_grpc.RegistryServiceStub),
             roles=grpc_factory(roles_pb2_grpc.RoleServiceStub),
             sandbox_workspace=grpc_factory(sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub),

--- a/nominal/core/_utils/pagination_tools.py
+++ b/nominal/core/_utils/pagination_tools.py
@@ -21,6 +21,7 @@ from nominal_api import (
 
 from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.query_tools import ArchiveStatusFilter
+from nominal.protos.authorization.markings.v1 import markings_pb2, markings_pb2_grpc
 from nominal.protos.event.v2 import event_pb2, event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2, containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2, registry_pb2_grpc
@@ -241,6 +242,27 @@ def search_runs_by_asset_paginated(
 
     for response in paginate_rpc(run.get_runs_by_asset, auth_header, request_factory=factory):
         yield from response.results
+
+
+def search_markings_paginated(
+    markings: markings_pb2_grpc.MarkingServiceStub,
+    query: markings_pb2.SearchMarkingsQuery,
+) -> Iterable[markings_pb2.MarkingMetadata]:
+    """Yield markings matching a query, oldest first.
+
+    Unlike its neighbours, the request type carries no sort options: the service always orders by
+    creation time ascending. Archived markings are excluded by the service and never appear here.
+    """
+
+    def factory(page_token: str | None) -> markings_pb2.SearchMarkingsRequest:
+        return markings_pb2.SearchMarkingsRequest(
+            page_size=DEFAULT_PAGE_SIZE,
+            query=query,
+            next_page_token=page_token,
+        )
+
+    for response in paginate_grpc(markings.SearchMarkings, request_factory=factory):
+        yield from response.marking_metadatas
 
 
 def search_secrets_paginated(

--- a/nominal/core/_utils/query_tools.py
+++ b/nominal/core/_utils/query_tools.py
@@ -20,6 +20,7 @@ from nominal_api import (
 
 from nominal.core._event_types import EventType, SearchEventOriginType
 from nominal.core._utils.api_tools import rid_from_instance_or_string
+from nominal.protos.authorization.markings.v1 import markings_pb2
 from nominal.protos.event.v2 import event_pb2
 from nominal.protos.registry.v2 import registry_pb2
 from nominal.protos.secrets.v1 import secrets_pb2
@@ -150,6 +151,18 @@ def _backfill_workbook_template_archive_query_clause(
             )
 
     raise ValueError(f"Unexpected archive_status for workbook template search: {archive_status}")
+
+
+def create_search_markings_query(id_substring: str | None = None) -> markings_pb2.SearchMarkingsQuery:
+    """Build a marking search query. With no arguments, matches every marking in the organization."""
+    queries = []
+    if id_substring is not None:
+        queries.append(markings_pb2.SearchMarkingsQuery(id_exact_substring_search=id_substring))
+    # `and` is a Python keyword, and generated typing stubs cannot expose it as a named argument.
+    # Unlike most search queries in this API, `and` holds a message wrapping the list, not a repeated field.
+    return markings_pb2.SearchMarkingsQuery(
+        **{"and": markings_pb2.SearchMarkingsQueryList(queries=queries)}  # type: ignore[arg-type]
+    )
 
 
 def create_search_secrets_query(

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -93,7 +93,7 @@ from nominal.core.dataset import (
 )
 from nominal.core.dataset_file import DatasetFile
 from nominal.core.datasource import DataSource
-from nominal.core.elements import Color, Symbol
+from nominal.core.elements import Symbol
 from nominal.core.event import Event, _create_event, _get_event, _get_events, _search_events
 from nominal.core.exceptions import (
     LegacyVideoDeprecationWarning,
@@ -552,7 +552,7 @@ class NominalClient:
         description: str | None = None,
         authorized_group_rids: Sequence[str] = (),
         symbol: Symbol | None = None,
-        color: Color | None = None,
+        color: str | None = None,
     ) -> Marking:
         """Create a marking in the current organization.
 
@@ -564,13 +564,14 @@ class NominalClient:
             authorized_group_rids: RIDs of the groups authorized to access data sources carrying
                 this marking.
             symbol: Symbol identifying the marking in the Nominal app.
-            color: Color identifying the marking in the Nominal app.
+            color: Lowercase six-digit hex color identifying the marking in the Nominal app,
+                e.g. `#cc0000`.
 
         Returns:
             Reference to the created marking.
 
         Raises:
-            ValueError: If `id` is not a valid marking id.
+            ValueError: If `id` is not a valid marking id, or `color` is not a valid hex color.
             NominalError: If creation fails, including when the caller is not an organization admin
                 or a marking with this id already exists.
         """

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -865,7 +865,9 @@ class NominalClient:
             labels: Text labels to apply to the created dataset
             properties: Key-value properties to apply to the cleated dataset
             prefix_tree_delimiter: If present, the delimiter to represent tiers when viewing channels hierarchically.
-            markings: If present, markings (or marking RIDs) to apply to the created dataset
+            markings: If present, markings (or marking RIDs) to apply to the created dataset. Markings are
+                applied in a separate step after the dataset is created, so creation and marking are not
+                atomic; if that matters, verify with `list_markings()`.
 
         Returns:
             Reference to the created dataset in Nominal.
@@ -908,7 +910,9 @@ class NominalClient:
             description: Description of the video to create in nominal
             labels: Labels to apply to the video in nominal
             properties: Properties to apply to the video in nominal
-            markings: If present, markings (or marking RIDs) to apply to the created video
+            markings: If present, markings (or marking RIDs) to apply to the created video. Markings are
+                applied in a separate step after the video is created, so creation and marking are not
+                atomic; if that matters, verify with `list_markings()`.
 
         Returns:
             Handle to the created video

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -110,7 +110,6 @@ from nominal.core.marking import (
     _get_marking,
     _get_marking_by_id,
     _get_markings,
-    _iter_search_markings,
     _search_markings,
 )
 from nominal.core.run import Run, _create_run
@@ -122,7 +121,6 @@ from nominal.core.video import Video, _create_video
 from nominal.core.workbook import Workbook, _search_workbooks
 from nominal.core.workbook_template import WorkbookTemplate
 from nominal.core.workspace import Workspace
-from nominal.protos.authorization.markings.v1 import markings_pb2
 from nominal.protos.secrets.v1 import secrets_pb2
 from nominal.protos.units.v1 import units_pb2
 from nominal.protos.workspaces.v1 import workspaces_pb2
@@ -609,9 +607,6 @@ class NominalClient:
         Markings that do not exist, or that the user cannot read, are omitted from the result.
         """
         return _get_markings(self._clients, rids)
-
-    def _iter_search_markings(self, query: markings_pb2.SearchMarkingsQuery) -> Iterable[Marking]:
-        yield from _iter_search_markings(self._clients, query)
 
     def search_markings(self, id_substring: str | None = None) -> Sequence[Marking]:
         """Search markings in the current organization, oldest first.

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -109,7 +109,6 @@ from nominal.core.marking import (
     _create_marking,
     _get_marking,
     _get_marking_by_id,
-    _get_markings,
     _search_markings,
 )
 from nominal.core.run import Run, _create_run
@@ -600,13 +599,6 @@ class NominalClient:
             NominalError: If no marking with the given id exists or it is not accessible.
         """
         return _get_marking_by_id(self._clients, id)
-
-    def get_markings(self, rids: Iterable[str]) -> Sequence[Marking]:
-        """Retrieve markings by RID.
-
-        Markings that do not exist, or that the user cannot read, are omitted from the result.
-        """
-        return _get_markings(self._clients, rids)
 
     def search_markings(self, id_substring: str | None = None) -> Sequence[Marking]:
         """Search markings in the current organization, oldest first.

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -855,7 +855,7 @@ class NominalClient:
         labels: Sequence[str] = (),
         properties: Mapping[str, str] | None = None,
         prefix_tree_delimiter: str | None = None,
-        markings: Sequence[str] | None = None,
+        markings: Sequence[Marking | str] | None = None,
     ) -> Dataset:
         """Create an empty dataset.
 
@@ -865,7 +865,7 @@ class NominalClient:
             labels: Text labels to apply to the created dataset
             properties: Key-value properties to apply to the cleated dataset
             prefix_tree_delimiter: If present, the delimiter to represent tiers when viewing channels hierarchically.
-            markings: If present, RIDs of markings to apply to the created dataset
+            markings: If present, markings (or marking RIDs) to apply to the created dataset
 
         Returns:
             Reference to the created dataset in Nominal.
@@ -878,7 +878,7 @@ class NominalClient:
             labels=labels,
             properties=properties,
             workspace_rid=self._clients.resolve_default_workspace_rid(),
-            marking_rids=markings,
+            marking_rids=None if markings is None else [rid_from_instance_or_string(m) for m in markings],
         )
         dataset = Dataset._from_conjure(self._clients, response)
 
@@ -899,6 +899,7 @@ class NominalClient:
         description: str | None = None,
         labels: Sequence[str] = (),
         properties: Mapping[str, str] | None = None,
+        markings: Sequence[Marking | str] | None = None,
     ) -> Video:
         """Create an empty video to append video files to.
 
@@ -907,6 +908,7 @@ class NominalClient:
             description: Description of the video to create in nominal
             labels: Labels to apply to the video in nominal
             properties: Properties to apply to the video in nominal
+            markings: If present, markings (or marking RIDs) to apply to the created video
 
         Returns:
             Handle to the created video
@@ -919,6 +921,7 @@ class NominalClient:
             labels=labels,
             properties=properties,
             workspace_rid=self._clients.resolve_default_workspace_rid(),
+            marking_rids=None if markings is None else [rid_from_instance_or_string(m) for m in markings],
         )
         return Video._from_conjure(self._clients, response)
 
@@ -1164,6 +1167,7 @@ class NominalClient:
         datasource_description: str | None = None,
         *,
         required_tag_names: list[str] | None = None,
+        markings: Sequence[Marking | str] | None = None,
     ) -> StreamingConnection:
         workspace_rid = self._clients.resolve_default_workspace_rid()
         datasource_response = self._clients.storage.create(
@@ -1196,7 +1200,7 @@ class NominalClient:
                 available_tag_values={},
                 should_scrape=True,
                 workspace=workspace_rid,
-                marking_rids=[],
+                marking_rids=[] if markings is None else [rid_from_instance_or_string(m) for m in markings],
             ),
         )
         conn = Connection._from_conjure(self._clients, connection_response)

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -93,6 +93,7 @@ from nominal.core.dataset import (
 )
 from nominal.core.dataset_file import DatasetFile
 from nominal.core.datasource import DataSource
+from nominal.core.elements import Color, Symbol
 from nominal.core.event import Event, _create_event, _get_event, _get_events, _search_events
 from nominal.core.exceptions import (
     LegacyVideoDeprecationWarning,
@@ -103,6 +104,15 @@ from nominal.core.exceptions import (
 )
 from nominal.core.filetype import FileType, FileTypes
 from nominal.core.ingestion_job import IngestionJob, IngestionJobStatus
+from nominal.core.marking import (
+    Marking,
+    _create_marking,
+    _get_marking,
+    _get_marking_by_id,
+    _get_markings,
+    _iter_search_markings,
+    _search_markings,
+)
 from nominal.core.run import Run, _create_run
 from nominal.core.secret import Secret
 from nominal.core.streaming_checklist import _iter_list_streaming_checklists
@@ -112,6 +122,7 @@ from nominal.core.video import Video, _create_video
 from nominal.core.workbook import Workbook, _search_workbooks
 from nominal.core.workbook_template import WorkbookTemplate
 from nominal.core.workspace import Workspace
+from nominal.protos.authorization.markings.v1 import markings_pb2
 from nominal.protos.secrets.v1 import secrets_pb2
 from nominal.protos.units.v1 import units_pb2
 from nominal.protos.workspaces.v1 import workspaces_pb2
@@ -536,6 +547,87 @@ class NominalClient:
             workspace_rid=self._workspace_rid_for_search(workspace),
         )
         return list(self._iter_search_secrets(query, archive_status))
+
+    def create_marking(
+        self,
+        id: str,
+        *,
+        description: str | None = None,
+        authorized_group_rids: Sequence[str] = (),
+        symbol: Symbol | None = None,
+        color: Color | None = None,
+    ) -> Marking:
+        """Create a marking in the current organization.
+
+        Args:
+            id: Human-readable identifier for the marking, unique within the organization. Must be
+                lowercase alphanumeric characters optionally separated by hyphens, starting with a
+                letter, e.g. `export-controlled`.
+            description: Human readable description of the marking.
+            authorized_group_rids: RIDs of the groups authorized to access data sources carrying
+                this marking.
+            symbol: Symbol identifying the marking in the Nominal app.
+            color: Color identifying the marking in the Nominal app.
+
+        Returns:
+            Reference to the created marking.
+
+        Raises:
+            ValueError: If `id` is not a valid marking id.
+            NominalError: If creation fails, including when the caller is not an organization admin
+                or a marking with this id already exists.
+        """
+        return _create_marking(
+            self._clients,
+            id=id,
+            description=description,
+            authorized_group_rids=authorized_group_rids,
+            symbol=symbol,
+            color=color,
+        )
+
+    def get_marking(self, rid: str) -> Marking:
+        """Retrieve a marking by RID.
+
+        Raises:
+            NominalNotFoundError: If no marking with the given RID exists or it is not accessible.
+        """
+        return _get_marking(self._clients, rid)
+
+    def get_marking_by_id(self, id: str) -> Marking:
+        """Retrieve a marking by its human-readable id, unique within the organization.
+
+        Raises:
+            ValueError: If `id` is not a valid marking id.
+            NominalError: If no marking with the given id exists or it is not accessible.
+        """
+        return _get_marking_by_id(self._clients, id)
+
+    def get_markings(self, rids: Iterable[str]) -> Sequence[Marking]:
+        """Retrieve markings by RID.
+
+        Markings that do not exist, or that the user cannot read, are omitted from the result.
+        """
+        return _get_markings(self._clients, rids)
+
+    def _iter_search_markings(self, query: markings_pb2.SearchMarkingsQuery) -> Iterable[Marking]:
+        yield from _iter_search_markings(self._clients, query)
+
+    def search_markings(self, id_substring: str | None = None) -> Sequence[Marking]:
+        """Search markings in the current organization, oldest first.
+
+        Args:
+            id_substring: Case-insensitive substring that a marking's id must contain to be included.
+
+        Returns:
+            All markings matching the given conditions.
+
+        Note:
+            Markings are scoped to an organization rather than a workspace, so this search takes no
+            workspace filter. Archived markings are never returned; fetch them by RID with
+            `get_marking` instead.
+        """
+        return _search_markings(self._clients, id_substring=id_substring)
 
     def _iter_search_videos(
         self,

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -109,6 +109,7 @@ from nominal.core.marking import (
     _create_marking,
     _get_marking,
     _get_marking_by_id,
+    _marking_rids,
     _search_markings,
 )
 from nominal.core.run import Run, _create_run
@@ -610,7 +611,8 @@ class NominalClient:
 
         Raises:
             ValueError: If `id` is not a valid marking id.
-            NominalError: If no marking with the given id exists or it is not accessible.
+            NominalNotFoundError: If no marking with the given id exists.
+            NominalPermissionDeniedError: If the caller cannot read it.
         """
         return _get_marking_by_id(self._clients, id)
 
@@ -618,7 +620,7 @@ class NominalClient:
         """Search markings in the current organization, oldest first.
 
         Args:
-            id_substring: Case-insensitive substring that a marking's id must contain to be included.
+            id_substring: Substring that a marking's id must contain to be included.
 
         Returns:
             All markings matching the given conditions.
@@ -871,9 +873,8 @@ class NominalClient:
             labels: Text labels to apply to the created dataset
             properties: Key-value properties to apply to the cleated dataset
             prefix_tree_delimiter: If present, the delimiter to represent tiers when viewing channels hierarchically.
-            markings: If present, markings (or marking RIDs) to apply to the created dataset. Markings are
-                applied in a separate step after the dataset is created, so creation and marking are not
-                atomic; if that matters, verify with `list_markings()`.
+            markings: If present, markings (or marking RIDs) applied to the dataset. Sent as part of
+                the creation request rather than applied in a follow-up call.
 
         Returns:
             Reference to the created dataset in Nominal.
@@ -886,7 +887,7 @@ class NominalClient:
             labels=labels,
             properties=properties,
             workspace_rid=self._clients.resolve_default_workspace_rid(),
-            marking_rids=None if markings is None else [rid_from_instance_or_string(m) for m in markings],
+            marking_rids=_marking_rids(markings),
         )
         dataset = Dataset._from_conjure(self._clients, response)
 
@@ -916,9 +917,8 @@ class NominalClient:
             description: Description of the video to create in nominal
             labels: Labels to apply to the video in nominal
             properties: Properties to apply to the video in nominal
-            markings: If present, markings (or marking RIDs) to apply to the created video. Markings are
-                applied in a separate step after the video is created, so creation and marking are not
-                atomic; if that matters, verify with `list_markings()`.
+            markings: If present, markings (or marking RIDs) applied to the video. Sent as part of
+                the creation request rather than applied in a follow-up call.
 
         Returns:
             Handle to the created video
@@ -931,7 +931,7 @@ class NominalClient:
             labels=labels,
             properties=properties,
             workspace_rid=self._clients.resolve_default_workspace_rid(),
-            marking_rids=None if markings is None else [rid_from_instance_or_string(m) for m in markings],
+            marking_rids=_marking_rids(markings),
         )
         return Video._from_conjure(self._clients, response)
 
@@ -1210,7 +1210,7 @@ class NominalClient:
                 available_tag_values={},
                 should_scrape=True,
                 workspace=workspace_rid,
-                marking_rids=[] if markings is None else [rid_from_instance_or_string(m) for m in markings],
+                marking_rids=_marking_rids(markings),
             ),
         )
         conn = Connection._from_conjure(self._clients, connection_response)

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -577,8 +577,8 @@ class NominalClient:
             authorized_groups: RIDs of the groups authorized to access data sources carrying
                 this marking.
             symbol: Symbol identifying the marking in the Nominal app.
-            color: Lowercase six-digit hex color identifying the marking in the Nominal app,
-                e.g. `#cc0000`.
+            color: Six-digit hex color identifying the marking in the Nominal app, e.g. `#cc0000`.
+                Either case is accepted; the value is lowercased before being sent.
 
         Returns:
             Reference to the created marking.

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -93,6 +93,7 @@ from nominal.core.dataset import (
 )
 from nominal.core.dataset_file import DatasetFile
 from nominal.core.datasource import DataSource
+from nominal.core.elements import Symbol
 from nominal.core.event import Event, _create_event, _get_event, _get_events, _search_events
 from nominal.core.exceptions import (
     LegacyVideoDeprecationWarning,
@@ -103,6 +104,13 @@ from nominal.core.exceptions import (
 )
 from nominal.core.filetype import FileType, FileTypes
 from nominal.core.ingestion_job import IngestionJob, IngestionJobStatus
+from nominal.core.marking import (
+    Marking,
+    _create_marking,
+    _get_marking,
+    _get_marking_by_id,
+    _search_markings,
+)
 from nominal.core.run import Run, _create_run
 from nominal.core.secret import Secret
 from nominal.core.streaming_checklist import _iter_list_streaming_checklists
@@ -549,6 +557,78 @@ class NominalClient:
         )
         return list(self._iter_search_secrets(query, archive_status))
 
+    def create_marking(
+        self,
+        id: str,
+        *,
+        description: str | None = None,
+        authorized_groups: Sequence[str] = (),
+        symbol: Symbol | None = None,
+        color: str | None = None,
+    ) -> Marking:
+        """Create a marking in the current organization.
+
+        Args:
+            id: Human-readable identifier for the marking, unique within the organization. Must be
+                lowercase alphanumeric characters optionally separated by hyphens, starting with a
+                letter, e.g. `export-controlled`.
+            description: Human readable description of the marking.
+            authorized_groups: RIDs of the groups authorized to access data sources carrying
+                this marking.
+            symbol: Symbol identifying the marking in the Nominal app.
+            color: Lowercase six-digit hex color identifying the marking in the Nominal app,
+                e.g. `#cc0000`.
+
+        Returns:
+            Reference to the created marking.
+
+        Raises:
+            ValueError: If `id` is not a valid marking id, or `color` is not a valid hex color.
+            NominalError: If creation fails, including when the caller is not an organization admin
+                or a marking with this id already exists.
+        """
+        return _create_marking(
+            self._clients,
+            id=id,
+            description=description,
+            authorized_groups=authorized_groups,
+            symbol=symbol,
+            color=color,
+        )
+
+    def get_marking(self, rid: str) -> Marking:
+        """Retrieve a marking by RID.
+
+        Raises:
+            NominalNotFoundError: If no marking with the given RID exists or it is not accessible.
+        """
+        return _get_marking(self._clients, rid)
+
+    def get_marking_by_id(self, id: str) -> Marking:
+        """Retrieve a marking by its human-readable id, unique within the organization.
+
+        Raises:
+            ValueError: If `id` is not a valid marking id.
+            NominalError: If no marking with the given id exists or it is not accessible.
+        """
+        return _get_marking_by_id(self._clients, id)
+
+    def search_markings(self, id_substring: str | None = None) -> Sequence[Marking]:
+        """Search markings in the current organization, oldest first.
+
+        Args:
+            id_substring: Case-insensitive substring that a marking's id must contain to be included.
+
+        Returns:
+            All markings matching the given conditions.
+
+        Note:
+            Markings are scoped to an organization rather than a workspace, so this search takes no
+            workspace filter. Archived markings are never returned; fetch them by RID with
+            `get_marking` instead.
+        """
+        return _search_markings(self._clients, id_substring=id_substring)
+
     def _iter_search_videos(
         self,
         query: scout_video_api.SearchVideosQuery,
@@ -780,7 +860,7 @@ class NominalClient:
         labels: Sequence[str] = (),
         properties: Mapping[str, str] | None = None,
         prefix_tree_delimiter: str | None = None,
-        markings: Sequence[str] | None = None,
+        markings: Sequence[Marking | str] | None = None,
     ) -> Dataset:
         """Create an empty dataset.
 
@@ -790,7 +870,9 @@ class NominalClient:
             labels: Text labels to apply to the created dataset
             properties: Key-value properties to apply to the cleated dataset
             prefix_tree_delimiter: If present, the delimiter to represent tiers when viewing channels hierarchically.
-            markings: If present, RIDs of markings to apply to the created dataset
+            markings: If present, markings (or marking RIDs) to apply to the created dataset. Markings are
+                applied in a separate step after the dataset is created, so creation and marking are not
+                atomic; if that matters, verify with `list_markings()`.
 
         Returns:
             Reference to the created dataset in Nominal.
@@ -803,7 +885,7 @@ class NominalClient:
             labels=labels,
             properties=properties,
             workspace_rid=self._clients.resolve_default_workspace_rid(),
-            marking_rids=markings,
+            marking_rids=None if markings is None else [rid_from_instance_or_string(m) for m in markings],
         )
         dataset = Dataset._from_conjure(self._clients, response)
 
@@ -824,6 +906,7 @@ class NominalClient:
         description: str | None = None,
         labels: Sequence[str] = (),
         properties: Mapping[str, str] | None = None,
+        markings: Sequence[Marking | str] | None = None,
     ) -> Video:
         """Create an empty video to append video files to.
 
@@ -832,6 +915,9 @@ class NominalClient:
             description: Description of the video to create in nominal
             labels: Labels to apply to the video in nominal
             properties: Properties to apply to the video in nominal
+            markings: If present, markings (or marking RIDs) to apply to the created video. Markings are
+                applied in a separate step after the video is created, so creation and marking are not
+                atomic; if that matters, verify with `list_markings()`.
 
         Returns:
             Handle to the created video
@@ -844,6 +930,7 @@ class NominalClient:
             labels=labels,
             properties=properties,
             workspace_rid=self._clients.resolve_default_workspace_rid(),
+            marking_rids=None if markings is None else [rid_from_instance_or_string(m) for m in markings],
         )
         return Video._from_conjure(self._clients, response)
 
@@ -1089,6 +1176,7 @@ class NominalClient:
         datasource_description: str | None = None,
         *,
         required_tag_names: list[str] | None = None,
+        markings: Sequence[Marking | str] | None = None,
     ) -> StreamingConnection:
         workspace_rid = self._clients.resolve_default_workspace_rid()
         datasource_response = self._clients.storage.create(
@@ -1121,7 +1209,7 @@ class NominalClient:
                 available_tag_values={},
                 should_scrape=True,
                 workspace=workspace_rid,
-                marking_rids=[],
+                marking_rids=[] if markings is None else [rid_from_instance_or_string(m) for m in markings],
             ),
         )
         conn = Connection._from_conjure(self._clients, connection_response)

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -600,7 +600,8 @@ class NominalClient:
         """Retrieve a marking by RID.
 
         Raises:
-            NominalNotFoundError: If no marking with the given RID exists or it is not accessible.
+            NominalNotFoundError: If no marking with the given RID exists.
+            NominalPermissionDeniedError: If the caller cannot read it.
         """
         return _get_marking(self._clients, rid)
 

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -1651,6 +1651,7 @@ def _construct_new_ingest_options(
     s3_path: str,
     workspace_rid: str | None,
     tags: Mapping[str, str] | None,
+    marking_rids: Sequence[str] | None = None,
 ) -> ingest_api.IngestOptions:
     source = ingest_api.IngestSource(s3=ingest_api.S3IngestSource(path=s3_path))
     target = ingest_api.DatasetIngestTarget(
@@ -1661,7 +1662,7 @@ def _construct_new_ingest_options(
             dataset_description=description,
             dataset_name=name,
             workspace=workspace_rid,
-            marking_rids=[],
+            marking_rids=list(marking_rids or []),
         )
     )
     timestamp_metadata = ingest_api.TimestampMetadata(

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -1657,6 +1657,7 @@ def _construct_new_ingest_options(
     s3_path: str,
     workspace_rid: str | None,
     tags: Mapping[str, str] | None,
+    marking_rids: Sequence[str] | None = None,
 ) -> ingest_api.IngestOptions:
     source = ingest_api.IngestSource(s3=ingest_api.S3IngestSource(path=s3_path))
     target = ingest_api.DatasetIngestTarget(
@@ -1667,7 +1668,7 @@ def _construct_new_ingest_options(
             dataset_description=description,
             dataset_name=name,
             workspace=workspace_rid,
-            marking_rids=[],
+            marking_rids=list(marking_rids or []),
         )
     )
     timestamp_metadata = ingest_api.TimestampMetadata(

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -1657,7 +1657,6 @@ def _construct_new_ingest_options(
     s3_path: str,
     workspace_rid: str | None,
     tags: Mapping[str, str] | None,
-    marking_rids: Sequence[str] | None = None,
 ) -> ingest_api.IngestOptions:
     source = ingest_api.IngestSource(s3=ingest_api.S3IngestSource(path=s3_path))
     target = ingest_api.DatasetIngestTarget(
@@ -1668,7 +1667,7 @@ def _construct_new_ingest_options(
             dataset_description=description,
             dataset_name=name,
             workspace=workspace_rid,
-            marking_rids=list(marking_rids or []),
+            marking_rids=[],
         )
     )
     timestamp_metadata = ingest_api.TimestampMetadata(

--- a/nominal/core/datasource.py
+++ b/nominal/core/datasource.py
@@ -31,7 +31,9 @@ from nominal.core._stream.write_stream import DataStream, WriteStream
 from nominal.core._types import PathLike
 from nominal.core._utils.api_tools import HasRid
 from nominal.core.channel import Channel, ChannelDataType
+from nominal.core.marking import MarkableMixin
 from nominal.core.unit import UnitMapping, _build_unit_update, _error_on_invalid_units
+from nominal.protos.authorization.markings.v1 import markings_pb2_grpc
 from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2_grpc
@@ -61,7 +63,7 @@ class BatchAddChannelsResult:
 
 
 @dataclass(frozen=True)
-class DataSource(HasRid):
+class DataSource(HasRid, MarkableMixin):
     rid: str
     _clients: _Clients = field(repr=False)
 
@@ -102,6 +104,8 @@ class DataSource(HasRid):
         def authentication(self) -> authentication_api.AuthenticationServiceV2: ...
         @property
         def roles(self) -> roles_pb2_grpc.RoleServiceStub: ...
+        @property
+        def markings(self) -> markings_pb2_grpc.MarkingServiceStub: ...
 
     def get_channel(self, name: str) -> Channel:
         for channel in self.get_channels(names=[name]):

--- a/nominal/core/elements.py
+++ b/nominal/core/elements.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from typing_extensions import Self, assert_never
+
+from nominal.protos.scout.elements.v1 import elements_pb2
+
+
+class SymbolKind(Enum):
+    """The kind of symbol carried by a `Symbol`."""
+
+    ICON = "ICON"
+    """A named icon, e.g. `castle`."""
+    EMOJI = "EMOJI"
+    """An emoji name, e.g. `:castle:`."""
+    IMAGE = "IMAGE"
+    """A URL pointing at an image."""
+
+
+@dataclass(frozen=True)
+class Symbol:
+    """A symbol used to identify a resource in the Nominal app.
+
+    Construct with `Symbol.icon`, `Symbol.emoji`, or `Symbol.image` rather than calling
+    the constructor directly.
+    """
+
+    kind: SymbolKind
+    value: str
+
+    @classmethod
+    def icon(cls, name: str) -> Self:
+        """A symbol from a named icon, e.g. `castle`."""
+        return cls(SymbolKind.ICON, name)
+
+    @classmethod
+    def emoji(cls, name: str) -> Self:
+        """A symbol from an emoji name, e.g. `:castle:`."""
+        return cls(SymbolKind.EMOJI, name)
+
+    @classmethod
+    def image(cls, url: str) -> Self:
+        """A symbol from the URL of an image."""
+        return cls(SymbolKind.IMAGE, url)
+
+    def _to_proto(self) -> elements_pb2.Symbol:
+        match self.kind:
+            case SymbolKind.ICON:
+                return elements_pb2.Symbol(icon=self.value)
+            case SymbolKind.EMOJI:
+                return elements_pb2.Symbol(emoji=self.value)
+            case SymbolKind.IMAGE:
+                return elements_pb2.Symbol(image=self.value)
+            case _:
+                assert_never(self.kind)
+
+    @classmethod
+    def _from_proto(cls, symbol: elements_pb2.Symbol) -> Self | None:
+        """The symbol carried by a proto, or None if the oneof is unset."""
+        match symbol.WhichOneof("symbol"):
+            case "icon":
+                return cls(SymbolKind.ICON, symbol.icon)
+            case "emoji":
+                return cls(SymbolKind.EMOJI, symbol.emoji)
+            case "image":
+                return cls(SymbolKind.IMAGE, symbol.image)
+            case _:
+                return None
+
+
+_HEX_COLOR = re.compile(r"^#[0-9a-f]{6}$")
+
+
+@dataclass(frozen=True)
+class Color:
+    """A color used to identify a resource in the Nominal app."""
+
+    hex_code: str
+    """A lowercase six-digit hex color, e.g. `#cc0000`."""
+
+    def __post_init__(self) -> None:
+        """Validate the hex code at construction time."""
+        if _HEX_COLOR.match(self.hex_code) is None:
+            raise ValueError(f"expected a lowercase six-digit hex color such as '#cc0000', got {self.hex_code!r}")
+
+    def _to_proto(self) -> elements_pb2.Color:
+        return elements_pb2.Color(hex_code=self.hex_code)
+
+    @classmethod
+    def _from_proto(cls, color: elements_pb2.Color) -> Self | None:
+        """The color carried by a proto, or None if the oneof is unset.
+
+        Values are lowercased on the way in: the backend only accepts lowercase, but tolerating
+        case drift here keeps read paths from raising on historical data.
+        """
+        if color.WhichOneof("color") != "hex_code":
+            return None
+        return cls(hex_code=color.hex_code.lower())

--- a/nominal/core/elements.py
+++ b/nominal/core/elements.py
@@ -76,26 +76,36 @@ _HEX_COLOR = re.compile(r"^#[0-9a-f]{6}$")
 
 @dataclass(frozen=True)
 class Color:
-    """A color used to identify a resource in the Nominal app."""
+    """A color used to identify a resource in the Nominal app.
+
+    Construct with `Color.create` rather than calling the constructor directly: only `create`
+    checks that the hex code is one Nominal accepts.
+    """
 
     hex_code: str
     """A lowercase six-digit hex color, e.g. `#cc0000`."""
 
-    def __post_init__(self) -> None:
-        """Validate the hex code at construction time."""
-        if _HEX_COLOR.match(self.hex_code) is None:
-            raise ValueError(f"expected a lowercase six-digit hex color such as '#cc0000', got {self.hex_code!r}")
+    @classmethod
+    def create(cls, hex_code: str) -> Self:
+        """A color from a lowercase six-digit hex code, e.g. `#cc0000`.
+
+        Args:
+            hex_code: The hex code, including the leading `#`.
+
+        Raises:
+            ValueError: If `hex_code` is not a lowercase six-digit hex color, which Nominal
+                would reject.
+        """
+        if _HEX_COLOR.match(hex_code) is None:
+            raise ValueError(f"expected a lowercase six-digit hex color such as '#cc0000', got {hex_code!r}")
+        return cls(hex_code=hex_code)
 
     def _to_proto(self) -> elements_pb2.Color:
         return elements_pb2.Color(hex_code=self.hex_code)
 
     @classmethod
     def _from_proto(cls, color: elements_pb2.Color) -> Self | None:
-        """The color carried by a proto, or None if the oneof is unset.
-
-        Values are lowercased on the way in: the backend only accepts lowercase, but tolerating
-        case drift here keeps read paths from raising on historical data.
-        """
+        """The color carried by a proto, or None if the oneof is unset."""
         if color.WhichOneof("color") != "hex_code":
             return None
-        return cls(hex_code=color.hex_code.lower())
+        return cls(hex_code=color.hex_code)

--- a/nominal/core/elements.py
+++ b/nominal/core/elements.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from typing_extensions import Self, assert_never
+
+from nominal.protos.scout.elements.v1 import elements_pb2
+
+
+class SymbolKind(Enum):
+    """The kind of symbol carried by a `Symbol`."""
+
+    ICON = "ICON"
+    """A named icon, e.g. `castle`."""
+    EMOJI = "EMOJI"
+    """An emoji name, e.g. `:castle:`."""
+    IMAGE = "IMAGE"
+    """A URL pointing at an image."""
+
+
+@dataclass(frozen=True)
+class Symbol:
+    """A symbol used to identify a resource in the Nominal app.
+
+    Construct with `Symbol.icon`, `Symbol.emoji`, or `Symbol.image` rather than calling
+    the constructor directly.
+    """
+
+    kind: SymbolKind
+    value: str
+
+    @classmethod
+    def icon(cls, name: str) -> Self:
+        """A symbol from a named icon, e.g. `castle`."""
+        return cls(SymbolKind.ICON, name)
+
+    @classmethod
+    def emoji(cls, name: str) -> Self:
+        """A symbol from an emoji name, e.g. `:castle:`."""
+        return cls(SymbolKind.EMOJI, name)
+
+    @classmethod
+    def image(cls, url: str) -> Self:
+        """A symbol from the URL of an image."""
+        return cls(SymbolKind.IMAGE, url)
+
+    def _to_proto(self) -> elements_pb2.Symbol:
+        match self.kind:
+            case SymbolKind.ICON:
+                return elements_pb2.Symbol(icon=self.value)
+            case SymbolKind.EMOJI:
+                return elements_pb2.Symbol(emoji=self.value)
+            case SymbolKind.IMAGE:
+                return elements_pb2.Symbol(image=self.value)
+            case _:
+                assert_never(self.kind)
+
+    @classmethod
+    def _from_proto(cls, symbol: elements_pb2.Symbol) -> Self | None:
+        """The symbol carried by a proto, or None if the oneof is unset."""
+        match symbol.WhichOneof("symbol"):
+            case "icon":
+                return cls(SymbolKind.ICON, symbol.icon)
+            case "emoji":
+                return cls(SymbolKind.EMOJI, symbol.emoji)
+            case "image":
+                return cls(SymbolKind.IMAGE, symbol.image)
+            case _:
+                return None
+
+
+# A color is a bare hex string rather than a type: unlike `Symbol`, its wire representation has a
+# single arm, so there is no tag to carry and a wrapper would only add ceremony.
+_HEX_COLOR = re.compile(r"^#[0-9a-f]{6}$")
+
+
+def _validate_hex_color(hex_code: str) -> str:
+    """The hex code, if Nominal would accept it.
+
+    Raises:
+        ValueError: If `hex_code` is not a lowercase six-digit hex color, e.g. `#cc0000`.
+    """
+    if _HEX_COLOR.match(hex_code) is None:
+        raise ValueError(f"expected a lowercase six-digit hex color such as '#cc0000', got {hex_code!r}")
+    return hex_code
+
+
+def _color_to_proto(hex_code: str) -> elements_pb2.Color:
+    return elements_pb2.Color(hex_code=hex_code)
+
+
+def _color_from_proto(color: elements_pb2.Color) -> str | None:
+    """The hex code carried by a proto, or None if the oneof is unset."""
+    if color.WhichOneof("color") != "hex_code":
+        return None
+    return color.hex_code

--- a/nominal/core/elements.py
+++ b/nominal/core/elements.py
@@ -71,44 +71,28 @@ class Symbol:
                 return None
 
 
+# A color is a bare hex string rather than a type: unlike `Symbol`, its wire representation has a
+# single arm, so there is no tag to carry and a wrapper would only add ceremony.
 _HEX_COLOR = re.compile(r"^#[0-9a-f]{6}$")
 
 
-@dataclass(frozen=True)
-class Color:
-    """A color used to identify a resource in the Nominal app.
+def _validate_hex_color(hex_code: str) -> str:
+    """The hex code, if Nominal would accept it.
 
-    Construct with `Color.create` rather than calling the constructor directly: only `create`
-    checks that the hex code is one Nominal accepts.
+    Raises:
+        ValueError: If `hex_code` is not a lowercase six-digit hex color, e.g. `#cc0000`.
     """
+    if _HEX_COLOR.match(hex_code) is None:
+        raise ValueError(f"expected a lowercase six-digit hex color such as '#cc0000', got {hex_code!r}")
+    return hex_code
 
-    hex_code: str
-    """A lowercase six-digit hex color, e.g. `#cc0000`.
 
-    Validated by `Color.create`; the constructor itself does not check it.
-    """
+def _color_to_proto(hex_code: str) -> elements_pb2.Color:
+    return elements_pb2.Color(hex_code=hex_code)
 
-    @classmethod
-    def create(cls, hex_code: str) -> Self:
-        """A color from a lowercase six-digit hex code, e.g. `#cc0000`.
 
-        Args:
-            hex_code: The hex code, including the leading `#`.
-
-        Raises:
-            ValueError: If `hex_code` is not a lowercase six-digit hex color, which Nominal
-                would reject.
-        """
-        if _HEX_COLOR.match(hex_code) is None:
-            raise ValueError(f"expected a lowercase six-digit hex color such as '#cc0000', got {hex_code!r}")
-        return cls(hex_code=hex_code)
-
-    def _to_proto(self) -> elements_pb2.Color:
-        return elements_pb2.Color(hex_code=self.hex_code)
-
-    @classmethod
-    def _from_proto(cls, color: elements_pb2.Color) -> Self | None:
-        """The color carried by a proto, or None if the oneof is unset."""
-        if color.WhichOneof("color") != "hex_code":
-            return None
-        return cls(hex_code=color.hex_code)
+def _color_from_proto(color: elements_pb2.Color) -> str | None:
+    """The hex code carried by a proto, or None if the oneof is unset."""
+    if color.WhichOneof("color") != "hex_code":
+        return None
+    return color.hex_code

--- a/nominal/core/elements.py
+++ b/nominal/core/elements.py
@@ -83,7 +83,10 @@ class Color:
     """
 
     hex_code: str
-    """A lowercase six-digit hex color, e.g. `#cc0000`."""
+    """A lowercase six-digit hex color, e.g. `#cc0000`.
+
+    Validated by `Color.create`; the constructor itself does not check it.
+    """
 
     @classmethod
     def create(cls, hex_code: str) -> Self:

--- a/nominal/core/elements.py
+++ b/nominal/core/elements.py
@@ -73,18 +73,23 @@ class Symbol:
 
 # A color is a bare hex string rather than a type: unlike `Symbol`, its wire representation has a
 # single arm, so there is no tag to carry and a wrapper would only add ceremony.
-_HEX_COLOR = re.compile(r"^#[0-9a-f]{6}$")
+_HEX_COLOR = re.compile(r"^#[0-9a-fA-F]{6}$")
 
 
-def _validate_hex_color(hex_code: str) -> str:
-    """The hex code, if Nominal would accept it.
+def _normalize_hex_color(hex_code: str) -> str:
+    """The hex code, lowercased.
+
+    The service validates `hex_code` against `^#[0-9a-f]{6}$` (buf.validate, `scout.elements.v1`), so
+    lowercase six digits is the only accepted form. Case carries no meaning in a hex color, so an
+    uppercase code is lowercased for the caller rather than rejected. The six-digit shape is not:
+    it mirrors the server pattern, so rejecting it here turns a server error into a local one.
 
     Raises:
-        ValueError: If `hex_code` is not a lowercase six-digit hex color, e.g. `#cc0000`.
+        ValueError: If `hex_code` is not a six-digit hex color, e.g. `#cc0000`.
     """
     if _HEX_COLOR.match(hex_code) is None:
-        raise ValueError(f"expected a lowercase six-digit hex color such as '#cc0000', got {hex_code!r}")
-    return hex_code
+        raise ValueError(f"expected a six-digit hex color such as '#cc0000', got {hex_code!r}")
+    return hex_code.lower()
 
 
 def _color_to_proto(hex_code: str) -> elements_pb2.Color:

--- a/nominal/core/marking.py
+++ b/nominal/core/marking.py
@@ -11,7 +11,7 @@ from nominal.core._utils.api_tools import HasRid, RefreshableGrpcMixin, rid_from
 from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.pagination_tools import search_markings_paginated
 from nominal.core._utils.query_tools import create_search_markings_query
-from nominal.core.elements import Color, Symbol
+from nominal.core.elements import Symbol, _color_from_proto, _color_to_proto, _validate_hex_color
 from nominal.protos.authorization.markings.v1 import markings_pb2, markings_pb2_grpc
 from nominal.ts import IntegralNanosecondsUTC
 
@@ -40,7 +40,8 @@ class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
     """Human-readable identifier, unique within the organization. Markings have no separate name."""
     description: str
     symbol: Symbol | None
-    color: Color | None
+    color: str | None
+    """A lowercase six-digit hex color, e.g. `#cc0000`."""
     created_at: IntegralNanosecondsUTC
     updated_at: IntegralNanosecondsUTC
     is_archived: bool
@@ -77,7 +78,7 @@ class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
         description: str | None = None,
         authorized_group_rids: Sequence[str] | None = None,
         symbol: Symbol | None | _NotProvided = _NotProvided(),
-        color: Color | None | _NotProvided = _NotProvided(),
+        color: str | None | _NotProvided = _NotProvided(),
     ) -> Self:
         """Replace marking metadata, updating the current instance and returning it.
 
@@ -86,7 +87,7 @@ class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
             description: New description for the marking.
             authorized_group_rids: Group RIDs replacing the existing ones. An empty sequence clears them.
             symbol: New symbol. Pass None to remove the marking's symbol.
-            color: New color. Pass None to remove the marking's color.
+            color: New lowercase six-digit hex color, e.g. `#cc0000`. Pass None to remove it.
 
         Returns:
             This marking, updated in place.
@@ -120,7 +121,7 @@ class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
                 None
                 if isinstance(color, self._NotProvided)
                 else markings_pb2.UpdateMarkingRequest.UpdateMarkingColorWrapper(
-                    value=None if color is None else color._to_proto()
+                    value=None if color is None else _color_to_proto(_validate_hex_color(color))
                 )
             ),
         )
@@ -156,7 +157,7 @@ class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
             id=marking.id,
             description=marking.description,
             symbol=Symbol._from_proto(marking.symbol),
-            color=Color._from_proto(marking.color),
+            color=_color_from_proto(marking.color),
             created_at=marking.created_at.ToNanoseconds(),
             updated_at=marking.updated_at.ToNanoseconds(),
             is_archived=marking.is_archived,
@@ -171,14 +172,14 @@ def _create_marking(
     description: str | None,
     authorized_group_rids: Sequence[str],
     symbol: Symbol | None,
-    color: Color | None,
+    color: str | None,
 ) -> Marking:
     request = markings_pb2.CreateMarkingRequest(
         id=_validate_marking_id(id),
         description=description or "",
         authorized_groups=markings_pb2.AuthorizedGroups(group_rids=list(authorized_group_rids)),
         symbol=None if symbol is None else symbol._to_proto(),
-        color=None if color is None else color._to_proto(),
+        color=None if color is None else _color_to_proto(_validate_hex_color(color)),
     )
     with translate_grpc_errors():
         response = clients.markings.CreateMarking(request)

--- a/nominal/core/marking.py
+++ b/nominal/core/marking.py
@@ -7,7 +7,7 @@ from typing import Any, Iterable, Protocol, Sequence
 from typing_extensions import Self
 
 from nominal.core._clientsbunch import HasScoutParams
-from nominal.core._utils.api_tools import HasRid, RefreshableGrpcMixin
+from nominal.core._utils.api_tools import HasRid, RefreshableGrpcMixin, rid_from_instance_or_string
 from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.pagination_tools import search_markings_paginated
 from nominal.core._utils.query_tools import create_search_markings_query
@@ -242,3 +242,95 @@ def _iter_search_markings(clients: Marking._Clients, query: markings_pb2.SearchM
 
 def _search_markings(clients: Marking._Clients, *, id_substring: str | None = None) -> Sequence[Marking]:
     return tuple(_iter_search_markings(clients, create_search_markings_query(id_substring=id_substring)))
+
+
+class MarkableMixin:
+    """Markings applied to a data source.
+
+    Concrete: classes gain these methods by listing this mixin as a base and exposing a `markings`
+    client. Markings can only be applied to data sources — datasets, connections, and videos.
+    """
+
+    rid: str
+    _clients: Marking._Clients
+
+    def list_markings(self) -> Sequence[Marking]:
+        """The markings currently applied to this resource.
+
+        Markings the user does not have permission to read are omitted.
+
+        Raises:
+            NominalError: If the request fails.
+        """
+        return _get_marking_metadata(self._clients, _applied_marking_rids(self._clients, self.rid))
+
+    def apply_markings(self, markings: Iterable[Marking | str]) -> None:
+        """Apply markings to this resource, leaving any already-applied markings in place.
+
+        Applying a marking that is already applied is a no-op rather than an error.
+
+        Args:
+            markings: Markings, or marking RIDs, to apply.
+
+        Raises:
+            NominalError: If the request fails, including when a marking is archived or the user
+                lacks permission to change markings on this resource.
+        """
+        _update_markings_on_resource(self._clients, self.rid, apply=markings, remove=())
+
+    def remove_markings(self, markings: Iterable[Marking | str]) -> None:
+        """Remove markings from this resource.
+
+        Removing a marking that is not applied is a no-op rather than an error.
+
+        Args:
+            markings: Markings, or marking RIDs, to remove.
+
+        Raises:
+            NominalError: If the request fails.
+        """
+        _update_markings_on_resource(self._clients, self.rid, apply=(), remove=markings)
+
+    def set_markings(self, markings: Iterable[Marking | str]) -> None:
+        """Replace the markings on this resource with exactly the given markings.
+
+        The difference against the currently-applied markings is computed and sent as a single
+        atomic update. An empty sequence removes every marking from the resource.
+
+        Args:
+            markings: Markings, or marking RIDs, the resource should carry.
+
+        Raises:
+            NominalError: If the request fails.
+        """
+        desired = {rid_from_instance_or_string(marking) for marking in markings}
+        current = set(_applied_marking_rids(self._clients, self.rid))
+        to_apply = desired - current
+        to_remove = current - desired
+        if not to_apply and not to_remove:
+            return
+        _update_markings_on_resource(self._clients, self.rid, apply=to_apply, remove=to_remove)
+
+
+def _applied_marking_rids(clients: Marking._Clients, resource_rid: str) -> Sequence[str]:
+    request = markings_pb2.GetMarkingsForResourcesRequest(resources=[resource_rid])
+    with translate_grpc_errors():
+        response = clients.markings.GetMarkingsForResources(request)
+    applied = response.resource_to_markings[resource_rid].applied_markings
+    return tuple(marking.marking_rid for marking in applied)
+
+
+def _update_markings_on_resource(
+    clients: Marking._Clients,
+    resource_rid: str,
+    *,
+    apply: Iterable[Marking | str],
+    remove: Iterable[Marking | str],
+) -> None:
+    request = markings_pb2.UpdateMarkingsOnResourceRequest(
+        resource=resource_rid,
+        markings_to_apply=[rid_from_instance_or_string(marking) for marking in apply],
+        markings_to_remove=[rid_from_instance_or_string(marking) for marking in remove],
+    )
+    with translate_grpc_errors():
+        clients.markings.UpdateMarkingsOnResource(request)

--- a/nominal/core/marking.py
+++ b/nominal/core/marking.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Protocol, Sequence
+
+from typing_extensions import Self
+
+from nominal.core._clientsbunch import HasScoutParams
+from nominal.core._utils.api_tools import HasRid, RefreshableGrpcMixin
+from nominal.core._utils.grpc_tools import translate_grpc_errors
+from nominal.core._utils.pagination_tools import search_markings_paginated
+from nominal.core._utils.query_tools import create_search_markings_query
+from nominal.core.elements import Color, Symbol
+from nominal.core.exceptions import NominalNotFoundError
+from nominal.protos.authorization.markings.v1 import markings_pb2, markings_pb2_grpc
+from nominal.ts import IntegralNanosecondsUTC
+
+_MARKING_ID = re.compile(r"^[a-z][a-z0-9-]*$")
+
+# Sentinel distinguishing "leave this field alone" from "clear this field" (None) on update.
+_UNCHANGED: Any = object()
+
+
+def _validate_marking_id(id: str) -> str:
+    if _MARKING_ID.match(id) is None:
+        raise ValueError(
+            f"marking id must be lowercase alphanumeric, optionally hyphen-separated, and start with a letter "
+            f"(e.g. 'export-controlled'), got {id!r}"
+        )
+    return id
+
+
+@dataclass(frozen=True)
+class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
+    """A marking, restricting access to the data sources it is applied to.
+
+    Markings are scoped to an organization. Creating, updating, and archiving markings requires
+    organization admin permissions; any member of the organization can read them.
+    """
+
+    rid: str
+    id: str
+    """Human-readable identifier, unique within the organization. Markings have no separate name."""
+    description: str
+    symbol: Symbol | None
+    color: Color | None
+    created_at: IntegralNanosecondsUTC
+    updated_at: IntegralNanosecondsUTC
+    is_archived: bool
+
+    _clients: _Clients = field(repr=False)
+
+    class _Clients(HasScoutParams, Protocol):
+        @property
+        def markings(self) -> markings_pb2_grpc.MarkingServiceStub: ...
+
+    def _get_latest_api(self) -> markings_pb2.Marking:
+        return _get_marking_proto(self._clients, self.rid)
+
+    def authorized_group_rids(self) -> Sequence[str]:
+        """The RIDs of groups authorized to access data sources carrying this marking.
+
+        Groups the user does not have permission to read are omitted.
+
+        Raises:
+            NominalError: If the request fails.
+        """
+        request = markings_pb2.GetAuthorizedGroupsByMarkingRequest(marking_rids=[self.rid])
+        with translate_grpc_errors():
+            response = self._clients.markings.GetAuthorizedGroupsByMarking(request)
+        return tuple(response.authorized_groups_by_marking[self.rid].group_rids)
+
+    def update(
+        self,
+        *,
+        id: str | None = None,
+        description: str | None = None,
+        authorized_group_rids: Sequence[str] | None = None,
+        symbol: Symbol | None = _UNCHANGED,
+        color: Color | None = _UNCHANGED,
+    ) -> Self:
+        """Replace marking metadata, updating the current instance and returning it.
+
+        Args:
+            id: New human-readable identifier. Must be unique within the organization.
+            description: New description for the marking.
+            authorized_group_rids: Group RIDs replacing the existing ones. An empty sequence clears them.
+            symbol: New symbol. Pass None to remove the marking's symbol.
+            color: New color. Pass None to remove the marking's color.
+
+        Returns:
+            This marking, updated in place.
+
+        Note:
+            Every argument left unset is omitted from the request and the corresponding field is left
+            unchanged. That is distinct from passing None to `symbol`/`color` or an empty sequence to
+            `authorized_group_rids`, which clear those fields.
+
+        Raises:
+            ValueError: If `id` is not a valid marking id.
+            NominalError: If the update request fails, including when the marking is archived.
+        """
+        request = markings_pb2.UpdateMarkingRequest(
+            rid=self.rid,
+            id=None if id is None else _validate_marking_id(id),
+            description=description,
+            authorized_groups=(
+                None
+                if authorized_group_rids is None
+                else markings_pb2.AuthorizedGroups(group_rids=list(authorized_group_rids))
+            ),
+            symbol=(
+                None
+                if symbol is _UNCHANGED
+                else markings_pb2.UpdateMarkingRequest.UpdateMarkingSymbolWrapper(
+                    value=None if symbol is None else symbol._to_proto()
+                )
+            ),
+            color=(
+                None
+                if color is _UNCHANGED
+                else markings_pb2.UpdateMarkingRequest.UpdateMarkingColorWrapper(
+                    value=None if color is None else color._to_proto()
+                )
+            ),
+        )
+        with translate_grpc_errors():
+            response = self._clients.markings.UpdateMarking(request)
+        return self._refresh_from_api(response.marking)
+
+    def archive(self) -> None:
+        """Archive the marking, preventing it from being applied or modified.
+
+        Archived markings are excluded from search but can still be retrieved by RID. Archiving fails
+        if the marking is still applied to any resource.
+
+        Note: this does not update the instance in place; call `refresh()` to see the change reflected.
+        """
+        with translate_grpc_errors():
+            self._clients.markings.ArchiveMarkings(markings_pb2.ArchiveMarkingsRequest(marking_rids=[self.rid]))
+
+    def unarchive(self) -> None:
+        """Unarchive the marking, restoring the ability to apply and modify it.
+
+        Note: this does not update the instance in place; call `refresh()` to see the change reflected.
+        """
+        with translate_grpc_errors():
+            self._clients.markings.UnarchiveMarkings(markings_pb2.UnarchiveMarkingsRequest(marking_rids=[self.rid]))
+
+    @classmethod
+    def _from_proto(cls, clients: _Clients, marking: markings_pb2.Marking | markings_pb2.MarkingMetadata) -> Self:
+        # `Marking` and `MarkingMetadata` carry the same field names (the latter simply omits the
+        # authorized groups), so one constructor covers every response shape.
+        return cls(
+            rid=marking.rid,
+            id=marking.id,
+            description=marking.description,
+            symbol=Symbol._from_proto(marking.symbol),
+            color=Color._from_proto(marking.color),
+            created_at=marking.created_at.ToNanoseconds(),
+            updated_at=marking.updated_at.ToNanoseconds(),
+            is_archived=marking.is_archived,
+            _clients=clients,
+        )
+
+
+def _create_marking(
+    clients: Marking._Clients,
+    *,
+    id: str,
+    description: str | None,
+    authorized_group_rids: Sequence[str],
+    symbol: Symbol | None,
+    color: Color | None,
+) -> Marking:
+    request = markings_pb2.CreateMarkingRequest(
+        id=_validate_marking_id(id),
+        description=description or "",
+        authorized_groups=markings_pb2.AuthorizedGroups(group_rids=list(authorized_group_rids)),
+        symbol=None if symbol is None else symbol._to_proto(),
+        color=None if color is None else color._to_proto(),
+    )
+    with translate_grpc_errors():
+        response = clients.markings.CreateMarking(request)
+    return Marking._from_proto(clients, response.marking)
+
+
+def _get_marking_proto(clients: Marking._Clients, rid: str) -> markings_pb2.Marking:
+    """The marking with the given rid.
+
+    Raises:
+        NominalNotFoundError: If no marking has that rid, or it is not accessible to the user.
+    """
+    markings = _get_marking_protos(clients, [rid])
+    if not markings:
+        raise NominalNotFoundError(f"no marking found with RID {rid!r}")
+    if len(markings) != 1:
+        raise ValueError(f"Expected exactly one marking with rid {rid!r}, received {len(markings)}")
+    return markings[0]
+
+
+def _get_marking_protos(clients: Marking._Clients, rids: Sequence[str]) -> Sequence[markings_pb2.Marking]:
+    request = markings_pb2.BatchGetMarkingsRequest(marking_rids=list(rids))
+    with translate_grpc_errors():
+        return tuple(clients.markings.BatchGetMarkings(request).markings)
+
+
+def _get_marking(clients: Marking._Clients, rid: str) -> Marking:
+    return Marking._from_proto(clients, _get_marking_proto(clients, rid))
+
+
+def _get_markings(clients: Marking._Clients, rids: Iterable[str]) -> Sequence[Marking]:
+    """Markings with the given rids. Markings that do not exist or are not readable are omitted."""
+    return tuple(Marking._from_proto(clients, m) for m in _get_marking_protos(clients, list(rids)))
+
+
+def _get_marking_by_id(clients: Marking._Clients, id: str) -> Marking:
+    request = markings_pb2.GetMarkingByIdRequest(id=_validate_marking_id(id))
+    with translate_grpc_errors():
+        response = clients.markings.GetMarkingById(request)
+    return Marking._from_proto(clients, response.marking)
+
+
+def _get_marking_metadata(clients: Marking._Clients, rids: Sequence[str]) -> Sequence[Marking]:
+    """Markings with the given rids, without their authorized groups.
+
+    Cheaper than `_get_markings` when only the marking's metadata is needed.
+    """
+    if not rids:
+        return ()
+    request = markings_pb2.BatchGetMarkingMetadataRequest(marking_rids=list(rids))
+    with translate_grpc_errors():
+        response = clients.markings.BatchGetMarkingMetadata(request)
+    return tuple(Marking._from_proto(clients, m) for m in response.marking_metadatas)
+
+
+def _iter_search_markings(clients: Marking._Clients, query: markings_pb2.SearchMarkingsQuery) -> Iterable[Marking]:
+    for marking in search_markings_paginated(clients.markings, query):
+        yield Marking._from_proto(clients, marking)
+
+
+def _search_markings(clients: Marking._Clients, *, id_substring: str | None = None) -> Sequence[Marking]:
+    return tuple(_iter_search_markings(clients, create_search_markings_query(id_substring=id_substring)))

--- a/nominal/core/marking.py
+++ b/nominal/core/marking.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Protocol, Sequence
+from typing import Iterable, Protocol, Sequence
 
 from typing_extensions import Self
 
@@ -17,9 +17,6 @@ from nominal.protos.authorization.markings.v1 import markings_pb2, markings_pb2_
 from nominal.ts import IntegralNanosecondsUTC
 
 _MARKING_ID = re.compile(r"^[a-z][a-z0-9-]*$")
-
-# Sentinel distinguishing "leave this field alone" from "clear this field" (None) on update.
-_UNCHANGED: Any = object()
 
 
 def _validate_marking_id(id: str) -> str:
@@ -55,6 +52,9 @@ class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
         @property
         def markings(self) -> markings_pb2_grpc.MarkingServiceStub: ...
 
+    class _NotProvided:
+        """Sentinel distinguishing "leave this field alone" from "clear this field" (None) on update."""
+
     def _get_latest_api(self) -> markings_pb2.Marking:
         return _get_marking_proto(self._clients, self.rid)
 
@@ -77,8 +77,8 @@ class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
         id: str | None = None,
         description: str | None = None,
         authorized_group_rids: Sequence[str] | None = None,
-        symbol: Symbol | None = _UNCHANGED,
-        color: Color | None = _UNCHANGED,
+        symbol: Symbol | None | _NotProvided = _NotProvided(),
+        color: Color | None | _NotProvided = _NotProvided(),
     ) -> Self:
         """Replace marking metadata, updating the current instance and returning it.
 
@@ -112,14 +112,14 @@ class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
             ),
             symbol=(
                 None
-                if symbol is _UNCHANGED
+                if isinstance(symbol, self._NotProvided)
                 else markings_pb2.UpdateMarkingRequest.UpdateMarkingSymbolWrapper(
                     value=None if symbol is None else symbol._to_proto()
                 )
             ),
             color=(
                 None
-                if color is _UNCHANGED
+                if isinstance(color, self._NotProvided)
                 else markings_pb2.UpdateMarkingRequest.UpdateMarkingColorWrapper(
                     value=None if color is None else color._to_proto()
                 )

--- a/nominal/core/marking.py
+++ b/nominal/core/marking.py
@@ -12,7 +12,6 @@ from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.pagination_tools import search_markings_paginated
 from nominal.core._utils.query_tools import create_search_markings_query
 from nominal.core.elements import Color, Symbol
-from nominal.core.exceptions import NominalNotFoundError
 from nominal.protos.authorization.markings.v1 import markings_pb2, markings_pb2_grpc
 from nominal.ts import IntegralNanosecondsUTC
 
@@ -190,20 +189,11 @@ def _get_marking_proto(clients: Marking._Clients, rid: str) -> markings_pb2.Mark
     """The marking with the given rid.
 
     Raises:
-        NominalNotFoundError: If no marking has that rid, or it is not accessible to the user.
+        NominalNotFoundError: If no marking has that rid.
+        NominalPermissionDeniedError: If the user cannot read it.
     """
-    markings = _get_marking_protos(clients, [rid])
-    if not markings:
-        raise NominalNotFoundError(f"no marking found with RID {rid!r}")
-    if len(markings) != 1:
-        raise ValueError(f"Expected exactly one marking with rid {rid!r}, received {len(markings)}")
-    return markings[0]
-
-
-def _get_marking_protos(clients: Marking._Clients, rids: Sequence[str]) -> Sequence[markings_pb2.Marking]:
-    request = markings_pb2.BatchGetMarkingsRequest(marking_rids=list(rids))
     with translate_grpc_errors():
-        return tuple(clients.markings.BatchGetMarkings(request).markings)
+        return clients.markings.GetMarking(markings_pb2.GetMarkingRequest(rid=rid)).marking
 
 
 def _get_marking(clients: Marking._Clients, rid: str) -> Marking:

--- a/nominal/core/marking.py
+++ b/nominal/core/marking.py
@@ -210,11 +210,6 @@ def _get_marking(clients: Marking._Clients, rid: str) -> Marking:
     return Marking._from_proto(clients, _get_marking_proto(clients, rid))
 
 
-def _get_markings(clients: Marking._Clients, rids: Iterable[str]) -> Sequence[Marking]:
-    """Markings with the given rids. Markings that do not exist or are not readable are omitted."""
-    return tuple(Marking._from_proto(clients, m) for m in _get_marking_protos(clients, list(rids)))
-
-
 def _get_marking_by_id(clients: Marking._Clients, id: str) -> Marking:
     request = markings_pb2.GetMarkingByIdRequest(id=_validate_marking_id(id))
     with translate_grpc_errors():
@@ -225,7 +220,7 @@ def _get_marking_by_id(clients: Marking._Clients, id: str) -> Marking:
 def _get_marking_metadata(clients: Marking._Clients, rids: Sequence[str]) -> Sequence[Marking]:
     """Markings with the given rids, without their authorized groups.
 
-    Cheaper than `_get_markings` when only the marking's metadata is needed.
+    Cheaper than fetching full markings when only the marking's metadata is needed.
     """
     if not rids:
         return ()

--- a/nominal/core/marking.py
+++ b/nominal/core/marking.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Iterable, Protocol, Sequence
+
+from typing_extensions import Self
+
+from nominal.core._clientsbunch import HasScoutParams
+from nominal.core._utils.api_tools import HasRid, RefreshableGrpcMixin, rid_from_instance_or_string
+from nominal.core._utils.grpc_tools import translate_grpc_errors
+from nominal.core._utils.pagination_tools import search_markings_paginated
+from nominal.core._utils.query_tools import create_search_markings_query
+from nominal.core.elements import Symbol, _color_from_proto, _color_to_proto, _validate_hex_color
+from nominal.protos.authorization.markings.v1 import markings_pb2, markings_pb2_grpc
+from nominal.ts import IntegralNanosecondsUTC
+
+_MARKING_ID = re.compile(r"^[a-z][a-z0-9-]*$")
+
+
+def _validate_marking_id(id: str) -> str:
+    if _MARKING_ID.match(id) is None:
+        raise ValueError(
+            f"marking id must be lowercase alphanumeric, optionally hyphen-separated, and start with a letter "
+            f"(e.g. 'export-controlled'), got {id!r}"
+        )
+    return id
+
+
+@dataclass(frozen=True)
+class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
+    """A marking, restricting access to the data sources it is applied to.
+
+    Markings are scoped to an organization. Creating, updating, and archiving markings requires
+    organization admin permissions; any member of the organization can read them.
+    """
+
+    rid: str
+    id: str
+    """Human-readable identifier, unique within the organization. Markings have no separate name."""
+    description: str
+    symbol: Symbol | None
+    color: str | None
+    """A lowercase six-digit hex color, e.g. `#cc0000`."""
+    created_at: IntegralNanosecondsUTC
+    updated_at: IntegralNanosecondsUTC
+    is_archived: bool
+
+    _clients: _Clients = field(repr=False)
+
+    class _Clients(HasScoutParams, Protocol):
+        @property
+        def markings(self) -> markings_pb2_grpc.MarkingServiceStub: ...
+
+    class _NotProvided:
+        """Sentinel distinguishing "leave this field alone" from "clear this field" (None) on update."""
+
+    def _get_latest_api(self) -> markings_pb2.Marking:
+        return _get_marking_proto(self._clients, self.rid)
+
+    def authorized_group_rids(self) -> Sequence[str]:
+        """The RIDs of groups authorized to access data sources carrying this marking.
+
+        Groups the user does not have permission to read are omitted.
+
+        Raises:
+            NominalError: If the request fails.
+        """
+        request = markings_pb2.GetAuthorizedGroupsByMarkingRequest(marking_rids=[self.rid])
+        with translate_grpc_errors():
+            response = self._clients.markings.GetAuthorizedGroupsByMarking(request)
+        return tuple(response.authorized_groups_by_marking[self.rid].group_rids)
+
+    def update(
+        self,
+        *,
+        id: str | None = None,
+        description: str | None = None,
+        authorized_groups: Sequence[str] | None = None,
+        symbol: Symbol | None | _NotProvided = _NotProvided(),
+        color: str | None | _NotProvided = _NotProvided(),
+    ) -> Self:
+        """Replace marking metadata, updating the current instance and returning it.
+
+        Args:
+            id: New human-readable identifier. Must be unique within the organization.
+            description: New description for the marking.
+            authorized_groups: Group RIDs replacing the existing ones. An empty sequence clears them.
+            symbol: New symbol. Pass None to remove the marking's symbol.
+            color: New lowercase six-digit hex color, e.g. `#cc0000`. Pass None to remove it.
+
+        Returns:
+            This marking, updated in place.
+
+        Note:
+            Every argument left unset is omitted from the request and the corresponding field is left
+            unchanged. That is distinct from passing None to `symbol`/`color` or an empty sequence to
+            `authorized_groups`, which clear those fields.
+
+        Raises:
+            ValueError: If `id` is not a valid marking id.
+            NominalError: If the update request fails, including when the marking is archived.
+        """
+        request = markings_pb2.UpdateMarkingRequest(
+            rid=self.rid,
+            id=None if id is None else _validate_marking_id(id),
+            description=description,
+            authorized_groups=(
+                None if authorized_groups is None else markings_pb2.AuthorizedGroups(group_rids=list(authorized_groups))
+            ),
+            symbol=(
+                None
+                if isinstance(symbol, self._NotProvided)
+                else markings_pb2.UpdateMarkingRequest.UpdateMarkingSymbolWrapper(
+                    value=None if symbol is None else symbol._to_proto()
+                )
+            ),
+            color=(
+                None
+                if isinstance(color, self._NotProvided)
+                else markings_pb2.UpdateMarkingRequest.UpdateMarkingColorWrapper(
+                    value=None if color is None else _color_to_proto(_validate_hex_color(color))
+                )
+            ),
+        )
+        with translate_grpc_errors():
+            response = self._clients.markings.UpdateMarking(request)
+        return self._refresh_from_api(response.marking)
+
+    def archive(self) -> None:
+        """Archive the marking, preventing it from being applied or modified.
+
+        Archived markings are excluded from search but can still be retrieved by RID. Archiving fails
+        if the marking is still applied to any resource.
+
+        Note: this does not update the instance in place; call `refresh()` to see the change reflected.
+        """
+        with translate_grpc_errors():
+            self._clients.markings.ArchiveMarkings(markings_pb2.ArchiveMarkingsRequest(marking_rids=[self.rid]))
+
+    def unarchive(self) -> None:
+        """Unarchive the marking, restoring the ability to apply and modify it.
+
+        Note: this does not update the instance in place; call `refresh()` to see the change reflected.
+        """
+        with translate_grpc_errors():
+            self._clients.markings.UnarchiveMarkings(markings_pb2.UnarchiveMarkingsRequest(marking_rids=[self.rid]))
+
+    @classmethod
+    def _from_proto(cls, clients: _Clients, marking: markings_pb2.Marking | markings_pb2.MarkingMetadata) -> Self:
+        # `Marking` and `MarkingMetadata` carry the same field names (the latter simply omits the
+        # authorized groups), so one constructor covers every response shape.
+        return cls(
+            rid=marking.rid,
+            id=marking.id,
+            description=marking.description,
+            symbol=Symbol._from_proto(marking.symbol),
+            color=_color_from_proto(marking.color),
+            created_at=marking.created_at.ToNanoseconds(),
+            updated_at=marking.updated_at.ToNanoseconds(),
+            is_archived=marking.is_archived,
+            _clients=clients,
+        )
+
+
+def _create_marking(
+    clients: Marking._Clients,
+    *,
+    id: str,
+    description: str | None,
+    authorized_groups: Sequence[str],
+    symbol: Symbol | None,
+    color: str | None,
+) -> Marking:
+    request = markings_pb2.CreateMarkingRequest(
+        id=_validate_marking_id(id),
+        description=description or "",
+        authorized_groups=markings_pb2.AuthorizedGroups(group_rids=list(authorized_groups)),
+        symbol=None if symbol is None else symbol._to_proto(),
+        color=None if color is None else _color_to_proto(_validate_hex_color(color)),
+    )
+    with translate_grpc_errors():
+        response = clients.markings.CreateMarking(request)
+    return Marking._from_proto(clients, response.marking)
+
+
+def _get_marking_proto(clients: Marking._Clients, rid: str) -> markings_pb2.Marking:
+    """The marking with the given rid.
+
+    Raises:
+        NominalNotFoundError: If no marking has that rid.
+        NominalPermissionDeniedError: If the user cannot read it.
+    """
+    with translate_grpc_errors():
+        return clients.markings.GetMarking(markings_pb2.GetMarkingRequest(rid=rid)).marking
+
+
+def _get_marking(clients: Marking._Clients, rid: str) -> Marking:
+    return Marking._from_proto(clients, _get_marking_proto(clients, rid))
+
+
+def _get_marking_by_id(clients: Marking._Clients, id: str) -> Marking:
+    request = markings_pb2.GetMarkingByIdRequest(id=_validate_marking_id(id))
+    with translate_grpc_errors():
+        response = clients.markings.GetMarkingById(request)
+    return Marking._from_proto(clients, response.marking)
+
+
+def _get_marking_metadata(clients: Marking._Clients, rids: Sequence[str]) -> Sequence[Marking]:
+    """Markings with the given rids, without their authorized groups.
+
+    Cheaper than fetching full markings when only the marking's metadata is needed.
+    """
+    if not rids:
+        return ()
+    request = markings_pb2.BatchGetMarkingMetadataRequest(marking_rids=list(rids))
+    with translate_grpc_errors():
+        response = clients.markings.BatchGetMarkingMetadata(request)
+    return tuple(Marking._from_proto(clients, m) for m in response.marking_metadatas)
+
+
+def _iter_search_markings(clients: Marking._Clients, query: markings_pb2.SearchMarkingsQuery) -> Iterable[Marking]:
+    for marking in search_markings_paginated(clients.markings, query):
+        yield Marking._from_proto(clients, marking)
+
+
+def _search_markings(clients: Marking._Clients, *, id_substring: str | None = None) -> Sequence[Marking]:
+    return tuple(_iter_search_markings(clients, create_search_markings_query(id_substring=id_substring)))
+
+
+class MarkableMixin:
+    """Markings applied to a data source.
+
+    Concrete: classes gain these methods by listing this mixin as a base and exposing a `markings`
+    client. Markings can only be applied to data sources — datasets, connections, and videos.
+    """
+
+    rid: str
+    _clients: Marking._Clients
+
+    def list_markings(self) -> Sequence[Marking]:
+        """The markings currently applied to this resource.
+
+        Markings the user does not have permission to read are omitted.
+
+        Raises:
+            NominalError: If the request fails.
+        """
+        return _get_marking_metadata(self._clients, _applied_marking_rids(self._clients, self.rid))
+
+    def apply_markings(self, markings: Iterable[Marking | str]) -> None:
+        """Apply markings to this resource, leaving any already-applied markings in place.
+
+        Applying a marking that is already applied is a no-op rather than an error.
+
+        Args:
+            markings: Markings, or marking RIDs, to apply.
+
+        Raises:
+            NominalError: If the request fails, including when a marking is archived or the user
+                lacks permission to change markings on this resource.
+        """
+        _update_markings_on_resource(self._clients, self.rid, apply=markings, remove=())
+
+    def remove_markings(self, markings: Iterable[Marking | str]) -> None:
+        """Remove markings from this resource.
+
+        Removing a marking that is not applied is a no-op rather than an error.
+
+        Args:
+            markings: Markings, or marking RIDs, to remove.
+
+        Raises:
+            NominalError: If the request fails.
+        """
+        _update_markings_on_resource(self._clients, self.rid, apply=(), remove=markings)
+
+    def set_markings(self, markings: Iterable[Marking | str]) -> None:
+        """Replace the markings on this resource with exactly the given markings.
+
+        The difference against the currently-applied markings is computed and sent as a single
+        atomic update. An empty sequence removes every marking from the resource.
+
+        Args:
+            markings: Markings, or marking RIDs, the resource should carry.
+
+        Raises:
+            NominalError: If the request fails.
+        """
+        desired = {rid_from_instance_or_string(marking) for marking in markings}
+        current = set(_applied_marking_rids(self._clients, self.rid))
+        to_apply = desired - current
+        to_remove = current - desired
+        if not to_apply and not to_remove:
+            return
+        _update_markings_on_resource(self._clients, self.rid, apply=to_apply, remove=to_remove)
+
+
+def _applied_marking_rids(clients: Marking._Clients, resource_rid: str) -> Sequence[str]:
+    request = markings_pb2.GetMarkingsForResourcesRequest(resources=[resource_rid])
+    with translate_grpc_errors():
+        response = clients.markings.GetMarkingsForResources(request)
+    applied = response.resource_to_markings[resource_rid].applied_markings
+    return tuple(marking.marking_rid for marking in applied)
+
+
+def _update_markings_on_resource(
+    clients: Marking._Clients,
+    resource_rid: str,
+    *,
+    apply: Iterable[Marking | str],
+    remove: Iterable[Marking | str],
+) -> None:
+    request = markings_pb2.UpdateMarkingsOnResourceRequest(
+        resource=resource_rid,
+        markings_to_apply=[rid_from_instance_or_string(marking) for marking in apply],
+        markings_to_remove=[rid_from_instance_or_string(marking) for marking in remove],
+    )
+    with translate_grpc_errors():
+        clients.markings.UpdateMarkingsOnResource(request)

--- a/nominal/core/marking.py
+++ b/nominal/core/marking.py
@@ -41,7 +41,11 @@ class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
     description: str
     symbol: Symbol | None
     color: str | None
-    """A lowercase six-digit hex color, e.g. `#cc0000`."""
+    """A six-digit hex color, e.g. `#cc0000`.
+
+    Colors passed to the SDK must be lowercase; a color read back is whatever was stored, so a marking
+    created outside the SDK may carry uppercase hex.
+    """
     created_at: IntegralNanosecondsUTC
     updated_at: IntegralNanosecondsUTC
     is_archived: bool
@@ -161,6 +165,11 @@ class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
             is_archived=marking.is_archived,
             _clients=clients,
         )
+
+
+def _marking_rids(markings: Iterable[Marking | str] | None) -> list[str]:
+    """The RIDs of the given markings. Absent markings and an empty sequence both mean "no markings"."""
+    return [] if markings is None else [rid_from_instance_or_string(marking) for marking in markings]
 
 
 def _create_marking(
@@ -283,6 +292,13 @@ class MarkableMixin:
 
         Args:
             markings: Markings, or marking RIDs, the resource should carry.
+
+        Note:
+            This replaces the markings rather than appending to them, and the difference is computed
+            against every applied marking — including any the caller cannot read, which
+            `list_markings` omits. A read-modify-write built on `list_markings` therefore removes the
+            markings it could not see. To add a marking without disturbing the others, use
+            `apply_markings` rather than merging into `set_markings`.
 
         Raises:
             NominalError: If the request fails.

--- a/nominal/core/marking.py
+++ b/nominal/core/marking.py
@@ -252,6 +252,13 @@ class MarkableMixin:
 
         Markings the user does not have permission to read are omitted.
 
+        Note:
+            The service filters unreadable markings out of the response, so this may be a strict
+            subset of what is actually applied. Treat it as "what I can see", not "what is there":
+            a resource can carry markings that never appear here. Use `apply_markings` and
+            `remove_markings`, which name their targets outright, rather than computing a desired
+            set from this list.
+
         Raises:
             NominalError: If the request fails.
         """
@@ -283,33 +290,6 @@ class MarkableMixin:
             NominalError: If the request fails.
         """
         _update_markings_on_resource(self._clients, self.rid, apply=(), remove=markings)
-
-    def set_markings(self, markings: Iterable[Marking | str]) -> None:
-        """Replace the markings on this resource with exactly the given markings.
-
-        The difference against the currently-applied markings is computed and sent as a single
-        atomic update. An empty sequence removes every marking from the resource.
-
-        Args:
-            markings: Markings, or marking RIDs, the resource should carry.
-
-        Note:
-            This replaces the markings rather than appending to them, and the difference is computed
-            against every applied marking — including any the caller cannot read, which
-            `list_markings` omits. A read-modify-write built on `list_markings` therefore removes the
-            markings it could not see. To add a marking without disturbing the others, use
-            `apply_markings` rather than merging into `set_markings`.
-
-        Raises:
-            NominalError: If the request fails.
-        """
-        desired = {rid_from_instance_or_string(marking) for marking in markings}
-        current = set(_applied_marking_rids(self._clients, self.rid))
-        to_apply = desired - current
-        to_remove = current - desired
-        if not to_apply and not to_remove:
-            return
-        _update_markings_on_resource(self._clients, self.rid, apply=to_apply, remove=to_remove)
 
 
 def _applied_marking_rids(clients: Marking._Clients, resource_rid: str) -> Sequence[str]:

--- a/nominal/core/marking.py
+++ b/nominal/core/marking.py
@@ -11,7 +11,7 @@ from nominal.core._utils.api_tools import HasRid, RefreshableGrpcMixin, rid_from
 from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.core._utils.pagination_tools import search_markings_paginated
 from nominal.core._utils.query_tools import create_search_markings_query
-from nominal.core.elements import Symbol, _color_from_proto, _color_to_proto, _validate_hex_color
+from nominal.core.elements import Symbol, _color_from_proto, _color_to_proto, _normalize_hex_color
 from nominal.protos.authorization.markings.v1 import markings_pb2, markings_pb2_grpc
 from nominal.ts import IntegralNanosecondsUTC
 
@@ -41,10 +41,10 @@ class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
     description: str
     symbol: Symbol | None
     color: str | None
-    """A six-digit hex color, e.g. `#cc0000`.
+    """A lowercase six-digit hex color, e.g. `#cc0000`.
 
-    Colors passed to the SDK must be lowercase; a color read back is whatever was stored, so a marking
-    created outside the SDK may carry uppercase hex.
+    The service constrains stored colors to this form, so a color read back is always lowercase.
+    An uppercase code passed to the SDK is lowercased rather than rejected.
     """
     created_at: IntegralNanosecondsUTC
     updated_at: IntegralNanosecondsUTC
@@ -91,7 +91,7 @@ class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
             description: New description for the marking.
             authorized_groups: Group RIDs replacing the existing ones. An empty sequence clears them.
             symbol: New symbol. Pass None to remove the marking's symbol.
-            color: New lowercase six-digit hex color, e.g. `#cc0000`. Pass None to remove it.
+            color: New six-digit hex color, e.g. `#cc0000`, in either case. Pass None to remove it.
 
         Returns:
             This marking, updated in place.
@@ -102,7 +102,7 @@ class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
             `authorized_groups`, which clear those fields.
 
         Raises:
-            ValueError: If `id` is not a valid marking id.
+            ValueError: If `id` is not a valid marking id, or `color` is not a valid hex color.
             NominalError: If the update request fails, including when the marking is archived.
         """
         request = markings_pb2.UpdateMarkingRequest(
@@ -123,7 +123,7 @@ class Marking(HasRid, RefreshableGrpcMixin[markings_pb2.Marking]):
                 None
                 if isinstance(color, self._NotProvided)
                 else markings_pb2.UpdateMarkingRequest.UpdateMarkingColorWrapper(
-                    value=None if color is None else _color_to_proto(_validate_hex_color(color))
+                    value=None if color is None else _color_to_proto(_normalize_hex_color(color))
                 )
             ),
         )
@@ -186,7 +186,7 @@ def _create_marking(
         description=description or "",
         authorized_groups=markings_pb2.AuthorizedGroups(group_rids=list(authorized_groups)),
         symbol=None if symbol is None else symbol._to_proto(),
-        color=None if color is None else _color_to_proto(_validate_hex_color(color)),
+        color=None if color is None else _color_to_proto(_normalize_hex_color(color)),
     )
     with translate_grpc_errors():
         response = clients.markings.CreateMarking(request)

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -26,7 +26,9 @@ from nominal.core.exceptions import (
     NominalVideoTimestampModeError,
 )
 from nominal.core.filetype import FileType, FileTypes
+from nominal.core.marking import MarkableMixin
 from nominal.core.video_file import VideoFile
+from nominal.protos.authorization.markings.v1 import markings_pb2_grpc
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
 
 logger = logging.getLogger(__name__)
@@ -36,7 +38,7 @@ _ONE_OF_THREE_MODES_ERROR = "exactly one of 'start', 'frame_timestamps', or 'mca
 
 
 @dataclass(frozen=True)
-class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
+class Video(HasRid, MarkableMixin, RefreshableConjureMixin[scout_video_api.Video]):
     rid: str
     name: str
     description: str | None
@@ -58,6 +60,8 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
         def video_file(self) -> scout_video.VideoFileService: ...
         @property
         def catalog(self) -> scout_catalog.CatalogService: ...
+        @property
+        def markings(self) -> markings_pb2_grpc.MarkingServiceStub: ...
 
     @deprecated(
         "Polling a standalone `Video` is deprecated in favor of video channels on a dataset. Poll the individual files "

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -583,6 +583,7 @@ def _create_video(
     labels: Sequence[str] = (),
     properties: Mapping[str, str] | None = None,
     workspace_rid: str | None = None,
+    marking_rids: Sequence[str] | None = None,
 ) -> scout_video_api.Video:
     request = scout_video_api.CreateVideoRequest(
         title=name,
@@ -590,6 +591,6 @@ def _create_video(
         properties={} if properties is None else {**properties},
         description=description,
         workspace=workspace_rid,
-        marking_rids=[],
+        marking_rids=list(marking_rids or []),
     )
     return client.create(auth_header, request)

--- a/nominal/core/video.py
+++ b/nominal/core/video.py
@@ -26,7 +26,9 @@ from nominal.core.exceptions import (
     NominalVideoTimestampModeError,
 )
 from nominal.core.filetype import FileType, FileTypes
+from nominal.core.marking import MarkableMixin
 from nominal.core.video_file import VideoFile
+from nominal.protos.authorization.markings.v1 import markings_pb2_grpc
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
 
 logger = logging.getLogger(__name__)
@@ -36,7 +38,7 @@ _ONE_OF_THREE_MODES_ERROR = "exactly one of 'start', 'frame_timestamps', or 'mca
 
 
 @dataclass(frozen=True)
-class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
+class Video(HasRid, MarkableMixin, RefreshableConjureMixin[scout_video_api.Video]):
     rid: str
     name: str
     description: str | None
@@ -58,6 +60,8 @@ class Video(HasRid, RefreshableConjureMixin[scout_video_api.Video]):
         def video_file(self) -> scout_video.VideoFileService: ...
         @property
         def catalog(self) -> scout_catalog.CatalogService: ...
+        @property
+        def markings(self) -> markings_pb2_grpc.MarkingServiceStub: ...
 
     @deprecated(
         "Polling a standalone `Video` is deprecated in favor of video channels on a dataset. Poll the individual files "
@@ -579,6 +583,7 @@ def _create_video(
     labels: Sequence[str] = (),
     properties: Mapping[str, str] | None = None,
     workspace_rid: str | None = None,
+    marking_rids: Sequence[str] | None = None,
 ) -> scout_video_api.Video:
     request = scout_video_api.CreateVideoRequest(
         title=name,
@@ -586,6 +591,6 @@ def _create_video(
         properties={} if properties is None else {**properties},
         description=description,
         workspace=workspace_rid,
-        marking_rids=[],
+        marking_rids=list(marking_rids or []),
     )
     return client.create(auth_header, request)

--- a/nominal/experimental/compute_as_code/_derived_datasets.py
+++ b/nominal/experimental/compute_as_code/_derived_datasets.py
@@ -7,7 +7,7 @@ import nominal_compute
 from conjure_python_client import ConjureDecoder
 from nominal_api import scout_catalog, scout_compute_api
 
-from nominal.core import NominalClient
+from nominal.core import Marking, NominalClient
 from nominal.core._utils.api_tools import rid_from_instance_or_string
 from nominal.core.dataset import Dataset
 
@@ -28,6 +28,7 @@ def create_derived_dataset(
     description: str | None = None,
     labels: Sequence[str] = (),
     properties: Mapping[str, str] | None = None,
+    markings: Sequence[Marking | str] | None = None,
 ) -> Dataset:
     """Create a derived dataset defined by a ``nominal_compute`` graph.
 
@@ -43,6 +44,9 @@ def create_derived_dataset(
         description: Human readable description of the dataset.
         labels: Text labels to apply to the created dataset.
         properties: Key-value properties to apply to the created dataset.
+        markings: If present, markings (or marking RIDs) to apply to the created dataset. Markings are
+            applied in a separate step after the dataset is created, so creation and marking are not
+            atomic; if that matters, verify with `list_markings()`.
 
     Returns:
         Reference to the created derived dataset in Nominal.
@@ -57,7 +61,7 @@ def create_derived_dataset(
         metadata={},
         origin_metadata=scout_catalog.DatasetOriginMetadata(),
         workspace=client._clients.resolve_default_workspace_rid(),
-        marking_rids=[],
+        marking_rids=[] if markings is None else [rid_from_instance_or_string(m) for m in markings],
         derived_definition=scout_catalog.CreateDerivedDefinition(spec=_to_conjure_dataset(spec), message=message),
     )
     response = client._clients.catalog.create_dataset(client._clients.auth_header, request)

--- a/nominal/experimental/compute_as_code/_derived_datasets.py
+++ b/nominal/experimental/compute_as_code/_derived_datasets.py
@@ -7,7 +7,7 @@ import nominal_compute
 from conjure_python_client import ConjureDecoder
 from nominal_api import scout_catalog, scout_compute_api
 
-from nominal.core import NominalClient
+from nominal.core import Marking, NominalClient
 from nominal.core._utils.api_tools import rid_from_instance_or_string
 from nominal.core.dataset import Dataset
 
@@ -28,6 +28,7 @@ def create_derived_dataset(
     description: str | None = None,
     labels: Sequence[str] = (),
     properties: Mapping[str, str] | None = None,
+    markings: Sequence[Marking | str] | None = None,
 ) -> Dataset:
     """Create a derived dataset defined by a ``nominal_compute`` graph.
 
@@ -43,6 +44,7 @@ def create_derived_dataset(
         description: Human readable description of the dataset.
         labels: Text labels to apply to the created dataset.
         properties: Key-value properties to apply to the created dataset.
+        markings: If present, markings (or marking RIDs) to apply to the created dataset.
 
     Returns:
         Reference to the created derived dataset in Nominal.
@@ -57,7 +59,7 @@ def create_derived_dataset(
         metadata={},
         origin_metadata=scout_catalog.DatasetOriginMetadata(),
         workspace=client._clients.resolve_default_workspace_rid(),
-        marking_rids=[],
+        marking_rids=[] if markings is None else [rid_from_instance_or_string(m) for m in markings],
         derived_definition=scout_catalog.CreateDerivedDefinition(spec=_to_conjure_dataset(spec), message=message),
     )
     response = client._clients.catalog.create_dataset(client._clients.auth_header, request)

--- a/nominal/experimental/compute_as_code/_derived_datasets.py
+++ b/nominal/experimental/compute_as_code/_derived_datasets.py
@@ -44,7 +44,9 @@ def create_derived_dataset(
         description: Human readable description of the dataset.
         labels: Text labels to apply to the created dataset.
         properties: Key-value properties to apply to the created dataset.
-        markings: If present, markings (or marking RIDs) to apply to the created dataset.
+        markings: If present, markings (or marking RIDs) to apply to the created dataset. Markings are
+            applied in a separate step after the dataset is created, so creation and marking are not
+            atomic; if that matters, verify with `list_markings()`.
 
     Returns:
         Reference to the created derived dataset in Nominal.

--- a/nominal/experimental/compute_as_code/_derived_datasets.py
+++ b/nominal/experimental/compute_as_code/_derived_datasets.py
@@ -10,6 +10,7 @@ from nominal_api import scout_catalog, scout_compute_api
 from nominal.core import Marking, NominalClient
 from nominal.core._utils.api_tools import rid_from_instance_or_string
 from nominal.core.dataset import Dataset
+from nominal.core.marking import _marking_rids
 
 
 def _to_conjure_dataset(spec: nominal_compute.Dataset) -> scout_compute_api.Dataset:
@@ -44,9 +45,8 @@ def create_derived_dataset(
         description: Human readable description of the dataset.
         labels: Text labels to apply to the created dataset.
         properties: Key-value properties to apply to the created dataset.
-        markings: If present, markings (or marking RIDs) to apply to the created dataset. Markings are
-            applied in a separate step after the dataset is created, so creation and marking are not
-            atomic; if that matters, verify with `list_markings()`.
+        markings: If present, markings (or marking RIDs) applied to the dataset. Sent as part of
+            the creation request rather than applied in a follow-up call.
 
     Returns:
         Reference to the created derived dataset in Nominal.
@@ -61,7 +61,7 @@ def create_derived_dataset(
         metadata={},
         origin_metadata=scout_catalog.DatasetOriginMetadata(),
         workspace=client._clients.resolve_default_workspace_rid(),
-        marking_rids=[] if markings is None else [rid_from_instance_or_string(m) for m in markings],
+        marking_rids=_marking_rids(markings),
         derived_definition=scout_catalog.CreateDerivedDefinition(spec=_to_conjure_dataset(spec), message=message),
     )
     response = client._clients.catalog.create_dataset(client._clients.auth_header, request)

--- a/nominal/experimental/dataset_utils/_dataset_utils.py
+++ b/nominal/experimental/dataset_utils/_dataset_utils.py
@@ -2,7 +2,8 @@ from collections.abc import Mapping, Sequence
 
 from nominal_api import scout_catalog
 
-from nominal.core import Dataset, NominalClient, User
+from nominal.core import Dataset, Marking, NominalClient, User
+from nominal.core._utils.api_tools import rid_from_instance_or_string
 from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.protos.authorization.roles.v1 import roles_pb2
 
@@ -15,6 +16,7 @@ def create_dataset_with_uuid(
     description: str | None = None,
     labels: Sequence[str] = (),
     properties: Mapping[str, str] | None = None,
+    markings: Sequence[Marking | str] | None = None,
 ) -> Dataset:
     """Create a dataset with a specific UUID.
 
@@ -31,6 +33,7 @@ def create_dataset_with_uuid(
         description: Human readable description of the dataset.
         labels: Text labels to apply to the created dataset.
         properties: Key-value properties to apply to the created dataset.
+        markings: If present, markings (or marking RIDs) to apply to the created dataset.
 
     Returns:
         Reference to the created dataset in Nominal.
@@ -45,7 +48,7 @@ def create_dataset_with_uuid(
         metadata={},
         origin_metadata=scout_catalog.DatasetOriginMetadata(),
         workspace=client._clients.resolve_default_workspace_rid(),
-        marking_rids=[],
+        marking_rids=[] if markings is None else [rid_from_instance_or_string(m) for m in markings],
     )
     request = scout_catalog.CreateDatasetWithUuidRequest(
         create_dataset=create_dataset_request,

--- a/nominal/experimental/dataset_utils/_dataset_utils.py
+++ b/nominal/experimental/dataset_utils/_dataset_utils.py
@@ -2,7 +2,8 @@ from collections.abc import Mapping, Sequence
 
 from nominal_api import scout_catalog
 
-from nominal.core import Dataset, NominalClient, User
+from nominal.core import Dataset, Marking, NominalClient, User
+from nominal.core._utils.api_tools import rid_from_instance_or_string
 from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.protos.authorization.roles.v1 import roles_pb2
 
@@ -15,6 +16,7 @@ def create_dataset_with_uuid(
     description: str | None = None,
     labels: Sequence[str] = (),
     properties: Mapping[str, str] | None = None,
+    markings: Sequence[Marking | str] | None = None,
 ) -> Dataset:
     """Create a dataset with a specific UUID.
 
@@ -31,6 +33,9 @@ def create_dataset_with_uuid(
         description: Human readable description of the dataset.
         labels: Text labels to apply to the created dataset.
         properties: Key-value properties to apply to the created dataset.
+        markings: If present, markings (or marking RIDs) to apply to the created dataset. Markings are
+            applied in a separate step after the dataset is created, so creation and marking are not
+            atomic; if that matters, verify with `list_markings()`.
 
     Returns:
         Reference to the created dataset in Nominal.
@@ -45,7 +50,7 @@ def create_dataset_with_uuid(
         metadata={},
         origin_metadata=scout_catalog.DatasetOriginMetadata(),
         workspace=client._clients.resolve_default_workspace_rid(),
-        marking_rids=[],
+        marking_rids=[] if markings is None else [rid_from_instance_or_string(m) for m in markings],
     )
     request = scout_catalog.CreateDatasetWithUuidRequest(
         create_dataset=create_dataset_request,

--- a/nominal/experimental/dataset_utils/_dataset_utils.py
+++ b/nominal/experimental/dataset_utils/_dataset_utils.py
@@ -33,7 +33,9 @@ def create_dataset_with_uuid(
         description: Human readable description of the dataset.
         labels: Text labels to apply to the created dataset.
         properties: Key-value properties to apply to the created dataset.
-        markings: If present, markings (or marking RIDs) to apply to the created dataset.
+        markings: If present, markings (or marking RIDs) to apply to the created dataset. Markings are
+            applied in a separate step after the dataset is created, so creation and marking are not
+            atomic; if that matters, verify with `list_markings()`.
 
     Returns:
         Reference to the created dataset in Nominal.

--- a/nominal/experimental/dataset_utils/_dataset_utils.py
+++ b/nominal/experimental/dataset_utils/_dataset_utils.py
@@ -3,8 +3,8 @@ from collections.abc import Mapping, Sequence
 from nominal_api import scout_catalog
 
 from nominal.core import Dataset, Marking, NominalClient, User
-from nominal.core._utils.api_tools import rid_from_instance_or_string
 from nominal.core._utils.grpc_tools import translate_grpc_errors
+from nominal.core.marking import _marking_rids
 from nominal.protos.authorization.roles.v1 import roles_pb2
 
 
@@ -33,9 +33,8 @@ def create_dataset_with_uuid(
         description: Human readable description of the dataset.
         labels: Text labels to apply to the created dataset.
         properties: Key-value properties to apply to the created dataset.
-        markings: If present, markings (or marking RIDs) to apply to the created dataset. Markings are
-            applied in a separate step after the dataset is created, so creation and marking are not
-            atomic; if that matters, verify with `list_markings()`.
+        markings: If present, markings (or marking RIDs) applied to the dataset. Sent as part of
+            the creation request rather than applied in a follow-up call.
 
     Returns:
         Reference to the created dataset in Nominal.
@@ -50,7 +49,7 @@ def create_dataset_with_uuid(
         metadata={},
         origin_metadata=scout_catalog.DatasetOriginMetadata(),
         workspace=client._clients.resolve_default_workspace_rid(),
-        marking_rids=[] if markings is None else [rid_from_instance_or_string(m) for m in markings],
+        marking_rids=_marking_rids(markings),
     )
     request = scout_catalog.CreateDatasetWithUuidRequest(
         create_dataset=create_dataset_request,

--- a/tests/core/test_elements.py
+++ b/tests/core/test_elements.py
@@ -29,7 +29,7 @@ def test_symbol_from_unset_proto_is_none() -> None:
 
 
 def test_color_round_trips_through_proto() -> None:
-    color = Color("#cc0000")
+    color = Color.create("#cc0000")
 
     assert color._to_proto().hex_code == "#cc0000"
     assert Color._from_proto(color._to_proto()) == color
@@ -39,13 +39,13 @@ def test_color_from_unset_proto_is_none() -> None:
     assert Color._from_proto(elements_pb2.Color()) is None
 
 
-def test_color_normalizes_server_casing() -> None:
-    """The server's pattern is lowercase-only; tolerate case drift on read rather than raising."""
-    assert Color._from_proto(elements_pb2.Color(hex_code="#CC0000")) == Color("#cc0000")
+def test_color_reads_back_what_the_server_sent() -> None:
+    """Reads are faithful: validation guards user input, so it must not reject stored values."""
+    assert Color._from_proto(elements_pb2.Color(hex_code="#CC0000")) == Color("#CC0000")
 
 
 @pytest.mark.parametrize("bad", ["cc0000", "#ccc", "#gg0000", "#cc00000", "red", ""])
-def test_color_rejects_values_the_server_would_reject(bad: str) -> None:
+def test_create_color_rejects_values_the_server_would_reject(bad: str) -> None:
     """Guard client-side: users cannot see the backend's validation rule."""
     with pytest.raises(ValueError, match="hex color"):
-        Color(bad)
+        Color.create(bad)

--- a/tests/core/test_elements.py
+++ b/tests/core/test_elements.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from nominal.core.elements import Symbol, _color_from_proto, _color_to_proto, _validate_hex_color
+from nominal.protos.scout.elements.v1 import elements_pb2
+
+
+@pytest.mark.parametrize(
+    ("symbol", "oneof_name", "value"),
+    [
+        (Symbol.icon("castle"), "icon", "castle"),
+        (Symbol.emoji(":castle:"), "emoji", ":castle:"),
+        (Symbol.image("https://example.com/x.png"), "image", "https://example.com/x.png"),
+    ],
+)
+def test_symbol_sets_the_matching_proto_oneof_arm(symbol: Symbol, oneof_name: str, value: str) -> None:
+    """Each constructor targets its own oneof arm, so the kind survives a round trip."""
+    proto = symbol._to_proto()
+
+    assert proto.WhichOneof("symbol") == oneof_name
+    assert getattr(proto, oneof_name) == value
+    assert Symbol._from_proto(proto) == symbol
+
+
+def test_symbol_from_unset_proto_is_none() -> None:
+    """An unset symbol oneof maps to None, matching the optional field on Marking."""
+    assert Symbol._from_proto(elements_pb2.Symbol()) is None
+
+
+def test_color_round_trips_through_proto() -> None:
+    assert _color_to_proto("#cc0000").hex_code == "#cc0000"
+    assert _color_from_proto(_color_to_proto("#cc0000")) == "#cc0000"
+
+
+def test_color_from_unset_proto_is_none() -> None:
+    assert _color_from_proto(elements_pb2.Color()) is None
+
+
+def test_color_reads_back_what_the_server_sent() -> None:
+    """Reads are faithful: validation guards user input, so it must not reject stored values."""
+    assert _color_from_proto(elements_pb2.Color(hex_code="#CC0000")) == "#CC0000"
+
+
+@pytest.mark.parametrize("bad", ["cc0000", "#ccc", "#gg0000", "#cc00000", "red", ""])
+def test_validate_hex_color_rejects_values_the_server_would_reject(bad: str) -> None:
+    """Guard client-side: users cannot see the backend's validation rule."""
+    with pytest.raises(ValueError, match="hex color"):
+        _validate_hex_color(bad)

--- a/tests/core/test_elements.py
+++ b/tests/core/test_elements.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from nominal.core.elements import Color, Symbol
+from nominal.protos.scout.elements.v1 import elements_pb2
+
+
+@pytest.mark.parametrize(
+    ("symbol", "oneof_name", "value"),
+    [
+        (Symbol.icon("castle"), "icon", "castle"),
+        (Symbol.emoji(":castle:"), "emoji", ":castle:"),
+        (Symbol.image("https://example.com/x.png"), "image", "https://example.com/x.png"),
+    ],
+)
+def test_symbol_sets_the_matching_proto_oneof_arm(symbol: Symbol, oneof_name: str, value: str) -> None:
+    """Each constructor targets its own oneof arm, so the kind survives a round trip."""
+    proto = symbol._to_proto()
+
+    assert proto.WhichOneof("symbol") == oneof_name
+    assert getattr(proto, oneof_name) == value
+    assert Symbol._from_proto(proto) == symbol
+
+
+def test_symbol_from_unset_proto_is_none() -> None:
+    """An unset symbol oneof maps to None, matching the optional field on Marking."""
+    assert Symbol._from_proto(elements_pb2.Symbol()) is None
+
+
+def test_color_round_trips_through_proto() -> None:
+    color = Color("#cc0000")
+
+    assert color._to_proto().hex_code == "#cc0000"
+    assert Color._from_proto(color._to_proto()) == color
+
+
+def test_color_from_unset_proto_is_none() -> None:
+    assert Color._from_proto(elements_pb2.Color()) is None
+
+
+def test_color_normalizes_server_casing() -> None:
+    """The server's pattern is lowercase-only; tolerate case drift on read rather than raising."""
+    assert Color._from_proto(elements_pb2.Color(hex_code="#CC0000")) == Color("#cc0000")
+
+
+@pytest.mark.parametrize("bad", ["cc0000", "#ccc", "#gg0000", "#cc00000", "red", ""])
+def test_color_rejects_values_the_server_would_reject(bad: str) -> None:
+    """Guard client-side: users cannot see the backend's validation rule."""
+    with pytest.raises(ValueError, match="hex color"):
+        Color(bad)

--- a/tests/core/test_elements.py
+++ b/tests/core/test_elements.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from nominal.core.elements import Color, Symbol
+from nominal.core.elements import Symbol, _color_from_proto, _color_to_proto, _validate_hex_color
 from nominal.protos.scout.elements.v1 import elements_pb2
 
 
@@ -29,23 +29,21 @@ def test_symbol_from_unset_proto_is_none() -> None:
 
 
 def test_color_round_trips_through_proto() -> None:
-    color = Color.create("#cc0000")
-
-    assert color._to_proto().hex_code == "#cc0000"
-    assert Color._from_proto(color._to_proto()) == color
+    assert _color_to_proto("#cc0000").hex_code == "#cc0000"
+    assert _color_from_proto(_color_to_proto("#cc0000")) == "#cc0000"
 
 
 def test_color_from_unset_proto_is_none() -> None:
-    assert Color._from_proto(elements_pb2.Color()) is None
+    assert _color_from_proto(elements_pb2.Color()) is None
 
 
 def test_color_reads_back_what_the_server_sent() -> None:
     """Reads are faithful: validation guards user input, so it must not reject stored values."""
-    assert Color._from_proto(elements_pb2.Color(hex_code="#CC0000")) == Color("#CC0000")
+    assert _color_from_proto(elements_pb2.Color(hex_code="#CC0000")) == "#CC0000"
 
 
 @pytest.mark.parametrize("bad", ["cc0000", "#ccc", "#gg0000", "#cc00000", "red", ""])
-def test_create_color_rejects_values_the_server_would_reject(bad: str) -> None:
+def test_validate_hex_color_rejects_values_the_server_would_reject(bad: str) -> None:
     """Guard client-side: users cannot see the backend's validation rule."""
     with pytest.raises(ValueError, match="hex color"):
-        Color.create(bad)
+        _validate_hex_color(bad)

--- a/tests/core/test_elements.py
+++ b/tests/core/test_elements.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from typing import Any, Callable
+
 import pytest
 
-from nominal.core.elements import Symbol, _color_from_proto, _color_to_proto, _normalize_hex_color
+from nominal.core.elements import Symbol, _color_from_proto, _normalize_hex_color
 from nominal.protos.scout.elements.v1 import elements_pb2
 
 
@@ -23,25 +25,14 @@ def test_symbol_sets_the_matching_proto_oneof_arm(symbol: Symbol, oneof_name: st
     assert Symbol._from_proto(proto) == symbol
 
 
-def test_symbol_from_unset_proto_is_none() -> None:
-    """An unset symbol oneof maps to None, matching the optional field on Marking."""
-    assert Symbol._from_proto(elements_pb2.Symbol()) is None
-
-
-def test_color_round_trips_through_proto() -> None:
-    """A hex color survives conversion to the proto oneof and back."""
-    assert _color_to_proto("#cc0000").hex_code == "#cc0000"
-    assert _color_from_proto(_color_to_proto("#cc0000")) == "#cc0000"
-
-
-def test_color_from_unset_proto_is_none() -> None:
-    """An unset color oneof reads back as None rather than an empty string."""
-    assert _color_from_proto(elements_pb2.Color()) is None
-
-
-def test_color_reads_back_what_the_server_sent() -> None:
-    """Reads never re-validate, so an unexpected stored value surfaces rather than raising."""
-    assert _color_from_proto(elements_pb2.Color(hex_code="#CC0000")) == "#CC0000"
+@pytest.mark.parametrize(
+    ("read", "empty_proto"),
+    [(Symbol._from_proto, elements_pb2.Symbol()), (_color_from_proto, elements_pb2.Color())],
+    ids=["symbol", "color"],
+)
+def test_an_unset_oneof_reads_back_as_none(read: Callable[[Any], object], empty_proto: Any) -> None:
+    """An absent symbol or color becomes None, matching the optional attributes on Marking."""
+    assert read(empty_proto) is None
 
 
 @pytest.mark.parametrize("bad", ["cc0000", "#ccc", "#gg0000", "#cc00000", "red", ""])

--- a/tests/core/test_elements.py
+++ b/tests/core/test_elements.py
@@ -29,11 +29,13 @@ def test_symbol_from_unset_proto_is_none() -> None:
 
 
 def test_color_round_trips_through_proto() -> None:
+    """A hex color survives conversion to the proto oneof and back."""
     assert _color_to_proto("#cc0000").hex_code == "#cc0000"
     assert _color_from_proto(_color_to_proto("#cc0000")) == "#cc0000"
 
 
 def test_color_from_unset_proto_is_none() -> None:
+    """An unset color oneof reads back as None rather than an empty string."""
     assert _color_from_proto(elements_pb2.Color()) is None
 
 

--- a/tests/core/test_elements.py
+++ b/tests/core/test_elements.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from nominal.core.elements import Symbol, _color_from_proto, _color_to_proto, _validate_hex_color
+from nominal.core.elements import Symbol, _color_from_proto, _color_to_proto, _normalize_hex_color
 from nominal.protos.scout.elements.v1 import elements_pb2
 
 
@@ -40,12 +40,18 @@ def test_color_from_unset_proto_is_none() -> None:
 
 
 def test_color_reads_back_what_the_server_sent() -> None:
-    """Reads are faithful: validation guards user input, so it must not reject stored values."""
+    """Reads never re-validate, so an unexpected stored value surfaces rather than raising."""
     assert _color_from_proto(elements_pb2.Color(hex_code="#CC0000")) == "#CC0000"
 
 
 @pytest.mark.parametrize("bad", ["cc0000", "#ccc", "#gg0000", "#cc00000", "red", ""])
-def test_validate_hex_color_rejects_values_the_server_would_reject(bad: str) -> None:
-    """Guard client-side: users cannot see the backend's validation rule."""
+def test_normalize_hex_color_rejects_anything_but_a_six_digit_hex(bad: str) -> None:
+    """Mirrors the server's own `^#[0-9a-f]{6}$` constraint, failing locally instead of over the wire."""
     with pytest.raises(ValueError, match="hex color"):
-        _validate_hex_color(bad)
+        _normalize_hex_color(bad)
+
+
+@pytest.mark.parametrize("given", ["#cc0000", "#CC0000", "#Cc0000"])
+def test_normalize_hex_color_lowercases_so_writes_are_case_insensitive(given: str) -> None:
+    """Case carries no meaning in a hex color, so any case is accepted and sent as lowercase."""
+    assert _normalize_hex_color(given) == "#cc0000"

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -9,7 +9,7 @@ from nominal.core._utils.pagination_tools import search_markings_paginated
 from nominal.core._utils.query_tools import create_search_markings_query
 from nominal.core.client import NominalClient
 from nominal.core.connection import StreamingConnection
-from nominal.core.elements import Color, Symbol
+from nominal.core.elements import Symbol
 from nominal.core.exceptions import NominalNotFoundError, NominalPermissionDeniedError
 from nominal.core.marking import (
     MarkableMixin,
@@ -96,7 +96,7 @@ def test_from_proto_reads_both_marking_shapes() -> None:
 
     assert from_full.id == from_metadata.id == "itar"
     assert from_full.symbol == from_metadata.symbol == Symbol.emoji(":lock:")
-    assert from_full.color == Color("#cc0000")
+    assert from_full.color == "#cc0000"
 
 
 def test_create_rejects_ids_the_server_would_reject() -> None:
@@ -119,7 +119,7 @@ def test_create_sends_symbol_and_color() -> None:
         description="controlled",
         authorized_group_rids=["ri.group.a"],
         symbol=Symbol.emoji(":lock:"),
-        color=Color.create("#cc0000"),
+        color="#cc0000",
     )
 
     request = clients.markings.CreateMarking.call_args.args[0]
@@ -349,7 +349,7 @@ def test_client_create_marking_returns_the_created_marking() -> None:
     clients.markings.CreateMarking.return_value = markings_pb2.CreateMarkingResponse(marking=_marking())
     client = NominalClient(_clients=clients)
 
-    marking = client.create_marking("itar", description="controlled", color=Color.create("#cc0000"))
+    marking = client.create_marking("itar", description="controlled", color="#cc0000")
 
     assert marking.id == "itar"
     assert clients.markings.CreateMarking.call_args.args[0].color.hex_code == "#cc0000"

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -8,6 +8,7 @@ from nominal.core._utils.pagination_tools import search_markings_paginated
 from nominal.core._utils.query_tools import create_search_markings_query
 from nominal.core.elements import Color, Symbol
 from nominal.core.marking import (
+    MarkableMixin,
     Marking,
     _create_marking,
     _get_marking,
@@ -178,3 +179,87 @@ def test_authorized_group_rids_reads_this_markings_entry() -> None:
     clients.markings.GetAuthorizedGroupsByMarking.return_value = response
 
     assert marking.authorized_group_rids() == ("ri.group.a",)
+
+
+class _Markable(MarkableMixin):
+    """Minimal stand-in for a data source, exercising the mixin's own behavior."""
+
+    def __init__(self, rid: str, clients: MagicMock) -> None:
+        self.rid = rid
+        self._clients = clients
+
+
+def _applied(clients: MagicMock, resource: str, *marking_rids: str) -> None:
+    response = markings_pb2.GetMarkingsForResourcesResponse()
+    for marking_rid in marking_rids:
+        response.resource_to_markings[resource].applied_markings.add(marking_rid=marking_rid)
+    clients.markings.GetMarkingsForResources.return_value = response
+
+
+def test_list_markings_hydrates_applied_rids() -> None:
+    clients = _clients()
+    _applied(clients, "ri.dataset.a", "ri.marking.a")
+    clients.markings.BatchGetMarkingMetadata.return_value = markings_pb2.BatchGetMarkingMetadataResponse(
+        marking_metadatas=[_metadata("ri.marking.a", id="itar")]
+    )
+
+    markings = _Markable("ri.dataset.a", clients).list_markings()
+
+    assert [m.id for m in markings] == ["itar"]
+    assert list(clients.markings.BatchGetMarkingMetadata.call_args.args[0].marking_rids) == ["ri.marking.a"]
+
+
+def test_list_markings_on_unmarked_resource_is_empty_without_a_second_call() -> None:
+    clients = _clients()
+    _applied(clients, "ri.dataset.a")
+
+    assert _Markable("ri.dataset.a", clients).list_markings() == ()
+    clients.markings.BatchGetMarkingMetadata.assert_not_called()
+
+
+def test_apply_and_remove_send_one_sided_updates() -> None:
+    clients = _clients()
+    markable = _Markable("ri.dataset.a", clients)
+
+    markable.apply_markings(["ri.marking.a"])
+    applied = clients.markings.UpdateMarkingsOnResource.call_args.args[0]
+    assert applied.resource == "ri.dataset.a"
+    assert list(applied.markings_to_apply) == ["ri.marking.a"]
+    assert list(applied.markings_to_remove) == []
+
+    markable.remove_markings(["ri.marking.a"])
+    removed = clients.markings.UpdateMarkingsOnResource.call_args.args[0]
+    assert list(removed.markings_to_apply) == []
+    assert list(removed.markings_to_remove) == ["ri.marking.a"]
+
+
+def test_set_markings_sends_the_diff_in_one_call() -> None:
+    """Replacing the set adds what is missing and removes what is no longer wanted, atomically."""
+    clients = _clients()
+    _applied(clients, "ri.dataset.a", "ri.marking.keep", "ri.marking.drop")
+
+    _Markable("ri.dataset.a", clients).set_markings(["ri.marking.keep", "ri.marking.add"])
+
+    assert clients.markings.UpdateMarkingsOnResource.call_count == 1
+    request = clients.markings.UpdateMarkingsOnResource.call_args.args[0]
+    assert sorted(request.markings_to_apply) == ["ri.marking.add"]
+    assert sorted(request.markings_to_remove) == ["ri.marking.drop"]
+
+
+def test_set_markings_skips_the_call_when_nothing_changes() -> None:
+    clients = _clients()
+    _applied(clients, "ri.dataset.a", "ri.marking.keep")
+
+    _Markable("ri.dataset.a", clients).set_markings(["ri.marking.keep"])
+
+    clients.markings.UpdateMarkingsOnResource.assert_not_called()
+
+
+def test_markings_accept_instances_as_well_as_rids() -> None:
+    clients = _clients()
+    marking = Marking._from_proto(clients, _marking(rid="ri.marking.a"))
+
+    _Markable("ri.dataset.a", clients).apply_markings([marking])
+
+    request = clients.markings.UpdateMarkingsOnResource.call_args.args[0]
+    assert list(request.markings_to_apply) == ["ri.marking.a"]

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -292,3 +292,63 @@ def test_client_create_marking_returns_the_created_marking() -> None:
 
     assert marking.id == "itar"
     assert clients.markings.CreateMarking.call_args.args[0].color.hex_code == "#cc0000"
+
+
+def test_create_dataset_forwards_marking_rids() -> None:
+    """Markings may be given as instances or as RIDs."""
+    from nominal.core.client import NominalClient
+
+    clients = _clients()
+    client = NominalClient(_clients=clients)
+    marking = Marking._from_proto(clients, _marking(rid="ri.marking.a"))
+
+    client.create_dataset("ds", markings=[marking, "ri.marking.b"])
+
+    request = clients.catalog.create_dataset.call_args.args[1]
+    assert request.marking_rids == ["ri.marking.a", "ri.marking.b"]
+
+
+def test_create_dataset_without_markings_sends_an_empty_list() -> None:
+    from nominal.core.client import NominalClient
+
+    clients = _clients()
+    NominalClient(_clients=clients).create_dataset("ds")
+
+    assert clients.catalog.create_dataset.call_args.args[1].marking_rids == []
+
+
+def test_create_streaming_connection_forwards_marking_rids() -> None:
+    from nominal.core.client import NominalClient
+
+    clients = _clients()
+    with pytest.warns(DeprecationWarning, match="create_streaming_connection"):
+        NominalClient(_clients=clients).create_streaming_connection("ds-id", "conn", markings=["ri.marking.a"])
+
+    request = clients.connection.create_connection.call_args.args[1]
+    assert request.marking_rids == ["ri.marking.a"]
+
+
+def test_new_ingest_destination_carries_marking_rids() -> None:
+    """Called directly: this builder has no callers yet, but must not drop markings when it gains one."""
+    from nominal.core.dataset import _construct_new_ingest_options
+    from nominal.core.filetype import FileTypes
+    from nominal.ts import Iso8601
+
+    options = _construct_new_ingest_options(
+        name="ds",
+        timestamp_column="ts",
+        timestamp_type=Iso8601(),
+        file_type=FileTypes.CSV,
+        description=None,
+        labels=[],
+        properties={},
+        prefix_tree_delimiter=None,
+        channel_prefix=None,
+        tag_columns=None,
+        s3_path="s3://bucket/key.csv",
+        workspace_rid="ri.workspace.a",
+        tags=None,
+        marking_rids=["ri.marking.a"],
+    )
+
+    assert options.csv.target.new.marking_rids == ["ri.marking.a"]

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from nominal.core._utils.pagination_tools import search_markings_paginated
+from nominal.core._utils.query_tools import create_search_markings_query
+from nominal.protos.authorization.markings.v1 import markings_pb2
+
+
+def _metadata(rid: str, id: str = "itar") -> markings_pb2.MarkingMetadata:
+    return markings_pb2.MarkingMetadata(rid=rid, id=id, description="", is_archived=False)
+
+
+def test_empty_query_matches_everything() -> None:
+    """No filters is expressed as an empty AND list, which the backend treats as match-all."""
+    query = create_search_markings_query()
+
+    assert query.WhichOneof("query") == "and"
+    assert list(getattr(query, "and").queries) == []
+
+
+def test_id_substring_becomes_a_substring_clause() -> None:
+    query = create_search_markings_query(id_substring="ita")
+
+    clauses = list(getattr(query, "and").queries)
+    assert [c.id_exact_substring_search for c in clauses] == ["ita"]
+
+
+def test_search_pagination_follows_cursors_until_exhausted() -> None:
+    markings = MagicMock()
+    markings.SearchMarkings.side_effect = [
+        markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("a")], next_page_token="tok"),
+        markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("b")], next_page_token=""),
+    ]
+
+    results = list(search_markings_paginated(markings, create_search_markings_query()))
+
+    assert [m.rid for m in results] == ["a", "b"]
+    assert markings.SearchMarkings.call_count == 2
+    assert markings.SearchMarkings.call_args_list[1].args[0].next_page_token == "tok"

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -2,8 +2,17 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from nominal.core._utils.pagination_tools import search_markings_paginated
 from nominal.core._utils.query_tools import create_search_markings_query
+from nominal.core.elements import Color, Symbol
+from nominal.core.marking import (
+    Marking,
+    _create_marking,
+    _get_marking,
+    _search_markings,
+)
 from nominal.protos.authorization.markings.v1 import markings_pb2
 
 
@@ -38,3 +47,134 @@ def test_search_pagination_follows_cursors_until_exhausted() -> None:
     assert [m.rid for m in results] == ["a", "b"]
     assert markings.SearchMarkings.call_count == 2
     assert markings.SearchMarkings.call_args_list[1].args[0].next_page_token == "tok"
+
+
+def _clients() -> MagicMock:
+    clients = MagicMock()
+    clients.auth_header = "Bearer test-token"
+    return clients
+
+
+def _marking(rid: str = "ri.marking.a", id: str = "itar") -> markings_pb2.Marking:
+    marking = markings_pb2.Marking(rid=rid, id=id, description="controlled", is_archived=False)
+    marking.symbol.emoji = ":lock:"
+    marking.color.hex_code = "#cc0000"
+    marking.created_at.FromNanoseconds(1_000)
+    marking.updated_at.FromNanoseconds(2_000)
+    return marking
+
+
+def test_from_proto_reads_both_marking_shapes() -> None:
+    """Search returns MarkingMetadata and gets return Marking; one dataclass covers both."""
+    clients = _clients()
+    metadata = markings_pb2.MarkingMetadata(rid="ri.marking.a", id="itar", description="controlled")
+    metadata.symbol.emoji = ":lock:"
+
+    from_full = Marking._from_proto(clients, _marking())
+    from_metadata = Marking._from_proto(clients, metadata)
+
+    assert from_full.id == from_metadata.id == "itar"
+    assert from_full.symbol == from_metadata.symbol == Symbol.emoji(":lock:")
+    assert from_full.color == Color("#cc0000")
+
+
+def test_create_rejects_ids_the_server_would_reject() -> None:
+    """Guard client-side, before the RPC: users cannot see the backend's validation rule."""
+    clients = _clients()
+
+    with pytest.raises(ValueError, match="lowercase"):
+        _create_marking(clients, id="ITAR", description=None, authorized_group_rids=(), symbol=None, color=None)
+
+    clients.markings.CreateMarking.assert_not_called()
+
+
+def test_create_sends_symbol_and_color() -> None:
+    clients = _clients()
+    clients.markings.CreateMarking.return_value = markings_pb2.CreateMarkingResponse(marking=_marking())
+
+    marking = _create_marking(
+        clients,
+        id="itar",
+        description="controlled",
+        authorized_group_rids=["ri.group.a"],
+        symbol=Symbol.emoji(":lock:"),
+        color=Color("#cc0000"),
+    )
+
+    request = clients.markings.CreateMarking.call_args.args[0]
+    assert request.id == "itar"
+    assert request.symbol.emoji == ":lock:"
+    assert request.color.hex_code == "#cc0000"
+    assert list(request.authorized_groups.group_rids) == ["ri.group.a"]
+    assert marking.rid == "ri.marking.a"
+
+
+def test_get_marking_raises_when_absent() -> None:
+    """BatchGetMarkings filters out markings the user cannot see, so an empty result means not found."""
+    clients = _clients()
+    clients.markings.BatchGetMarkings.return_value = markings_pb2.BatchGetMarkingsResponse(markings=[])
+
+    from nominal.core.exceptions import NominalNotFoundError
+
+    with pytest.raises(NominalNotFoundError):
+        _get_marking(clients, "ri.marking.missing")
+
+
+def test_update_distinguishes_unchanged_from_cleared_symbol() -> None:
+    """Omitting symbol leaves it alone; passing None clears it. The wrapper encodes that difference."""
+    clients = _clients()
+    clients.markings.UpdateMarking.return_value = markings_pb2.UpdateMarkingResponse(marking=_marking())
+    marking = Marking._from_proto(clients, _marking())
+
+    marking.update(description="new")
+    unchanged = clients.markings.UpdateMarking.call_args.args[0]
+    assert not unchanged.HasField("symbol")
+    assert unchanged.description == "new"
+
+    marking.update(symbol=None)
+    cleared = clients.markings.UpdateMarking.call_args.args[0]
+    assert cleared.HasField("symbol")
+    assert not cleared.symbol.HasField("value")
+
+    marking.update(symbol=Symbol.icon("castle"))
+    assigned = clients.markings.UpdateMarking.call_args.args[0]
+    assert assigned.symbol.value.icon == "castle"
+
+
+def test_update_clears_authorized_groups_with_an_empty_sequence() -> None:
+    """None leaves groups alone; an empty sequence clears them."""
+    clients = _clients()
+    clients.markings.UpdateMarking.return_value = markings_pb2.UpdateMarkingResponse(marking=_marking())
+    marking = Marking._from_proto(clients, _marking())
+
+    marking.update(description="x")
+    assert not clients.markings.UpdateMarking.call_args.args[0].HasField("authorized_groups")
+
+    marking.update(authorized_group_rids=[])
+    cleared = clients.markings.UpdateMarking.call_args.args[0]
+    assert cleared.HasField("authorized_groups")
+    assert list(cleared.authorized_groups.group_rids) == []
+
+
+def test_search_returns_markings_across_pages() -> None:
+    clients = _clients()
+    clients.markings.SearchMarkings.side_effect = [
+        markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("a")], next_page_token="tok"),
+        markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("b")], next_page_token=""),
+    ]
+
+    results = _search_markings(clients, id_substring="ita")
+
+    assert [m.rid for m in results] == ["a", "b"]
+    query = clients.markings.SearchMarkings.call_args_list[0].args[0].query
+    assert [c.id_exact_substring_search for c in getattr(query, "and").queries] == ["ita"]
+
+
+def test_authorized_group_rids_reads_this_markings_entry() -> None:
+    clients = _clients()
+    marking = Marking._from_proto(clients, _marking())
+    response = markings_pb2.GetAuthorizedGroupsByMarkingResponse()
+    response.authorized_groups_by_marking["ri.marking.a"].group_rids.append("ri.group.a")
+    clients.markings.GetAuthorizedGroupsByMarking.return_value = response
+
+    assert marking.authorized_group_rids() == ("ri.group.a",)

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import grpc
 import pytest
 
 from nominal.core._utils.pagination_tools import search_markings_paginated
@@ -9,7 +10,7 @@ from nominal.core._utils.query_tools import create_search_markings_query
 from nominal.core.client import NominalClient
 from nominal.core.connection import StreamingConnection
 from nominal.core.elements import Color, Symbol
-from nominal.core.exceptions import NominalNotFoundError
+from nominal.core.exceptions import NominalNotFoundError, NominalPermissionDeniedError
 from nominal.core.marking import (
     MarkableMixin,
     Marking,
@@ -129,13 +130,32 @@ def test_create_sends_symbol_and_color() -> None:
     assert marking.rid == "ri.marking.a"
 
 
-def test_get_marking_raises_when_absent() -> None:
-    """BatchGetMarkings filters out markings the user cannot see, so an empty result means not found."""
+def test_get_marking_fetches_by_rid() -> None:
+    """A single get, not a one-element batch: the service distinguishes missing from unreadable."""
     clients = _clients()
-    clients.markings.BatchGetMarkings.return_value = markings_pb2.BatchGetMarkingsResponse(markings=[])
+    clients.markings.GetMarking.return_value = markings_pb2.GetMarkingResponse(marking=_marking())
+
+    marking = _get_marking(clients, "ri.marking.a")
+
+    assert marking.rid == "ri.marking.a"
+    assert clients.markings.GetMarking.call_args.args[0].rid == "ri.marking.a"
+
+
+def test_get_marking_surfaces_a_missing_marking_as_not_found(fake_rpc_error) -> None:
+    clients = _clients()
+    clients.markings.GetMarking.side_effect = fake_rpc_error(grpc.StatusCode.NOT_FOUND)
 
     with pytest.raises(NominalNotFoundError):
         _get_marking(clients, "ri.marking.missing")
+
+
+def test_get_marking_surfaces_an_unreadable_marking_as_permission_denied(fake_rpc_error) -> None:
+    """Distinct from not-found: a batch get would have conflated the two."""
+    clients = _clients()
+    clients.markings.GetMarking.side_effect = fake_rpc_error(grpc.StatusCode.PERMISSION_DENIED)
+
+    with pytest.raises(NominalPermissionDeniedError):
+        _get_marking(clients, "ri.marking.hidden")
 
 
 def test_update_distinguishes_unchanged_from_cleared_symbol() -> None:

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -118,7 +118,7 @@ def test_create_sends_symbol_and_color() -> None:
         description="controlled",
         authorized_group_rids=["ri.group.a"],
         symbol=Symbol.emoji(":lock:"),
-        color=Color("#cc0000"),
+        color=Color.create("#cc0000"),
     )
 
     request = clients.markings.CreateMarking.call_args.args[0]
@@ -329,7 +329,7 @@ def test_client_create_marking_returns_the_created_marking() -> None:
     clients.markings.CreateMarking.return_value = markings_pb2.CreateMarkingResponse(marking=_marking())
     client = NominalClient(_clients=clients)
 
-    marking = client.create_marking("itar", description="controlled", color=Color("#cc0000"))
+    marking = client.create_marking("itar", description="controlled", color=Color.create("#cc0000"))
 
     assert marking.id == "itar"
     assert clients.markings.CreateMarking.call_args.args[0].color.hex_code == "#cc0000"

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -263,3 +263,32 @@ def test_markings_accept_instances_as_well_as_rids() -> None:
 
     request = clients.markings.UpdateMarkingsOnResource.call_args.args[0]
     assert list(request.markings_to_apply) == ["ri.marking.a"]
+
+
+def test_client_search_markings_passes_the_substring_through() -> None:
+    from nominal.core.client import NominalClient
+
+    clients = _clients()
+    clients.markings.SearchMarkings.return_value = markings_pb2.SearchMarkingsResponse(
+        marking_metadatas=[_metadata("ri.marking.a")], next_page_token=""
+    )
+    client = NominalClient(_clients=clients)
+
+    results = client.search_markings(id_substring="ita")
+
+    assert [m.rid for m in results] == ["ri.marking.a"]
+    query = clients.markings.SearchMarkings.call_args.args[0].query
+    assert [c.id_exact_substring_search for c in getattr(query, "and").queries] == ["ita"]
+
+
+def test_client_create_marking_returns_the_created_marking() -> None:
+    from nominal.core.client import NominalClient
+
+    clients = _clients()
+    clients.markings.CreateMarking.return_value = markings_pb2.CreateMarkingResponse(marking=_marking())
+    client = NominalClient(_clients=clients)
+
+    marking = client.create_marking("itar", description="controlled", color=Color("#cc0000"))
+
+    assert marking.id == "itar"
+    assert clients.markings.CreateMarking.call_args.args[0].color.hex_code == "#cc0000"

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -6,7 +6,10 @@ import pytest
 
 from nominal.core._utils.pagination_tools import search_markings_paginated
 from nominal.core._utils.query_tools import create_search_markings_query
+from nominal.core.client import NominalClient
+from nominal.core.connection import StreamingConnection
 from nominal.core.elements import Color, Symbol
+from nominal.core.exceptions import NominalNotFoundError
 from nominal.core.marking import (
     MarkableMixin,
     Marking,
@@ -14,11 +17,42 @@ from nominal.core.marking import (
     _get_marking,
     _search_markings,
 )
+from nominal.core.video import Video
 from nominal.protos.authorization.markings.v1 import markings_pb2
 
 
 def _metadata(rid: str, id: str = "itar") -> markings_pb2.MarkingMetadata:
     return markings_pb2.MarkingMetadata(rid=rid, id=id, description="", is_archived=False)
+
+
+def _clients() -> MagicMock:
+    clients = MagicMock()
+    clients.auth_header = "Bearer test-token"
+    return clients
+
+
+def _marking(rid: str = "ri.marking.a", id: str = "itar") -> markings_pb2.Marking:
+    marking = markings_pb2.Marking(rid=rid, id=id, description="controlled", is_archived=False)
+    marking.symbol.emoji = ":lock:"
+    marking.color.hex_code = "#cc0000"
+    marking.created_at.FromNanoseconds(1_000)
+    marking.updated_at.FromNanoseconds(2_000)
+    return marking
+
+
+class _Markable(MarkableMixin):
+    """Minimal stand-in for a data source, exercising the mixin's own behavior."""
+
+    def __init__(self, rid: str, clients: MagicMock) -> None:
+        self.rid = rid
+        self._clients = clients
+
+
+def _applied(clients: MagicMock, resource: str, *marking_rids: str) -> None:
+    response = markings_pb2.GetMarkingsForResourcesResponse()
+    for marking_rid in marking_rids:
+        response.resource_to_markings[resource].applied_markings.add(marking_rid=marking_rid)
+    clients.markings.GetMarkingsForResources.return_value = response
 
 
 def test_empty_query_matches_everything() -> None:
@@ -48,21 +82,6 @@ def test_search_pagination_follows_cursors_until_exhausted() -> None:
     assert [m.rid for m in results] == ["a", "b"]
     assert markings.SearchMarkings.call_count == 2
     assert markings.SearchMarkings.call_args_list[1].args[0].next_page_token == "tok"
-
-
-def _clients() -> MagicMock:
-    clients = MagicMock()
-    clients.auth_header = "Bearer test-token"
-    return clients
-
-
-def _marking(rid: str = "ri.marking.a", id: str = "itar") -> markings_pb2.Marking:
-    marking = markings_pb2.Marking(rid=rid, id=id, description="controlled", is_archived=False)
-    marking.symbol.emoji = ":lock:"
-    marking.color.hex_code = "#cc0000"
-    marking.created_at.FromNanoseconds(1_000)
-    marking.updated_at.FromNanoseconds(2_000)
-    return marking
 
 
 def test_from_proto_reads_both_marking_shapes() -> None:
@@ -114,8 +133,6 @@ def test_get_marking_raises_when_absent() -> None:
     """BatchGetMarkings filters out markings the user cannot see, so an empty result means not found."""
     clients = _clients()
     clients.markings.BatchGetMarkings.return_value = markings_pb2.BatchGetMarkingsResponse(markings=[])
-
-    from nominal.core.exceptions import NominalNotFoundError
 
     with pytest.raises(NominalNotFoundError):
         _get_marking(clients, "ri.marking.missing")
@@ -179,21 +196,6 @@ def test_authorized_group_rids_reads_this_markings_entry() -> None:
     clients.markings.GetAuthorizedGroupsByMarking.return_value = response
 
     assert marking.authorized_group_rids() == ("ri.group.a",)
-
-
-class _Markable(MarkableMixin):
-    """Minimal stand-in for a data source, exercising the mixin's own behavior."""
-
-    def __init__(self, rid: str, clients: MagicMock) -> None:
-        self.rid = rid
-        self._clients = clients
-
-
-def _applied(clients: MagicMock, resource: str, *marking_rids: str) -> None:
-    response = markings_pb2.GetMarkingsForResourcesResponse()
-    for marking_rid in marking_rids:
-        response.resource_to_markings[resource].applied_markings.add(marking_rid=marking_rid)
-    clients.markings.GetMarkingsForResources.return_value = response
 
 
 def test_list_markings_hydrates_applied_rids() -> None:
@@ -265,9 +267,50 @@ def test_markings_accept_instances_as_well_as_rids() -> None:
     assert list(request.markings_to_apply) == ["ri.marking.a"]
 
 
-def test_client_search_markings_passes_the_substring_through() -> None:
-    from nominal.core.client import NominalClient
+def test_video_lists_its_markings() -> None:
+    """Pins that `Video` is actually wired to `MarkableMixin`: it does not inherit `DataSource`, so
+    nothing else in the library would notice if that base were dropped.
+    """
+    clients = _clients()
+    _applied(clients, "ri.video.a", "ri.marking.a")
+    clients.markings.BatchGetMarkingMetadata.return_value = markings_pb2.BatchGetMarkingMetadataResponse(
+        marking_metadatas=[_metadata("ri.marking.a", id="itar")]
+    )
+    video = Video(
+        rid="ri.video.a",
+        name="v",
+        description=None,
+        properties={},
+        labels=[],
+        created_at=0,
+        is_archived=False,
+        _clients=clients,
+    )
 
+    assert [m.id for m in video.list_markings()] == ["itar"]
+
+
+def test_streaming_connection_lists_its_markings() -> None:
+    """Pins that `DataSource` is actually wired to `MarkableMixin`, covering `StreamingConnection` (and by
+    inheritance `Dataset`/`Connection`) via the real class rather than the `_Markable` stand-in.
+    """
+    clients = _clients()
+    _applied(clients, "ri.connection.a", "ri.marking.a")
+    clients.markings.BatchGetMarkingMetadata.return_value = markings_pb2.BatchGetMarkingMetadataResponse(
+        marking_metadatas=[_metadata("ri.marking.a", id="itar")]
+    )
+    connection = StreamingConnection(
+        rid="ri.connection.a",
+        name="c",
+        description=None,
+        _clients=clients,
+        nominal_data_source_rid="ri.connection.a",
+    )
+
+    assert [m.id for m in connection.list_markings()] == ["itar"]
+
+
+def test_client_search_markings_passes_the_substring_through() -> None:
     clients = _clients()
     clients.markings.SearchMarkings.return_value = markings_pb2.SearchMarkingsResponse(
         marking_metadatas=[_metadata("ri.marking.a")], next_page_token=""
@@ -282,8 +325,6 @@ def test_client_search_markings_passes_the_substring_through() -> None:
 
 
 def test_client_create_marking_returns_the_created_marking() -> None:
-    from nominal.core.client import NominalClient
-
     clients = _clients()
     clients.markings.CreateMarking.return_value = markings_pb2.CreateMarkingResponse(marking=_marking())
     client = NominalClient(_clients=clients)
@@ -296,8 +337,6 @@ def test_client_create_marking_returns_the_created_marking() -> None:
 
 def test_create_dataset_forwards_marking_rids() -> None:
     """Markings may be given as instances or as RIDs."""
-    from nominal.core.client import NominalClient
-
     clients = _clients()
     client = NominalClient(_clients=clients)
     marking = Marking._from_proto(clients, _marking(rid="ri.marking.a"))
@@ -309,8 +348,6 @@ def test_create_dataset_forwards_marking_rids() -> None:
 
 
 def test_create_dataset_without_markings_sends_an_empty_list() -> None:
-    from nominal.core.client import NominalClient
-
     clients = _clients()
     NominalClient(_clients=clients).create_dataset("ds")
 
@@ -318,8 +355,6 @@ def test_create_dataset_without_markings_sends_an_empty_list() -> None:
 
 
 def test_create_streaming_connection_forwards_marking_rids() -> None:
-    from nominal.core.client import NominalClient
-
     clients = _clients()
     with pytest.warns(DeprecationWarning, match="create_streaming_connection"):
         NominalClient(_clients=clients).create_streaming_connection("ds-id", "conn", markings=["ri.marking.a"])

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -274,29 +274,6 @@ def test_apply_and_remove_send_one_sided_updates() -> None:
     assert list(removed.markings_to_remove) == ["ri.marking.a"]
 
 
-def test_set_markings_sends_the_diff_in_one_call() -> None:
-    """Replacing the set adds what is missing and removes what is no longer wanted, atomically."""
-    clients = _clients()
-    _applied(clients, "ri.dataset.a", "ri.marking.keep", "ri.marking.drop")
-
-    _Markable("ri.dataset.a", clients).set_markings(["ri.marking.keep", "ri.marking.add"])
-
-    assert clients.markings.UpdateMarkingsOnResource.call_count == 1
-    request = clients.markings.UpdateMarkingsOnResource.call_args.args[0]
-    assert sorted(request.markings_to_apply) == ["ri.marking.add"]
-    assert sorted(request.markings_to_remove) == ["ri.marking.drop"]
-
-
-def test_set_markings_skips_the_call_when_nothing_changes() -> None:
-    """An unchanged set sends no update request at all."""
-    clients = _clients()
-    _applied(clients, "ri.dataset.a", "ri.marking.keep")
-
-    _Markable("ri.dataset.a", clients).set_markings(["ri.marking.keep"])
-
-    clients.markings.UpdateMarkingsOnResource.assert_not_called()
-
-
 def test_markings_accept_instances_as_well_as_rids() -> None:
     """A Marking instance is coerced to its rid on the wire."""
     clients = _clients()

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -65,6 +65,7 @@ def test_empty_query_matches_everything() -> None:
 
 
 def test_id_substring_becomes_a_substring_clause() -> None:
+    """A substring filter becomes a single id-substring clause inside the AND list."""
     query = create_search_markings_query(id_substring="ita")
 
     clauses = list(getattr(query, "and").queries)
@@ -72,6 +73,7 @@ def test_id_substring_becomes_a_substring_clause() -> None:
 
 
 def test_search_pagination_follows_cursors_until_exhausted() -> None:
+    """Pagination feeds each response's token into the next request and stops on an empty token."""
     markings = MagicMock()
     markings.SearchMarkings.side_effect = [
         markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("a")], next_page_token="tok"),
@@ -110,6 +112,7 @@ def test_create_rejects_ids_the_server_would_reject() -> None:
 
 
 def test_create_sends_symbol_and_color() -> None:
+    """Create forwards id, symbol, color, and authorized groups, and returns the created marking."""
     clients = _clients()
     clients.markings.CreateMarking.return_value = markings_pb2.CreateMarkingResponse(marking=_marking())
 
@@ -142,6 +145,7 @@ def test_get_marking_fetches_by_rid() -> None:
 
 
 def test_get_marking_surfaces_a_missing_marking_as_not_found(fake_rpc_error) -> None:
+    """A NOT_FOUND from the service is translated rather than leaking the raw RpcError."""
     clients = _clients()
     clients.markings.GetMarking.side_effect = fake_rpc_error(grpc.StatusCode.NOT_FOUND)
 
@@ -195,6 +199,7 @@ def test_update_clears_authorized_groups_with_an_empty_sequence() -> None:
 
 
 def test_search_returns_markings_across_pages() -> None:
+    """Search concatenates every page and applies the substring filter to the first request."""
     clients = _clients()
     clients.markings.SearchMarkings.side_effect = [
         markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("a")], next_page_token="tok"),
@@ -209,6 +214,7 @@ def test_search_returns_markings_across_pages() -> None:
 
 
 def test_authorized_groups_reads_this_markings_entry() -> None:
+    """The batch response is indexed by this marking's own rid rather than taking the first entry."""
     clients = _clients()
     marking = Marking._from_proto(clients, _marking())
     response = markings_pb2.GetAuthorizedGroupsByMarkingResponse()
@@ -219,6 +225,7 @@ def test_authorized_groups_reads_this_markings_entry() -> None:
 
 
 def test_list_markings_hydrates_applied_rids() -> None:
+    """Applied rids are resolved to full markings via a batch metadata get."""
     clients = _clients()
     _applied(clients, "ri.dataset.a", "ri.marking.a")
     clients.markings.BatchGetMarkingMetadata.return_value = markings_pb2.BatchGetMarkingMetadataResponse(
@@ -232,6 +239,7 @@ def test_list_markings_hydrates_applied_rids() -> None:
 
 
 def test_list_markings_on_unmarked_resource_is_empty_without_a_second_call() -> None:
+    """With no applied markings the batch get is skipped entirely."""
     clients = _clients()
     _applied(clients, "ri.dataset.a")
 
@@ -240,6 +248,7 @@ def test_list_markings_on_unmarked_resource_is_empty_without_a_second_call() -> 
 
 
 def test_apply_and_remove_send_one_sided_updates() -> None:
+    """Apply and remove each populate only their own side of the update request."""
     clients = _clients()
     markable = _Markable("ri.dataset.a", clients)
 
@@ -269,6 +278,7 @@ def test_set_markings_sends_the_diff_in_one_call() -> None:
 
 
 def test_set_markings_skips_the_call_when_nothing_changes() -> None:
+    """An unchanged set sends no update request at all."""
     clients = _clients()
     _applied(clients, "ri.dataset.a", "ri.marking.keep")
 
@@ -278,6 +288,7 @@ def test_set_markings_skips_the_call_when_nothing_changes() -> None:
 
 
 def test_markings_accept_instances_as_well_as_rids() -> None:
+    """A Marking instance is coerced to its rid on the wire."""
     clients = _clients()
     marking = Marking._from_proto(clients, _marking(rid="ri.marking.a"))
 
@@ -331,6 +342,7 @@ def test_streaming_connection_lists_its_markings() -> None:
 
 
 def test_client_search_markings_passes_the_substring_through() -> None:
+    """The client method forwards its substring to the query and returns hydrated markings."""
     clients = _clients()
     clients.markings.SearchMarkings.return_value = markings_pb2.SearchMarkingsResponse(
         marking_metadatas=[_metadata("ri.marking.a")], next_page_token=""
@@ -345,6 +357,7 @@ def test_client_search_markings_passes_the_substring_through() -> None:
 
 
 def test_client_create_marking_returns_the_created_marking() -> None:
+    """The client method validates and forwards color, returning the created marking."""
     clients = _clients()
     clients.markings.CreateMarking.return_value = markings_pb2.CreateMarkingResponse(marking=_marking())
     client = NominalClient(_clients=clients)
@@ -368,6 +381,7 @@ def test_create_dataset_forwards_marking_rids() -> None:
 
 
 def test_create_dataset_without_markings_sends_an_empty_list() -> None:
+    """Omitting markings sends an empty list, not null, to the catalog."""
     clients = _clients()
     NominalClient(_clients=clients).create_dataset("ds")
 
@@ -375,35 +389,10 @@ def test_create_dataset_without_markings_sends_an_empty_list() -> None:
 
 
 def test_create_streaming_connection_forwards_marking_rids() -> None:
+    """Markings reach the connection create request even on the deprecated path."""
     clients = _clients()
     with pytest.warns(DeprecationWarning, match="create_streaming_connection"):
         NominalClient(_clients=clients).create_streaming_connection("ds-id", "conn", markings=["ri.marking.a"])
 
     request = clients.connection.create_connection.call_args.args[1]
     assert request.marking_rids == ["ri.marking.a"]
-
-
-def test_new_ingest_destination_carries_marking_rids() -> None:
-    """Called directly: this builder has no callers yet, but must not drop markings when it gains one."""
-    from nominal.core.dataset import _construct_new_ingest_options
-    from nominal.core.filetype import FileTypes
-    from nominal.ts import Iso8601
-
-    options = _construct_new_ingest_options(
-        name="ds",
-        timestamp_column="ts",
-        timestamp_type=Iso8601(),
-        file_type=FileTypes.CSV,
-        description=None,
-        labels=[],
-        properties={},
-        prefix_tree_delimiter=None,
-        channel_prefix=None,
-        tag_columns=None,
-        s3_path="s3://bucket/key.csv",
-        workspace_rid="ri.workspace.a",
-        tags=None,
-        marking_rids=["ri.marking.a"],
-    )
-
-    assert options.csv.target.new.marking_rids == ["ri.marking.a"]

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -215,7 +215,7 @@ def test_authorized_groups_reads_this_markings_entry() -> None:
     response.authorized_groups_by_marking["ri.marking.a"].group_rids.append("ri.group.a")
     clients.markings.GetAuthorizedGroupsByMarking.return_value = response
 
-    assert marking.authorized_groups() == ("ri.group.a",)
+    assert marking.authorized_group_rids() == ("ri.group.a",)
 
 
 def test_list_markings_hydrates_applied_rids() -> None:

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -133,6 +133,16 @@ def test_create_sends_symbol_and_color() -> None:
     assert marking.rid == "ri.marking.a"
 
 
+def test_create_lowercases_an_uppercase_color() -> None:
+    """Either case is accepted at the boundary; the wire value is always lowercase."""
+    clients = _clients()
+    clients.markings.CreateMarking.return_value = markings_pb2.CreateMarkingResponse(marking=_marking())
+
+    _create_marking(clients, id="itar", description=None, authorized_groups=[], symbol=None, color="#CC0000")
+
+    assert clients.markings.CreateMarking.call_args.args[0].color.hex_code == "#cc0000"
+
+
 def test_get_marking_fetches_by_rid() -> None:
     """A single get, not a one-element batch: the service distinguishes missing from unreadable."""
     clients = _clients()

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import grpc
+import pytest
+
+from nominal.core._utils.pagination_tools import search_markings_paginated
+from nominal.core._utils.query_tools import create_search_markings_query
+from nominal.core.client import NominalClient
+from nominal.core.connection import StreamingConnection
+from nominal.core.elements import Symbol
+from nominal.core.exceptions import NominalNotFoundError, NominalPermissionDeniedError
+from nominal.core.marking import (
+    MarkableMixin,
+    Marking,
+    _create_marking,
+    _get_marking,
+    _search_markings,
+)
+from nominal.core.video import Video
+from nominal.protos.authorization.markings.v1 import markings_pb2
+
+
+def _metadata(rid: str, id: str = "itar") -> markings_pb2.MarkingMetadata:
+    return markings_pb2.MarkingMetadata(rid=rid, id=id, description="", is_archived=False)
+
+
+def _clients() -> MagicMock:
+    clients = MagicMock()
+    clients.auth_header = "Bearer test-token"
+    return clients
+
+
+def _marking(rid: str = "ri.marking.a", id: str = "itar") -> markings_pb2.Marking:
+    marking = markings_pb2.Marking(rid=rid, id=id, description="controlled", is_archived=False)
+    marking.symbol.emoji = ":lock:"
+    marking.color.hex_code = "#cc0000"
+    marking.created_at.FromNanoseconds(1_000)
+    marking.updated_at.FromNanoseconds(2_000)
+    return marking
+
+
+class _Markable(MarkableMixin):
+    """Minimal stand-in for a data source, exercising the mixin's own behavior."""
+
+    def __init__(self, rid: str, clients: MagicMock) -> None:
+        self.rid = rid
+        self._clients = clients
+
+
+def _applied(clients: MagicMock, resource: str, *marking_rids: str) -> None:
+    response = markings_pb2.GetMarkingsForResourcesResponse()
+    for marking_rid in marking_rids:
+        response.resource_to_markings[resource].applied_markings.add(marking_rid=marking_rid)
+    clients.markings.GetMarkingsForResources.return_value = response
+
+
+def test_empty_query_matches_everything() -> None:
+    """No filters is expressed as an empty AND list, which the backend treats as match-all."""
+    query = create_search_markings_query()
+
+    assert query.WhichOneof("query") == "and"
+    assert list(getattr(query, "and").queries) == []
+
+
+def test_id_substring_becomes_a_substring_clause() -> None:
+    query = create_search_markings_query(id_substring="ita")
+
+    clauses = list(getattr(query, "and").queries)
+    assert [c.id_exact_substring_search for c in clauses] == ["ita"]
+
+
+def test_search_pagination_follows_cursors_until_exhausted() -> None:
+    markings = MagicMock()
+    markings.SearchMarkings.side_effect = [
+        markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("a")], next_page_token="tok"),
+        markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("b")], next_page_token=""),
+    ]
+
+    results = list(search_markings_paginated(markings, create_search_markings_query()))
+
+    assert [m.rid for m in results] == ["a", "b"]
+    assert markings.SearchMarkings.call_count == 2
+    assert markings.SearchMarkings.call_args_list[1].args[0].next_page_token == "tok"
+
+
+def test_from_proto_reads_both_marking_shapes() -> None:
+    """Search returns MarkingMetadata and gets return Marking; one dataclass covers both."""
+    clients = _clients()
+    metadata = markings_pb2.MarkingMetadata(rid="ri.marking.a", id="itar", description="controlled")
+    metadata.symbol.emoji = ":lock:"
+
+    from_full = Marking._from_proto(clients, _marking())
+    from_metadata = Marking._from_proto(clients, metadata)
+
+    assert from_full.id == from_metadata.id == "itar"
+    assert from_full.symbol == from_metadata.symbol == Symbol.emoji(":lock:")
+    assert from_full.color == "#cc0000"
+
+
+def test_create_rejects_ids_the_server_would_reject() -> None:
+    """Guard client-side, before the RPC: users cannot see the backend's validation rule."""
+    clients = _clients()
+
+    with pytest.raises(ValueError, match="lowercase"):
+        _create_marking(clients, id="ITAR", description=None, authorized_groups=(), symbol=None, color=None)
+
+    clients.markings.CreateMarking.assert_not_called()
+
+
+def test_create_sends_symbol_and_color() -> None:
+    clients = _clients()
+    clients.markings.CreateMarking.return_value = markings_pb2.CreateMarkingResponse(marking=_marking())
+
+    marking = _create_marking(
+        clients,
+        id="itar",
+        description="controlled",
+        authorized_groups=["ri.group.a"],
+        symbol=Symbol.emoji(":lock:"),
+        color="#cc0000",
+    )
+
+    request = clients.markings.CreateMarking.call_args.args[0]
+    assert request.id == "itar"
+    assert request.symbol.emoji == ":lock:"
+    assert request.color.hex_code == "#cc0000"
+    assert list(request.authorized_groups.group_rids) == ["ri.group.a"]
+    assert marking.rid == "ri.marking.a"
+
+
+def test_get_marking_fetches_by_rid() -> None:
+    """A single get, not a one-element batch: the service distinguishes missing from unreadable."""
+    clients = _clients()
+    clients.markings.GetMarking.return_value = markings_pb2.GetMarkingResponse(marking=_marking())
+
+    marking = _get_marking(clients, "ri.marking.a")
+
+    assert marking.rid == "ri.marking.a"
+    assert clients.markings.GetMarking.call_args.args[0].rid == "ri.marking.a"
+
+
+def test_get_marking_surfaces_a_missing_marking_as_not_found(fake_rpc_error) -> None:
+    clients = _clients()
+    clients.markings.GetMarking.side_effect = fake_rpc_error(grpc.StatusCode.NOT_FOUND)
+
+    with pytest.raises(NominalNotFoundError):
+        _get_marking(clients, "ri.marking.missing")
+
+
+def test_get_marking_surfaces_an_unreadable_marking_as_permission_denied(fake_rpc_error) -> None:
+    """Distinct from not-found: a batch get would have conflated the two."""
+    clients = _clients()
+    clients.markings.GetMarking.side_effect = fake_rpc_error(grpc.StatusCode.PERMISSION_DENIED)
+
+    with pytest.raises(NominalPermissionDeniedError):
+        _get_marking(clients, "ri.marking.hidden")
+
+
+def test_update_distinguishes_unchanged_from_cleared_symbol() -> None:
+    """Omitting symbol leaves it alone; passing None clears it. The wrapper encodes that difference."""
+    clients = _clients()
+    clients.markings.UpdateMarking.return_value = markings_pb2.UpdateMarkingResponse(marking=_marking())
+    marking = Marking._from_proto(clients, _marking())
+
+    marking.update(description="new")
+    unchanged = clients.markings.UpdateMarking.call_args.args[0]
+    assert not unchanged.HasField("symbol")
+    assert unchanged.description == "new"
+
+    marking.update(symbol=None)
+    cleared = clients.markings.UpdateMarking.call_args.args[0]
+    assert cleared.HasField("symbol")
+    assert not cleared.symbol.HasField("value")
+
+    marking.update(symbol=Symbol.icon("castle"))
+    assigned = clients.markings.UpdateMarking.call_args.args[0]
+    assert assigned.symbol.value.icon == "castle"
+
+
+def test_update_clears_authorized_groups_with_an_empty_sequence() -> None:
+    """None leaves groups alone; an empty sequence clears them."""
+    clients = _clients()
+    clients.markings.UpdateMarking.return_value = markings_pb2.UpdateMarkingResponse(marking=_marking())
+    marking = Marking._from_proto(clients, _marking())
+
+    marking.update(description="x")
+    assert not clients.markings.UpdateMarking.call_args.args[0].HasField("authorized_groups")
+
+    marking.update(authorized_groups=[])
+    cleared = clients.markings.UpdateMarking.call_args.args[0]
+    assert cleared.HasField("authorized_groups")
+    assert list(cleared.authorized_groups.group_rids) == []
+
+
+def test_search_returns_markings_across_pages() -> None:
+    clients = _clients()
+    clients.markings.SearchMarkings.side_effect = [
+        markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("a")], next_page_token="tok"),
+        markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("b")], next_page_token=""),
+    ]
+
+    results = _search_markings(clients, id_substring="ita")
+
+    assert [m.rid for m in results] == ["a", "b"]
+    query = clients.markings.SearchMarkings.call_args_list[0].args[0].query
+    assert [c.id_exact_substring_search for c in getattr(query, "and").queries] == ["ita"]
+
+
+def test_authorized_groups_reads_this_markings_entry() -> None:
+    clients = _clients()
+    marking = Marking._from_proto(clients, _marking())
+    response = markings_pb2.GetAuthorizedGroupsByMarkingResponse()
+    response.authorized_groups_by_marking["ri.marking.a"].group_rids.append("ri.group.a")
+    clients.markings.GetAuthorizedGroupsByMarking.return_value = response
+
+    assert marking.authorized_groups() == ("ri.group.a",)
+
+
+def test_list_markings_hydrates_applied_rids() -> None:
+    clients = _clients()
+    _applied(clients, "ri.dataset.a", "ri.marking.a")
+    clients.markings.BatchGetMarkingMetadata.return_value = markings_pb2.BatchGetMarkingMetadataResponse(
+        marking_metadatas=[_metadata("ri.marking.a", id="itar")]
+    )
+
+    markings = _Markable("ri.dataset.a", clients).list_markings()
+
+    assert [m.id for m in markings] == ["itar"]
+    assert list(clients.markings.BatchGetMarkingMetadata.call_args.args[0].marking_rids) == ["ri.marking.a"]
+
+
+def test_list_markings_on_unmarked_resource_is_empty_without_a_second_call() -> None:
+    clients = _clients()
+    _applied(clients, "ri.dataset.a")
+
+    assert _Markable("ri.dataset.a", clients).list_markings() == ()
+    clients.markings.BatchGetMarkingMetadata.assert_not_called()
+
+
+def test_apply_and_remove_send_one_sided_updates() -> None:
+    clients = _clients()
+    markable = _Markable("ri.dataset.a", clients)
+
+    markable.apply_markings(["ri.marking.a"])
+    applied = clients.markings.UpdateMarkingsOnResource.call_args.args[0]
+    assert applied.resource == "ri.dataset.a"
+    assert list(applied.markings_to_apply) == ["ri.marking.a"]
+    assert list(applied.markings_to_remove) == []
+
+    markable.remove_markings(["ri.marking.a"])
+    removed = clients.markings.UpdateMarkingsOnResource.call_args.args[0]
+    assert list(removed.markings_to_apply) == []
+    assert list(removed.markings_to_remove) == ["ri.marking.a"]
+
+
+def test_set_markings_sends_the_diff_in_one_call() -> None:
+    """Replacing the set adds what is missing and removes what is no longer wanted, atomically."""
+    clients = _clients()
+    _applied(clients, "ri.dataset.a", "ri.marking.keep", "ri.marking.drop")
+
+    _Markable("ri.dataset.a", clients).set_markings(["ri.marking.keep", "ri.marking.add"])
+
+    assert clients.markings.UpdateMarkingsOnResource.call_count == 1
+    request = clients.markings.UpdateMarkingsOnResource.call_args.args[0]
+    assert sorted(request.markings_to_apply) == ["ri.marking.add"]
+    assert sorted(request.markings_to_remove) == ["ri.marking.drop"]
+
+
+def test_set_markings_skips_the_call_when_nothing_changes() -> None:
+    clients = _clients()
+    _applied(clients, "ri.dataset.a", "ri.marking.keep")
+
+    _Markable("ri.dataset.a", clients).set_markings(["ri.marking.keep"])
+
+    clients.markings.UpdateMarkingsOnResource.assert_not_called()
+
+
+def test_markings_accept_instances_as_well_as_rids() -> None:
+    clients = _clients()
+    marking = Marking._from_proto(clients, _marking(rid="ri.marking.a"))
+
+    _Markable("ri.dataset.a", clients).apply_markings([marking])
+
+    request = clients.markings.UpdateMarkingsOnResource.call_args.args[0]
+    assert list(request.markings_to_apply) == ["ri.marking.a"]
+
+
+def test_video_lists_its_markings() -> None:
+    """Pins that `Video` is actually wired to `MarkableMixin`: it does not inherit `DataSource`, so
+    nothing else in the library would notice if that base were dropped.
+    """
+    clients = _clients()
+    _applied(clients, "ri.video.a", "ri.marking.a")
+    clients.markings.BatchGetMarkingMetadata.return_value = markings_pb2.BatchGetMarkingMetadataResponse(
+        marking_metadatas=[_metadata("ri.marking.a", id="itar")]
+    )
+    video = Video(
+        rid="ri.video.a",
+        name="v",
+        description=None,
+        properties={},
+        labels=[],
+        created_at=0,
+        is_archived=False,
+        _clients=clients,
+    )
+
+    assert [m.id for m in video.list_markings()] == ["itar"]
+
+
+def test_streaming_connection_lists_its_markings() -> None:
+    """Pins that `DataSource` is actually wired to `MarkableMixin`, covering `StreamingConnection` (and by
+    inheritance `Dataset`/`Connection`) via the real class rather than the `_Markable` stand-in.
+    """
+    clients = _clients()
+    _applied(clients, "ri.connection.a", "ri.marking.a")
+    clients.markings.BatchGetMarkingMetadata.return_value = markings_pb2.BatchGetMarkingMetadataResponse(
+        marking_metadatas=[_metadata("ri.marking.a", id="itar")]
+    )
+    connection = StreamingConnection(
+        rid="ri.connection.a",
+        name="c",
+        description=None,
+        _clients=clients,
+        nominal_data_source_rid="ri.connection.a",
+    )
+
+    assert [m.id for m in connection.list_markings()] == ["itar"]
+
+
+def test_client_search_markings_passes_the_substring_through() -> None:
+    clients = _clients()
+    clients.markings.SearchMarkings.return_value = markings_pb2.SearchMarkingsResponse(
+        marking_metadatas=[_metadata("ri.marking.a")], next_page_token=""
+    )
+    client = NominalClient(_clients=clients)
+
+    results = client.search_markings(id_substring="ita")
+
+    assert [m.rid for m in results] == ["ri.marking.a"]
+    query = clients.markings.SearchMarkings.call_args.args[0].query
+    assert [c.id_exact_substring_search for c in getattr(query, "and").queries] == ["ita"]
+
+
+def test_client_create_marking_returns_the_created_marking() -> None:
+    clients = _clients()
+    clients.markings.CreateMarking.return_value = markings_pb2.CreateMarkingResponse(marking=_marking())
+    client = NominalClient(_clients=clients)
+
+    marking = client.create_marking("itar", description="controlled", color="#cc0000")
+
+    assert marking.id == "itar"
+    assert clients.markings.CreateMarking.call_args.args[0].color.hex_code == "#cc0000"
+
+
+def test_create_dataset_forwards_marking_rids() -> None:
+    """Markings may be given as instances or as RIDs."""
+    clients = _clients()
+    client = NominalClient(_clients=clients)
+    marking = Marking._from_proto(clients, _marking(rid="ri.marking.a"))
+
+    client.create_dataset("ds", markings=[marking, "ri.marking.b"])
+
+    request = clients.catalog.create_dataset.call_args.args[1]
+    assert request.marking_rids == ["ri.marking.a", "ri.marking.b"]
+
+
+def test_create_dataset_without_markings_sends_an_empty_list() -> None:
+    clients = _clients()
+    NominalClient(_clients=clients).create_dataset("ds")
+
+    assert clients.catalog.create_dataset.call_args.args[1].marking_rids == []
+
+
+def test_create_streaming_connection_forwards_marking_rids() -> None:
+    clients = _clients()
+    with pytest.warns(DeprecationWarning, match="create_streaming_connection"):
+        NominalClient(_clients=clients).create_streaming_connection("ds-id", "conn", markings=["ri.marking.a"])
+
+    request = clients.connection.create_connection.call_args.args[1]
+    assert request.marking_rids == ["ri.marking.a"]
+
+
+def test_new_ingest_destination_carries_marking_rids() -> None:
+    """Called directly: this builder has no callers yet, but must not drop markings when it gains one."""
+    from nominal.core.dataset import _construct_new_ingest_options
+    from nominal.core.filetype import FileTypes
+    from nominal.ts import Iso8601
+
+    options = _construct_new_ingest_options(
+        name="ds",
+        timestamp_column="ts",
+        timestamp_type=Iso8601(),
+        file_type=FileTypes.CSV,
+        description=None,
+        labels=[],
+        properties={},
+        prefix_tree_delimiter=None,
+        channel_prefix=None,
+        tag_columns=None,
+        s3_path="s3://bucket/key.csv",
+        workspace_rid="ri.workspace.a",
+        tags=None,
+        marking_rids=["ri.marking.a"],
+    )
+
+    assert options.csv.target.new.marking_rids == ["ri.marking.a"]

--- a/tests/core/test_marking.py
+++ b/tests/core/test_marking.py
@@ -1,35 +1,18 @@
 from __future__ import annotations
 
+from typing import Callable
 from unittest.mock import MagicMock
 
 import grpc
 import pytest
 
-from nominal.core._utils.pagination_tools import search_markings_paginated
-from nominal.core._utils.query_tools import create_search_markings_query
 from nominal.core.client import NominalClient
 from nominal.core.connection import StreamingConnection
 from nominal.core.elements import Symbol
-from nominal.core.exceptions import NominalNotFoundError, NominalPermissionDeniedError
-from nominal.core.marking import (
-    MarkableMixin,
-    Marking,
-    _create_marking,
-    _get_marking,
-    _search_markings,
-)
+from nominal.core.exceptions import NominalError, NominalNotFoundError, NominalPermissionDeniedError
+from nominal.core.marking import MarkableMixin, Marking
 from nominal.core.video import Video
 from nominal.protos.authorization.markings.v1 import markings_pb2
-
-
-def _metadata(rid: str, id: str = "itar") -> markings_pb2.MarkingMetadata:
-    return markings_pb2.MarkingMetadata(rid=rid, id=id, description="", is_archived=False)
-
-
-def _clients() -> MagicMock:
-    clients = MagicMock()
-    clients.auth_header = "Bearer test-token"
-    return clients
 
 
 def _marking(rid: str = "ri.marking.a", id: str = "itar") -> markings_pb2.Marking:
@@ -41,6 +24,10 @@ def _marking(rid: str = "ri.marking.a", id: str = "itar") -> markings_pb2.Markin
     return marking
 
 
+def _metadata(rid: str, id: str = "itar") -> markings_pb2.MarkingMetadata:
+    return markings_pb2.MarkingMetadata(rid=rid, id=id, description="", is_archived=False)
+
+
 class _Markable(MarkableMixin):
     """Minimal stand-in for a data source, exercising the mixin's own behavior."""
 
@@ -49,253 +36,33 @@ class _Markable(MarkableMixin):
         self._clients = clients
 
 
-def _applied(clients: MagicMock, resource: str, *marking_rids: str) -> None:
+@pytest.fixture
+def client(mock_clients: MagicMock) -> NominalClient:
+    """A NominalClient over the shared mock clients bunch."""
+    return NominalClient(_clients=mock_clients)
+
+
+@pytest.fixture
+def markable(mock_clients: MagicMock) -> _Markable:
+    """A data source stand-in carrying no markings until `applied` says otherwise."""
+    _apply_to(mock_clients, "ri.dataset.a")
+    return _Markable("ri.dataset.a", mock_clients)
+
+
+def _apply_to(clients: MagicMock, resource: str, *marking_rids: str) -> None:
+    """Make the service report `marking_rids` as applied to `resource`, echoing them back on lookup."""
     response = markings_pb2.GetMarkingsForResourcesResponse()
     for marking_rid in marking_rids:
         response.resource_to_markings[resource].applied_markings.add(marking_rid=marking_rid)
     clients.markings.GetMarkingsForResources.return_value = response
-
-
-def test_empty_query_matches_everything() -> None:
-    """No filters is expressed as an empty AND list, which the backend treats as match-all."""
-    query = create_search_markings_query()
-
-    assert query.WhichOneof("query") == "and"
-    assert list(getattr(query, "and").queries) == []
-
-
-def test_id_substring_becomes_a_substring_clause() -> None:
-    """A substring filter becomes a single id-substring clause inside the AND list."""
-    query = create_search_markings_query(id_substring="ita")
-
-    clauses = list(getattr(query, "and").queries)
-    assert [c.id_exact_substring_search for c in clauses] == ["ita"]
-
-
-def test_search_pagination_follows_cursors_until_exhausted() -> None:
-    """Pagination feeds each response's token into the next request and stops on an empty token."""
-    markings = MagicMock()
-    markings.SearchMarkings.side_effect = [
-        markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("a")], next_page_token="tok"),
-        markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("b")], next_page_token=""),
-    ]
-
-    results = list(search_markings_paginated(markings, create_search_markings_query()))
-
-    assert [m.rid for m in results] == ["a", "b"]
-    assert markings.SearchMarkings.call_count == 2
-    assert markings.SearchMarkings.call_args_list[1].args[0].next_page_token == "tok"
-
-
-def test_from_proto_reads_both_marking_shapes() -> None:
-    """Search returns MarkingMetadata and gets return Marking; one dataclass covers both."""
-    clients = _clients()
-    metadata = markings_pb2.MarkingMetadata(rid="ri.marking.a", id="itar", description="controlled")
-    metadata.symbol.emoji = ":lock:"
-
-    from_full = Marking._from_proto(clients, _marking())
-    from_metadata = Marking._from_proto(clients, metadata)
-
-    assert from_full.id == from_metadata.id == "itar"
-    assert from_full.symbol == from_metadata.symbol == Symbol.emoji(":lock:")
-    assert from_full.color == "#cc0000"
-
-
-def test_create_rejects_ids_the_server_would_reject() -> None:
-    """Guard client-side, before the RPC: users cannot see the backend's validation rule."""
-    clients = _clients()
-
-    with pytest.raises(ValueError, match="lowercase"):
-        _create_marking(clients, id="ITAR", description=None, authorized_groups=(), symbol=None, color=None)
-
-    clients.markings.CreateMarking.assert_not_called()
-
-
-def test_create_sends_symbol_and_color() -> None:
-    """Create forwards id, symbol, color, and authorized groups, and returns the created marking."""
-    clients = _clients()
-    clients.markings.CreateMarking.return_value = markings_pb2.CreateMarkingResponse(marking=_marking())
-
-    marking = _create_marking(
-        clients,
-        id="itar",
-        description="controlled",
-        authorized_groups=["ri.group.a"],
-        symbol=Symbol.emoji(":lock:"),
-        color="#cc0000",
+    clients.markings.BatchGetMarkingMetadata.side_effect = lambda request: (
+        markings_pb2.BatchGetMarkingMetadataResponse(marking_metadatas=[_metadata(rid) for rid in request.marking_rids])
     )
 
-    request = clients.markings.CreateMarking.call_args.args[0]
-    assert request.id == "itar"
-    assert request.symbol.emoji == ":lock:"
-    assert request.color.hex_code == "#cc0000"
-    assert list(request.authorized_groups.group_rids) == ["ri.group.a"]
-    assert marking.rid == "ri.marking.a"
 
-
-def test_create_lowercases_an_uppercase_color() -> None:
-    """Either case is accepted at the boundary; the wire value is always lowercase."""
-    clients = _clients()
-    clients.markings.CreateMarking.return_value = markings_pb2.CreateMarkingResponse(marking=_marking())
-
-    _create_marking(clients, id="itar", description=None, authorized_groups=[], symbol=None, color="#CC0000")
-
-    assert clients.markings.CreateMarking.call_args.args[0].color.hex_code == "#cc0000"
-
-
-def test_get_marking_fetches_by_rid() -> None:
-    """A single get, not a one-element batch: the service distinguishes missing from unreadable."""
-    clients = _clients()
-    clients.markings.GetMarking.return_value = markings_pb2.GetMarkingResponse(marking=_marking())
-
-    marking = _get_marking(clients, "ri.marking.a")
-
-    assert marking.rid == "ri.marking.a"
-    assert clients.markings.GetMarking.call_args.args[0].rid == "ri.marking.a"
-
-
-def test_get_marking_surfaces_a_missing_marking_as_not_found(fake_rpc_error) -> None:
-    """A NOT_FOUND from the service is translated rather than leaking the raw RpcError."""
-    clients = _clients()
-    clients.markings.GetMarking.side_effect = fake_rpc_error(grpc.StatusCode.NOT_FOUND)
-
-    with pytest.raises(NominalNotFoundError):
-        _get_marking(clients, "ri.marking.missing")
-
-
-def test_get_marking_surfaces_an_unreadable_marking_as_permission_denied(fake_rpc_error) -> None:
-    """Distinct from not-found: a batch get would have conflated the two."""
-    clients = _clients()
-    clients.markings.GetMarking.side_effect = fake_rpc_error(grpc.StatusCode.PERMISSION_DENIED)
-
-    with pytest.raises(NominalPermissionDeniedError):
-        _get_marking(clients, "ri.marking.hidden")
-
-
-def test_update_distinguishes_unchanged_from_cleared_symbol() -> None:
-    """Omitting symbol leaves it alone; passing None clears it. The wrapper encodes that difference."""
-    clients = _clients()
-    clients.markings.UpdateMarking.return_value = markings_pb2.UpdateMarkingResponse(marking=_marking())
-    marking = Marking._from_proto(clients, _marking())
-
-    marking.update(description="new")
-    unchanged = clients.markings.UpdateMarking.call_args.args[0]
-    assert not unchanged.HasField("symbol")
-    assert unchanged.description == "new"
-
-    marking.update(symbol=None)
-    cleared = clients.markings.UpdateMarking.call_args.args[0]
-    assert cleared.HasField("symbol")
-    assert not cleared.symbol.HasField("value")
-
-    marking.update(symbol=Symbol.icon("castle"))
-    assigned = clients.markings.UpdateMarking.call_args.args[0]
-    assert assigned.symbol.value.icon == "castle"
-
-
-def test_update_clears_authorized_groups_with_an_empty_sequence() -> None:
-    """None leaves groups alone; an empty sequence clears them."""
-    clients = _clients()
-    clients.markings.UpdateMarking.return_value = markings_pb2.UpdateMarkingResponse(marking=_marking())
-    marking = Marking._from_proto(clients, _marking())
-
-    marking.update(description="x")
-    assert not clients.markings.UpdateMarking.call_args.args[0].HasField("authorized_groups")
-
-    marking.update(authorized_groups=[])
-    cleared = clients.markings.UpdateMarking.call_args.args[0]
-    assert cleared.HasField("authorized_groups")
-    assert list(cleared.authorized_groups.group_rids) == []
-
-
-def test_search_returns_markings_across_pages() -> None:
-    """Search concatenates every page and applies the substring filter to the first request."""
-    clients = _clients()
-    clients.markings.SearchMarkings.side_effect = [
-        markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("a")], next_page_token="tok"),
-        markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("b")], next_page_token=""),
-    ]
-
-    results = _search_markings(clients, id_substring="ita")
-
-    assert [m.rid for m in results] == ["a", "b"]
-    query = clients.markings.SearchMarkings.call_args_list[0].args[0].query
-    assert [c.id_exact_substring_search for c in getattr(query, "and").queries] == ["ita"]
-
-
-def test_authorized_groups_reads_this_markings_entry() -> None:
-    """The batch response is indexed by this marking's own rid rather than taking the first entry."""
-    clients = _clients()
-    marking = Marking._from_proto(clients, _marking())
-    response = markings_pb2.GetAuthorizedGroupsByMarkingResponse()
-    response.authorized_groups_by_marking["ri.marking.a"].group_rids.append("ri.group.a")
-    clients.markings.GetAuthorizedGroupsByMarking.return_value = response
-
-    assert marking.authorized_group_rids() == ("ri.group.a",)
-
-
-def test_list_markings_hydrates_applied_rids() -> None:
-    """Applied rids are resolved to full markings via a batch metadata get."""
-    clients = _clients()
-    _applied(clients, "ri.dataset.a", "ri.marking.a")
-    clients.markings.BatchGetMarkingMetadata.return_value = markings_pb2.BatchGetMarkingMetadataResponse(
-        marking_metadatas=[_metadata("ri.marking.a", id="itar")]
-    )
-
-    markings = _Markable("ri.dataset.a", clients).list_markings()
-
-    assert [m.id for m in markings] == ["itar"]
-    assert list(clients.markings.BatchGetMarkingMetadata.call_args.args[0].marking_rids) == ["ri.marking.a"]
-
-
-def test_list_markings_on_unmarked_resource_is_empty_without_a_second_call() -> None:
-    """With no applied markings the batch get is skipped entirely."""
-    clients = _clients()
-    _applied(clients, "ri.dataset.a")
-
-    assert _Markable("ri.dataset.a", clients).list_markings() == ()
-    clients.markings.BatchGetMarkingMetadata.assert_not_called()
-
-
-def test_apply_and_remove_send_one_sided_updates() -> None:
-    """Apply and remove each populate only their own side of the update request."""
-    clients = _clients()
-    markable = _Markable("ri.dataset.a", clients)
-
-    markable.apply_markings(["ri.marking.a"])
-    applied = clients.markings.UpdateMarkingsOnResource.call_args.args[0]
-    assert applied.resource == "ri.dataset.a"
-    assert list(applied.markings_to_apply) == ["ri.marking.a"]
-    assert list(applied.markings_to_remove) == []
-
-    markable.remove_markings(["ri.marking.a"])
-    removed = clients.markings.UpdateMarkingsOnResource.call_args.args[0]
-    assert list(removed.markings_to_apply) == []
-    assert list(removed.markings_to_remove) == ["ri.marking.a"]
-
-
-def test_markings_accept_instances_as_well_as_rids() -> None:
-    """A Marking instance is coerced to its rid on the wire."""
-    clients = _clients()
-    marking = Marking._from_proto(clients, _marking(rid="ri.marking.a"))
-
-    _Markable("ri.dataset.a", clients).apply_markings([marking])
-
-    request = clients.markings.UpdateMarkingsOnResource.call_args.args[0]
-    assert list(request.markings_to_apply) == ["ri.marking.a"]
-
-
-def test_video_lists_its_markings() -> None:
-    """Pins that `Video` is actually wired to `MarkableMixin`: it does not inherit `DataSource`, so
-    nothing else in the library would notice if that base were dropped.
-    """
-    clients = _clients()
-    _applied(clients, "ri.video.a", "ri.marking.a")
-    clients.markings.BatchGetMarkingMetadata.return_value = markings_pb2.BatchGetMarkingMetadataResponse(
-        marking_metadatas=[_metadata("ri.marking.a", id="itar")]
-    )
-    video = Video(
-        rid="ri.video.a",
+def _build_video(clients: MagicMock, rid: str) -> Video:
+    return Video(
+        rid=rid,
         name="v",
         description=None,
         properties={},
@@ -305,81 +72,263 @@ def test_video_lists_its_markings() -> None:
         _clients=clients,
     )
 
-    assert [m.id for m in video.list_markings()] == ["itar"]
 
-
-def test_streaming_connection_lists_its_markings() -> None:
-    """Pins that `DataSource` is actually wired to `MarkableMixin`, covering `StreamingConnection` (and by
-    inheritance `Dataset`/`Connection`) via the real class rather than the `_Markable` stand-in.
-    """
-    clients = _clients()
-    _applied(clients, "ri.connection.a", "ri.marking.a")
-    clients.markings.BatchGetMarkingMetadata.return_value = markings_pb2.BatchGetMarkingMetadataResponse(
-        marking_metadatas=[_metadata("ri.marking.a", id="itar")]
-    )
-    connection = StreamingConnection(
-        rid="ri.connection.a",
+def _build_streaming_connection(clients: MagicMock, rid: str) -> StreamingConnection:
+    return StreamingConnection(
+        rid=rid,
         name="c",
         description=None,
         _clients=clients,
-        nominal_data_source_rid="ri.connection.a",
+        nominal_data_source_rid=rid,
     )
 
-    assert [m.id for m in connection.list_markings()] == ["itar"]
 
-
-def test_client_search_markings_passes_the_substring_through() -> None:
-    """The client method forwards its substring to the query and returns hydrated markings."""
-    clients = _clients()
-    clients.markings.SearchMarkings.return_value = markings_pb2.SearchMarkingsResponse(
+@pytest.mark.parametrize(
+    ("id_substring", "expected_clauses"),
+    [(None, []), ("ita", ["ita"])],
+    ids=["unfiltered", "substring"],
+)
+def test_search_sends_only_the_filters_the_caller_asked_for(
+    client: NominalClient, mock_clients: MagicMock, id_substring: str | None, expected_clauses: list[str]
+) -> None:
+    """Searching without a substring filters on nothing; passing one sends exactly that filter."""
+    mock_clients.markings.SearchMarkings.return_value = markings_pb2.SearchMarkingsResponse(
         marking_metadatas=[_metadata("ri.marking.a")], next_page_token=""
     )
-    client = NominalClient(_clients=clients)
 
-    results = client.search_markings(id_substring="ita")
+    client.search_markings(id_substring)
 
-    assert [m.rid for m in results] == ["ri.marking.a"]
-    query = clients.markings.SearchMarkings.call_args.args[0].query
-    assert [c.id_exact_substring_search for c in getattr(query, "and").queries] == ["ita"]
+    query = mock_clients.markings.SearchMarkings.call_args.args[0].query
+    assert [c.id_exact_substring_search for c in getattr(query, "and").queries] == expected_clauses
 
 
-def test_client_create_marking_returns_the_created_marking() -> None:
-    """The client method validates and forwards color, returning the created marking."""
-    clients = _clients()
-    clients.markings.CreateMarking.return_value = markings_pb2.CreateMarkingResponse(marking=_marking())
-    client = NominalClient(_clients=clients)
+def test_search_returns_markings_from_every_page(client: NominalClient, mock_clients: MagicMock) -> None:
+    """Pagination is invisible to the caller: markings from every page come back in one sequence."""
+    mock_clients.markings.SearchMarkings.side_effect = [
+        markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("a", id="first")], next_page_token="tok"),
+        markings_pb2.SearchMarkingsResponse(marking_metadatas=[_metadata("b", id="second")], next_page_token=""),
+    ]
 
-    marking = client.create_marking("itar", description="controlled", color="#cc0000")
+    results = client.search_markings()
 
+    assert [(m.rid, m.id) for m in results] == [("a", "first"), ("b", "second")]
+
+
+@pytest.mark.parametrize("bad_id", ["ITAR", "1itar", "-itar", "it_ar", "it ar", ""])
+@pytest.mark.parametrize("method", ["create_marking", "get_marking_by_id"], ids=["create", "get_by_id"])
+def test_marking_ids_are_rejected_locally_when_the_service_would_reject_them(
+    client: NominalClient, mock_clients: MagicMock, method: str, bad_id: str
+) -> None:
+    """An invalid id fails before the round trip, wherever an id is accepted."""
+    with pytest.raises(ValueError, match="marking id"):
+        getattr(client, method)(bad_id)
+
+    assert mock_clients.markings.mock_calls == []
+
+
+def test_create_marking_sends_its_metadata_and_returns_the_marking(
+    client: NominalClient, mock_clients: MagicMock
+) -> None:
+    """Every field the caller supplies reaches the request, with an uppercase color lowercased."""
+    mock_clients.markings.CreateMarking.return_value = markings_pb2.CreateMarkingResponse(marking=_marking())
+
+    marking = client.create_marking(
+        "itar",
+        description="controlled",
+        authorized_groups=["ri.group.a"],
+        symbol=Symbol.emoji(":lock:"),
+        color="#CC0000",
+    )
+
+    request = mock_clients.markings.CreateMarking.call_args.args[0]
+    assert request.id == "itar"
+    assert request.description == "controlled"
+    assert list(request.authorized_groups.group_rids) == ["ri.group.a"]
+    assert request.symbol.emoji == ":lock:"
+    assert request.color.hex_code == "#cc0000"
+    assert marking.rid == "ri.marking.a"
+
+
+def test_get_marking_returns_a_fully_hydrated_marking(client: NominalClient, mock_clients: MagicMock) -> None:
+    """A retrieved marking carries every field the service sent, not just its RID."""
+    mock_clients.markings.GetMarking.return_value = markings_pb2.GetMarkingResponse(marking=_marking())
+
+    marking = client.get_marking("ri.marking.a")
+
+    assert marking.rid == "ri.marking.a"
     assert marking.id == "itar"
-    assert clients.markings.CreateMarking.call_args.args[0].color.hex_code == "#cc0000"
+    assert marking.description == "controlled"
+    assert marking.symbol == Symbol.emoji(":lock:")
+    assert marking.color == "#cc0000"
+    assert marking.created_at == 1_000
+    assert marking.updated_at == 2_000
+    assert marking.is_archived is False
 
 
-def test_create_dataset_forwards_marking_rids() -> None:
-    """Markings may be given as instances or as RIDs."""
-    clients = _clients()
-    client = NominalClient(_clients=clients)
-    marking = Marking._from_proto(clients, _marking(rid="ri.marking.a"))
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [
+        (grpc.StatusCode.NOT_FOUND, NominalNotFoundError),
+        (grpc.StatusCode.PERMISSION_DENIED, NominalPermissionDeniedError),
+    ],
+    ids=["missing", "unreadable"],
+)
+def test_get_marking_keeps_missing_and_unreadable_distinct(
+    client: NominalClient,
+    mock_clients: MagicMock,
+    fake_rpc_error: Callable[[grpc.StatusCode], grpc.RpcError],
+    status_code: grpc.StatusCode,
+    expected: type[NominalError],
+) -> None:
+    """A marking that is absent and one the caller cannot read raise different errors."""
+    mock_clients.markings.GetMarking.side_effect = fake_rpc_error(status_code)
+
+    with pytest.raises(expected):
+        client.get_marking("ri.marking.a")
+
+
+def test_update_distinguishes_unchanged_from_cleared_symbol(mock_clients: MagicMock) -> None:
+    """Omitting symbol leaves it alone; passing None clears it. The wrapper encodes that difference."""
+    mock_clients.markings.UpdateMarking.return_value = markings_pb2.UpdateMarkingResponse(marking=_marking())
+    marking = Marking._from_proto(mock_clients, _marking())
+
+    marking.update(description="new")
+    unchanged = mock_clients.markings.UpdateMarking.call_args.args[0]
+    assert not unchanged.HasField("symbol")
+    assert unchanged.description == "new"
+
+    marking.update(symbol=None)
+    cleared = mock_clients.markings.UpdateMarking.call_args.args[0]
+    assert cleared.HasField("symbol")
+    assert not cleared.symbol.HasField("value")
+
+    marking.update(symbol=Symbol.icon("castle"))
+    assigned = mock_clients.markings.UpdateMarking.call_args.args[0]
+    assert assigned.symbol.value.icon == "castle"
+
+
+def test_update_clears_authorized_groups_with_an_empty_sequence(mock_clients: MagicMock) -> None:
+    """None leaves groups alone; an empty sequence clears them."""
+    mock_clients.markings.UpdateMarking.return_value = markings_pb2.UpdateMarkingResponse(marking=_marking())
+    marking = Marking._from_proto(mock_clients, _marking())
+
+    marking.update(description="x")
+    assert not mock_clients.markings.UpdateMarking.call_args.args[0].HasField("authorized_groups")
+
+    marking.update(authorized_groups=[])
+    cleared = mock_clients.markings.UpdateMarking.call_args.args[0]
+    assert cleared.HasField("authorized_groups")
+    assert list(cleared.authorized_groups.group_rids) == []
+
+
+def test_authorized_group_rids_reads_this_markings_entry(mock_clients: MagicMock) -> None:
+    """The batch-keyed response is indexed by this marking's own RID, not taken from the first entry."""
+    response = markings_pb2.GetAuthorizedGroupsByMarkingResponse()
+    response.authorized_groups_by_marking["ri.marking.other"].group_rids.append("ri.group.wrong")
+    response.authorized_groups_by_marking["ri.marking.a"].group_rids.append("ri.group.a")
+    mock_clients.markings.GetAuthorizedGroupsByMarking.return_value = response
+    marking = Marking._from_proto(mock_clients, _marking())
+
+    assert marking.authorized_group_rids() == ("ri.group.a",)
+
+
+@pytest.mark.parametrize(
+    "applied",
+    [(), ("ri.marking.a",), ("ri.marking.a", "ri.marking.b")],
+    ids=["none", "one", "several"],
+)
+def test_list_markings_returns_the_markings_applied_to_the_resource(
+    mock_clients: MagicMock, applied: tuple[str, ...]
+) -> None:
+    """Listing hydrates exactly the applied markings, and is empty when the resource carries none."""
+    _apply_to(mock_clients, "ri.dataset.a", *applied)
+
+    markings = _Markable("ri.dataset.a", mock_clients).list_markings()
+
+    assert tuple(m.rid for m in markings) == applied
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_apply", "expected_remove"),
+    [("apply_markings", ["ri.marking.a"], []), ("remove_markings", [], ["ri.marking.a"])],
+    ids=["apply", "remove"],
+)
+def test_apply_and_remove_each_send_a_one_sided_update(
+    markable: _Markable,
+    mock_clients: MagicMock,
+    method: str,
+    expected_apply: list[str],
+    expected_remove: list[str],
+) -> None:
+    """Applying never removes and removing never applies, so neither disturbs the other markings."""
+    getattr(markable, method)(["ri.marking.a"])
+
+    request = mock_clients.markings.UpdateMarkingsOnResource.call_args.args[0]
+    assert request.resource == "ri.dataset.a"
+    assert list(request.markings_to_apply) == expected_apply
+    assert list(request.markings_to_remove) == expected_remove
+
+
+@pytest.mark.parametrize("as_instance", [True, False], ids=["instance", "rid"])
+def test_markings_may_be_given_as_instances_or_rids(
+    markable: _Markable, mock_clients: MagicMock, as_instance: bool
+) -> None:
+    """A Marking and its RID are interchangeable wherever markings are accepted."""
+    marking = Marking._from_proto(mock_clients, _marking(rid="ri.marking.a"))
+
+    markable.apply_markings([marking if as_instance else "ri.marking.a"])
+
+    request = mock_clients.markings.UpdateMarkingsOnResource.call_args.args[0]
+    assert list(request.markings_to_apply) == ["ri.marking.a"]
+
+
+@pytest.mark.parametrize(
+    "build_resource",
+    [_build_video, _build_streaming_connection],
+    ids=["video", "streaming_connection"],
+)
+def test_every_data_source_type_exposes_its_markings(
+    mock_clients: MagicMock, build_resource: Callable[[MagicMock, str], MarkableMixin]
+) -> None:
+    """Pins the mixin onto the real classes: `Video` and `DataSource` each carry it independently."""
+    _apply_to(mock_clients, "ri.resource.a", "ri.marking.a")
+
+    resource = build_resource(mock_clients, "ri.resource.a")
+
+    assert [m.id for m in resource.list_markings()] == ["itar"]
+
+
+@pytest.mark.parametrize(
+    ("markings", "expected_rids"),
+    [(None, []), (["ri.marking.b"], ["ri.marking.b"])],
+    ids=["omitted", "given"],
+)
+def test_create_dataset_forwards_markings(
+    client: NominalClient,
+    mock_clients: MagicMock,
+    markings: list[str] | None,
+    expected_rids: list[str],
+) -> None:
+    """Markings reach the create request, and omitting them sends an empty list rather than null."""
+    client.create_dataset("ds", markings=markings)
+
+    assert mock_clients.catalog.create_dataset.call_args.args[1].marking_rids == expected_rids
+
+
+def test_create_dataset_accepts_marking_instances(client: NominalClient, mock_clients: MagicMock) -> None:
+    """A Marking instance is accepted at creation, not just its RID."""
+    marking = Marking._from_proto(mock_clients, _marking(rid="ri.marking.a"))
 
     client.create_dataset("ds", markings=[marking, "ri.marking.b"])
 
-    request = clients.catalog.create_dataset.call_args.args[1]
+    request = mock_clients.catalog.create_dataset.call_args.args[1]
     assert request.marking_rids == ["ri.marking.a", "ri.marking.b"]
 
 
-def test_create_dataset_without_markings_sends_an_empty_list() -> None:
-    """Omitting markings sends an empty list, not null, to the catalog."""
-    clients = _clients()
-    NominalClient(_clients=clients).create_dataset("ds")
-
-    assert clients.catalog.create_dataset.call_args.args[1].marking_rids == []
-
-
-def test_create_streaming_connection_forwards_marking_rids() -> None:
+def test_create_streaming_connection_forwards_markings(client: NominalClient, mock_clients: MagicMock) -> None:
     """Markings reach the connection create request even on the deprecated path."""
-    clients = _clients()
     with pytest.warns(DeprecationWarning, match="create_streaming_connection"):
-        NominalClient(_clients=clients).create_streaming_connection("ds-id", "conn", markings=["ri.marking.a"])
+        client.create_streaming_connection("ds-id", "conn", markings=["ri.marking.a"])
 
-    request = clients.connection.create_connection.call_args.args[1]
+    request = mock_clients.connection.create_connection.call_args.args[1]
     assert request.marking_rids == ["ri.marking.a"]

--- a/tests/e2e/test_markings.py
+++ b/tests/e2e/test_markings.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from nominal.core import NominalClient
 from nominal.core.dataset import Dataset
 
@@ -16,7 +18,7 @@ def test_search_markings_filters_by_id_substring(client: NominalClient) -> None:
     """The substring filter narrows an unfiltered search rather than widening it."""
     all_markings = client.search_markings()
     if not all_markings:
-        return  # organization has no markings; nothing to narrow
+        pytest.skip("organization has no markings to narrow")
 
     target = all_markings[0]
     filtered = client.search_markings(id_substring=target.id)

--- a/tests/e2e/test_markings.py
+++ b/tests/e2e/test_markings.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from nominal.core import NominalClient
+from nominal.core.dataset import Dataset
+
+
+def test_search_markings_returns_unarchived_markings(client: NominalClient) -> None:
+    """Search succeeds and never returns archived markings, regardless of how many exist."""
+    markings = client.search_markings()
+
+    assert all(not marking.is_archived for marking in markings)
+    assert all(marking.rid for marking in markings)
+
+
+def test_search_markings_filters_by_id_substring(client: NominalClient) -> None:
+    """The substring filter narrows an unfiltered search rather than widening it."""
+    all_markings = client.search_markings()
+    if not all_markings:
+        return  # organization has no markings; nothing to narrow
+
+    target = all_markings[0]
+    filtered = client.search_markings(id_substring=target.id)
+
+    assert target.rid in {marking.rid for marking in filtered}
+    assert len(filtered) <= len(all_markings)
+
+
+def test_dataset_lists_its_markings(client: NominalClient, ingested_dataset: Dataset) -> None:
+    """Listing markings on a data source succeeds; a fresh dataset typically carries none."""
+    markings = ingested_dataset.list_markings()
+
+    assert all(marking.rid for marking in markings)

--- a/tests/e2e/test_markings.py
+++ b/tests/e2e/test_markings.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from nominal.core import NominalClient
+from nominal.core.dataset import Dataset
+
+
+def test_search_markings_returns_unarchived_markings(client: NominalClient) -> None:
+    """Search succeeds and never returns archived markings, regardless of how many exist."""
+    markings = client.search_markings()
+
+    assert all(not marking.is_archived for marking in markings)
+    assert all(marking.rid for marking in markings)
+
+
+def test_search_markings_filters_by_id_substring(client: NominalClient) -> None:
+    """The substring filter narrows an unfiltered search rather than widening it."""
+    all_markings = client.search_markings()
+    if not all_markings:
+        pytest.skip("organization has no markings to narrow")
+
+    target = all_markings[0]
+    filtered = client.search_markings(id_substring=target.id)
+
+    assert target.rid in {marking.rid for marking in filtered}
+    assert len(filtered) <= len(all_markings)
+
+
+def test_dataset_lists_its_markings(client: NominalClient, ingested_dataset: Dataset) -> None:
+    """Listing markings on a data source succeeds; a fresh dataset typically carries none."""
+    markings = ingested_dataset.list_markings()
+
+    assert all(marking.rid for marking in markings)

--- a/tests/e2e/test_markings.py
+++ b/tests/e2e/test_markings.py
@@ -11,7 +11,6 @@ def test_search_markings_returns_unarchived_markings(client: NominalClient) -> N
     markings = client.search_markings()
 
     assert all(not marking.is_archived for marking in markings)
-    assert all(marking.rid for marking in markings)
 
 
 def test_search_markings_filters_by_id_substring(client: NominalClient) -> None:
@@ -27,8 +26,6 @@ def test_search_markings_filters_by_id_substring(client: NominalClient) -> None:
     assert len(filtered) <= len(all_markings)
 
 
-def test_dataset_lists_its_markings(client: NominalClient, ingested_dataset: Dataset) -> None:
-    """Listing markings on a data source succeeds; a fresh dataset typically carries none."""
-    markings = ingested_dataset.list_markings()
-
-    assert all(marking.rid for marking in markings)
+def test_dataset_lists_its_markings(ingested_dataset: Dataset) -> None:
+    """A dataset created without markings carries none."""
+    assert ingested_dataset.list_markings() == ()


### PR DESCRIPTION
Adds support for markings — the access-control primitive that restricts a data source to users in the marking's authorized groups. Markings were previously reachable only as raw RID strings on `create_dataset`; this makes them a first-class resource.

## What's new

**`Marking`** — a frozen dataclass with `rid`, `id` (a slug unique within the organization), `description`, `symbol`, `color`, `created_at`, `updated_at`, `is_archived`, plus `update()`, `archive()`, `unarchive()`, `refresh()`, and `authorized_group_rids()`.

**`Symbol`** — display metadata, built through classmethod constructors: `Symbol.icon(...)`, `Symbol.emoji(...)`, `Symbol.image(...)`. A marking's color is a plain hex string (`"#cc0000"`). The service stores only `^#[0-9a-f]{6}$`, so the SDK enforces the six-digit shape at the call boundary the way it does `id`, but accepts either case and lowercases it rather than making the caller do so.

**Markings on resources** — `Dataset`, `Connection`, `StreamingConnection`, and `Video` gain three methods from a shared mixin:

```python
dataset.list_markings()
dataset.apply_markings([itar])              # accepts Marking instances or RIDs
dataset.remove_markings(["ri.marking.x"])
```

**Client methods** — `create_marking`, `get_marking`, `get_marking_by_id`, `search_markings`.

**Markings at creation** — `markings=` on `create_dataset`, `create_streaming_connection`, `create_video`, and the experimental dataset helpers. Accepts `Marking` instances or RID strings; the existing string form is unchanged.

```python
itar = client.create_marking("export-controlled", description="ITAR", color="#cc0000")
dataset = client.create_dataset("flight-data", markings=[itar])
```

## Notes for reviewers

- **Markings apply only to data sources** (datasets, connections, videos). The mixin's membership is the guard — other resource types simply don't have these methods.
- **The interface is add/remove, not set-replace.** This is the one deliberate departure from how labels and properties work, and it is forced by the API. `GetMarkingsForResources` filters out markings the caller cannot read, so the applied set is never fully observable from the client; there is also no set/replace RPC, only an `UpdateMarkingsOnResource` delta of `markings_to_apply`/`markings_to_remove`. An earlier revision had a `set_markings` that computed that delta against `list_markings()`, but it could not honor its own contract: with an unreadable marking applied, "replace with exactly these" silently left it in place, and `set_markings([])` removed only what the caller could see. `apply_markings`/`remove_markings` name their targets outright, so they are correct without a view of the current state and need no read-then-write. The labels/properties idiom does not transfer because labels carry no per-item read permission.
- **`list_markings` may be a strict subset** of what is applied, for the same filtering reason. Its docstring says so, and says not to compute a desired set from it.
- **Creation with markings is atomic**: `marking_rids` is part of each create request, not a follow-up `apply_markings` call.
- **`search_markings` intentionally takes no `workspace` or `archive_status` argument** — markings are organization-scoped, and archived markings are excluded from search regardless. Results are oldest-first; no sort option is exposed. It also takes no case-insensitivity claim: `id` is server-validated as `^[a-z][a-z0-9-]*$`, so an id cannot contain uppercase and the question is unobservable.
- **Creating, updating, and archiving markings requires organization admin permission**; reading requires organization membership. Docstrings state this.
- `Marking` carries no `name` — only the `id` slug.
- `get_marking` and `get_marking_by_id` use the single-get endpoints rather than a one-element batch, so a marking that is missing and one the caller cannot read raise distinct errors (`NominalNotFoundError` vs `NominalPermissionDeniedError`) instead of both reporting as not-found.
- Deferred by design: a batch get-by-RIDs accessor, listing the resources a marking applies to, and `applied_at` timestamps. Also deferred: the RPC supports applying and removing in one atomic call, which nothing currently exposes — swapping one marking for another takes two calls. Worth adding as `update_markings(apply=..., remove=...)` if a caller needs it.

## Testing

730 unit tests pass; `just check` and strict mypy are clean. End-to-end coverage is read-only (`search_markings`, `list_markings`) because the write paths require organization-admin rights the e2e token isn't guaranteed to have — those paths have unit coverage only.

Suggest squash-merging: several commits here are intra-branch cleanups of private helpers that never shipped, and they would otherwise appear in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
