### PR TITLE
feat: retry transient asset task failures in the parallel executor

### DIFF
--- a/nominal/experimental/migration/migrator/asset_migrator.py
+++ b/nominal/experimental/migration/migrator/asset_migrator.py
@@ -23,6 +23,7 @@ from nominal.experimental.migration.migrator.run_migrator import RunCopyOptions,
 from nominal.experimental.migration.migrator.video_migrator import VideoCopyOptions, VideoMigrator
 from nominal.experimental.migration.migrator.workbook_migrator import WorkbookCopyOptions, WorkbookMigrator
 from nominal.experimental.migration.resource_type import ResourceType
+from nominal.experimental.migration.utils.retry_utils import is_transient_error
 
 logger = logging.getLogger(__name__)
 
@@ -347,7 +348,8 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             if not workbook.asset_rids:
                 continue
             if len(workbook.asset_rids) == 1:
-                workbook_migrator.copy_from(
+                self._copy_workbook_containing_failures(
+                    workbook_migrator,
                     workbook,
                     WorkbookCopyOptions(source_to_destination_asset_rid_mapping={source_asset.rid: new_asset.rid}),
                 )
@@ -389,7 +391,8 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
             # every reference to those other assets instead of waiting for a complete mapping.
             source_run_asset_rids = list(source_run.assets)
             if len(workbook.run_rids) == 1 and len(source_run_asset_rids) <= 1:
-                workbook_migrator.copy_from(
+                self._copy_workbook_containing_failures(
+                    workbook_migrator,
                     workbook,
                     WorkbookCopyOptions(
                         source_to_destination_asset_rid_mapping={source_asset.rid: new_asset.rid},
@@ -398,6 +401,34 @@ class AssetMigrator(Migrator[Asset, AssetCopyOptions]):
                 )
             else:
                 self._enqueue_multi_run_workbook(workbook, list(workbook.run_rids), source_run_asset_rids)
+
+    def _copy_workbook_containing_failures(
+        self,
+        workbook_migrator: WorkbookMigrator,
+        workbook: Workbook,
+        options: WorkbookCopyOptions,
+    ) -> None:
+        """One bad workbook must not abort the whole asset task (observed in production: a
+        connection reset on a single workbook read killed the asset task and every sibling
+        resource behind it).
+
+        Transient errors propagate — the executor retries the whole task, which resumes
+        cheaply from migration state — while anything else records a skip for the end-of-run
+        summary and lets the asset's remaining resources migrate. With no mapping recorded,
+        a rerun re-attempts the workbook.
+        """
+        try:
+            workbook_migrator.copy_from(workbook, options)
+        except Exception as error:
+            if is_transient_error(error):
+                raise
+            logger.exception("Failed to copy workbook (rid: %s)", workbook.rid)
+            self.ctx.migration_state.set_skip(ResourceType.WORKBOOK, workbook.rid, f"copy failed: {error}")
+            return
+        # This attempt's outcome supersedes any copy-failure skip from an earlier run. Safe to
+        # clear unconditionally: terminal workbook skips are recorded only in the deferred
+        # multi-asset/multi-run flush, never on this single-scope path.
+        self.ctx.migration_state.set_skip(ResourceType.WORKBOOK, workbook.rid, None)
 
     def _enqueue_multi_asset_workbook(self, workbook: Workbook, source_asset_rids: list[str]) -> None:
         if not self._should_enqueue_deferred_workbook(workbook, source_asset_rids):

--- a/nominal/experimental/migration/parallel_migration_executor.py
+++ b/nominal/experimental/migration/parallel_migration_executor.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import concurrent.futures
 import logging
 import os
-import random
-import time
 from dataclasses import dataclass
 from typing import Callable
 
-from nominal.experimental.migration.utils.retry_utils import DEFAULT_BACKOFF_CAP_SECONDS, is_transient_error
+from nominal.experimental.migration.utils.retry_utils import retry_transient
 
 logger = logging.getLogger(__name__)
 
@@ -39,68 +37,50 @@ def run_concurrent(
     executor: concurrent.futures.ThreadPoolExecutor,
     tasks: list[MigrationTask],
     on_task_complete: Callable[[], None] | None = None,
+    sleep: Callable[[float], None] | None = None,
 ) -> None:
     """Submit tasks concurrently and raise a RuntimeError listing all failures.
 
-    A task that fails with a transient network error is resubmitted with jittered backoff, up
-    to ``TASK_ATTEMPTS`` total attempts — copies are state-resumable, so a retried task skips
-    children the failed attempt already migrated. Non-transient failures, and transient ones
-    that exhaust the budget, are collected and raised together at the end.
+    Each task runs under ``retry_transient``: a transient network failure retries the whole
+    task in place with jittered backoff, up to ``TASK_ATTEMPTS`` total attempts. Copies are
+    state-resumable, so a retry re-runs only what the failed attempt did not complete. The
+    backoff holds that task's worker slot; other tasks keep running on theirs. Non-transient
+    failures, and transient ones that exhaust the budget, are collected and raised together.
 
     Args:
         executor: The thread pool to submit tasks to.
         tasks: The migration tasks to run.
-        on_task_complete: Called after every task attempt settles (success or failure) — used
-            to persist migration state incrementally. The parallel runner passes a debounced
+        on_task_complete: Called after every task settles (success or failure) — used to
+            persist migration state incrementally. The parallel runner passes a debounced
             save, so persistence may lag by up to one debounce interval; unconditional
             saves happen at the signal flush and the runner's final `finally`.
+        sleep: Injectable backoff sleep for tests; defaults to time.sleep.
     """
     if not tasks:
         return
 
     errors: list[Exception] = []
-    attempts_by_task_id: dict[int, int] = {}
-    pending: dict[concurrent.futures.Future[None], MigrationTask] = {executor.submit(task.fn): task for task in tasks}
-    while pending:
-        done, _ = concurrent.futures.wait(pending, return_when=concurrent.futures.FIRST_COMPLETED)
-        for future in done:
-            task = pending.pop(future)
-            try:
-                future.result()
-                logger.info("Completed migration for %s (rid: %s)", task.label, task.rid)
-            except Exception as exc:
-                attempt = attempts_by_task_id.get(id(task), 1)
-                if is_transient_error(exc) and attempt < TASK_ATTEMPTS:
-                    attempts_by_task_id[id(task)] = attempt + 1
-                    # Full jitter over a doubling window, matching the per-operation retries.
-                    delay = random.uniform(
-                        0, min(DEFAULT_BACKOFF_CAP_SECONDS, _TASK_BACKOFF_BASE_SECONDS * 2 ** (attempt - 1))
-                    )
-                    logger.warning(
-                        "Transient failure migrating %s (rid: %s) on attempt %d/%d — retrying in %.1fs, "
-                        "resuming from migration state: %s",
-                        task.label,
-                        task.rid,
-                        attempt,
-                        TASK_ATTEMPTS,
-                        delay,
-                        exc,
-                    )
-                    # The delay runs inside the worker so this loop never blocks other tasks.
-                    pending[executor.submit(_delayed(task.fn, delay))] = task
-                else:
-                    logger.error("Failed to migrate %s (rid: %s)", task.label, task.rid, exc_info=exc)
-                    errors.append(exc)
-            if on_task_complete is not None:
-                on_task_complete()
+    futures = {
+        executor.submit(
+            retry_transient,
+            task.fn,
+            description=f"migration of {task.label} (rid: {task.rid})",
+            max_attempts=TASK_ATTEMPTS,
+            backoff_base_seconds=_TASK_BACKOFF_BASE_SECONDS,
+            sleep=sleep,
+        ): task
+        for task in tasks
+    }
+    for future in concurrent.futures.as_completed(futures):
+        task = futures[future]
+        try:
+            future.result()
+            logger.info("Completed migration for %s (rid: %s)", task.label, task.rid)
+        except Exception as exc:
+            logger.error("Failed to migrate %s (rid: %s)", task.label, task.rid, exc_info=exc)
+            errors.append(exc)
+        if on_task_complete is not None:
+            on_task_complete()
     if errors:
         error_summary = "; ".join(str(e) for e in errors)
         raise RuntimeError(f"Parallel migration had {len(errors)} failure(s): {error_summary}")
-
-
-def _delayed(fn: Callable[[], None], delay_seconds: float) -> Callable[[], None]:
-    def run() -> None:
-        time.sleep(delay_seconds)
-        fn()
-
-    return run

--- a/nominal/experimental/migration/parallel_migration_executor.py
+++ b/nominal/experimental/migration/parallel_migration_executor.py
@@ -5,10 +5,21 @@ from __future__ import annotations
 import concurrent.futures
 import logging
 import os
+import random
+import time
 from dataclasses import dataclass
 from typing import Callable
 
+from nominal.experimental.migration.utils.retry_utils import DEFAULT_BACKOFF_CAP_SECONDS, is_transient_error
+
 logger = logging.getLogger(__name__)
+
+# Total attempts per task, including the first. A retried task resumes from migration state,
+# so it re-runs only what the failed attempt did not complete. This is the safety net for
+# transient failures on calls the per-operation retries don't wrap (e.g. a connection reset
+# mid-body on a workbook read, observed killing asset tasks in a production migration).
+TASK_ATTEMPTS = 3
+_TASK_BACKOFF_BASE_SECONDS = 2.0
 
 
 @dataclass(frozen=True)
@@ -31,11 +42,16 @@ def run_concurrent(
 ) -> None:
     """Submit tasks concurrently and raise a RuntimeError listing all failures.
 
+    A task that fails with a transient network error is resubmitted with jittered backoff, up
+    to ``TASK_ATTEMPTS`` total attempts — copies are state-resumable, so a retried task skips
+    children the failed attempt already migrated. Non-transient failures, and transient ones
+    that exhaust the budget, are collected and raised together at the end.
+
     Args:
         executor: The thread pool to submit tasks to.
         tasks: The migration tasks to run.
-        on_task_complete: Called after every task settles (success or failure) — used to
-            persist migration state incrementally. The parallel runner passes a debounced
+        on_task_complete: Called after every task attempt settles (success or failure) — used
+            to persist migration state incrementally. The parallel runner passes a debounced
             save, so persistence may lag by up to one debounce interval; unconditional
             saves happen at the signal flush and the runner's final `finally`.
     """
@@ -43,17 +59,48 @@ def run_concurrent(
         return
 
     errors: list[Exception] = []
-    futures = {executor.submit(task.fn): task for task in tasks}
-    for future in concurrent.futures.as_completed(futures):
-        task = futures[future]
-        try:
-            future.result()
-            logger.info("Completed migration for %s (rid: %s)", task.label, task.rid)
-        except Exception as exc:  # pragma: no cover - exercised by production callers
-            logger.error("Failed to migrate %s (rid: %s)", task.label, task.rid, exc_info=exc)
-            errors.append(exc)
-        if on_task_complete is not None:
-            on_task_complete()
+    attempts_by_task_id: dict[int, int] = {}
+    pending: dict[concurrent.futures.Future[None], MigrationTask] = {executor.submit(task.fn): task for task in tasks}
+    while pending:
+        done, _ = concurrent.futures.wait(pending, return_when=concurrent.futures.FIRST_COMPLETED)
+        for future in done:
+            task = pending.pop(future)
+            try:
+                future.result()
+                logger.info("Completed migration for %s (rid: %s)", task.label, task.rid)
+            except Exception as exc:
+                attempt = attempts_by_task_id.get(id(task), 1)
+                if is_transient_error(exc) and attempt < TASK_ATTEMPTS:
+                    attempts_by_task_id[id(task)] = attempt + 1
+                    # Full jitter over a doubling window, matching the per-operation retries.
+                    delay = random.uniform(
+                        0, min(DEFAULT_BACKOFF_CAP_SECONDS, _TASK_BACKOFF_BASE_SECONDS * 2 ** (attempt - 1))
+                    )
+                    logger.warning(
+                        "Transient failure migrating %s (rid: %s) on attempt %d/%d — retrying in %.1fs, "
+                        "resuming from migration state: %s",
+                        task.label,
+                        task.rid,
+                        attempt,
+                        TASK_ATTEMPTS,
+                        delay,
+                        exc,
+                    )
+                    # The delay runs inside the worker so this loop never blocks other tasks.
+                    pending[executor.submit(_delayed(task.fn, delay))] = task
+                else:
+                    logger.error("Failed to migrate %s (rid: %s)", task.label, task.rid, exc_info=exc)
+                    errors.append(exc)
+            if on_task_complete is not None:
+                on_task_complete()
     if errors:
         error_summary = "; ".join(str(e) for e in errors)
         raise RuntimeError(f"Parallel migration had {len(errors)} failure(s): {error_summary}")
+
+
+def _delayed(fn: Callable[[], None], delay_seconds: float) -> Callable[[], None]:
+    def run() -> None:
+        time.sleep(delay_seconds)
+        fn()
+
+    return run

--- a/tests/core/test_migration_task_retry.py
+++ b/tests/core/test_migration_task_retry.py
@@ -110,3 +110,60 @@ def test_retries_do_not_block_other_tasks_and_all_failures_are_collected(
     assert calls == {"flaky": TASK_ATTEMPTS, "ok": 1, "broken": 1}
     # Every attempt settles the persist hook: flaky's retries included.
     assert settled["n"] == TASK_ATTEMPTS + 2
+
+
+# ---------------------------------------------------------------------------
+# Workbook failure containment inside an asset task
+# ---------------------------------------------------------------------------
+
+from unittest.mock import MagicMock  # noqa: E402
+
+from nominal.experimental.migration.migration_state import MigrationState  # noqa: E402
+from nominal.experimental.migration.migrator.asset_migrator import AssetMigrator  # noqa: E402
+from nominal.experimental.migration.migrator.context import MigrationContext  # noqa: E402
+from nominal.experimental.migration.migrator.workbook_migrator import WorkbookCopyOptions  # noqa: E402
+from nominal.experimental.migration.resource_type import ResourceType  # noqa: E402
+
+_WORKBOOK_RID = "ri.scout.cerulean-staging.notebook.00000001-0000-0000-0000-000000000000"
+
+
+def _asset_migrator_fixture() -> tuple[AssetMigrator, MagicMock, MagicMock]:
+    ctx = MigrationContext(destination_client=MagicMock(), migration_state=MigrationState())
+    workbook = MagicMock()
+    workbook.rid = _WORKBOOK_RID
+    return AssetMigrator(ctx), MagicMock(), workbook
+
+
+def test_non_transient_workbook_failure_is_contained_as_skip() -> None:
+    """A broken workbook records a skip and the asset task lives on; a rerun re-attempts it."""
+    migrator, workbook_migrator, workbook = _asset_migrator_fixture()
+    workbook_migrator.copy_from.side_effect = ValueError("corrupt workbook content")
+
+    migrator._copy_workbook_containing_failures(workbook_migrator, workbook, WorkbookCopyOptions())
+
+    assert migrator.ctx.migration_state.get_mapped_rid(ResourceType.WORKBOOK, _WORKBOOK_RID) is None
+    assert [skip.reason for skip in migrator.ctx.migration_state.skipped_resources] == [
+        "copy failed: corrupt workbook content"
+    ]
+
+
+def test_transient_workbook_failure_propagates_for_task_retry() -> None:
+    """A connection reset must reach the executor, whose task-level retry resumes from state —
+    converting it to a skip here would leave a healthy workbook behind for no reason.
+    """
+    migrator, workbook_migrator, workbook = _asset_migrator_fixture()
+    workbook_migrator.copy_from.side_effect = _reset()
+
+    with pytest.raises(urllib3.exceptions.ProtocolError):
+        migrator._copy_workbook_containing_failures(workbook_migrator, workbook, WorkbookCopyOptions())
+
+    assert migrator.ctx.migration_state.skipped_resources == []
+
+
+def test_workbook_success_clears_stale_copy_failure_skip() -> None:
+    migrator, workbook_migrator, workbook = _asset_migrator_fixture()
+    migrator.ctx.migration_state.set_skip(ResourceType.WORKBOOK, _WORKBOOK_RID, "copy failed: transient")
+
+    migrator._copy_workbook_containing_failures(workbook_migrator, workbook, WorkbookCopyOptions())
+
+    assert migrator.ctx.migration_state.skipped_resources == []

--- a/tests/core/test_migration_task_retry.py
+++ b/tests/core/test_migration_task_retry.py
@@ -2,12 +2,13 @@
 
 A production migration lost two whole asset tasks to a connection reset on a single workbook
 read — a call outside every per-operation retry. The executor is the safety net: transient
-task failures resubmit (copies resume from migration state), everything else still fails.
+task failures retry in place (copies resume from migration state), everything else still fails.
 """
 
 from __future__ import annotations
 
 import sys
+import threading
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -19,17 +20,15 @@ import urllib3.exceptions
 
 from nominal.experimental.migration.parallel_migration_executor import TASK_ATTEMPTS, MigrationTask, run_concurrent
 
-
-def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("nominal.experimental.migration.parallel_migration_executor.time.sleep", lambda _seconds: None)
+_NO_SLEEP = lambda _delay: None  # noqa: E731
 
 
 def _reset() -> urllib3.exceptions.ProtocolError:
     return urllib3.exceptions.ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')")
 
 
-def test_transient_task_failure_is_retried_to_success(monkeypatch: pytest.MonkeyPatch) -> None:
-    _no_sleep(monkeypatch)
+def test_transient_task_failure_is_retried_to_success() -> None:
+    """A transient failure retries the task, and the second attempt's success settles it cleanly."""
     calls = {"n": 0}
 
     def flaky() -> None:
@@ -38,13 +37,13 @@ def test_transient_task_failure_is_retried_to_success(monkeypatch: pytest.Monkey
             raise _reset()
 
     with ThreadPoolExecutor(max_workers=2) as executor:
-        run_concurrent(executor, [MigrationTask(rid="rid-1", label="asset", fn=flaky)])
+        run_concurrent(executor, [MigrationTask(rid="rid-1", label="asset", fn=flaky)], sleep=_NO_SLEEP)
 
     assert calls["n"] == 2
 
 
-def test_transient_task_failure_exhausts_budget_then_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    _no_sleep(monkeypatch)
+def test_transient_task_failure_exhausts_budget_then_raises() -> None:
+    """A transient failure that outlasts the whole budget surfaces as a task failure."""
     calls = {"n": 0}
 
     def always_reset() -> None:
@@ -53,13 +52,13 @@ def test_transient_task_failure_exhausts_budget_then_raises(monkeypatch: pytest.
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         with pytest.raises(RuntimeError, match="1 failure"):
-            run_concurrent(executor, [MigrationTask(rid="rid-1", label="asset", fn=always_reset)])
+            run_concurrent(executor, [MigrationTask(rid="rid-1", label="asset", fn=always_reset)], sleep=_NO_SLEEP)
 
     assert calls["n"] == TASK_ATTEMPTS
 
 
-def test_non_transient_task_failure_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
-    _no_sleep(monkeypatch)
+def test_non_transient_task_failure_is_not_retried() -> None:
+    """A permanent failure spends exactly one attempt — retrying cannot help."""
     calls = {"n": 0}
 
     def broken() -> None:
@@ -68,18 +67,49 @@ def test_non_transient_task_failure_is_not_retried(monkeypatch: pytest.MonkeyPat
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         with pytest.raises(RuntimeError, match="1 failure"):
-            run_concurrent(executor, [MigrationTask(rid="rid-1", label="asset", fn=broken)])
+            run_concurrent(executor, [MigrationTask(rid="rid-1", label="asset", fn=broken)], sleep=_NO_SLEEP)
 
     assert calls["n"] == 1
 
 
-def test_retries_do_not_block_other_tasks_and_all_failures_are_collected(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """One retrying task and one permanent failure: the healthy task completes, the permanent
-    one is reported once, and the summary counts each task's terminal outcome exactly once.
+def test_retrying_task_does_not_block_other_tasks() -> None:
+    """While one task is parked in its retry backoff, other tasks keep completing.
+
+    The backoff sleep is gated on the healthy task's completion event: if a retry blocked the
+    pool, the healthy task could never finish and the gate would time out the test.
     """
-    _no_sleep(monkeypatch)
+    healthy_done = threading.Event()
+    calls = {"flaky": 0, "ok": 0}
+
+    def gated_sleep(_delay: float) -> None:
+        assert healthy_done.wait(timeout=10), "healthy task did not complete while the retry was parked"
+
+    def flaky() -> None:
+        calls["flaky"] += 1
+        if calls["flaky"] == 1:
+            raise _reset()
+
+    def ok() -> None:
+        calls["ok"] += 1
+        healthy_done.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        run_concurrent(
+            executor,
+            [
+                MigrationTask(rid="rid-flaky", label="asset", fn=flaky),
+                MigrationTask(rid="rid-ok", label="asset", fn=ok),
+            ],
+            sleep=gated_sleep,
+        )
+
+    assert calls == {"flaky": 2, "ok": 1}
+
+
+def test_all_terminal_failures_are_collected_and_hook_fires_per_task() -> None:
+    """Mixed outcomes: the retried task recovers, the permanent one is reported exactly once,
+    and the persist hook fires once per settled task.
+    """
     calls = {"flaky": 0, "ok": 0, "broken": 0}
     settled = {"n": 0}
 
@@ -105,11 +135,11 @@ def test_retries_do_not_block_other_tasks_and_all_failures_are_collected(
                     MigrationTask(rid="rid-broken", label="asset", fn=broken),
                 ],
                 on_task_complete=lambda: settled.__setitem__("n", settled["n"] + 1),
+                sleep=_NO_SLEEP,
             )
 
     assert calls == {"flaky": TASK_ATTEMPTS, "ok": 1, "broken": 1}
-    # Every attempt settles the persist hook: flaky's retries included.
-    assert settled["n"] == TASK_ATTEMPTS + 2
+    assert settled["n"] == 3
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +191,7 @@ def test_transient_workbook_failure_propagates_for_task_retry() -> None:
 
 
 def test_workbook_success_clears_stale_copy_failure_skip() -> None:
+    """A workbook that failed transiently in an earlier run stops being reported once it copies."""
     migrator, workbook_migrator, workbook = _asset_migrator_fixture()
     migrator.ctx.migration_state.set_skip(ResourceType.WORKBOOK, _WORKBOOK_RID, "copy failed: transient")
 

--- a/tests/core/test_migration_task_retry.py
+++ b/tests/core/test_migration_task_retry.py
@@ -1,0 +1,112 @@
+"""Task-level transient retry in the parallel migration executor.
+
+A production migration lost two whole asset tasks to a connection reset on a single workbook
+read — a call outside every per-operation retry. The executor is the safety net: transient
+task failures resubmit (copies resume from migration state), everything else still fails.
+"""
+
+from __future__ import annotations
+
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+if sys.version_info < (3, 13):
+    pytest.skip("Migration module requires Python 3.13+ (TypeVar default parameter)", allow_module_level=True)
+
+import urllib3.exceptions
+
+from nominal.experimental.migration.parallel_migration_executor import TASK_ATTEMPTS, MigrationTask, run_concurrent
+
+
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nominal.experimental.migration.parallel_migration_executor.time.sleep", lambda _seconds: None)
+
+
+def _reset() -> urllib3.exceptions.ProtocolError:
+    return urllib3.exceptions.ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')")
+
+
+def test_transient_task_failure_is_retried_to_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    _no_sleep(monkeypatch)
+    calls = {"n": 0}
+
+    def flaky() -> None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _reset()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        run_concurrent(executor, [MigrationTask(rid="rid-1", label="asset", fn=flaky)])
+
+    assert calls["n"] == 2
+
+
+def test_transient_task_failure_exhausts_budget_then_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _no_sleep(monkeypatch)
+    calls = {"n": 0}
+
+    def always_reset() -> None:
+        calls["n"] += 1
+        raise _reset()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        with pytest.raises(RuntimeError, match="1 failure"):
+            run_concurrent(executor, [MigrationTask(rid="rid-1", label="asset", fn=always_reset)])
+
+    assert calls["n"] == TASK_ATTEMPTS
+
+
+def test_non_transient_task_failure_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    _no_sleep(monkeypatch)
+    calls = {"n": 0}
+
+    def broken() -> None:
+        calls["n"] += 1
+        raise ValueError("permanent")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        with pytest.raises(RuntimeError, match="1 failure"):
+            run_concurrent(executor, [MigrationTask(rid="rid-1", label="asset", fn=broken)])
+
+    assert calls["n"] == 1
+
+
+def test_retries_do_not_block_other_tasks_and_all_failures_are_collected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One retrying task and one permanent failure: the healthy task completes, the permanent
+    one is reported once, and the summary counts each task's terminal outcome exactly once.
+    """
+    _no_sleep(monkeypatch)
+    calls = {"flaky": 0, "ok": 0, "broken": 0}
+    settled = {"n": 0}
+
+    def flaky() -> None:
+        calls["flaky"] += 1
+        if calls["flaky"] < TASK_ATTEMPTS:
+            raise _reset()
+
+    def ok() -> None:
+        calls["ok"] += 1
+
+    def broken() -> None:
+        calls["broken"] += 1
+        raise ValueError("permanent")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        with pytest.raises(RuntimeError, match="1 failure"):
+            run_concurrent(
+                executor,
+                [
+                    MigrationTask(rid="rid-flaky", label="asset", fn=flaky),
+                    MigrationTask(rid="rid-ok", label="asset", fn=ok),
+                    MigrationTask(rid="rid-broken", label="asset", fn=broken),
+                ],
+                on_task_complete=lambda: settled.__setitem__("n", settled["n"] + 1),
+            )
+
+    assert calls == {"flaky": TASK_ATTEMPTS, "ok": 1, "broken": 1}
+    # Every attempt settles the persist hook: flaky's retries included.
+    assert settled["n"] == TASK_ATTEMPTS + 2


### PR DESCRIPTION
## Context

A production migration rerun failed with `Parallel migration had 2 failure(s)` — both a `ChunkedEncodingError` / `ConnectionResetError(104)` mid-response-body on a **workbook read** (`workbook.is_draft()` → `notebook.get`). That call sits outside every per-operation retry added in #934 (which wraps the video-file transfer path), and outside the conjure client's built-in retry (its `Retry` sets `read=0` deliberately — it retries all HTTP methods, so blind read-retries could duplicate writes). One reset on one unlucky GET killed each asset task.

Wrapping every conjure call in every migrator individually is whack-a-mole. The executor is the right safety net.

## Changes

`run_concurrent` resubmits a task that fails with a transient error (classified by the existing `is_transient_error`) with jittered backoff, up to 3 total attempts:

- Safe for every resource type at once: copies are **state-resumable**, so a retried task skips children the failed attempt already migrated and resumes at the failed call.
- Non-transient failures, and transients that exhaust the budget, are collected and raised exactly as before.
- The backoff sleeps inside the worker slot, so the completion loop never blocks other tasks' progress or the incremental state persistence.

Note on `--max-workers`: reducing concurrency lowers the odds of pooled-connection resets but cannot eliminate them (an idle keep-alive connection closed by the server can be reused even at 1 worker) — hence retry rather than tuning guidance.

## Also in this PR: workbook failure containment

The same incident showed a second gap: one bad workbook aborted its whole asset task. The two single-scope workbook copy call sites are now guarded — **transient** errors propagate (so the task-level retry above resumes the asset from state), while **non-transient** failures record a `copy failed` skip in the end-of-run summary and let the asset's remaining resources migrate. No mapping is recorded, so a rerun re-attempts the workbook, and a later success clears the stale skip. The two layers compose: retry what a retry can fix, contain what it cannot.

## Testing

- Unit: transient task failure retries to success; exhausted budget raises with the original error; non-transient fails once with no retry; a retrying task doesn't block healthy tasks (the backoff is gated on the healthy task's completion event, so the test asserts real ordering), terminal outcomes are each counted once, and the persist hook fires once per settled task. Full `tests/core` + `tests/experimental` pass (768 tests).
- `just check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

