### PR TITLE
feat: retry transient failures and log-and-continue in video file migration

### DIFF
--- a/nominal/experimental/migration/README.md
+++ b/nominal/experimental/migration/README.md
@@ -143,7 +143,7 @@ migrating. Whether a rerun re-attempts the file depends on the failure:
   re-attempt it — check the file by hand as the summary line instructs.
 
 A video file appears in the summary at most once, with its latest outcome: a rerun that succeeds
-clears the stale skip entry from the earlier attempt. Other resource types keep one entry per
+clears the stale skip entry from the earlier attempt. Checklist skips are still appended per
 attempt.
 
 Example — run with an explicit state path:

--- a/nominal/experimental/migration/README.md
+++ b/nominal/experimental/migration/README.md
@@ -126,6 +126,25 @@ The `nom migrate copy` command supports resumable migrations via the optional `-
 - If the state file already exists from a previous run, already-migrated resources are automatically skipped, so it is safe to re-run after a failure without duplicating resources.
 - Previous state files are automatically versioned (e.g. `migration_state.json` → `migration_state_v2.json`) so no history is lost.
 
+## Failure handling
+
+Transient network failures (connection resets, read timeouts, 429/5xx responses) during video file
+transfer are retried automatically with exponential backoff, including status-poll failures after an
+upload has already succeeded — so a single dropped request does not abandon a finished upload.
+
+A video file that still cannot be copied is recorded in the end-of-run skip summary
+(`N resource(s) were skipped or could not be confirmed`) and the rest of its asset continues
+migrating. Whether a rerun re-attempts the file depends on the failure:
+
+- **Copy failed** (network failure that outlasted retries): no mapping is recorded, so a rerun
+  re-attempts the file.
+- **Unusable at source / ingest failed at destination / ingest timed out / timestamp update
+  rejected**: retrying cannot help (or the copy is already recorded), so a rerun does not
+  re-attempt it — check the file by hand as the summary line instructs.
+
+Each resource appears in the summary at most once with its latest outcome: a rerun that succeeds
+clears the stale skip entry from the earlier attempt.
+
 Example — run with an explicit state path:
 
 ```sh

--- a/nominal/experimental/migration/README.md
+++ b/nominal/experimental/migration/README.md
@@ -142,8 +142,9 @@ migrating. Whether a rerun re-attempts the file depends on the failure:
   rejected**: retrying cannot help (or the copy is already recorded), so a rerun does not
   re-attempt it — check the file by hand as the summary line instructs.
 
-Each resource appears in the summary at most once with its latest outcome: a rerun that succeeds
-clears the stale skip entry from the earlier attempt.
+A video file appears in the summary at most once, with its latest outcome: a rerun that succeeds
+clears the stale skip entry from the earlier attempt. Other resource types keep one entry per
+attempt.
 
 Example — run with an explicit state path:
 

--- a/nominal/experimental/migration/migration_runner.py
+++ b/nominal/experimental/migration/migration_runner.py
@@ -189,7 +189,9 @@ class MigrationRunner:
 def log_skipped_resources(migration_state: MigrationState) -> None:
     """Summarize skips at the end of a run, so a partial migration is never mistaken for a complete one.
 
-    Sourced from the persisted state, so a resumed run still reports what earlier attempts skipped.
+    Sourced from the persisted state, so a resumed run still reports what earlier attempts
+    skipped — except entries superseded via set_skip (video files report only their latest
+    outcome).
     """
     if not migration_state.skipped_resources:
         return

--- a/nominal/experimental/migration/migration_state.py
+++ b/nominal/experimental/migration/migration_state.py
@@ -102,6 +102,25 @@ class MigrationState:
     def record_skip(self, resource_type: ResourceType, source_rid: str, reason: str) -> None:
         self.skipped_resources.append(SkippedResource(resource_type.value, source_rid, reason))
 
+    def clear_skips(self, resource_type: ResourceType, source_rid: str) -> bool:
+        """Drop skip records for a resource, returning whether any were removed.
+
+        Some skips (a transient copy failure, an unusable source file) are re-attempted on the
+        next run because no mapping was recorded; clearing before recording that attempt's
+        outcome keeps the end-of-run summary reporting each resource's latest state once,
+        rather than accumulating stale entries across reruns.
+        """
+        remaining = [
+            skipped
+            for skipped in self.skipped_resources
+            if not (skipped.resource_type == resource_type.value and skipped.source_rid == source_rid)
+        ]
+        changed = len(remaining) != len(self.skipped_resources)
+        # In place, so ThreadSafeMigrationState's to_json snapshot (which copies this list
+        # under its lock) and any other holder of the list reference stay consistent.
+        self.skipped_resources[:] = remaining
+        return changed
+
     def record_workbook_skip_and_clear_pending(self, workbook_rid: str, reason: str) -> bool:
         """Record a workbook skip as a terminal state and clear any stale pending entries."""
         changed = workbook_rid in self.pending_multi_asset_workbooks or workbook_rid in self.pending_multi_run_workbooks

--- a/nominal/experimental/migration/migration_state.py
+++ b/nominal/experimental/migration/migration_state.py
@@ -102,13 +102,14 @@ class MigrationState:
     def record_skip(self, resource_type: ResourceType, source_rid: str, reason: str) -> None:
         self.skipped_resources.append(SkippedResource(resource_type.value, source_rid, reason))
 
-    def clear_skips(self, resource_type: ResourceType, source_rid: str) -> bool:
-        """Drop skip records for a resource, returning whether any were removed.
+    def set_skip(self, resource_type: ResourceType, source_rid: str, reason: str | None) -> bool:
+        """Record a resource's latest skip outcome, replacing any earlier entries for it;
+        ``None`` clears them. Returns whether anything changed.
 
         Some skips (a transient copy failure, an unusable source file) are re-attempted on the
