### PR TITLE
fix: source video copy timing from segment metadata, not the as-ingested origin start

### DIFF
--- a/nominal/core/_video_types.py
+++ b/nominal/core/_video_types.py
@@ -15,10 +15,15 @@ class McapVideoDetails:
 
 @dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False)
 class TimestampOptions:
+    """A video file's current timing, as (start, scale) — the pair a re-ingest applies directly.
+
+    Both values come from segment metadata; an absolute ending is deliberately not carried,
+    since it is derivable (start + media duration x scale) and a second absolute invites the
+    mixed-source inconsistency that motivated this shape.
+    """
+
     starting_timestamp: IntegralNanosecondsUTC
-    ending_timestamp: IntegralNanosecondsUTC
     scaling_factor: float
-    true_framerate: float
 
 
 def _scale_parameter(

--- a/nominal/core/video_file.py
+++ b/nominal/core/video_file.py
@@ -201,16 +201,22 @@ class VideoFile(HasRid, RefreshableConjureMixin[scout_video_api.VideoFile]):
                     f"video file {self.rid!r} has no segment metadata, so it cannot be re-ingested elsewhere"
                 )
             if (
-                api_video_file.segment_metadata.max_absolute_timestamp is None
+                api_video_file.segment_metadata.min_absolute_timestamp is None
+                or api_video_file.segment_metadata.max_absolute_timestamp is None
                 or api_video_file.segment_metadata.scale_factor is None
                 or api_video_file.segment_metadata.media_frame_rate is None
             ):
                 raise NominalVideoFileMetadataError(
                     f"video file {self.rid!r} has incomplete segment metadata: {api_video_file.segment_metadata}"
                 )
+            # Everything comes from segment metadata, never from the origin manifest's declared
+            # start: origin metadata is frozen at original ingest, while start-time and scale
+            # edits rewrite the segments — so the segments are the file's current timing truth,
+            # and mixing the two sources produces inconsistent options for any file whose start
+            # was corrected after ingest.
             video_file_ingest_options = TimestampOptions(
                 starting_timestamp=_SecondsNanos.from_api(
-                    api_video_file.origin_metadata.timestamp_manifest.no_manifest.starting_timestamp
+                    api_video_file.segment_metadata.min_absolute_timestamp
                 ).to_nanoseconds(),
                 ending_timestamp=_SecondsNanos.from_api(
                     api_video_file.segment_metadata.max_absolute_timestamp

--- a/nominal/core/video_file.py
+++ b/nominal/core/video_file.py
@@ -202,14 +202,12 @@ class VideoFile(HasRid, RefreshableConjureMixin[scout_video_api.VideoFile]):
                 )
             if (
                 api_video_file.segment_metadata.min_absolute_timestamp is None
-                or api_video_file.segment_metadata.max_absolute_timestamp is None
                 or api_video_file.segment_metadata.scale_factor is None
-                or api_video_file.segment_metadata.media_frame_rate is None
             ):
                 raise NominalVideoFileMetadataError(
                     f"video file {self.rid!r} has incomplete segment metadata: {api_video_file.segment_metadata}"
                 )
-            # Everything comes from segment metadata, never from the origin manifest's declared
+            # Both values come from segment metadata, never from the origin manifest's declared
             # start: origin metadata is frozen at original ingest, while start-time and scale
             # edits rewrite the segments — so the segments are the file's current timing truth,
             # and mixing the two sources produces inconsistent options for any file whose start
@@ -218,11 +216,7 @@ class VideoFile(HasRid, RefreshableConjureMixin[scout_video_api.VideoFile]):
                 starting_timestamp=_SecondsNanos.from_api(
                     api_video_file.segment_metadata.min_absolute_timestamp
                 ).to_nanoseconds(),
-                ending_timestamp=_SecondsNanos.from_api(
-                    api_video_file.segment_metadata.max_absolute_timestamp
-                ).to_nanoseconds(),
                 scaling_factor=api_video_file.segment_metadata.scale_factor,
-                true_framerate=api_video_file.segment_metadata.media_frame_rate,
             )
             return (None, video_file_ingest_options)
 

