### PR TITLE
feat: skip migrating video files whose source ingest failed

### DIFF
--- a/nominal/experimental/migration/utils/video_file_utils.py
+++ b/nominal/experimental/migration/utils/video_file_utils.py
@@ -62,8 +62,8 @@ def _source_ingest_error(source_video_file: VideoFile) -> str | None:
         return None
     if ingest_status.type != "error":
         return None
-    error = ingest_status.error
-    return f"{error.message} ({error.error_type})" if error is not None else "no error details"
+    status_error = ingest_status.error
+    return f"{status_error.message} ({status_error.error_type})" if status_error is not None else "no error details"
 
 
 def copy_video_file_to_video_dataset(

--- a/nominal/experimental/migration/utils/video_file_utils.py
+++ b/nominal/experimental/migration/utils/video_file_utils.py
@@ -33,6 +33,26 @@ class VideoFileCopyOutcome:
     skip_reason: str | None = None
 
 
+def _source_ingest_error(source_video_file: VideoFile) -> str | None:
+    """The source file's own ingest error, if it has one.
+
+    A file whose ingest failed at the source is made of bytes the platform already refused
+    to process once — re-ingesting them at a destination fails the same way (observed in
+    production as a destination-side segmentation failure whose source file turned out to
+    have failed ingestion itself).
+    """
+    ingest_status = retry_transient(
+        lambda: source_video_file._clients.video_file.get_ingest_status(
+            source_video_file._clients.auth_header, source_video_file.rid
+        ),
+        description=f"source ingest status for video file {source_video_file.rid}",
+    ).ingest_status
+    if ingest_status.type != "error":
+        return None
+    error = ingest_status.error
+    return f"{error.message} ({error.error_type})" if error is not None else "no error details"
+
+
 def copy_video_file_to_video_dataset(
     source_video_file: VideoFile,
     destination_video_dataset: Video,
@@ -40,6 +60,23 @@ def copy_video_file_to_video_dataset(
 ) -> VideoFileCopyOutcome:
     log_extras = {"destination_client_workspace": destination_video_dataset._clients.workspace_rid}
     logger.debug("Copying video file: %s", source_video_file.name, extra=log_extras)
+
+    ingest_error = _source_ingest_error(source_video_file)
+    if ingest_error is not None:
+        logger.warning(
+            "Skipping video file %s (rid: %s): its own ingest failed at the source: %s",
+            source_video_file.name,
+            source_video_file.rid,
+            ingest_error,
+            extra=log_extras,
+        )
+        return VideoFileCopyOutcome(
+            file=None,
+            skip_reason=(
+                f"unusable at source: its own ingest failed there: {ingest_error} — "
+                f"re-ingesting it elsewhere would fail the same way"
+            ),
+        )
 
     try:
         # NominalVideoFileMetadataError is permanent, so it still raises on the first attempt.

--- a/nominal/experimental/migration/utils/video_file_utils.py
+++ b/nominal/experimental/migration/utils/video_file_utils.py
@@ -40,13 +40,26 @@ def _source_ingest_error(source_video_file: VideoFile) -> str | None:
     to process once — re-ingesting them at a destination fails the same way (observed in
     production as a destination-side segmentation failure whose source file turned out to
     have failed ingestion itself).
+
+    A failed lookup is swallowed: this gate exists to avoid wasting a transfer, not as a
+    prerequisite for one. If the status endpoint is unavailable — or the file predates
+    ingest-status tracking — the copy proceeds, and a genuinely bad file still surfaces
+    through the destination-ingest skip path.
     """
-    ingest_status = retry_transient(
-        lambda: source_video_file._clients.video_file.get_ingest_status(
-            source_video_file._clients.auth_header, source_video_file.rid
-        ),
-        description=f"source ingest status for video file {source_video_file.rid}",
-    ).ingest_status
+    try:
+        ingest_status = retry_transient(
+            lambda: source_video_file._clients.video_file.get_ingest_status(
+                source_video_file._clients.auth_header, source_video_file.rid
+            ),
+            description=f"source ingest status for video file {source_video_file.rid}",
+        ).ingest_status
+    except Exception as error:
+        logger.warning(
+            "Could not check source ingest status for video file (rid: %s); proceeding with the copy: %s",
+            source_video_file.rid,
+            error,
+        )
+        return None
     if ingest_status.type != "error":
         return None
     error = ingest_status.error
@@ -61,6 +74,10 @@ def copy_video_file_to_video_dataset(
     log_extras = {"destination_client_workspace": destination_video_dataset._clients.workspace_rid}
     logger.debug("Copying video file: %s", source_video_file.name, extra=log_extras)
 
+    # Deliberately ahead of the metadata gate below: a failed source ingest can leave
+    # (partial) segment metadata behind that passes that gate — the production incident file
+    # did, transferred cleanly, and only failed at the destination. Folding this check into
+    # the metadata handler would silently lose the fix.
     ingest_error = _source_ingest_error(source_video_file)
     if ingest_error is not None:
         logger.warning(

--- a/tests/core/test_video_file_migrator.py
+++ b/tests/core/test_video_file_migrator.py
@@ -49,7 +49,15 @@ def _make_source_video_file(rid: str, name: str = "video.mp4") -> MagicMock:
     source_file.name = name
     source_file.description = None
     source_file._clients.catalog.get_video_file_uri.return_value.uri = "https://example.invalid/video.mp4"
+    source_file._clients.video_file.get_ingest_status.return_value.ingest_status.type = "success"
     return source_file
+
+
+def _mark_source_ingest_failed(source_file: MagicMock, message: str, error_type: str) -> None:
+    status = source_file._clients.video_file.get_ingest_status.return_value.ingest_status
+    status.type = "error"
+    status.error.message = message
+    status.error.error_type = error_type
 
 
 def _make_destination_video(new_file: MagicMock) -> MagicMock:
@@ -116,6 +124,42 @@ def test_skipped_source_video_is_recorded_as_skip_and_not_mapped() -> None:
     assert [(skip.resource_type, skip.source_rid) for skip in ctx.migration_state.skipped_resources] == [
         (ResourceType.VIDEO_FILE.value, source_file.rid)
     ]
+
+
+def test_source_with_failed_ingest_is_skipped_before_transfer() -> None:
+    """A file whose ingest failed at the source is bytes the platform already refused once —
+    re-ingesting them elsewhere fails the same way, so skip before moving anything.
+    """
+    source_file = _make_source_video_file(_video_file_rid(19))
+    _mark_source_ingest_failed(
+        source_file, "Video failed to segment. Please contact support for assistance.", "VideoSegmenter:Internal"
+    )
+    destination_video = MagicMock()
+    destination_video._clients.workspace_rid = "ws-rid"
+
+    outcome = copy_video_file_to_video_dataset(source_file, destination_video)
+
+    assert outcome.file is None
+    assert outcome.skip_reason is not None
+    assert "its own ingest failed there" in outcome.skip_reason
+    assert "VideoSegmenter:Internal" in outcome.skip_reason
+    # Nothing was read beyond the status, and nothing was transferred or created.
+    source_file._get_file_ingest_options.assert_not_called()
+    source_file._clients.catalog.get_video_file_uri.assert_not_called()
+    destination_video.add_from_io.assert_not_called()
+
+
+def test_source_with_failed_ingest_records_skip_and_no_mapping() -> None:
+    """The failed-at-source file lands in the end-of-run summary and a rerun re-checks it cheaply."""
+    ctx = _make_context()
+    source_file = _make_source_video_file(_video_file_rid(20))
+    _mark_source_ingest_failed(source_file, "Video failed to segment.", "VideoSegmenter:Internal")
+
+    VideoFileMigrator(ctx).copy_from(source_file, MagicMock(_clients=MagicMock(workspace_rid="ws-rid")))
+
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) is None
+    assert len(ctx.migration_state.skipped_resources) == 1
+    assert "unusable at source" in ctx.migration_state.skipped_resources[0].reason
 
 
 def test_ingest_timeout_records_mapping_and_skip(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/core/test_video_file_migrator.py
+++ b/tests/core/test_video_file_migrator.py
@@ -162,6 +162,28 @@ def test_source_with_failed_ingest_records_skip_and_no_mapping() -> None:
     assert "unusable at source" in ctx.migration_state.skipped_resources[0].reason
 
 
+def test_unavailable_source_ingest_status_does_not_block_copy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The status gate avoids wasted transfer; its own lookup failing (e.g. a legacy file with
+    no ingest-status record) must degrade to copying, not block a healthy file.
+    """
+    ctx = _make_context()
+    source_file = _make_source_video_file(_video_file_rid(21))
+    source_file._clients.video_file.get_ingest_status.side_effect = _http_error(404)
+    source_file._get_file_ingest_options.return_value = (None, _timestamp_options())
+
+    new_file = MagicMock()
+    new_file.rid = _video_file_rid(210)
+    new_file.poll_until_ingestion_completed.return_value = None
+    destination_video = _make_destination_video(new_file)
+
+    _mock_stream_response(monkeypatch)
+
+    VideoFileMigrator(ctx).copy_from(source_file, destination_video)
+
+    assert ctx.migration_state.get_mapped_rid(ResourceType.VIDEO_FILE, source_file.rid) == new_file.rid
+    assert ctx.migration_state.skipped_resources == []
+
+
 def test_ingest_timeout_records_mapping_and_skip(monkeypatch: pytest.MonkeyPatch) -> None:
     """A timed-out ingest is mapped (so a rerun does not re-upload) *and* reported as incomplete."""
     ctx = _make_context()


### PR DESCRIPTION
## Context

Closes out the last unexplained failure from the recent production migration run: a video file that downloaded and uploaded cleanly, then failed segmentation at the destination (`VideoSegmenter:Internal`). Investigation with the source tenant showed the source file's **own ingest had failed** — the destination was re-processing bytes the platform had already refused once, so the failure was inevitable and would repeat on every rerun.

## Changes

- Before transferring a video file, check the source file's ingest status (`get_ingest_status`, wrapped in the transient retry). If the source's ingest failed, skip pre-transfer with a reason carrying the source's actual ingest error:
  `unusable at source: its own ingest failed there: <message> (<error type>) — re-ingesting it elsewhere would fail the same way`
- The check runs ahead of the segment-metadata gate, which upgrades diagnostics for the whole unusable-at-source class: files that previously reported the generic "no segment metadata" now name their root cause.

## Testing

- Unit: a failed-ingest source is skipped before any read beyond the status check (no metadata fetch, no download URI, no upload), recorded as a skip with no mapping; healthy-status fixtures keep every existing path green. Full `tests/core` + `tests/experimental` pass (759 tests).
- Live read-only validation against the source tenant from the incident: all 11 files previously flagged "no segment metadata" carry a failed-ingest status, and the check surfaces each one's specific error (`VideoSegmenter:Internal`, `Video:SegmentConflict` with exact bounds) — including the class of failure that produced the destination-side segmentation error.
- `just check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)