### PR TITLE
feat: predict video file outcomes in migration dry run

### DIFF
--- a/nominal/experimental/migration/README.md
+++ b/nominal/experimental/migration/README.md
@@ -61,6 +61,8 @@ Optional flags:
 - `--max-workers <n>` — number of assets/templates to migrate concurrently (default: 1). Start with 2–4
   workers and adjust based on performance and API rate limits.
 - `--dry-run` — log what would be created without writing anything to the destination tenant or state file.
+  Video files are evaluated through the real read path, so the end-of-run skip summary predicts what a
+  real run would flag (unusable files, timing payloads) before any bytes move.
 
 **`nom migrate summary`** — summarize a migration as a markdown table. Fully offline: no profiles or
 tokens required. Provide exactly one source:

--- a/nominal/experimental/migration/migrator/video_file_migrator.py
+++ b/nominal/experimental/migration/migrator/video_file_migrator.py
@@ -7,7 +7,10 @@ from nominal.core.video_file import VideoFile
 from nominal.experimental.migration.dry_run import DRY_RUN_PREFIX
 from nominal.experimental.migration.migrator.context import MigrationContext
 from nominal.experimental.migration.resource_type import ResourceType
-from nominal.experimental.migration.utils.video_file_utils import copy_video_file_to_video_dataset
+from nominal.experimental.migration.utils.video_file_utils import (
+    copy_video_file_to_video_dataset,
+    plan_video_file_copy,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +27,7 @@ class VideoFileMigrator:
             return
 
         if self.ctx.dry_run:
-            logger.info(f"{DRY_RUN_PREFIX} Would copy video file %s to destination", source_file.rid)
+            self._dry_run_predict(source_file)
             return
 
         try:
@@ -44,3 +47,23 @@ class VideoFileMigrator:
         # Ordered after record_mapping — each call persists separately, so a crash between the
         # two can only lose the summary line, never the mapping that stops a rerun re-uploading.
         self.ctx.migration_state.set_skip(ResourceType.VIDEO_FILE, source_file.rid, outcome.skip_reason)
+
+    def _dry_run_predict(self, source_file: VideoFile) -> None:
+        """Predict this file's copy outcome from source reads alone, so a dry run's end-of-run
+        summary forecasts the real run's — the plan comes from the same code path a real copy
+        executes, only the transfer is skipped.
+        """
+        try:
+            plan = plan_video_file_copy(source_file)
+        except Exception as error:
+            logger.exception("Failed to plan video file copy (rid: %s)", source_file.rid)
+            self.ctx.migration_state.set_skip(ResourceType.VIDEO_FILE, source_file.rid, f"copy would fail: {error}")
+            return
+
+        self.ctx.migration_state.set_skip(ResourceType.VIDEO_FILE, source_file.rid, plan.skip_reason)
+        if plan.skip_reason is not None:
+            logger.info(f"{DRY_RUN_PREFIX} Would skip video file %s — %s", source_file.rid, plan.skip_reason)
+        else:
+            logger.info(
+                f"{DRY_RUN_PREFIX} Would copy video file %s to destination %s", source_file.rid, plan.describe()
+            )

--- a/nominal/experimental/migration/utils/video_file_utils.py
+++ b/nominal/experimental/migration/utils/video_file_utils.py
@@ -66,14 +66,33 @@ def _source_ingest_error(source_video_file: VideoFile) -> str | None:
     return f"{status_error.message} ({status_error.error_type})" if status_error is not None else "no error details"
 
 
-def copy_video_file_to_video_dataset(
-    source_video_file: VideoFile,
-    destination_video_dataset: Video,
-    poll_timeout: timedelta | None = DEFAULT_INGEST_POLL_TIMEOUT,
-) -> VideoFileCopyOutcome:
-    log_extras = {"destination_client_workspace": destination_video_dataset._clients.workspace_rid}
-    logger.debug("Copying video file: %s", source_video_file.name, extra=log_extras)
+@dataclass(frozen=True)
+class VideoFileCopyPlan:
+    """What copying a video file would do, computed from source reads alone.
 
+    Either `skip_reason` is set (the copy would be skipped and flagged), or the ingest
+    options carry the timing the copy would apply. Shared by the real copy and dry run,
+    so a dry run's predictions come from the same code path a real run executes.
+    """
+
+    mcap_video_details: McapVideoDetails | None = None
+    timestamp_options: TimestampOptions | None = None
+    skip_reason: str | None = None
+
+    def describe(self) -> str:
+        if self.skip_reason is not None:
+            return self.skip_reason
+        if self.mcap_video_details is not None:
+            return f"as mcap (topic {self.mcap_video_details.mcap_channel_locator_topic!r})"
+        assert self.timestamp_options is not None
+        return (
+            f"with starting_timestamp={self.timestamp_options.starting_timestamp} "
+            f"scale_factor={self.timestamp_options.scaling_factor}"
+        )
+
+
+def plan_video_file_copy(source_video_file: VideoFile) -> VideoFileCopyPlan:
+    """Resolve what a copy of this file would do, from source reads alone (no writes)."""
     # Deliberately ahead of the metadata gate below: a failed source ingest can leave
     # (partial) segment metadata behind that passes that gate — the production incident file
     # did, transferred cleanly, and only failed at the destination. Folding this check into
@@ -85,14 +104,12 @@ def copy_video_file_to_video_dataset(
             source_video_file.name,
             source_video_file.rid,
             ingest_error,
-            extra=log_extras,
         )
-        return VideoFileCopyOutcome(
-            file=None,
+        return VideoFileCopyPlan(
             skip_reason=(
                 f"unusable at source: its own ingest failed there: {ingest_error} — "
                 f"re-ingesting it elsewhere would fail the same way"
-            ),
+            )
         )
 
     try:
@@ -108,9 +125,24 @@ def copy_video_file_to_video_dataset(
             source_video_file.name,
             source_video_file.rid,
             error,
-            extra=log_extras,
         )
-        return VideoFileCopyOutcome(file=None, skip_reason=f"unusable at source: {error}")
+        return VideoFileCopyPlan(skip_reason=f"unusable at source: {error}")
+    return VideoFileCopyPlan(mcap_video_details=mcap_video_details, timestamp_options=timestamp_options)
+
+
+def copy_video_file_to_video_dataset(
+    source_video_file: VideoFile,
+    destination_video_dataset: Video,
+    poll_timeout: timedelta | None = DEFAULT_INGEST_POLL_TIMEOUT,
+) -> VideoFileCopyOutcome:
+    log_extras = {"destination_client_workspace": destination_video_dataset._clients.workspace_rid}
+    logger.debug("Copying video file: %s", source_video_file.name, extra=log_extras)
+
+    plan = plan_video_file_copy(source_video_file)
+    if plan.skip_reason is not None:
+        return VideoFileCopyOutcome(file=None, skip_reason=plan.skip_reason)
+    mcap_video_details = plan.mcap_video_details
+    timestamp_options = plan.timestamp_options
 
     # Download + upload retry as one unit: the source download is streamed straight into the
     # upload, so a connection broken in either leg restarts from a fresh presigned URI. A

--- a/tests/core/test_video_file_migrator.py
+++ b/tests/core/test_video_file_migrator.py
@@ -480,6 +480,61 @@ def test_rerun_success_clears_stale_skip_from_earlier_attempt(monkeypatch: pytes
     assert ctx.migration_state.skipped_resources == []
 
 
+def test_dry_run_predicts_skip_for_unusable_source() -> None:
+    """A dry run records the same skip a real run would, so its summary forecasts the real one."""
+    ctx = _make_context()
+    ctx.dry_run = True
+    source_file = _make_source_video_file(_video_file_rid(16))
+    source_file._get_file_ingest_options.side_effect = NominalVideoFileMetadataError("no segment metadata")
+    destination_video = MagicMock()
+    destination_video._clients.workspace_rid = "ws-rid"
+
+    VideoFileMigrator(ctx).copy_from(source_file, destination_video)
+
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) is None
+    assert [skipped.reason for skipped in ctx.migration_state.skipped_resources] == [
+        "unusable at source: no segment metadata"
+    ]
+    destination_video.add_from_io.assert_not_called()
+
+
+def test_dry_run_predicts_clean_copy_without_transfer() -> None:
+    """A healthy file predicts a clean copy with no download, upload, or destination call.
+
+    The streamed download is deliberately not stubbed: if the dry run ever transferred, the
+    real requests.get against the fake URI would fail this test loudly.
+    """
+    ctx = _make_context()
+    ctx.dry_run = True
+    source_file = _make_source_video_file(_video_file_rid(17))
+    source_file._get_file_ingest_options.return_value = (None, _timestamp_options())
+    destination_video = MagicMock()
+    destination_video._clients.workspace_rid = "ws-rid"
+
+    VideoFileMigrator(ctx).copy_from(source_file, destination_video)
+
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) is None
+    assert ctx.migration_state.skipped_resources == []
+    destination_video.add_from_io.assert_not_called()
+    source_file._clients.catalog.get_video_file_uri.assert_not_called()
+
+
+def test_dry_run_prediction_failure_records_skip_not_abort() -> None:
+    """An unexpected read failure during prediction is flagged, not raised — the dry run continues."""
+    ctx = _make_context()
+    ctx.dry_run = True
+    source_file = _make_source_video_file(_video_file_rid(18))
+    source_file._get_file_ingest_options.side_effect = RuntimeError("unexpected manifest shape")
+    destination_video = MagicMock()
+    destination_video._clients.workspace_rid = "ws-rid"
+
+    VideoFileMigrator(ctx).copy_from(source_file, destination_video)
+
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) is None
+    assert len(ctx.migration_state.skipped_resources) == 1
+    assert "copy would fail" in ctx.migration_state.skipped_resources[0].reason
+
+
 def test_parallel_runner_passes_video_ingest_timeout_to_context(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/core/test_video_file_migrator.py
+++ b/tests/core/test_video_file_migrator.py
@@ -480,6 +480,28 @@ def test_rerun_success_clears_stale_skip_from_earlier_attempt(monkeypatch: pytes
     assert ctx.migration_state.skipped_resources == []
 
 
+def test_dry_run_predicts_skip_for_failed_source_ingest() -> None:
+    """The failed-at-source gate lives in the shared planner, so a dry run predicts the skip
+    with the source's real ingest error — before any real run wastes a transfer on it.
+    """
+    ctx = _make_context()
+    ctx.dry_run = True
+    source_file = _make_source_video_file(_video_file_rid(22))
+    _mark_source_ingest_failed(source_file, "Video failed to segment.", "VideoSegmenter:Internal")
+    destination_video = MagicMock()
+    destination_video._clients.workspace_rid = "ws-rid"
+
+    VideoFileMigrator(ctx).copy_from(source_file, destination_video)
+
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) is None
+    assert len(ctx.migration_state.skipped_resources) == 1
+    reason = ctx.migration_state.skipped_resources[0].reason
+    assert "its own ingest failed there" in reason
+    assert "VideoSegmenter:Internal" in reason
+    source_file._get_file_ingest_options.assert_not_called()
+    destination_video.add_from_io.assert_not_called()
+
+
 def test_dry_run_predicts_skip_for_unusable_source() -> None:
     """A dry run records the same skip a real run would, so its summary forecasts the real one."""
     ctx = _make_context()


### PR DESCRIPTION
## Context

Dry run previously returned from the video file migrator before reading anything, so it couldn't predict the largest source of migration surprises: which video files will skip, and what timing each copy will apply. Validating a recent production migration required a one-off script for exactly this — this PR folds that capability into `--dry-run` itself.

## Changes

- The read-only planning step of a video file copy is extracted into `plan_video_file_copy` — the same ingest-options path, transient retry, and skip classification the real copy executes — and the real copy now consumes it, so dry-run predictions can't drift from real behavior.
- In dry run, each video file is planned:
  - predicted skips are recorded in migration state, so the **end-of-run skip summary forecasts the real run's**
  - clean files log `[DRY RUN] Would copy video file <rid> ... with starting_timestamp=X scale_factor=Y` (or the mcap topic)
  - an unexpected read failure is flagged as a `copy would fail` skip rather than aborting the dry run
- No download, upload, or destination call happens; `nom migrate summary`'s `Would create` tally is unaffected (new lines use `Would copy`/`Would skip`).

## Testing

- Unit: dry-run predictions record the same skip a real run would, a healthy file predicts a clean copy with zero transfer (the streamed download is deliberately left unstubbed so any transfer attempt fails the test loudly), and prediction failures flag-and-continue. Full `tests/core` + `tests/experimental` pass (760 tests).
- Live validation: a full `MigrationRunner` dry run against a real customer source tenant (72 assets) with this branch predicts, via `--dry-run` alone, all four video-file skips the customer's real migration run reported plus one more their narrower asset scope had not reached, alongside the checklist and workbook skips — and clean files log the exact timing payload verified against live data.
- `just check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