--- a/nominal/experimental/migration/utils/video_file_utils.py
+++ b/nominal/experimental/migration/utils/video_file_utils.py
@@ -163,29 +163,35 @@ def _finish_copy(
         # Applied even on timeout: the copy is recorded as migrated either way, so no rerun
         # will come back to set the video's timing. Skipped when ingest failed outright —
         # the file needs hand-checking anyway.
+        #
+        # The scale factor, not the segment-derived ending timestamp, is sent: segment
+        # absolutes are computed at ingest and go stale if the declared start is later edited
+        # (observed in production as an inverted start/end pair the destination rejected with
+        # "Invalid bounds"). start + scale is the source's self-consistent defining pair, and
+        # yields the segment ending whenever the source is healthy.
         try:
             retry_transient(
                 lambda: new_file.update(
                     starting_timestamp=timestamp_options.starting_timestamp,
-                    ending_timestamp=timestamp_options.ending_timestamp,
+                    scale_factor=timestamp_options.scaling_factor,
                 ),
                 description=f"timestamp update for video file {new_file.rid}",
             )
         except Exception as error:
-            # The sent values come from the source's segment metadata; recording them here is
-            # often the only way to diagnose a destination-side rejection (the server may not
-            # say which argument it refused).
+            # The sent values come from the source's metadata; recording them here is often
+            # the only way to diagnose a destination-side rejection (the server may not say
+            # which argument it refused).
             logger.warning(
-                "Timestamp update failed for video file (rid: %s), sent starting_timestamp=%s ending_timestamp=%s: %s",
+                "Timestamp update failed for video file (rid: %s), sent starting_timestamp=%s scale_factor=%s: %s",
                 new_file.rid,
                 timestamp_options.starting_timestamp,
-                timestamp_options.ending_timestamp,
+                timestamp_options.scaling_factor,
                 error,
             )
             skip_reasons.append(
                 f"the timestamp update was rejected: {error} "
                 f"(sent starting_timestamp={timestamp_options.starting_timestamp}, "
-                f"ending_timestamp={timestamp_options.ending_timestamp}); "
+                f"scale_factor={timestamp_options.scaling_factor}); "
                 f"a rerun will not retry it — set timing on {new_file.rid} by hand"
             )
 

--- a/tests/core/test_video_file_migrator.py
+++ b/tests/core/test_video_file_migrator.py
@@ -63,6 +63,7 @@ def _timestamp_options() -> MagicMock:
     options = MagicMock()
     options.starting_timestamp = 0
     options.ending_timestamp = 1
+    options.scaling_factor = 2.0
     return options
 
 
@@ -156,7 +157,10 @@ def test_successful_copy_records_mapping_and_no_skip(monkeypatch: pytest.MonkeyP
 
     assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) == new_file.rid
     assert ctx.migration_state.skipped_resources == []
-    new_file.update.assert_called_once()
+    # Timing is set from the source's defining pair (start + scale), never the segment-derived
+    # ending: segment absolutes go stale if the source's declared start was edited after
+    # segmentation, producing an inverted start/end pair the destination rejects.
+    new_file.update.assert_called_once_with(starting_timestamp=0, scale_factor=2.0)
 
 
 def test_percent_encoded_source_filename_is_sanitized_before_upload(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -367,7 +371,7 @@ def test_rejected_timestamp_update_records_mapping_and_skip(monkeypatch: pytest.
     assert "timestamp update was rejected" in reason
     # The sent values are recorded — often the only way to diagnose a destination-side 400.
     assert "starting_timestamp=0" in reason
-    assert "ending_timestamp=1" in reason
+    assert "scale_factor=2.0" in reason
 
 
 def test_unexpected_copy_failure_is_recorded_and_does_not_abort(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/core/test_video_file_migrator.py
+++ b/tests/core/test_video_file_migrator.py
@@ -62,7 +62,6 @@ def _make_destination_video(new_file: MagicMock) -> MagicMock:
 def _timestamp_options() -> MagicMock:
     options = MagicMock()
     options.starting_timestamp = 0
-    options.ending_timestamp = 1
     options.scaling_factor = 2.0
     return options
 
@@ -142,6 +141,10 @@ def test_ingest_timeout_records_mapping_and_skip(monkeypatch: pytest.MonkeyPatch
 
 
 def test_successful_copy_records_mapping_and_no_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A clean copy records the mapping and sets timing from the source's defining pair —
+    start + scale, never a segment-derived absolute ending, which goes stale if the source's
+    declared start was edited after segmentation (the inverted-bounds production failure).
+    """
     ctx = _make_context()
     source_file = _make_source_video_file(_video_file_rid(4))
     source_file._get_file_ingest_options.return_value = (None, _timestamp_options())
@@ -157,9 +160,6 @@ def test_successful_copy_records_mapping_and_no_skip(monkeypatch: pytest.MonkeyP
 
     assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) == new_file.rid
     assert ctx.migration_state.skipped_resources == []
-    # Timing is set from the source's defining pair (start + scale), never the segment-derived
-    # ending: segment absolutes go stale if the source's declared start was edited after
-    # segmentation, producing an inverted start/end pair the destination rejects.
     new_file.update.assert_called_once_with(starting_timestamp=0, scale_factor=2.0)
 
 


### PR DESCRIPTION
## Context

Follow-up to #934, closing the root cause of the two `400 INVALID_ARGUMENT` failures from a production migration run (#934 contained their blast radius but still sent the same payload).

The destination's log showed the rejection: `Invalid bounds: minTimestamp=1766080533264000000, maxTimestamp=1766077950090612992`. Tracing it on the source tenant and through the backend's video-file update flow established the actual data model:

- **Origin metadata is frozen at original ingest.** The update endpoint writes only title/description/size and carries origin metadata through unchanged; start-time and scale edits rewrite the *segments*. So `origin_metadata.timestamp_manifest.no_manifest.starting_timestamp` is the as-ingested declaration (provenance), and **segment metadata is the file's current timing truth**. (The scale factor shown in the UI is derived on read from segments, which is why affected files look healthy there.)
- The migration's copy options mixed the two sources: starting timestamp from origin metadata, ending timestamp from segment metadata. For any file whose start was **corrected after ingest**, that pair is inconsistent — the offending file was ingested with a start near its upload time, later corrected ~2 days back to its recording time, and the copy then resurrected the stale as-ingested start alongside the corrected segment ending. A source tenant scan found five such files.
- The server derives scale from an ending-timestamp update as `(ending − currentSegmentStart)/mediaDuration`; for the offending file that is **−2583.173387008**, and with exactly 1.0 s segments the first rescaled segment inverts by exactly that gap — matching the rejected bounds to the nanosecond.

## Changes

- `_get_file_ingest_options` now sources the starting timestamp from `segment_metadata.min_absolute_timestamp` instead of origin metadata, so **every timing option comes from segment metadata** — one internally consistent, current-truth source. Identical for never-edited files; for corrected files the copy lands at the corrected position instead of the stale as-ingested one.
- The post-ingest `update()` sends the **scale factor** with the starting timestamp instead of a segment-derived absolute ending — start + scale is the pair the destination applies directly, and it reproduces the source's segment window exactly.
- The rejected-update log line and skip reason (from #934) record the sent scale factor in place of the ending timestamp.

Origin metadata itself is left alone — its immutability is by design (ingest provenance), and preserving it is what made this diagnosable. The client just no longer treats it as current timing.

## Testing

- Unit: the success-path test pins the exact update payload (`starting_timestamp` + `scale_factor`, no ending); the rejected-update test asserts the sent values appear in the skip reason. Full `tests/core` + `tests/experimental` pass (757 tests).
- E2E (`prod` → `staging-sandbox`): `test_migrate_asset_maximal` passes — the destination accepts the scale-factor update and the migrated video's file fully ingests with correct linkage.
- `just check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
