### PR TITLE
fix(migration): preserve dataset owners during impersonation

### DIFF
--- a/nominal/experimental/migration/migration_cli.py
+++ b/nominal/experimental/migration/migration_cli.py
@@ -11,9 +11,10 @@ import click
 import yaml
 
 from nominal.cli.util.global_decorators import client_options, global_options
-from nominal.core import ArchiveStatusFilter, Asset, Checklist, NominalClient, Workbook
+from nominal.core import ArchiveStatusFilter, Asset, Checklist, Dataset, NominalClient, Workbook
 from nominal.core._utils.grpc_tools import translate_grpc_errors
 from nominal.experimental import as_user
+from nominal.experimental.dataset_utils import get_dataset_owner_rid
 from nominal.experimental.migration.config.migration_data_config import AssetInclusionConfig, MigrationDatasetConfig
 from nominal.experimental.migration.config.migration_resources import AssetResources, MigrationResources
 from nominal.experimental.migration.migration_decorators import migration_client_options
@@ -237,20 +238,21 @@ def get_source_user_rid(source_resource: Any) -> str | None:
         return user_rid
 
     latest_api_getter = getattr(source_resource, "_get_latest_api", None)
-    if not callable(latest_api_getter):
-        return None
+    if callable(latest_api_getter):
+        try:
+            latest_api = latest_api_getter()
+        except Exception:
+            logger.debug("Unable to fetch latest API object while resolving source user RID.", exc_info=True)
+        else:
+            user_rid = _extract_user_rid_from_object(latest_api)
+            if user_rid is not None:
+                return user_rid
 
-    try:
-        latest_api = latest_api_getter()
-    except Exception:
-        logger.debug("Unable to fetch latest API object while resolving source user RID.", exc_info=True)
-        return None
+            user_rid = _extract_user_rid_from_object(getattr(latest_api, "metadata", None))
+            if user_rid is not None:
+                return user_rid
 