-        next run because no mapping was recorded; clearing before recording that attempt's
-        outcome keeps the end-of-run summary reporting each resource's latest state once,
-        rather than accumulating stale entries across reruns.
+        next run because no mapping was recorded; an upsert keeps the end-of-run summary
+        reporting each such resource's latest state once, rather than accumulating one stale
+        entry per attempt.
         """
         remaining = [
             skipped
@@ -116,6 +117,9 @@ class MigrationState:
             if not (skipped.resource_type == resource_type.value and skipped.source_rid == source_rid)
         ]
         changed = len(remaining) != len(self.skipped_resources)
+        if reason is not None:
+            remaining.append(SkippedResource(resource_type.value, source_rid, reason))
+            changed = True
         # In place, so ThreadSafeMigrationState's to_json snapshot (which copies this list
         # under its lock) and any other holder of the list reference stay consistent.
         self.skipped_resources[:] = remaining

--- a/nominal/experimental/migration/migrator/video_file_migrator.py
+++ b/nominal/experimental/migration/migrator/video_file_migrator.py
@@ -27,9 +27,20 @@ class VideoFileMigrator:
             logger.info(f"{DRY_RUN_PREFIX} Would copy video file %s to destination", source_file.rid)
             return
 
-        outcome = copy_video_file_to_video_dataset(
-            source_file, destination_video, poll_timeout=self.ctx.video_ingest_timeout
-        )
+        try:
+            outcome = copy_video_file_to_video_dataset(
+                source_file, destination_video, poll_timeout=self.ctx.video_ingest_timeout
+            )
+        except Exception as error:
+            # One bad file must not abort the whole asset task (and every sibling resource
+            # behind it). With no mapping recorded, a rerun re-attempts this file.
+            logger.exception("Failed to copy video file (rid: %s)", source_file.rid)
+            self.ctx.migration_state.clear_skips(ResourceType.VIDEO_FILE, source_file.rid)
+            self.ctx.migration_state.record_skip(ResourceType.VIDEO_FILE, source_file.rid, f"copy failed: {error}")
+            return
+
+        # This attempt's outcome supersedes any skip recorded by an earlier run's attempt.
+        self.ctx.migration_state.clear_skips(ResourceType.VIDEO_FILE, source_file.rid)
         if outcome.skip_reason is not None:
             self.ctx.migration_state.record_skip(ResourceType.VIDEO_FILE, source_file.rid, outcome.skip_reason)
         if outcome.file is not None:

--- a/nominal/experimental/migration/migrator/video_file_migrator.py
+++ b/nominal/experimental/migration/migrator/video_file_migrator.py
@@ -35,13 +35,10 @@ class VideoFileMigrator:
             # One bad file must not abort the whole asset task (and every sibling resource
             # behind it). With no mapping recorded, a rerun re-attempts this file.
             logger.exception("Failed to copy video file (rid: %s)", source_file.rid)
-            self.ctx.migration_state.clear_skips(ResourceType.VIDEO_FILE, source_file.rid)
-            self.ctx.migration_state.record_skip(ResourceType.VIDEO_FILE, source_file.rid, f"copy failed: {error}")
+            self.ctx.migration_state.set_skip(ResourceType.VIDEO_FILE, source_file.rid, f"copy failed: {error}")
             return
 
         # This attempt's outcome supersedes any skip recorded by an earlier run's attempt.
-        self.ctx.migration_state.clear_skips(ResourceType.VIDEO_FILE, source_file.rid)
-        if outcome.skip_reason is not None:
-            self.ctx.migration_state.record_skip(ResourceType.VIDEO_FILE, source_file.rid, outcome.skip_reason)
+        self.ctx.migration_state.set_skip(ResourceType.VIDEO_FILE, source_file.rid, outcome.skip_reason)
         if outcome.file is not None:
             self.ctx.migration_state.record_mapping(ResourceType.VIDEO_FILE, source_file.rid, outcome.file.rid)

--- a/nominal/experimental/migration/migrator/video_file_migrator.py
+++ b/nominal/experimental/migration/migrator/video_file_migrator.py
@@ -38,7 +38,9 @@ class VideoFileMigrator:
             self.ctx.migration_state.set_skip(ResourceType.VIDEO_FILE, source_file.rid, f"copy failed: {error}")
             return
 
-        # This attempt's outcome supersedes any skip recorded by an earlier run's attempt.
-        self.ctx.migration_state.set_skip(ResourceType.VIDEO_FILE, source_file.rid, outcome.skip_reason)
         if outcome.file is not None:
             self.ctx.migration_state.record_mapping(ResourceType.VIDEO_FILE, source_file.rid, outcome.file.rid)
+        # This attempt's outcome supersedes any skip recorded by an earlier run's attempt.
+        # Ordered after record_mapping — each call persists separately, so a crash between the
+        # two can only lose the summary line, never the mapping that stops a rerun re-uploading.
+        self.ctx.migration_state.set_skip(ResourceType.VIDEO_FILE, source_file.rid, outcome.skip_reason)

--- a/nominal/experimental/migration/parallel_migration_state.py
+++ b/nominal/experimental/migration/parallel_migration_state.py
@@ -105,6 +105,13 @@ class ThreadSafeMigrationState(MigrationState):
             super().record_skip(resource_type, source_rid, reason)
         self._persist()
 
+    def clear_skips(self, resource_type: ResourceType, source_rid: str) -> bool:
+        with self._lock:
+            changed = super().clear_skips(resource_type, source_rid)
+        if changed:
+            self._persist()
+        return changed
+
     def record_workbook_skip_and_clear_pending(self, workbook_rid: str, reason: str) -> bool:
         with self._lock:
             changed = super().record_workbook_skip_and_clear_pending(workbook_rid, reason)
@@ -121,8 +128,9 @@ class ThreadSafeMigrationState(MigrationState):
         # seconds, and holding the lock that long blocks every worker's record_mapping /
         # get_mapped_rid — collapsing parallel workers to a single thread. The snapshot uses
         # C-level container copies, which are orders of magnitude cheaper than serialization.
-        # SkippedResource entries are append-only and never mutated, so sharing them with the
-        # snapshot is safe. If MigrationState gains a field, it must be copied here too
+        # SkippedResource entries themselves are never mutated (the list gains and drops
+        # entries under the lock, via record_skip/clear_skips), so sharing the items with
+        # the snapshot is safe. If MigrationState gains a field, it must be copied here too
         # (guarded by a test asserting the expected field set).
         with self._lock:
             snapshot = MigrationState(

--- a/nominal/experimental/migration/parallel_migration_state.py
+++ b/nominal/experimental/migration/parallel_migration_state.py
@@ -105,9 +105,9 @@ class ThreadSafeMigrationState(MigrationState):
             super().record_skip(resource_type, source_rid, reason)
         self._persist()
 
-    def clear_skips(self, resource_type: ResourceType, source_rid: str) -> bool:
+    def set_skip(self, resource_type: ResourceType, source_rid: str, reason: str | None) -> bool:
         with self._lock:
-            changed = super().clear_skips(resource_type, source_rid)
+            changed = super().set_skip(resource_type, source_rid, reason)
         if changed:
             self._persist()
         return changed
@@ -129,7 +129,7 @@ class ThreadSafeMigrationState(MigrationState):
         # get_mapped_rid — collapsing parallel workers to a single thread. The snapshot uses
         # C-level container copies, which are orders of magnitude cheaper than serialization.
         # SkippedResource entries themselves are never mutated (the list gains and drops
-        # entries under the lock, via record_skip/clear_skips), so sharing the items with
+        # entries under the lock, via record_skip/set_skip), so sharing the items with
         # the snapshot is safe. If MigrationState gains a field, it must be copied here too
         # (guarded by a test asserting the expected field set).
         with self._lock:

--- a/nominal/experimental/migration/utils/retry_utils.py
+++ b/nominal/experimental/migration/utils/retry_utils.py
@@ -18,6 +18,9 @@ import grpc
 import requests
 import urllib3.exceptions
 
+# Remove this import once the minimum supported Python version is 3.11+.
+from exceptiongroup import BaseExceptionGroup
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
@@ -41,27 +44,33 @@ def is_transient_error(error: BaseException) -> bool:
     # Covers ConjureHTTPError too: it subclasses HTTPError and keeps `.response`.
     if isinstance(error, requests.exceptions.HTTPError):
         return error.response is not None and error.response.status_code in _RETRYABLE_STATUS_CODES
+    # Requests-level connection/timeout failures, plus the urllib3/socket errors that
+    # streaming a source download straight into an upload surfaces without the requests
+    # wrappers (e.g. ProtocolError(ConnectionResetError(104, ...))).
     if isinstance(
         error,
         (
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,
             requests.exceptions.ChunkedEncodingError,
+            urllib3.exceptions.ProtocolError,
+            urllib3.exceptions.TimeoutError,
+            ConnectionError,
+            TimeoutError,
         ),
     ):
         return True
-    # Streaming a source download straight into an upload surfaces urllib3/socket errors
-    # without the requests wrappers (e.g. ProtocolError(ConnectionResetError(104, ...))).
-    if isinstance(
-        error,
-        (urllib3.exceptions.ProtocolError, urllib3.exceptions.TimeoutError, ConnectionError, TimeoutError),
-    ):
-        return True
-    # gRPC legs (e.g. the multipart upload) surface as NominalError subclasses via
-    # translate_grpc_errors, which chains the original grpc.RpcError — classify by its status.
-    rpc_error = error if isinstance(error, grpc.RpcError) else error.__cause__
-    if isinstance(rpc_error, grpc.RpcError):
-        return rpc_error.code() in _RETRYABLE_GRPC_STATUS_CODES
+    # gRPC legs surface either raw or as NominalError subclasses via translate_grpc_errors,
+    # which chains the original grpc.RpcError — classify by its status.
+    if isinstance(error, grpc.RpcError):
+        return error.code() in _RETRYABLE_GRPC_STATUS_CODES
+    # Wrapper shapes: multipart upload failures arrive as an ExceptionGroup of per-attempt
+    # errors (the group itself has no __cause__), and each member — like translate_grpc_errors'
+    # output — chains the real failure via __cause__. Classify by what's underneath.
+    if isinstance(error, BaseExceptionGroup):
+        return any(is_transient_error(inner) for inner in error.exceptions)
+    if error.__cause__ is not None:
+        return is_transient_error(error.__cause__)
     return False
 
 

--- a/nominal/experimental/migration/utils/retry_utils.py
+++ b/nominal/experimental/migration/utils/retry_utils.py
@@ -1,0 +1,95 @@
+"""Retry helpers for transient network failures during migration.
+
+The conjure client already retries connect errors and 308/429/503 responses with jittered
+exponential backoff, but its coverage has holes that have killed real migrations: 502s are
+not in its status forcelist, read errors are explicitly not retried (``read=0``), and the
+raw ``requests`` streaming used to transfer video files bypasses it entirely. These helpers
+close those gaps at the migration layer.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from typing import Callable, TypeVar
+
+import requests
+import urllib3.exceptions
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+DEFAULT_MAX_ATTEMPTS = 5
+DEFAULT_BACKOFF_BASE_SECONDS = 1.0
+DEFAULT_BACKOFF_CAP_SECONDS = 60.0
+
+# 429 is throttling; the 5xx set covers transient server-side failures. 4xx (other than 429)
+# means the request itself is wrong and will fail identically on every attempt.
+_RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+def is_transient_error(error: BaseException) -> bool:
+    """Whether an exception is a transient network/server failure worth retrying."""
+    # Covers ConjureHTTPError too: it subclasses HTTPError and keeps `.response`.
+    if isinstance(error, requests.exceptions.HTTPError):
+        return error.response is not None and error.response.status_code in _RETRYABLE_STATUS_CODES
+    if isinstance(
+        error,
+        (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.ChunkedEncodingError,
+        ),
+    ):
+        return True
+    # Streaming a source download straight into an upload surfaces urllib3/socket errors
+    # without the requests wrappers (e.g. ProtocolError(ConnectionResetError(104, ...))).
+    if isinstance(
+        error,
+        (urllib3.exceptions.ProtocolError, urllib3.exceptions.TimeoutError, ConnectionError, TimeoutError),
+    ):
+        return True
+    return False
+
+
+def retry_transient(
+    fn: Callable[[], T],
+    *,
+    description: str,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    backoff_base_seconds: float = DEFAULT_BACKOFF_BASE_SECONDS,
+    backoff_cap_seconds: float = DEFAULT_BACKOFF_CAP_SECONDS,
+    sleep: Callable[[float], None] = time.sleep,
+) -> T:
+    """Run ``fn``, retrying transient failures with jittered exponential backoff.
+
+    Non-transient exceptions, and transient ones on the final attempt, propagate unchanged.
+
+    Args:
+        fn: Zero-arg callable to run. Must be safe to re-run from scratch on failure.
+        description: What is being attempted, for retry log lines.
+        max_attempts: Total attempts including the first.
+        backoff_base_seconds: Backoff before the second attempt; doubles per attempt.
+        backoff_cap_seconds: Upper bound on the backoff window.
+        sleep: Injectable for tests.
+    """
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return fn()
+        except Exception as error:
+            if attempt >= max_attempts or not is_transient_error(error):
+                raise
+            # Full jitter (uniform over the window), matching the conjure client's style.
+            delay = random.uniform(0, min(backoff_cap_seconds, backoff_base_seconds * 2 ** (attempt - 1)))
+            logger.warning(
+                "Transient failure in %s (attempt %d/%d), retrying in %.1fs: %s",
+                description,
+                attempt,
+                max_attempts,
+                delay,
+                error,
+            )
+            sleep(delay)
+    raise AssertionError("unreachable: loop either returns or raises")

--- a/nominal/experimental/migration/utils/retry_utils.py
+++ b/nominal/experimental/migration/utils/retry_utils.py
@@ -53,6 +53,11 @@ def is_transient_error(error: BaseException) -> bool:
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,
             requests.exceptions.ChunkedEncodingError,
+            # Raised when a session's own urllib3 Retry exhausts its status_forcelist budget
+            # (e.g. sustained S3 503s on multipart part PUTs); requests raises it without
+            # `from`, so there is no __cause__ to follow.
+            requests.exceptions.RetryError,
+            urllib3.exceptions.MaxRetryError,
             urllib3.exceptions.ProtocolError,
             urllib3.exceptions.TimeoutError,
             ConnectionError,

--- a/nominal/experimental/migration/utils/retry_utils.py
+++ b/nominal/experimental/migration/utils/retry_utils.py
@@ -14,6 +14,7 @@ import random
 import time
 from typing import Callable, TypeVar
 
+import grpc
 import requests
 import urllib3.exceptions
 
@@ -28,6 +29,11 @@ DEFAULT_BACKOFF_CAP_SECONDS = 60.0
 # 429 is throttling; the 5xx set covers transient server-side failures. 4xx (other than 429)
 # means the request itself is wrong and will fail identically on every attempt.
 _RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+# The standard retryable gRPC statuses: server unreachable/overloaded or the deadline hit.
+_RETRYABLE_GRPC_STATUS_CODES = frozenset(
+    {grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.DEADLINE_EXCEEDED, grpc.StatusCode.RESOURCE_EXHAUSTED}
+)
 
 
 def is_transient_error(error: BaseException) -> bool:
@@ -51,6 +57,11 @@ def is_transient_error(error: BaseException) -> bool:
         (urllib3.exceptions.ProtocolError, urllib3.exceptions.TimeoutError, ConnectionError, TimeoutError),
     ):
         return True
+    # gRPC legs (e.g. the multipart upload) surface as NominalError subclasses via
+    # translate_grpc_errors, which chains the original grpc.RpcError — classify by its status.
+    rpc_error = error if isinstance(error, grpc.RpcError) else error.__cause__
+    if isinstance(rpc_error, grpc.RpcError):
+        return rpc_error.code() in _RETRYABLE_GRPC_STATUS_CODES
     return False
 
 
@@ -61,7 +72,7 @@ def retry_transient(
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
     backoff_base_seconds: float = DEFAULT_BACKOFF_BASE_SECONDS,
     backoff_cap_seconds: float = DEFAULT_BACKOFF_CAP_SECONDS,
-    sleep: Callable[[float], None] = time.sleep,
+    sleep: Callable[[float], None] | None = None,
 ) -> T:
     """Run ``fn``, retrying transient failures with jittered exponential backoff.
 
@@ -73,8 +84,10 @@ def retry_transient(
         max_attempts: Total attempts including the first.
         backoff_base_seconds: Backoff before the second attempt; doubles per attempt.
         backoff_cap_seconds: Upper bound on the backoff window.
-        sleep: Injectable for tests.
+        sleep: Injectable for tests; defaults to time.sleep, resolved at call time so
+            monkeypatching the time module works for callers that can't pass this through.
     """
+    sleep_fn = time.sleep if sleep is None else sleep
     for attempt in range(1, max_attempts + 1):
         try:
             return fn()
@@ -91,5 +104,5 @@ def retry_transient(
                 delay,
                 error,
             )
-            sleep(delay)
+            sleep_fn(delay)
     raise AssertionError("unreachable: loop either returns or raises")

