### PR TITLE
fix: use total_seconds instead of seconds for max_wait

### DIFF
--- a/nominal/core/_stream/write_stream.py
+++ b/nominal/core/_stream/write_stream.py
@@ -359,11 +359,13 @@ class WriteStream(WriteStreamBase[StreamType]):
                 logger.warning("Upload task still pending after flushing batch... increase timeout or setting to None")
 
     def _process_timeout_batches(self) -> None:
+        max_wait_seconds = self.max_wait.total_seconds()
+
         while not self._stop.is_set():
             now = time.monotonic()
 
             last_batch_time = self._thread_safe_batch.last_time
-            timeout = max(self.max_wait.total_seconds() - (now - last_batch_time), 0)
+            timeout = max(max_wait_seconds - (now - last_batch_time), 0)
             self._stop.wait(timeout=timeout)
 
             # check if flush has been called in the mean time

--- a/nominal/core/_stream/write_stream.py
+++ b/nominal/core/_stream/write_stream.py
@@ -363,7 +363,7 @@ class WriteStream(WriteStreamBase[StreamType]):
             now = time.monotonic()
 
             last_batch_time = self._thread_safe_batch.last_time
-            timeout = max(self.max_wait.seconds - (now - last_batch_time), 0)
+            timeout = max(self.max_wait.total_seconds() - (now - last_batch_time), 0)
             self._stop.wait(timeout=timeout)
 
             # check if flush has been called in the mean time

--- a/tests/test_write_stream.py
+++ b/tests/test_write_stream.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import threading
-import time
 from datetime import datetime, timedelta
 from typing import cast
 from unittest.mock import MagicMock, patch
@@ -1029,8 +1028,12 @@ def test_infer_point_type_dict():
 )
 def test_process_timeout_batches_waits_for_whole_max_wait(max_wait, expected_timeout):
     """max_wait converts to seconds in full: days scale up, fractions are preserved."""
+    # Freeze the clock at the batch's last swap: no elapsed time to subtract, so the
+    # computed wait is exactly the converted max_wait rather than a wall-clock race.
+    now = 1000.0
+
     batch = MagicMock()
-    batch.last_time = time.monotonic()
+    batch.last_time = now
     batch.swap.return_value = []
 
     stop = MagicMock(spec=threading.Event)
@@ -1045,7 +1048,8 @@ def test_process_timeout_batches_waits_for_whole_max_wait(max_wait, expected_tim
         _stop=stop,
         _pending_jobs=threading.BoundedSemaphore(3),
     )
-    stream._process_timeout_batches()
+    with patch("nominal.core._stream.write_stream.time.monotonic", return_value=now):
+        stream._process_timeout_batches()
 
     stop.wait.assert_called_once()
-    assert stop.wait.call_args.kwargs["timeout"] == pytest.approx(expected_timeout, abs=1e-3)
+    assert stop.wait.call_args.kwargs["timeout"] == expected_timeout

--- a/tests/test_write_stream.py
+++ b/tests/test_write_stream.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from datetime import datetime, timedelta
 from typing import cast
 from unittest.mock import MagicMock, patch