-    user_rid = _extract_user_rid_from_object(latest_api)
-    if user_rid is not None:
-        return user_rid
-
-    return _extract_user_rid_from_object(getattr(latest_api, "metadata", None))
+    return _get_dataset_owner_user_rid(source_resource)
 
 
 def build_destination_client_resolver(
@@ -345,6 +347,21 @@ def _extract_user_rid_from_identity(value: Any) -> str | None:
             return nested_value
 
     return None
+
+
+def _get_dataset_owner_user_rid(source_resource: Any) -> str | None:
+    if not isinstance(source_resource, Dataset):
+        return None
+
+    try:
+        return get_dataset_owner_rid(source_resource)
+    except Exception:
+        logger.debug(
+            "Dataset owner lookup failed while resolving source user RID for dataset %s.",
+            source_resource.rid,
+            exc_info=True,
+        )
+        return None
 
 
 def _load_migration_config(

--- a/tests/core/test_migration_impersonation.py
+++ b/tests/core/test_migration_impersonation.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if sys.version_info < (3, 13):
+    pytest.skip("Migration module requires Python 3.13+ (TypeVar default parameter)", allow_module_level=True)
+
+from nominal.core.dataset import Dataset
+from nominal.experimental.migration.migration_cli import (
+    ImpersonatingDestinationClientResolver,
+    ImpersonationConfig,
+    get_source_user_rid,
+)
+
+
+def _dataset() -> Dataset:
+    return Dataset(
+        rid="ri.catalog.main.dataset.00000000-0000-0000-0000-000000000001",
+        name="Source dataset",
+        description=None,
+        properties={},
+        labels=[],
+        bounds=None,
+        is_archived=False,
+        _clients=MagicMock(),
+    )
+
+
+def test_get_source_user_rid_reads_dataset_owner_via_role_service() -> None:
+    dataset = _dataset()
+    dataset._clients.catalog.get_enriched_datasets.side_effect = RuntimeError("catalog unavailable")  # type: ignore[attr-defined]
+
+    with patch(
+        "nominal.experimental.migration.migration_cli.get_dataset_owner_rid",
+        return_value="ri.authn.source.user.owner",
+    ) as get_owner:
+        assert get_source_user_rid(dataset) == "ri.authn.source.user.owner"
+
+    get_owner.assert_called_once_with(dataset)
+
+
+def test_get_source_user_rid_falls_back_when_dataset_owner_lookup_fails() -> None:
+    dataset = _dataset()
+
+    with patch(
+        "nominal.experimental.migration.migration_cli.get_dataset_owner_rid",
+        side_effect=ValueError("owner not found"),
+    ):
+        assert get_source_user_rid(dataset) is None
+
+
+def test_dataset_owner_selects_impersonated_destination_client() -> None:
+    dataset = _dataset()
+    destination_client = MagicMock(name="destination_client")
+    impersonated_client = MagicMock(name="impersonated_client")
+    resolver = ImpersonatingDestinationClientResolver(
+        destination_client,
+        ImpersonationConfig(
+            enabled=True,
+            source_to_destination_user_rids={
+                "ri.authn.source.user.owner": "ri.authn.destination.user.owner",
+            },
+        ),
+    )
+
+    with (
+        patch(
+            "nominal.experimental.migration.migration_cli.get_dataset_owner_rid",
+            return_value="ri.authn.source.user.owner",
+        ),
+        patch(
+            "nominal.experimental.migration.migration_cli.as_user",
+            return_value=impersonated_client,
+        ) as as_user,
+    ):
+        assert resolver(dataset) is impersonated_client
+
+    as_user.assert_called_once_with(destination_client, "ri.authn.destination.user.owner")

--- a/tests/e2e/migration/test_migration.py
+++ b/tests/e2e/migration/test_migration.py
@@ -14,6 +14,13 @@ Tests cover:
 Run with:
     uv run pytest tests/e2e/migration/ \
         --source-profile=<prod> --dest-profile=<staging> -v
+
+Run the dataset-owner impersonation check with:
+    uv run pytest tests/e2e/migration/test_migration.py \
+        -k dataset_owner_with_impersonation \
+        --source-profile=<source> --dest-profile=<destination> \
+        --impersonation-dest-user-rid=<destination-user-rid> \
+        --fail-on-skip -v
 """
 
 from __future__ import annotations
@@ -39,8 +46,13 @@ from nominal.core.run import Run
 from nominal.core.video import Video
 from nominal.core.workbook import Workbook
 from nominal.experimental.checklist_utils.checklist_utils import _create_checklist_with_content
+from nominal.experimental.dataset_utils import get_dataset_owner_rid
 from nominal.experimental.migration.config.migration_data_config import AssetInclusionConfig, MigrationDatasetConfig
 from nominal.experimental.migration.config.migration_resources import AssetResources, MigrationResources
+from nominal.experimental.migration.migration_cli import (
+    ImpersonationConfig,
+    build_destination_client_resolver,
+)
 from nominal.experimental.migration.migration_runner import MigrationRunner
 from nominal.experimental.migration.migration_state import MigrationState
 from nominal.experimental.migration.resource_type import ResourceType
@@ -1019,3 +1031,54 @@ def test_migrate_maps_checklist_assignee_without_impersonation(
         dest_client._clients.datareview.get(dest_client._clients.auth_header, dest_review_rid),
     )
     register_cleanup(dest_review.archive)
+
+
+def test_migrate_preserves_dataset_owner_with_impersonation(
+    source_client: NominalClient,
+    dest_client: NominalClient,
+    register_cleanup: RegisterCleanup,
+    tmp_path: Path,
+    pytestconfig,
+):
+    """A migrated dataset is owned by the mapped destination user, not the migration caller.
+
+    Requires --impersonation-dest-user-rid to name an active destination user and a
+    destination profile whose caller may impersonate that user.
+    """
+    dest_user_rid = pytestconfig.getoption("impersonation_dest_user_rid")
+    if not dest_user_rid:
+        pytest.skip("--impersonation-dest-user-rid required")
+
+    source_asset = _create_source_asset(source_client, register_cleanup)
+    source_dataset = _create_source_dataset(source_client, register_cleanup, source_asset)
+    actual_source_owner_rid = get_dataset_owner_rid(source_dataset)
+    source_user_rid = pytestconfig.getoption("impersonation_source_user_rid") or actual_source_owner_rid
+    assert actual_source_owner_rid == source_user_rid, (
+        "--impersonation-source-user-rid must match the owner of the source dataset"
+    )
+
+    destination_client_resolver = build_destination_client_resolver(
+        dest_client,
+        ImpersonationConfig(
+            enabled=True,
+            source_to_destination_user_rids={source_user_rid: dest_user_rid},
+        ),
+    )
+    assert destination_client_resolver is not None
+    runner = MigrationRunner(
+        migration_resources=_make_resources(source_asset),
+        dataset_config=_no_files_config(),
+        destination_client=dest_client,
+        destination_client_resolver=destination_client_resolver,
+        migration_state_path=tmp_path / "state.json",
+    )
+    runner.run_migration()
+
+    dest_asset = _dest_asset(runner, source_asset, dest_client)
+    register_cleanup(dest_asset.archive)
+    dest_dataset_rid = runner.migration_state.get_mapped_rid(ResourceType.DATASET, source_dataset.rid)
+    assert dest_dataset_rid is not None
+    dest_dataset = dest_client.get_dataset(dest_dataset_rid)
+    register_cleanup(dest_dataset.archive)
+
+    assert get_dataset_owner_rid(dest_dataset) == dest_user_rid


### PR DESCRIPTION
Dataset resources do not expose `created_by_rid` or `author_rid`, so the migration impersonation resolver silently fell back to the destination service user. This caused migrated datasets to be owned by the migration caller even when an impersonation mapping existed.

Use the existing Role Service-backed `get_dataset_owner_rid` helper as a dataset-specific fallback. Owner lookup failures retain the existing service-user behavior. Add regression coverage for owner resolution, graceful fallback, selection of the impersonated destination client, and a manual E2E that verifies the destination `ROLE_OWNER`.

### Testing

- `uv run ruff check nominal/experimental/migration/migration_cli.py tests/core/test_migration_impersonation.py tests/e2e/migration/test_migration.py`
- `uv run ruff format --check nominal/experimental/migration/migration_cli.py tests/core/test_migration_impersonation.py tests/e2e/migration/test_migration.py`
- `uv run pytest tests/core/test_migration_impersonation.py tests/core/test_experimental_dataset_utils.py tests/core/test_migration_destination_client_resolution.py tests/core/test_migration_user_attribution.py`
- `uv run pytest tests/e2e/migration/test_migration.py --collect-only -q`
- `uv run mypy -m nominal.experimental.migration.migration_cli`

### Manual E2E

Requires source and destination profiles plus an active destination user that the destination caller may impersonate. The test creates a source asset and dataset, migrates them, and verifies the destination dataset owner through Role Service.

```sh
uv run pytest tests/e2e/migration/test_migration.py \
  -k dataset_owner_with_impersonation \
  --source-profile=<source> \
  --dest-profile=<destination> \
  --impersonation-dest-user-rid=<destination-user-rid> \
  --fail-on-skip -v
```