--- a/nominal/experimental/migration/utils/retry_utils.py
+++ b/nominal/experimental/migration/utils/retry_utils.py
@@ -29,11 +29,15 @@ DEFAULT_MAX_ATTEMPTS = 5
 DEFAULT_BACKOFF_BASE_SECONDS = 1.0
 DEFAULT_BACKOFF_CAP_SECONDS = 60.0
 
-# 429 is throttling; the 5xx set covers transient server-side failures. 4xx (other than 429)
-# means the request itself is wrong and will fail identically on every attempt.
-_RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+# 408/429 are timeout and throttling; every 5xx is server-side, including codes proxies invent
+# (e.g. CDN 520–524). Enumerating specific 5xx codes is what left 502 unretried in the conjure
+# client's forcelist — match on the class instead. Any other 4xx means the request itself is
+# wrong and will fail identically on every attempt. Mirrors _is_transient_upload_error in
+# nominal/experimental/ingest/_multipart_uploader.py.
+_RETRYABLE_EXACT_STATUS_CODES = frozenset({408, 429})
 
-# The standard retryable gRPC statuses: server unreachable/overloaded or the deadline hit.
+# The standard retryable gRPC statuses: server unreachable, quota/throttle exhausted, or the
+# deadline hit.
 _RETRYABLE_GRPC_STATUS_CODES = frozenset(
     {grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.DEADLINE_EXCEEDED, grpc.StatusCode.RESOURCE_EXHAUSTED}
 )
@@ -43,7 +47,9 @@ def is_transient_error(error: BaseException) -> bool:
     """Whether an exception is a transient network/server failure worth retrying."""
     # Covers ConjureHTTPError too: it subclasses HTTPError and keeps `.response`.
     if isinstance(error, requests.exceptions.HTTPError):
-        return error.response is not None and error.response.status_code in _RETRYABLE_STATUS_CODES
+        return error.response is not None and (
+            error.response.status_code in _RETRYABLE_EXACT_STATUS_CODES or error.response.status_code >= 500
+        )
     # Requests-level connection/timeout failures, plus the urllib3/socket errors that
     # streaming a source download straight into an upload surfaces without the requests
     # wrappers (e.g. ProtocolError(ConnectionResetError(104, ...))).
@@ -73,7 +79,10 @@ def is_transient_error(error: BaseException) -> bool:
     # errors (the group itself has no __cause__), and each member — like translate_grpc_errors'
     # output — chains the real failure via __cause__. Classify by what's underneath.
     if isinstance(error, BaseExceptionGroup):
-        return any(is_transient_error(inner) for inner in error.exceptions)
+        # A group is a set of failed attempts: transient only if every attempt was, matching
+        # _is_transient_upload_error — a permanent failure anywhere (e.g. a 403 from rotated
+        # credentials) means a retry would spend the whole transfer to fail the same way.
+        return all(is_transient_error(inner) for inner in error.exceptions)
     if error.__cause__ is not None:
         return is_transient_error(error.__cause__)
     return False

--- a/nominal/experimental/migration/utils/video_file_utils.py
+++ b/nominal/experimental/migration/utils/video_file_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
@@ -10,10 +11,11 @@ import requests
 
 from nominal.core._utils.filenames import sanitize_upload_filename
 from nominal.core._video_types import McapVideoDetails, TimestampOptions
-from nominal.core.exceptions import NominalIngestTimeout, NominalVideoFileMetadataError
+from nominal.core.exceptions import NominalIngestFailed, NominalIngestTimeout, NominalVideoFileMetadataError
 from nominal.core.filetype import FileTypes
 from nominal.core.video import Video
 from nominal.core.video_file import VideoFile
+from nominal.experimental.migration.utils.retry_utils import retry_transient
 
 logger = logging.getLogger(__name__)
 
@@ -24,11 +26,21 @@ DEFAULT_INGEST_POLL_TIMEOUT = timedelta(hours=2)
 @dataclass(frozen=True)
 class VideoFileCopyOutcome:
     """`file` is what was created (record it in state); `skip_reason` is set when the copy was
-    less than a clean success. A timed-out ingest sets both.
+    less than a clean success. A timed-out or failed ingest sets both.
     """
 
     file: VideoFile | None
     skip_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class _IngestOutcome:
+    """`failed` marks a terminal destination-side ingest error (as opposed to a timeout),
+    which downstream steps like the timestamp update must not run against.
+    """
+
+    skip_reason: str | None = None
+    failed: bool = False
 
 
 def copy_video_file_to_video_dataset(
@@ -52,6 +64,58 @@ def copy_video_file_to_video_dataset(
         )
         return VideoFileCopyOutcome(file=None, skip_reason=f"unusable at source: {error}")
 
+    # Download + upload retry as one unit: the source download is streamed straight into the
+    # upload, so a connection broken in either leg restarts from a fresh presigned URI. A
+    # failed upload creates no destination file record, so re-running does not duplicate.
+    new_file = retry_transient(
+        lambda: _upload_to_destination(
+            source_video_file, destination_video_dataset, mcap_video_details, timestamp_options
+        ),
+        description=f"copy of video file {source_video_file.rid}",
+    )
+
+    ingest_outcome = _await_ingestion(new_file, poll_timeout)
+    update_skip_reason: str | None = None
+    if timestamp_options is not None and not ingest_outcome.failed:
+        # Applied even on timeout: the copy is recorded as migrated either way, so no rerun
+        # will come back to set the video's timing. Skipped when ingest failed outright —
+        # the file needs hand-checking anyway.
+        try:
+            retry_transient(
+                lambda: new_file.update(
+                    starting_timestamp=timestamp_options.starting_timestamp,
+                    ending_timestamp=timestamp_options.ending_timestamp,
+                ),
+                description=f"timestamp update for video file {new_file.rid}",
+            )
+        except Exception as error:
+            # The upload and ingest already succeeded — failing the whole copy here would
+            # abort the asset and leave a rerun to upload a duplicate. Record the file as
+            # migrated and surface the unset timing in the end-of-run summary instead.
+            logger.warning(
+                "Timestamp update failed for video file (rid: %s): %s", new_file.rid, error, extra=log_extras
+            )
+            update_skip_reason = (
+                f"copied but the timestamp update was rejected: {error}; "
+                f"a rerun will not retry it — set timing on {new_file.rid} by hand"
+            )
+
+    skip_reasons = [reason for reason in (ingest_outcome.skip_reason, update_skip_reason) if reason is not None]
+    logger.debug(
+        "New video file created %s in video dataset: %s (rid: %s)",
+        new_file.name,
+        destination_video_dataset.name,
+        destination_video_dataset.rid,
+    )
+    return VideoFileCopyOutcome(file=new_file, skip_reason="; ".join(skip_reasons) if skip_reasons else None)
+
+
+def _upload_to_destination(
+    source_video_file: VideoFile,
+    destination_video_dataset: Video,
+    mcap_video_details: McapVideoDetails | None,
+    timestamp_options: TimestampOptions | None,
+) -> VideoFile:
     old_file_uri = source_video_file._clients.catalog.get_video_file_uri(
         source_video_file._clients.auth_header, source_video_file.rid
     ).uri
@@ -59,58 +123,25 @@ def copy_video_file_to_video_dataset(
     # timeout bounds connect and per-chunk reads — the same stalled-server hang the poll deadline catches.
     response = requests.get(old_file_uri, stream=True, timeout=60)
     response.raise_for_status()
+    raw_video_stream = cast(BinaryIO, response.raw)
 
-    outcome = _create_destination_video_file(
-        source_video_file,
-        destination_video_dataset,
-        cast(BinaryIO, response.raw),
-        mcap_video_details,
-        timestamp_options,
-        poll_timeout,
-    )
-    logger.debug(
-        "New video file created %s in video dataset: %s (rid: %s)",
-        outcome.file.name if outcome.file else None,
-        destination_video_dataset.name,
-        destination_video_dataset.rid,
-    )
-    return outcome
-
-
-def _create_destination_video_file(
-    source_video_file: VideoFile,
-    destination_video_dataset: Video,
-    raw_video_stream: BinaryIO,
-    mcap_video_details: McapVideoDetails | None,
-    timestamp_options: TimestampOptions | None,
-    poll_timeout: timedelta | None,
-) -> VideoFileCopyOutcome:
     file_stem = sanitize_upload_filename(_resolve_destination_file_stem(source_video_file.name))
     if timestamp_options is not None:
-        new_file = destination_video_dataset.add_from_io(
+        return destination_video_dataset.add_from_io(
             video=raw_video_stream,
             name=file_stem,
             start=timestamp_options.starting_timestamp,
             description=source_video_file.description,
         )
-        skip_reason = _await_ingestion(new_file, poll_timeout)
-        # Applied even on timeout: the copy is recorded as migrated either way, so no rerun
-        # will come back to set the video's timing.
-        new_file.update(
-            starting_timestamp=timestamp_options.starting_timestamp,
-            ending_timestamp=timestamp_options.ending_timestamp,
-        )
-        return VideoFileCopyOutcome(file=new_file, skip_reason=skip_reason)
 
     if mcap_video_details is not None:
-        new_file = destination_video_dataset.add_mcap_from_io(
+        return destination_video_dataset.add_mcap_from_io(
             mcap=raw_video_stream,
             name=file_stem,
             topic=mcap_video_details.mcap_channel_locator_topic,
             description=source_video_file.description,
             file_type=FileTypes.MCAP,
         )
-        return VideoFileCopyOutcome(file=new_file, skip_reason=_await_ingestion(new_file, poll_timeout))
 
     raise ValueError(
         "Unsupported video file ingest options for copying video file. "
@@ -118,17 +149,45 @@ def _create_destination_video_file(
     )
 
 
-def _await_ingestion(new_file: VideoFile, poll_timeout: timedelta | None) -> str | None:
-    """Wait for a copied video to finish ingesting; return a skip reason on timeout."""
+def _await_ingestion(new_file: VideoFile, poll_timeout: timedelta | None) -> _IngestOutcome:
+    """Wait for a copied video to finish ingesting; return a skip reason on timeout or failure."""
+    deadline = None if poll_timeout is None else time.monotonic() + poll_timeout.total_seconds()
+    first_attempt = True
+
+    def _poll() -> None:
+        nonlocal first_attempt
+        if first_attempt:
+            first_attempt = False
+            remaining = poll_timeout
+        else:
+            # Resume against the original deadline, so flaky status checks don't stretch the budget.
+            remaining = None if deadline is None else timedelta(seconds=max(0.0, deadline - time.monotonic()))
+        new_file.poll_until_ingestion_completed(timeout=remaining)
+
     try:
-        new_file.poll_until_ingestion_completed(timeout=poll_timeout)
+        # A transient error on a single status check (e.g. a 502 from a gateway) must not
+        # abandon an upload that already succeeded — a rerun would duplicate the file.
+        retry_transient(_poll, description=f"ingest status poll for video file {new_file.rid}")
     except NominalIngestTimeout as error:
         logger.warning("Video file (rid: %s) did not finish ingesting: %s", new_file.rid, error)
-        return (
-            f"upload succeeded but ingest did not complete within {poll_timeout}; "
-            f"a rerun will not retry it — check {new_file.rid} by hand"
+        return _IngestOutcome(
+            skip_reason=(
+                f"upload succeeded but ingest did not complete within {poll_timeout}; "
+                f"a rerun will not retry it — check {new_file.rid} by hand"
+            )
         )
-    return None
+    except NominalIngestFailed as error:
+        # The destination rejected the media itself (e.g. a segmentation failure) — re-uploading
+        # the same bytes cannot help, so record it as a skip instead of failing the asset.
+        logger.warning("Video file (rid: %s) failed to ingest at destination: %s", new_file.rid, error)
+        return _IngestOutcome(
+            skip_reason=(
+                f"upload succeeded but ingest failed at destination: {error}; "
+                f"a rerun will not retry it — check {new_file.rid} by hand"
+            ),
+            failed=True,
+        )
+    return _IngestOutcome()
 
 
 def _resolve_destination_file_stem(file_name: str) -> str:

--- a/nominal/experimental/migration/utils/video_file_utils.py
+++ b/nominal/experimental/migration/utils/video_file_utils.py
@@ -42,7 +42,11 @@ def copy_video_file_to_video_dataset(
     logger.debug("Copying video file: %s", source_video_file.name, extra=log_extras)
 
     try:
-        (mcap_video_details, timestamp_options) = source_video_file._get_file_ingest_options()
+        # NominalVideoFileMetadataError is permanent, so it still raises on the first attempt.
+        (mcap_video_details, timestamp_options) = retry_transient(
+            source_video_file._get_file_ingest_options,
+            description=f"ingest options for video file {source_video_file.rid}",
+        )
     except NominalVideoFileMetadataError as error:
         # Unusable where it already lives; retrying cannot help. Skip it, not the whole asset.
         logger.warning(
@@ -168,9 +172,20 @@ def _finish_copy(
                 description=f"timestamp update for video file {new_file.rid}",
             )
         except Exception as error:
-            logger.warning("Timestamp update failed for video file (rid: %s): %s", new_file.rid, error)
+            # The sent values come from the source's segment metadata; recording them here is
+            # often the only way to diagnose a destination-side rejection (the server may not
+            # say which argument it refused).
+            logger.warning(
+                "Timestamp update failed for video file (rid: %s), sent starting_timestamp=%s ending_timestamp=%s: %s",
+                new_file.rid,
+                timestamp_options.starting_timestamp,
+                timestamp_options.ending_timestamp,
+                error,
+            )
             skip_reasons.append(
-                f"the timestamp update was rejected: {error}; "
+                f"the timestamp update was rejected: {error} "
+                f"(sent starting_timestamp={timestamp_options.starting_timestamp}, "
+                f"ending_timestamp={timestamp_options.ending_timestamp}); "
                 f"a rerun will not retry it — set timing on {new_file.rid} by hand"
             )
 

--- a/nominal/experimental/migration/utils/video_file_utils.py
+++ b/nominal/experimental/migration/utils/video_file_utils.py
@@ -33,16 +33,6 @@ class VideoFileCopyOutcome:
     skip_reason: str | None = None
 
 
-@dataclass(frozen=True)
-class _IngestOutcome:
-    """`failed` marks a terminal destination-side ingest error (as opposed to a timeout),
-    which downstream steps like the timestamp update must not run against.
-    """
-
-    skip_reason: str | None = None
-    failed: bool = False
-
-
 def copy_video_file_to_video_dataset(
     source_video_file: VideoFile,
     destination_video_dataset: Video,
@@ -66,7 +56,9 @@ def copy_video_file_to_video_dataset(
 
     # Download + upload retry as one unit: the source download is streamed straight into the
     # upload, so a connection broken in either leg restarts from a fresh presigned URI. A
-    # failed upload creates no destination file record, so re-running does not duplicate.
+    # failure during the transfer itself creates no destination record; only a failure in the
+    # upload call's final registration step can leave one behind, in which case the retry may
+    # strand a duplicate file — never a duplicate mapping.
     new_file = retry_transient(
         lambda: _upload_to_destination(
             source_video_file, destination_video_dataset, mcap_video_details, timestamp_options
@@ -74,40 +66,23 @@ def copy_video_file_to_video_dataset(
         description=f"copy of video file {source_video_file.rid}",
     )
 
-    ingest_outcome = _await_ingestion(new_file, poll_timeout)
-    update_skip_reason: str | None = None
-    if timestamp_options is not None and not ingest_outcome.failed:
-        # Applied even on timeout: the copy is recorded as migrated either way, so no rerun
-        # will come back to set the video's timing. Skipped when ingest failed outright —
-        # the file needs hand-checking anyway.
-        try:
-            retry_transient(
-                lambda: new_file.update(
-                    starting_timestamp=timestamp_options.starting_timestamp,
-                    ending_timestamp=timestamp_options.ending_timestamp,
-                ),
-                description=f"timestamp update for video file {new_file.rid}",
-            )
-        except Exception as error:
-            # The upload and ingest already succeeded — failing the whole copy here would
-            # abort the asset and leave a rerun to upload a duplicate. Record the file as
-            # migrated and surface the unset timing in the end-of-run summary instead.
-            logger.warning(
-                "Timestamp update failed for video file (rid: %s): %s", new_file.rid, error, extra=log_extras
-            )
-            update_skip_reason = (
-                f"copied but the timestamp update was rejected: {error}; "
-                f"a rerun will not retry it — set timing on {new_file.rid} by hand"
-            )
-
-    skip_reasons = [reason for reason in (ingest_outcome.skip_reason, update_skip_reason) if reason is not None]
+    # From here the destination file exists, so every path must return it — the caller records
+    # the mapping, and an escaping exception would leave a rerun to upload a duplicate.
+    try:
+        skip_reason = _finish_copy(new_file, timestamp_options, poll_timeout)
+    except Exception as error:
+        logger.warning("Post-upload steps failed for video file (rid: %s): %s", new_file.rid, error, extra=log_extras)
+        skip_reason = (
+            f"upload succeeded but its ingest could not be confirmed: {error}; "
+            f"a rerun will not retry it — check {new_file.rid} by hand"
+        )
     logger.debug(
         "New video file created %s in video dataset: %s (rid: %s)",
         new_file.name,
         destination_video_dataset.name,
         destination_video_dataset.rid,
     )
-    return VideoFileCopyOutcome(file=new_file, skip_reason="; ".join(skip_reasons) if skip_reasons else None)
+    return VideoFileCopyOutcome(file=new_file, skip_reason=skip_reason)
 
 
 def _upload_to_destination(
@@ -120,28 +95,30 @@ def _upload_to_destination(
         source_video_file._clients.auth_header, source_video_file.rid
     ).uri
 
-    # timeout bounds connect and per-chunk reads — the same stalled-server hang the poll deadline catches.
-    response = requests.get(old_file_uri, stream=True, timeout=60)
-    response.raise_for_status()
-    raw_video_stream = cast(BinaryIO, response.raw)
+    # timeout bounds connect and per-chunk reads — the same stalled-server hang the poll deadline
+    # catches. The context manager closes the connection on every exit path, so a failed attempt
+    # doesn't strand a partially-drained socket for each retry.
+    with requests.get(old_file_uri, stream=True, timeout=60) as response:
+        response.raise_for_status()
+        raw_video_stream = cast(BinaryIO, response.raw)
 
-    file_stem = sanitize_upload_filename(_resolve_destination_file_stem(source_video_file.name))
-    if timestamp_options is not None:
-        return destination_video_dataset.add_from_io(
-            video=raw_video_stream,
-            name=file_stem,
-            start=timestamp_options.starting_timestamp,
-            description=source_video_file.description,
-        )
+        file_stem = sanitize_upload_filename(_resolve_destination_file_stem(source_video_file.name))
+        if timestamp_options is not None:
+            return destination_video_dataset.add_from_io(
+                video=raw_video_stream,
+                name=file_stem,
+                start=timestamp_options.starting_timestamp,
+                description=source_video_file.description,
+            )
 
-    if mcap_video_details is not None:
-        return destination_video_dataset.add_mcap_from_io(
-            mcap=raw_video_stream,
-            name=file_stem,
-            topic=mcap_video_details.mcap_channel_locator_topic,
-            description=source_video_file.description,
-            file_type=FileTypes.MCAP,
-        )
+        if mcap_video_details is not None:
+            return destination_video_dataset.add_mcap_from_io(
+                mcap=raw_video_stream,
+                name=file_stem,
+                topic=mcap_video_details.mcap_channel_locator_topic,
+                description=source_video_file.description,
+                file_type=FileTypes.MCAP,
+            )
 
     raise ValueError(
         "Unsupported video file ingest options for copying video file. "
@@ -149,45 +126,74 @@ def _upload_to_destination(
     )
 
 
-def _await_ingestion(new_file: VideoFile, poll_timeout: timedelta | None) -> _IngestOutcome:
-    """Wait for a copied video to finish ingesting; return a skip reason on timeout or failure."""
-    deadline = None if poll_timeout is None else time.monotonic() + poll_timeout.total_seconds()
-    first_attempt = True
-
-    def _poll() -> None:
-        nonlocal first_attempt
-        if first_attempt:
-            first_attempt = False
-            remaining = poll_timeout
-        else:
-            # Resume against the original deadline, so flaky status checks don't stretch the budget.
-            remaining = None if deadline is None else timedelta(seconds=max(0.0, deadline - time.monotonic()))
-        new_file.poll_until_ingestion_completed(timeout=remaining)
-
+def _finish_copy(
+    new_file: VideoFile,
+    timestamp_options: TimestampOptions | None,
+    poll_timeout: timedelta | None,
+) -> str | None:
+    """Wait for ingest and apply source timing; a non-None return is the skip reason for a
+    less-than-clean copy. May raise — the caller converts that into a skip too, so the
+    already-uploaded file is always recorded as migrated.
+    """
+    skip_reasons: list[str] = []
+    ingest_failed = False
     try:
-        # A transient error on a single status check (e.g. a 502 from a gateway) must not
-        # abandon an upload that already succeeded — a rerun would duplicate the file.
-        retry_transient(_poll, description=f"ingest status poll for video file {new_file.rid}")
+        _await_ingestion(new_file, poll_timeout)
     except NominalIngestTimeout as error:
         logger.warning("Video file (rid: %s) did not finish ingesting: %s", new_file.rid, error)
-        return _IngestOutcome(
-            skip_reason=(
-                f"upload succeeded but ingest did not complete within {poll_timeout}; "
-                f"a rerun will not retry it — check {new_file.rid} by hand"
-            )
+        skip_reasons.append(
+            f"upload succeeded but ingest did not complete within {poll_timeout}; "
+            f"a rerun will not retry it — check {new_file.rid} by hand"
         )
     except NominalIngestFailed as error:
         # The destination rejected the media itself (e.g. a segmentation failure) — re-uploading
-        # the same bytes cannot help, so record it as a skip instead of failing the asset.
+        # the same bytes cannot help.
         logger.warning("Video file (rid: %s) failed to ingest at destination: %s", new_file.rid, error)
-        return _IngestOutcome(
-            skip_reason=(
-                f"upload succeeded but ingest failed at destination: {error}; "
-                f"a rerun will not retry it — check {new_file.rid} by hand"
-            ),
-            failed=True,
+        skip_reasons.append(
+            f"upload succeeded but ingest failed at destination: {error}; "
+            f"a rerun will not retry it — check {new_file.rid} by hand"
         )
-    return _IngestOutcome()
+        ingest_failed = True
+
+    if timestamp_options is not None and not ingest_failed:
+        # Applied even on timeout: the copy is recorded as migrated either way, so no rerun
+        # will come back to set the video's timing. Skipped when ingest failed outright —
+        # the file needs hand-checking anyway.
+        try:
+            retry_transient(
+                lambda: new_file.update(
+                    starting_timestamp=timestamp_options.starting_timestamp,
+                    ending_timestamp=timestamp_options.ending_timestamp,
+                ),
+                description=f"timestamp update for video file {new_file.rid}",
+            )
+        except Exception as error:
+            logger.warning("Timestamp update failed for video file (rid: %s): %s", new_file.rid, error)
+            skip_reasons.append(
+                f"the timestamp update was rejected: {error}; "
+                f"a rerun will not retry it — set timing on {new_file.rid} by hand"
+            )
+
+    return "; ".join(skip_reasons) if skip_reasons else None
+
+
+def _await_ingestion(new_file: VideoFile, poll_timeout: timedelta | None) -> None:
+    """Wait for a copied video to finish ingesting.
+
+    Raises NominalIngestTimeout/NominalIngestFailed (and, past the retry budget, transient
+    polling errors) — the callers above convert those into skip-with-mapping outcomes.
+    """
+    deadline = None if poll_timeout is None else time.monotonic() + poll_timeout.total_seconds()
+
+    def _poll() -> None:
+        # Always measured against the original deadline, so retried status checks don't
+        # stretch the overall poll budget.
+        remaining = None if deadline is None else timedelta(seconds=max(0.0, deadline - time.monotonic()))
+        new_file.poll_until_ingestion_completed(timeout=remaining)
+
+    # A transient error on a single status check (e.g. a 502 from a gateway) must not
+    # abandon an upload that already succeeded — a rerun would duplicate the file.
+    retry_transient(_poll, description=f"ingest status poll for video file {new_file.rid}")
 
 
 def _resolve_destination_file_stem(file_name: str) -> str:

--- a/tests/core/test_migration_retry_utils.py
+++ b/tests/core/test_migration_retry_utils.py
@@ -1,0 +1,114 @@
+"""Transient-vs-permanent classification and backoff behavior for migration retries.
+
+Each transient case mirrors a failure observed in a real tenant migration that the conjure
+client's built-in retry did not cover (502 not in its forcelist, read errors excluded, raw
+streaming transfers bypassing it entirely).
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+import urllib3.exceptions
+
+if sys.version_info < (3, 13):
+    pytest.skip("Migration module requires Python 3.13+ (TypeVar default parameter)", allow_module_level=True)
+
+from nominal.core.exceptions import NominalIngestFailed
+from nominal.experimental.migration.utils.retry_utils import is_transient_error, retry_transient
+
+
+def _http_error(status_code: int) -> requests.exceptions.HTTPError:
+    return requests.exceptions.HTTPError(f"{status_code} error", response=MagicMock(status_code=status_code))
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        urllib3.exceptions.ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')"),
+        requests.exceptions.ReadTimeout("HTTPSConnectionPool(host='api.example.com', port=443): Read timed out."),
+        requests.exceptions.ConnectionError("connection aborted"),
+        requests.exceptions.ChunkedEncodingError("Connection broken"),
+        ConnectionResetError(104, "Connection reset by peer"),
+        _http_error(502),
+        _http_error(503),
+        _http_error(429),
+    ],
+)
+def test_transient_errors_are_classified_transient(error: BaseException) -> None:
+    assert is_transient_error(error)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        _http_error(400),
+        _http_error(403),
+        _http_error(404),
+        NominalIngestFailed("Video failed to segment. (VideoSegmenter:Internal)"),
+        ValueError("bad ingest options"),
+    ],
+)
+def test_permanent_errors_are_classified_permanent(error: BaseException) -> None:
+    assert not is_transient_error(error)
+
+
+def test_retry_transient_returns_after_transient_failures() -> None:
+    calls = {"n": 0}
+    delays: list[float] = []
+
+    def flaky() -> str:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise _http_error(502)
+        return "ok"
+
+    result = retry_transient(flaky, description="test op", sleep=delays.append)
+
+    assert result == "ok"
+    assert calls["n"] == 3
+    # Jittered exponential backoff: each delay falls inside its doubling window.
+    assert len(delays) == 2
+    assert 0 <= delays[0] <= 1.0
+    assert 0 <= delays[1] <= 2.0
+
+
+def test_retry_transient_raises_permanent_error_immediately() -> None:
+    calls = {"n": 0}
+
+    def failing() -> None:
+        calls["n"] += 1
+        raise _http_error(400)
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        retry_transient(failing, description="test op", sleep=lambda _: None)
+    assert calls["n"] == 1
+
+
+def test_retry_transient_gives_up_after_max_attempts() -> None:
+    calls = {"n": 0}
+
+    def always_transient() -> None:
+        calls["n"] += 1
+        raise requests.exceptions.ReadTimeout("Read timed out.")
+
+    with pytest.raises(requests.exceptions.ReadTimeout):
+        retry_transient(always_transient, description="test op", max_attempts=3, sleep=lambda _: None)
+    assert calls["n"] == 3
+
+
+def test_retry_transient_caps_backoff_window() -> None:
+    delays: list[float] = []
+    calls = {"n": 0}
+
+    def flaky() -> None:
+        calls["n"] += 1
+        if calls["n"] < 8:
+            raise _http_error(502)
+
+    retry_transient(flaky, description="test op", max_attempts=8, backoff_cap_seconds=4.0, sleep=delays.append)
+
+    assert all(delay <= 4.0 for delay in delays)

--- a/tests/core/test_migration_retry_utils.py
+++ b/tests/core/test_migration_retry_utils.py
@@ -20,7 +20,13 @@ if sys.version_info < (3, 13):
 import grpc
 from conjure_python_client import ConjureHTTPError
 
-from nominal.core.exceptions import NominalError, NominalIngestFailed, NominalInvalidArgumentError
+from nominal.core.exceptions import (
+    NominalError,
+    NominalIngestFailed,
+    NominalInvalidArgumentError,
+    NominalMultipartUploadError,
+    NominalMultipartUploadFailed,
+)
 from nominal.experimental.migration.utils.retry_utils import is_transient_error, retry_transient
 
 
@@ -58,6 +64,15 @@ def _grpc_translated_error(code: grpc.StatusCode, exc_type: type[NominalError] =
     return error
 
 
+def _multipart_upload_failed(status_code: int) -> NominalMultipartUploadFailed:
+    """Build the shape put_multipart_upload raises: an ExceptionGroup of per-attempt wrappers,
+    each chaining the real failure via __cause__; the group itself has no __cause__.
+    """
+    attempt_error = NominalMultipartUploadError(f"part 1, attempt 3: {status_code} error")
+    attempt_error.__cause__ = _conjure_http_error(status_code)
+    return NominalMultipartUploadFailed("Multipart upload failed after 3 attempts", [attempt_error])
+
+
 @pytest.mark.parametrize(
     "error",
     [
@@ -78,6 +93,8 @@ def _grpc_translated_error(code: grpc.StatusCode, exc_type: type[NominalError] =
         _grpc_translated_error(grpc.StatusCode.UNAVAILABLE),
         _grpc_translated_error(grpc.StatusCode.DEADLINE_EXCEEDED),
         _FakeRpcError(grpc.StatusCode.UNAVAILABLE),
+        # A 502 on sign_part surfaces as an ExceptionGroup with the real error two levels down.
+        _multipart_upload_failed(502),
     ],
 )
 def test_transient_errors_are_classified_transient(error: BaseException) -> None:
@@ -93,6 +110,7 @@ def test_transient_errors_are_classified_transient(error: BaseException) -> None
         _conjure_http_error(400, body={"errorCode": "INVALID_ARGUMENT", "errorName": "Default:InvalidArgument"}),
         _grpc_translated_error(grpc.StatusCode.INVALID_ARGUMENT, NominalInvalidArgumentError),
         _grpc_translated_error(grpc.StatusCode.NOT_FOUND),
+        _multipart_upload_failed(403),
         NominalIngestFailed("Video failed to segment. (VideoSegmenter:Internal)"),
         ValueError("bad ingest options"),
     ],

--- a/tests/core/test_migration_retry_utils.py
+++ b/tests/core/test_migration_retry_utils.py
@@ -64,13 +64,16 @@ def _grpc_translated_error(code: grpc.StatusCode, exc_type: type[NominalError] =
     return error
 
 
-def _multipart_upload_failed(root_cause: BaseException) -> NominalMultipartUploadFailed:
+def _multipart_upload_failed(*root_causes: BaseException) -> NominalMultipartUploadFailed:
     """Build the shape put_multipart_upload raises: an ExceptionGroup of per-attempt wrappers,
     each chaining the real failure via __cause__; the group itself has no __cause__.
     """
-    attempt_error = NominalMultipartUploadError(f"part 1, attempt 3: {root_cause}")
-    attempt_error.__cause__ = root_cause
-    return NominalMultipartUploadFailed("Multipart upload failed after 3 attempts", [attempt_error])
+    attempt_errors = []
+    for attempt, root_cause in enumerate(root_causes, start=1):
+        attempt_error = NominalMultipartUploadError(f"part 1, attempt {attempt}: {root_cause}")
+        attempt_error.__cause__ = root_cause
+        attempt_errors.append(attempt_error)
+    return NominalMultipartUploadFailed("Multipart upload failed after retries", attempt_errors)
 
 
 @pytest.mark.parametrize(
@@ -84,12 +87,17 @@ def _multipart_upload_failed(root_cause: BaseException) -> NominalMultipartUploa
         _http_error(502),
         _http_error(503),
         _http_error(429),
+        _http_error(408),
+        # 5xx match on the class, not an enumeration — proxies invent codes (CDN 520-524).
+        _http_error(520),
         # The ingest status poll goes through conjure — if ConjureHTTPError ever stops carrying
         # `.response`, 502s during polling silently become permanent. Pin the real class.
         _conjure_http_error(502),
         _conjure_http_error(503, body={"errorCode": "UNAVAILABLE", "errorName": "Default:Unavailable"}),
-        # The multipart upload leg is gRPC: connection refused arrives as a NominalError
-        # chaining an UNAVAILABLE grpc.RpcError (via translate_grpc_errors).
+        # The upload leg's first destination call (workspace resolution in add_from_io) is
+        # gRPC: the live e2e test (test_retry_e2e.py) hit exactly this shape — connection
+        # refused arriving as a NominalError chaining an UNAVAILABLE grpc.RpcError via
+        # translate_grpc_errors.
         _grpc_translated_error(grpc.StatusCode.UNAVAILABLE),
         _grpc_translated_error(grpc.StatusCode.DEADLINE_EXCEEDED),
         _FakeRpcError(grpc.StatusCode.UNAVAILABLE),
@@ -116,6 +124,9 @@ def test_transient_errors_are_classified_transient(error: BaseException) -> None
         _grpc_translated_error(grpc.StatusCode.INVALID_ARGUMENT, NominalInvalidArgumentError),
         _grpc_translated_error(grpc.StatusCode.NOT_FOUND),
         _multipart_upload_failed(_conjure_http_error(403)),
+        # A permanent failure anywhere in the attempt group decides: retrying the whole
+        # transfer would fail the same way (e.g. rotated credentials after one 502).
+        _multipart_upload_failed(_conjure_http_error(502), _conjure_http_error(403)),
         NominalIngestFailed("Video failed to segment. (VideoSegmenter:Internal)"),
         ValueError("bad ingest options"),
     ],

--- a/tests/core/test_migration_retry_utils.py
+++ b/tests/core/test_migration_retry_utils.py
@@ -64,12 +64,12 @@ def _grpc_translated_error(code: grpc.StatusCode, exc_type: type[NominalError] =
     return error
 
 
-def _multipart_upload_failed(status_code: int) -> NominalMultipartUploadFailed:
+def _multipart_upload_failed(root_cause: BaseException) -> NominalMultipartUploadFailed:
     """Build the shape put_multipart_upload raises: an ExceptionGroup of per-attempt wrappers,
     each chaining the real failure via __cause__; the group itself has no __cause__.
     """
-    attempt_error = NominalMultipartUploadError(f"part 1, attempt 3: {status_code} error")
-    attempt_error.__cause__ = _conjure_http_error(status_code)
+    attempt_error = NominalMultipartUploadError(f"part 1, attempt 3: {root_cause}")
+    attempt_error.__cause__ = root_cause
     return NominalMultipartUploadFailed("Multipart upload failed after 3 attempts", [attempt_error])
 
 
@@ -94,7 +94,12 @@ def _multipart_upload_failed(status_code: int) -> NominalMultipartUploadFailed:
         _grpc_translated_error(grpc.StatusCode.DEADLINE_EXCEEDED),
         _FakeRpcError(grpc.StatusCode.UNAVAILABLE),
         # A 502 on sign_part surfaces as an ExceptionGroup with the real error two levels down.
-        _multipart_upload_failed(502),
+        _multipart_upload_failed(_conjure_http_error(502)),
+        # The multipart session's own urllib3 Retry exhausting its budget on sustained S3 5xx
+        # raises RetryError with no __cause__ — it must be transient by type alone.
+        requests.exceptions.RetryError("too many 503 error responses"),
+        urllib3.exceptions.MaxRetryError(MagicMock(), "https://s3.example.com/part"),
+        _multipart_upload_failed(requests.exceptions.RetryError("too many 503 error responses")),
     ],
 )
 def test_transient_errors_are_classified_transient(error: BaseException) -> None:
@@ -110,7 +115,7 @@ def test_transient_errors_are_classified_transient(error: BaseException) -> None
         _conjure_http_error(400, body={"errorCode": "INVALID_ARGUMENT", "errorName": "Default:InvalidArgument"}),
         _grpc_translated_error(grpc.StatusCode.INVALID_ARGUMENT, NominalInvalidArgumentError),
         _grpc_translated_error(grpc.StatusCode.NOT_FOUND),
-        _multipart_upload_failed(403),
+        _multipart_upload_failed(_conjure_http_error(403)),
         NominalIngestFailed("Video failed to segment. (VideoSegmenter:Internal)"),
         ValueError("bad ingest options"),
     ],

--- a/tests/core/test_migration_retry_utils.py
+++ b/tests/core/test_migration_retry_utils.py
@@ -17,12 +17,45 @@ import urllib3.exceptions
 if sys.version_info < (3, 13):
     pytest.skip("Migration module requires Python 3.13+ (TypeVar default parameter)", allow_module_level=True)
 
-from nominal.core.exceptions import NominalIngestFailed
+import grpc
+from conjure_python_client import ConjureHTTPError
+
+from nominal.core.exceptions import NominalError, NominalIngestFailed, NominalInvalidArgumentError
 from nominal.experimental.migration.utils.retry_utils import is_transient_error, retry_transient
 
 
 def _http_error(status_code: int) -> requests.exceptions.HTTPError:
     return requests.exceptions.HTTPError(f"{status_code} error", response=MagicMock(status_code=status_code))
+
+
+def _conjure_http_error(status_code: int, body: dict | None = None) -> ConjureHTTPError:
+    """Build a ConjureHTTPError the way the conjure client raises it, so the classification
+    test exercises the real class rather than a mock stand-in.
+    """
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = {"X-B3-TraceId": "abc123"}
+    if body is None:
+        response.json.side_effect = ValueError("no json body")
+        response.text = "gateway error"
+    else:
+        response.json.return_value = body
+    return ConjureHTTPError(requests.exceptions.HTTPError(f"{status_code} error", response=response))
+
+
+class _FakeRpcError(grpc.RpcError):
+    def __init__(self, code: grpc.StatusCode) -> None:
+        self._code = code
+
+    def code(self) -> grpc.StatusCode:
+        return self._code
+
+
+def _grpc_translated_error(code: grpc.StatusCode, exc_type: type[NominalError] = NominalError) -> NominalError:
+    """Build the shape translate_grpc_errors raises: a NominalError chaining the grpc.RpcError."""
+    error = exc_type(f"{code}: boom")
+    error.__cause__ = _FakeRpcError(code)
+    return error
 
 
 @pytest.mark.parametrize(
@@ -36,6 +69,15 @@ def _http_error(status_code: int) -> requests.exceptions.HTTPError:
         _http_error(502),
         _http_error(503),
         _http_error(429),
+        # The ingest status poll goes through conjure — if ConjureHTTPError ever stops carrying
+        # `.response`, 502s during polling silently become permanent. Pin the real class.
+        _conjure_http_error(502),
+        _conjure_http_error(503, body={"errorCode": "UNAVAILABLE", "errorName": "Default:Unavailable"}),
+        # The multipart upload leg is gRPC: connection refused arrives as a NominalError
+        # chaining an UNAVAILABLE grpc.RpcError (via translate_grpc_errors).
+        _grpc_translated_error(grpc.StatusCode.UNAVAILABLE),
+        _grpc_translated_error(grpc.StatusCode.DEADLINE_EXCEEDED),
+        _FakeRpcError(grpc.StatusCode.UNAVAILABLE),
     ],
 )
 def test_transient_errors_are_classified_transient(error: BaseException) -> None:
@@ -48,6 +90,9 @@ def test_transient_errors_are_classified_transient(error: BaseException) -> None
         _http_error(400),
         _http_error(403),
         _http_error(404),
+        _conjure_http_error(400, body={"errorCode": "INVALID_ARGUMENT", "errorName": "Default:InvalidArgument"}),
+        _grpc_translated_error(grpc.StatusCode.INVALID_ARGUMENT, NominalInvalidArgumentError),
+        _grpc_translated_error(grpc.StatusCode.NOT_FOUND),
         NominalIngestFailed("Video failed to segment. (VideoSegmenter:Internal)"),
         ValueError("bad ingest options"),
     ],

--- a/tests/core/test_video_file_migrator.py
+++ b/tests/core/test_video_file_migrator.py
@@ -12,7 +12,10 @@ import pytest
 if sys.version_info < (3, 13):
     pytest.skip("Migration module requires Python 3.13+ (TypeVar default parameter)", allow_module_level=True)
 
-from nominal.core.exceptions import NominalIngestTimeout, NominalVideoFileMetadataError
+import requests
+import urllib3.exceptions
+
+from nominal.core.exceptions import NominalIngestFailed, NominalIngestTimeout, NominalVideoFileMetadataError
 from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.migrator.context import MigrationContext
 from nominal.experimental.migration.migrator.video_file_migrator import VideoFileMigrator
@@ -178,6 +181,151 @@ def test_video_ingest_timeout_is_threaded_through_from_context(monkeypatch: pyte
     VideoFileMigrator(ctx).copy_from(source_file, destination_video)
 
     new_file.poll_until_ingestion_completed.assert_called_once_with(timeout=timedelta(seconds=5))
+
+
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nominal.experimental.migration.utils.retry_utils.time.sleep", lambda _seconds: None)
+
+
+def _mock_stream_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "nominal.experimental.migration.utils.video_file_utils.requests.get",
+        lambda *args, **kwargs: MagicMock(raw=MagicMock()),
+    )
+
+
+def _http_error(status_code: int) -> requests.exceptions.HTTPError:
+    return requests.exceptions.HTTPError(f"{status_code} error", response=MagicMock(status_code=status_code))
+
+
+def test_connection_broken_mid_transfer_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A connection reset while streaming source bytes into the upload restarts the transfer."""
+    _no_sleep(monkeypatch)
+    _mock_stream_response(monkeypatch)
+    ctx = _make_context()
+    source_file = _make_source_video_file(_video_file_rid(7))
+    source_file._get_file_ingest_options.return_value = (None, _timestamp_options())
+
+    new_file = MagicMock()
+    new_file.rid = _video_file_rid(70)
+    new_file.poll_until_ingestion_completed.return_value = None
+    destination_video = _make_destination_video(new_file)
+    destination_video.add_from_io.side_effect = [
+        urllib3.exceptions.ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')"),
+        new_file,
+    ]
+
+    VideoFileMigrator(ctx).copy_from(source_file, destination_video)
+
+    assert destination_video.add_from_io.call_count == 2
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) == new_file.rid
+    assert ctx.migration_state.skipped_resources == []
+
+
+def test_transient_error_during_ingest_poll_does_not_reupload(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 502 on a single status check must not abandon a finished upload — polling resumes instead."""
+    _no_sleep(monkeypatch)
+    _mock_stream_response(monkeypatch)
+    ctx = _make_context()
+    source_file = _make_source_video_file(_video_file_rid(8))
+    source_file._get_file_ingest_options.return_value = (None, _timestamp_options())
+
+    new_file = MagicMock()
+    new_file.rid = _video_file_rid(80)
+    new_file.poll_until_ingestion_completed.side_effect = [_http_error(502), None]
+    destination_video = _make_destination_video(new_file)
+
+    VideoFileMigrator(ctx).copy_from(source_file, destination_video)
+
+    assert destination_video.add_from_io.call_count == 1
+    assert new_file.poll_until_ingestion_completed.call_count == 2
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) == new_file.rid
+    assert ctx.migration_state.skipped_resources == []
+
+
+def test_destination_ingest_failure_records_mapping_and_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A terminal destination-side ingest error (e.g. segmentation failure) is a skip, not an abort."""
+    _mock_stream_response(monkeypatch)
+    ctx = _make_context()
+    source_file = _make_source_video_file(_video_file_rid(9))
+    source_file._get_file_ingest_options.return_value = (None, _timestamp_options())
+
+    new_file = MagicMock()
+    new_file.rid = _video_file_rid(90)
+    new_file.poll_until_ingestion_completed.side_effect = NominalIngestFailed(
+        "ingest failed for video: Video failed to segment. (VideoSegmenter:Internal)"
+    )
+    destination_video = _make_destination_video(new_file)
+
+    VideoFileMigrator(ctx).copy_from(source_file, destination_video)
+
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) == new_file.rid
+    assert len(ctx.migration_state.skipped_resources) == 1
+    assert "ingest failed at destination" in ctx.migration_state.skipped_resources[0].reason
+    # The file needs hand-checking anyway; don't push timing metadata onto a failed ingest.
+    new_file.update.assert_not_called()
+
+
+def test_rejected_timestamp_update_records_mapping_and_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 400 on the post-ingest timestamp update must not abort the asset or orphan the ingested copy."""
+    _mock_stream_response(monkeypatch)
+    ctx = _make_context()
+    source_file = _make_source_video_file(_video_file_rid(10))
+    source_file._get_file_ingest_options.return_value = (None, _timestamp_options())
+
+    new_file = MagicMock()
+    new_file.rid = _video_file_rid(100)
+    new_file.poll_until_ingestion_completed.return_value = None
+    new_file.update.side_effect = _http_error(400)
+    destination_video = _make_destination_video(new_file)
+
+    VideoFileMigrator(ctx).copy_from(source_file, destination_video)
+
+    # 400 is not transient: exactly one attempt.
+    new_file.update.assert_called_once()
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) == new_file.rid
+    assert len(ctx.migration_state.skipped_resources) == 1
+    assert "timestamp update was rejected" in ctx.migration_state.skipped_resources[0].reason
+
+
+def test_unexpected_copy_failure_is_recorded_and_does_not_abort(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Any copy failure logs-and-continues: the asset task survives, and a rerun re-attempts the file."""
+    _no_sleep(monkeypatch)
+    _mock_stream_response(monkeypatch)
+    ctx = _make_context()
+    source_file = _make_source_video_file(_video_file_rid(11))
+    source_file._get_file_ingest_options.return_value = (None, _timestamp_options())
+
+    destination_video = MagicMock()
+    destination_video._clients.workspace_rid = "ws-rid"
+    destination_video.add_from_io.side_effect = requests.exceptions.ReadTimeout(
+        "HTTPSConnectionPool(host='example.invalid', port=443): Read timed out."
+    )
+
+    VideoFileMigrator(ctx).copy_from(source_file, destination_video)
+
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) is None
+    assert len(ctx.migration_state.skipped_resources) == 1
+    assert "copy failed" in ctx.migration_state.skipped_resources[0].reason
+
+
+def test_rerun_success_clears_stale_skip_from_earlier_attempt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A resource that failed transiently last run and succeeds this run is not still reported as skipped."""
+    _mock_stream_response(monkeypatch)
+    ctx = _make_context()
+    source_file = _make_source_video_file(_video_file_rid(12))
+    source_file._get_file_ingest_options.return_value = (None, _timestamp_options())
+    ctx.migration_state.record_skip(ResourceType.VIDEO_FILE, source_file.rid, "copy failed: transient")
+
+    new_file = MagicMock()
+    new_file.rid = _video_file_rid(120)
+    new_file.poll_until_ingestion_completed.return_value = None
+    destination_video = _make_destination_video(new_file)
+
+    VideoFileMigrator(ctx).copy_from(source_file, destination_video)
+
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) == new_file.rid
+    assert ctx.migration_state.skipped_resources == []
 
 
 def test_parallel_runner_passes_video_ingest_timeout_to_context(

--- a/tests/core/test_video_file_migrator.py
+++ b/tests/core/test_video_file_migrator.py
@@ -27,6 +27,7 @@ from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.migrator.context import MigrationContext
 from nominal.experimental.migration.migrator.video_file_migrator import VideoFileMigrator
 from nominal.experimental.migration.resource_type import ResourceType
+from nominal.experimental.migration.utils.retry_utils import DEFAULT_MAX_ATTEMPTS
 from nominal.experimental.migration.utils.video_file_utils import copy_video_file_to_video_dataset
 
 _STACK = "cerulean-staging"
@@ -336,6 +337,8 @@ def test_exhausted_poll_retries_record_mapping_and_skip(monkeypatch: pytest.Monk
     VideoFileMigrator(ctx).copy_from(source_file, destination_video)
 
     assert destination_video.add_from_io.call_count == 1
+    # The full budget was spent before giving up — otherwise this test passes with retries off.
+    assert new_file.poll_until_ingestion_completed.call_count == DEFAULT_MAX_ATTEMPTS
     assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) == new_file.rid
     assert len(ctx.migration_state.skipped_resources) == 1
     assert "could not be confirmed" in ctx.migration_state.skipped_resources[0].reason

--- a/tests/core/test_video_file_migrator.py
+++ b/tests/core/test_video_file_migrator.py
@@ -15,7 +15,12 @@ if sys.version_info < (3, 13):
 import requests
 import urllib3.exceptions
 
-from nominal.core.exceptions import NominalIngestFailed, NominalIngestTimeout, NominalVideoFileMetadataError
+from nominal.core.exceptions import (
+    NominalIngestError,
+    NominalIngestFailed,
+    NominalIngestTimeout,
+    NominalVideoFileMetadataError,
+)
 from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.migrator.context import MigrationContext
 from nominal.experimental.migration.migrator.video_file_migrator import VideoFileMigrator
@@ -180,7 +185,11 @@ def test_video_ingest_timeout_is_threaded_through_from_context(monkeypatch: pyte
 
     VideoFileMigrator(ctx).copy_from(source_file, destination_video)
 
-    new_file.poll_until_ingestion_completed.assert_called_once_with(timeout=timedelta(seconds=5))
+    # The poll timeout is measured against a shared deadline, so assert the bound rather than
+    # an exact value.
+    new_file.poll_until_ingestion_completed.assert_called_once()
+    passed_timeout = new_file.poll_until_ingestion_completed.call_args.kwargs["timeout"]
+    assert timedelta(0) < passed_timeout <= timedelta(seconds=5)
 
 
 def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -264,6 +273,46 @@ def test_destination_ingest_failure_records_mapping_and_skip(monkeypatch: pytest
     assert "ingest failed at destination" in ctx.migration_state.skipped_resources[0].reason
     # The file needs hand-checking anyway; don't push timing metadata onto a failed ingest.
     new_file.update.assert_not_called()
+
+
+def test_unknown_ingest_status_records_mapping_and_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Any post-upload failure — even an unexpected one — must map the copy, or a rerun duplicates it."""
+    _mock_stream_response(monkeypatch)
+    ctx = _make_context()
+    source_file = _make_source_video_file(_video_file_rid(13))
+    source_file._get_file_ingest_options.return_value = (None, _timestamp_options())
+
+    new_file = MagicMock()
+    new_file.rid = _video_file_rid(130)
+    new_file.poll_until_ingestion_completed.side_effect = NominalIngestError("unhandled ingest status 'mystery'")
+    destination_video = _make_destination_video(new_file)
+
+    VideoFileMigrator(ctx).copy_from(source_file, destination_video)
+
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) == new_file.rid
+    assert len(ctx.migration_state.skipped_resources) == 1
+    assert "could not be confirmed" in ctx.migration_state.skipped_resources[0].reason
+
+
+def test_exhausted_poll_retries_record_mapping_and_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 502 that outlasts the retry budget after a successful upload maps the copy — no rerun re-upload."""
+    _no_sleep(monkeypatch)
+    _mock_stream_response(monkeypatch)
+    ctx = _make_context()
+    source_file = _make_source_video_file(_video_file_rid(14))
+    source_file._get_file_ingest_options.return_value = (None, _timestamp_options())
+
+    new_file = MagicMock()
+    new_file.rid = _video_file_rid(140)
+    new_file.poll_until_ingestion_completed.side_effect = _http_error(502)
+    destination_video = _make_destination_video(new_file)
+
+    VideoFileMigrator(ctx).copy_from(source_file, destination_video)
+
+    assert destination_video.add_from_io.call_count == 1
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) == new_file.rid
+    assert len(ctx.migration_state.skipped_resources) == 1
+    assert "could not be confirmed" in ctx.migration_state.skipped_resources[0].reason
 
 
 def test_rejected_timestamp_update_records_mapping_and_skip(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/core/test_video_file_migrator.py
+++ b/tests/core/test_video_file_migrator.py
@@ -19,6 +19,8 @@ from nominal.core.exceptions import (
     NominalIngestError,
     NominalIngestFailed,
     NominalIngestTimeout,
+    NominalMultipartUploadError,
+    NominalMultipartUploadFailed,
     NominalVideoFileMetadataError,
 )
 from nominal.experimental.migration.migration_state import MigrationState
@@ -196,11 +198,17 @@ def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("nominal.experimental.migration.utils.retry_utils.time.sleep", lambda _seconds: None)
 
 
-def _mock_stream_response(monkeypatch: pytest.MonkeyPatch) -> None:
+def _mock_stream_response(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Stub the streamed source download as the context manager the code enters; returns the
+    context-manager mock so tests can assert per-attempt open/close.
+    """
+    stream = MagicMock()
+    stream.__enter__.return_value = MagicMock(raw=MagicMock())
     monkeypatch.setattr(
         "nominal.experimental.migration.utils.video_file_utils.requests.get",
-        lambda *args, **kwargs: MagicMock(raw=MagicMock()),
+        lambda *args, **kwargs: stream,
     )
+    return stream
 
 
 def _http_error(status_code: int) -> requests.exceptions.HTTPError:
@@ -210,7 +218,7 @@ def _http_error(status_code: int) -> requests.exceptions.HTTPError:
 def test_connection_broken_mid_transfer_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
     """A connection reset while streaming source bytes into the upload restarts the transfer."""
     _no_sleep(monkeypatch)
-    _mock_stream_response(monkeypatch)
+    stream = _mock_stream_response(monkeypatch)
     ctx = _make_context()
     source_file = _make_source_video_file(_video_file_rid(7))
     source_file._get_file_ingest_options.return_value = (None, _timestamp_options())
@@ -221,6 +229,36 @@ def test_connection_broken_mid_transfer_is_retried(monkeypatch: pytest.MonkeyPat
     destination_video = _make_destination_video(new_file)
     destination_video.add_from_io.side_effect = [
         urllib3.exceptions.ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')"),
+        new_file,
+    ]
+
+    VideoFileMigrator(ctx).copy_from(source_file, destination_video)
+
+    assert destination_video.add_from_io.call_count == 2
+    # The download connection is closed once per attempt — retries must not stack open sockets.
+    assert stream.__exit__.call_count == 2
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) == new_file.rid
+    assert ctx.migration_state.skipped_resources == []
+
+
+def test_multipart_upload_failure_wrapping_transient_error_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """put_multipart_upload raises an ExceptionGroup of per-attempt wrappers (no __cause__ on the
+    group itself) — a transient root cause inside it must still be retried.
+    """
+    _no_sleep(monkeypatch)
+    _mock_stream_response(monkeypatch)
+    ctx = _make_context()
+    source_file = _make_source_video_file(_video_file_rid(15))
+    source_file._get_file_ingest_options.return_value = (None, _timestamp_options())
+
+    attempt_error = NominalMultipartUploadError("part 1, attempt 3: 502 Server Error")
+    attempt_error.__cause__ = _http_error(502)
+    new_file = MagicMock()
+    new_file.rid = _video_file_rid(150)
+    new_file.poll_until_ingestion_completed.return_value = None
+    destination_video = _make_destination_video(new_file)
+    destination_video.add_from_io.side_effect = [
+        NominalMultipartUploadFailed("upload failed after retries", [attempt_error]),
         new_file,
     ]
 

--- a/tests/core/test_video_file_migrator.py
+++ b/tests/core/test_video_file_migrator.py
@@ -65,6 +65,27 @@ def _timestamp_options() -> MagicMock:
     return options
 
 
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nominal.experimental.migration.utils.retry_utils.time.sleep", lambda _seconds: None)
+
+
+def _mock_stream_response(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Stub the streamed source download as the context manager the code enters; returns the
+    context-manager mock so tests can assert per-attempt open/close.
+    """
+    stream = MagicMock()
+    stream.__enter__.return_value = MagicMock(raw=MagicMock())
+    monkeypatch.setattr(
+        "nominal.experimental.migration.utils.video_file_utils.requests.get",
+        lambda *args, **kwargs: stream,
+    )
+    return stream
+
+
+def _http_error(status_code: int) -> requests.exceptions.HTTPError:
+    return requests.exceptions.HTTPError(f"{status_code} error", response=MagicMock(status_code=status_code))
+
+
 def test_source_video_without_segment_metadata_is_skipped_not_raised() -> None:
     """A video that never finished segmenting at the source is unusable — skip it, don't abort the asset."""
     source_file = _make_source_video_file(_video_file_rid(1))
@@ -107,10 +128,7 @@ def test_ingest_timeout_records_mapping_and_skip(monkeypatch: pytest.MonkeyPatch
     new_file.poll_until_ingestion_completed.side_effect = NominalIngestTimeout("still ingesting")
     destination_video = _make_destination_video(new_file)
 
-    monkeypatch.setattr(
-        "nominal.experimental.migration.utils.video_file_utils.requests.get",
-        lambda *args, **kwargs: MagicMock(raw=MagicMock()),
-    )
+    _mock_stream_response(monkeypatch)
 
     VideoFileMigrator(ctx).copy_from(source_file, destination_video)
 
@@ -131,10 +149,7 @@ def test_successful_copy_records_mapping_and_no_skip(monkeypatch: pytest.MonkeyP
     new_file.poll_until_ingestion_completed.return_value = None
     destination_video = _make_destination_video(new_file)
 
-    monkeypatch.setattr(
-        "nominal.experimental.migration.utils.video_file_utils.requests.get",
-        lambda *args, **kwargs: MagicMock(raw=MagicMock()),
-    )
+    _mock_stream_response(monkeypatch)
 
     VideoFileMigrator(ctx).copy_from(source_file, destination_video)
 
@@ -157,10 +172,7 @@ def test_percent_encoded_source_filename_is_sanitized_before_upload(monkeypatch:
     new_file.poll_until_ingestion_completed.return_value = None
     destination_video = _make_destination_video(new_file)
 
-    monkeypatch.setattr(
-        "nominal.experimental.migration.utils.video_file_utils.requests.get",
-        lambda *args, **kwargs: MagicMock(raw=MagicMock()),
-    )
+    _mock_stream_response(monkeypatch)
 
     VideoFileMigrator(ctx).copy_from(source_file, destination_video)
 
@@ -180,10 +192,7 @@ def test_video_ingest_timeout_is_threaded_through_from_context(monkeypatch: pyte
     new_file.rid = _video_file_rid(60)
     destination_video = _make_destination_video(new_file)
 
-    monkeypatch.setattr(
-        "nominal.experimental.migration.utils.video_file_utils.requests.get",
-        lambda *args, **kwargs: MagicMock(raw=MagicMock()),
-    )
+    _mock_stream_response(monkeypatch)
 
     VideoFileMigrator(ctx).copy_from(source_file, destination_video)
 
@@ -192,27 +201,6 @@ def test_video_ingest_timeout_is_threaded_through_from_context(monkeypatch: pyte
     new_file.poll_until_ingestion_completed.assert_called_once()
     passed_timeout = new_file.poll_until_ingestion_completed.call_args.kwargs["timeout"]
     assert timedelta(0) < passed_timeout <= timedelta(seconds=5)
-
-
-def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("nominal.experimental.migration.utils.retry_utils.time.sleep", lambda _seconds: None)
-
-
-def _mock_stream_response(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
-    """Stub the streamed source download as the context manager the code enters; returns the
-    context-manager mock so tests can assert per-attempt open/close.
-    """
-    stream = MagicMock()
-    stream.__enter__.return_value = MagicMock(raw=MagicMock())
-    monkeypatch.setattr(
-        "nominal.experimental.migration.utils.video_file_utils.requests.get",
-        lambda *args, **kwargs: stream,
-    )
-    return stream
-
-
-def _http_error(status_code: int) -> requests.exceptions.HTTPError:
-    return requests.exceptions.HTTPError(f"{status_code} error", response=MagicMock(status_code=status_code))
 
 
 def test_connection_broken_mid_transfer_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -372,7 +360,11 @@ def test_rejected_timestamp_update_records_mapping_and_skip(monkeypatch: pytest.
     new_file.update.assert_called_once()
     assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) == new_file.rid
     assert len(ctx.migration_state.skipped_resources) == 1
-    assert "timestamp update was rejected" in ctx.migration_state.skipped_resources[0].reason
+    reason = ctx.migration_state.skipped_resources[0].reason
+    assert "timestamp update was rejected" in reason
+    # The sent values are recorded — often the only way to diagnose a destination-side 400.
+    assert "starting_timestamp=0" in reason
+    assert "ending_timestamp=1" in reason
 
 
 def test_unexpected_copy_failure_is_recorded_and_does_not_abort(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/e2e/migration/test_retry_e2e.py
+++ b/tests/e2e/migration/test_retry_e2e.py
@@ -1,0 +1,73 @@
+"""Live-wire check that transient network failures are retried and contained.
+
+Unlike test_migration.py (which goes through MigrationRunner against two healthy
+environments), this exercises the failure path with a real socket: a destination client
+pointed at an unreachable address makes every upload attempt raise a genuine requests
+ConnectionError, verifying end to end that the error is classified transient, retried,
+and — once the retry budget is exhausted — recorded as a skip instead of aborting.
+
+Run with:
+    uv run pytest tests/e2e/migration/test_retry_e2e.py --source-profile=<prod> -v
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from datetime import datetime, timezone
+from io import BytesIO
+from uuid import uuid4
+
+import pytest
+
+from nominal.core import NominalClient
+from nominal.experimental.migration.migration_state import MigrationState
+from nominal.experimental.migration.migrator.context import MigrationContext
+from nominal.experimental.migration.migrator.video_file_migrator import VideoFileMigrator
+from nominal.experimental.migration.resource_type import ResourceType
+from tests.e2e import POLL_INTERVAL
+
+# Connection refused is near-instant (nothing listens on the discard port), so each retry
+# attempt fails fast instead of waiting out a timeout.
+_UNREACHABLE_BASE_URL = "http://127.0.0.1:9/api"
+
+
+def test_unreachable_destination_is_retried_then_recorded_as_skip(
+    source_client: NominalClient,
+    mp4_data: bytes,
+    register_cleanup,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A real source video file, so the copy exercises the genuine metadata + download legs
+    # before the upload leg hits the unreachable destination.
+    video = source_client.create_video(f"migration-e2e-retry-{uuid4().hex[:8]}")
+    register_cleanup(video.archive)
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    video.add_from_io(BytesIO(mp4_data), "retry-test.mp4", start=start).poll_until_ingestion_completed(
+        interval=POLL_INTERVAL
+    )
+    (source_file,) = video.list_files()
+
+    bogus_client = NominalClient.create(
+        base_url=_UNREACHABLE_BASE_URL,
+        token="bogus-token",
+        # Pinned so nothing tries to resolve a workspace over the dead socket before the upload.
+        workspace_rid="ri.security.main.workspace.00000000-0000-0000-0000-000000000000",
+    )
+    # A real Video handle rebound to the unreachable client: only the upload leg fails.
+    dest_video = dataclasses.replace(source_client.get_video(video.rid), _clients=bogus_client._clients)
+
+    ctx = MigrationContext(destination_client=bogus_client, migration_state=MigrationState())
+    with caplog.at_level(logging.WARNING, logger="nominal.experimental.migration"):
+        # Must not raise: exhausted retries log-and-continue.
+        VideoFileMigrator(ctx).copy_from(source_file, dest_video)
+
+    retry_lines = [
+        record for record in caplog.records if "Transient failure in copy of video file" in record.getMessage()
+    ]
+    assert retry_lines, "expected the unreachable upload to be classified transient and retried"
+
+    # No mapping (a rerun re-attempts the file), and the failure is surfaced as a skip.
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) is None
+    assert [skipped.source_rid for skipped in ctx.migration_state.skipped_resources] == [source_file.rid]
+    assert "copy failed" in ctx.migration_state.skipped_resources[0].reason


### PR DESCRIPTION
## Context

A recent large migration ended with `Parallel migration had 6 failure(s)`, all in video file transfer, each killing an entire asset task (and every sibling resource behind it). Classified:

- **Transient, but not retried**: a connection reset mid stream, a source read timeout, and a 502 on an ingest-status poll. The conjure client's built-in retry did not cover any of them — 502 is not in its `status_forcelist` (`[308, 429, 503]`), read errors are explicitly excluded (`read=0`), and the raw `requests` streaming used for the file transfer bypasses it entirely. The 502 case was the worst: the upload had already succeeded, and the rerun would re-upload a duplicate.
- **Terminal, destination ingest failure** (video failed to segment): re-uploading the same bytes cannot help, so failing the task just repeats the failure and duplicates the upload on every rerun.
- **Terminal, 400 on the post-ingest timestamp update** (x2): the file had already ingested successfully; each rerun would strand another duplicate before failing at the same point.

## Changes

- **`retry_utils`**: jittered exponential backoff for transient failures, applied at three points in the video file copy:
  - the download+upload as one unit (the source stream feeds the upload directly, so a break in either leg restarts from a fresh presigned URI)
  - the ingest status poll, always measured against the original deadline — a dropped status check no longer abandons a finished upload
  - the timestamp update (transient errors only; a real 400 still fails fast)
- **Transient classification covers all three transports and their wrapper shapes**: requests exceptions and 429/5xx `HTTPError`s (including `ConjureHTTPError`), raw urllib3/socket errors from the streaming transfer, `RetryError`/`MaxRetryError` from a session whose own urllib3 `Retry` budget is exhausted (sustained S3 5xx on multipart part PUTs), and gRPC failures — surfacing as `NominalError` chaining a `grpc.RpcError` (UNAVAILABLE / DEADLINE_EXCEEDED / RESOURCE_EXHAUSTED retry; others don't). `ExceptionGroup`s (e.g. `NominalMultipartUploadFailed`) are unwrapped and `__cause__` chains followed, so the classification sees the root failure regardless of wrapping. The gRPC gap was found by the live e2e test below, not code reading.
- **Diagnosability for the rejected timestamp update**: when the destination 400s the post-ingest update, the log line and skip reason record the starting/ending timestamps that were sent — the server may not say which argument it refused, so the sent values are often the only way to diagnose it from our side.
- **Upload succeeded ⇒ mapping recorded, structurally**: everything after a successful upload runs under `_finish_copy` with a catch-all, so *no* post-upload failure (ingest failed, ingest timeout, unknown ingest status, exhausted poll retries, rejected timestamp update, anything unexpected) can escape without returning the uploaded file. All become skip-with-mapping — surfaced in the end-of-run summary, never re-uploaded as a duplicate on rerun.
- **Log-and-continue**: a video file copy failure records a `copy failed` skip and lets the rest of the asset migrate; with no mapping recorded, a rerun re-attempts the file.
- **`set_skip`**: one atomic upsert for a resource's latest skip outcome (`None` clears), so re-attempted video files report once per resource instead of accumulating one summary entry per attempt.
- Streamed source download is closed on every exit path (no leaked connections across retries).
- README gains a "Failure handling" section documenting which skip reasons a rerun re-attempts.

## Testing

- **Unit**: one test per observed production failure mode plus the review-round findings (unknown ingest status, exhausted poll retries, stale-skip clearing). Transient/permanent classification is tested against real `ConjureHTTPError` and translated-gRPC error objects, not mock stand-ins. Full `tests/core` + `tests/experimental` pass (745 tests).
- **E2E, happy path** (`prod` → `staging-sandbox`): `test_migrate_asset_maximal` (asset with datasets, events, run, checklist, video with file, workbook), `test_migration_idempotency`, `test_resume_partial_migration` — all pass.
- **E2E, failure path** (new `tests/e2e/migration/test_retry_e2e.py`): a real source video with the destination client pointed at an unreachable address (`127.0.0.1:9`, instant connection-refused) verifies over a real socket that the failure is classified transient, retried with backoff, and finally recorded as a skip without aborting. This test caught the gRPC classification gap on its first run.
- `just check` clean (format, mypy, ruff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