@@ -7,7 +8,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from nominal.core._stream.batch_processor_proto import process_batch
-from nominal.core._stream.write_stream import BatchItem, DataItem, PointType, WriteStream, infer_point_type
+from nominal.core._stream.write_stream import (
+    BatchItem,
+    DataItem,
+    PointType,
+    ThreadSafeBatch,
+    WriteStream,
+    infer_point_type,
+)
 from nominal.core.connection import StreamingConnection
 from nominal.core.dataset import Dataset
 from nominal.protos.write.nominal_write_pb2 import (
@@ -1014,3 +1022,34 @@ def test_infer_point_type_dict():
     assert infer_point_type({"key": "value"}) == PointType.STRUCT
     assert infer_point_type({"nested": {"x": 1}}) == PointType.STRUCT
     assert infer_point_type({}) == PointType.STRUCT
+
+
+@pytest.mark.parametrize(
+    "max_wait, expected_timeout",
+    [
+        (timedelta(milliseconds=500), 0.5),
+        (timedelta(milliseconds=1500), 1.5),
+        (timedelta(seconds=5), 5.0),
+        (timedelta(minutes=2), 120.0),
+        (timedelta(days=1), 86400.0),
+    ],
+)
+def test_process_timeout_batches_waits_for_whole_max_wait(max_wait, expected_timeout):
+    """max_wait converts to seconds in full: days scale up, fractions are preserved."""
+    stop = threading.Event()
+
+    # Stop after one iteration, and record what that iteration asked to wait for.
+    with patch.object(stop, "wait", side_effect=lambda timeout: stop.set()) as mock_wait:
+        stream = WriteStream(
+            batch_size=10,
+            max_wait=max_wait,
+            _process_batch=MagicMock(),
+            _executor=MagicMock(),
+            _thread_safe_batch=ThreadSafeBatch(),
+            _stop=stop,
+            _pending_jobs=threading.BoundedSemaphore(3),
+        )
+        stream._process_timeout_batches()
+
+    mock_wait.assert_called_once()
+    assert mock_wait.call_args.kwargs["timeout"] == pytest.approx(expected_timeout, abs=0.05)

--- a/tests/test_write_stream.py
+++ b/tests/test_write_stream.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from datetime import datetime, timedelta
 from typing import cast
 from unittest.mock import MagicMock, patch
@@ -8,14 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from nominal.core._stream.batch_processor_proto import process_batch
-from nominal.core._stream.write_stream import (
-    BatchItem,
-    DataItem,
-    PointType,
-    ThreadSafeBatch,
-    WriteStream,
-    infer_point_type,
-)
+from nominal.core._stream.write_stream import BatchItem, DataItem, PointType, WriteStream, infer_point_type
 from nominal.core.connection import StreamingConnection
 from nominal.core.dataset import Dataset
 from nominal.protos.write.nominal_write_pb2 import (
@@ -1029,27 +1023,29 @@ def test_infer_point_type_dict():
     [
         (timedelta(milliseconds=500), 0.5),
         (timedelta(milliseconds=1500), 1.5),
-        (timedelta(seconds=5), 5.0),
         (timedelta(minutes=2), 120.0),
         (timedelta(days=1), 86400.0),
     ],
 )
 def test_process_timeout_batches_waits_for_whole_max_wait(max_wait, expected_timeout):
     """max_wait converts to seconds in full: days scale up, fractions are preserved."""
-    stop = threading.Event()
+    batch = MagicMock()
+    batch.last_time = time.monotonic()
+    batch.swap.return_value = []
 
-    # Stop after one iteration, and record what that iteration asked to wait for.
-    with patch.object(stop, "wait", side_effect=lambda timeout: stop.set()) as mock_wait:
-        stream = WriteStream(
-            batch_size=10,
-            max_wait=max_wait,
-            _process_batch=MagicMock(),
-            _executor=MagicMock(),
-            _thread_safe_batch=ThreadSafeBatch(),
-            _stop=stop,
-            _pending_jobs=threading.BoundedSemaphore(3),
-        )
-        stream._process_timeout_batches()
+    stop = MagicMock(spec=threading.Event)
+    stop.is_set.side_effect = [False, True]  # run exactly one iteration
 
-    mock_wait.assert_called_once()
-    assert mock_wait.call_args.kwargs["timeout"] == pytest.approx(expected_timeout, abs=0.05)
+    stream = WriteStream(
+        batch_size=10,
+        max_wait=max_wait,
+        _process_batch=MagicMock(),
+        _executor=MagicMock(),
+        _thread_safe_batch=batch,
+        _stop=stop,
+        _pending_jobs=threading.BoundedSemaphore(3),
+    )
+    stream._process_timeout_batches()
+
+    stop.wait.assert_called_once()
+    assert stop.wait.call_args.kwargs["timeout"] == pytest.approx(expected_timeout, abs=1e-3)


### PR DESCRIPTION
`_process_timeout_batches` slept on `max_wait.seconds` — the whole-seconds component — instead of `max_wait.total_seconds()`.

This meant that:

- `timedelta(milliseconds=500)` → 0s sleep, so the flush thread busy waits/pegs a CPU
- `timedelta(milliseconds=1500)` → sleeps 1.0s.
- `timedelta(days=1)` → 0s sleep, busy wait

Using total_seconds fixes all these to match what the caller passed in.
