### PR TITLE
fix: support plaintext gRPC for local runtimes

### DIFF
--- a/docs/src/networking-tls.md
+++ b/docs/src/networking-tls.md
@@ -3,9 +3,12 @@
 The Nominal client talks to the platform over two transports: HTTP (conjure services) and gRPC
 (e.g. the Role Service). HTTPS URLs verify the server's TLS certificate on both transports.
 
-## Local HTTP runtimes
+## Plaintext HTTP deployments
 
-For a local runtime, pass its HTTP ingress URL, including `/api`:
+An `http://` URL selects plaintext for both HTTP and gRPC on any host, including remote hosts.
+Credentials and custom headers are sent without TLS encryption. Use `https://` when TLS is required.
+
+For example, connect to a local runtime using its HTTP ingress URL, including `/api`:
 
 ```python
 client = NominalClient.from_token(token, base_url="http://127.0.0.1:20000/api")
@@ -18,7 +21,7 @@ service used to resolve the client's workspace. Desktop Core provides these rout
 loopback ingress. Authentication, custom headers, retries, deadlines, and Nominal exception
 translation apply to both plaintext and TLS gRPC calls. HTTPS URLs continue to use TLS.
 
-## How trust is established
+## How trust is established for HTTPS
 
 - **HTTP** uses your operating system's trust store directly (via `truststore`), plus certifi.
 - **gRPC** cannot use the OS trust store on demand, so at startup the client builds a CA bundle by

--- a/docs/src/networking-tls.md
+++ b/docs/src/networking-tls.md
@@ -1,7 +1,22 @@
 # Networking & TLS on corporate networks
 
 The Nominal client talks to the platform over two transports: HTTP (conjure services) and gRPC
-(e.g. the Role Service). Both verify the server's TLS certificate.
+(e.g. the Role Service). HTTPS URLs verify the server's TLS certificate on both transports.
+
+## Local HTTP runtimes
+
+For a local runtime, pass its HTTP ingress URL, including `/api`:
+
+```python
+client = NominalClient.from_token(token, base_url="http://127.0.0.1:20000/api")
+dataset = client.create_dataset("x")
+```
+
+For HTTP URLs, gRPC services use plaintext HTTP/2 on the same host and port as the HTTP API.
+The runtime ingress must support both ordinary HTTP and plaintext gRPC, including the workspace
+service used to resolve the client's workspace. Desktop Core provides these routes through its
+loopback ingress. Authentication, custom headers, retries, deadlines, and Nominal exception
+translation apply to both plaintext and TLS gRPC calls. HTTPS URLs continue to use TLS.
 
 ## How trust is established
 

--- a/nominal/core/_utils/grpc_tools.py
+++ b/nominal/core/_utils/grpc_tools.py
@@ -6,7 +6,8 @@ generated stub to, so every stub shares that one channel.
 
 The channel is configured to track the conjure HTTP transport as closely as gRPC allows:
 
-- TLS roots are the union of the configured trust store and the OS trust store (`_grpc_root_certificates`).
+- HTTP URLs select plaintext gRPC on any host; HTTPS URLs select TLS.
+- For TLS, roots combine the configured trust store and the OS trust store (`_grpc_root_certificates`).
 - Retry mirrors conjure's `RetryWithJitter` (`_service_config_json`).
 - Per-call auth metadata and a default deadline are injected by client interceptors, so call sites never
   pass `metadata=` / `timeout=` themselves.

--- a/nominal/core/_utils/grpc_tools.py
+++ b/nominal/core/_utils/grpc_tools.py
@@ -253,17 +253,12 @@ def create_grpc_channel(
     auth_header: str,
     header_provider: HeaderProvider | None,
 ) -> grpc.Channel:
-    """Build the single shared, fully-configured secure gRPC channel for a client.
+    """Build the shared gRPC channel, using plaintext for HTTP URLs and TLS otherwise.
 
-    Assembles everything the channel needs and returns it ready to host stubs: TLS credentials over the
-    union trust bundle, gzip compression, native retry, lifted message-size limits, the SDK user-agent, and
-    the auth-metadata + default-deadline interceptors. All of a client's gRPC stubs share this one channel.
+    Configures gzip compression, native retry, lifted message-size limits, the SDK user-agent, and the
+    auth-metadata + default-deadline interceptors. TLS channels use the union trust bundle; plaintext
+    channels do not load TLS credentials. All of a client's gRPC stubs share this one channel.
     """
-    credentials = grpc.ssl_channel_credentials(
-        root_certificates=_grpc_root_certificates(
-            None if service_config.security is None else service_config.security.trust_store_path
-        )
-    )
     options = [
         ("grpc.primary_user_agent", user_agent),
         ("grpc.enable_retries", 1),
@@ -271,9 +266,16 @@ def create_grpc_channel(
         ("grpc.max_send_message_length", _MAX_MESSAGE_LENGTH),
         ("grpc.max_receive_message_length", _MAX_MESSAGE_LENGTH),
     ]
-    channel = grpc.secure_channel(
-        api_base_url_to_grpc_target(api_base_url), credentials, options=options, compression=grpc.Compression.Gzip
-    )
+    target = api_base_url_to_grpc_target(api_base_url)
+    if urlparse(api_base_url).scheme == "http":
+        channel = grpc.insecure_channel(target, options=options, compression=grpc.Compression.Gzip)
+    else:
+        credentials = grpc.ssl_channel_credentials(
+            root_certificates=_grpc_root_certificates(
+                None if service_config.security is None else service_config.security.trust_store_path
+            )
+        )
+        channel = grpc.secure_channel(target, credentials, options=options, compression=grpc.Compression.Gzip)
     # The two interceptors are order-independent: one rewrites metadata, the other the deadline.
     return grpc.intercept_channel(
         channel,

--- a/tests/core/test_grpc.py
+++ b/tests/core/test_grpc.py
@@ -190,6 +190,7 @@ def test_create_grpc_channel_wires_credentials_options_and_interceptors(monkeypa
 
 
 def test_http_grpc_channel_uses_plaintext_and_retains_call_policy(monkeypatch) -> None:
+    """HTTP URLs use plaintext while retaining channel options, authentication, and deadlines."""
     secure, intercept, credentials = _patch_channel(monkeypatch)
     insecure = MagicMock(return_value="plaintext-channel")
     monkeypatch.setattr(grpc, "insecure_channel", insecure)

--- a/tests/core/test_grpc.py
+++ b/tests/core/test_grpc.py
@@ -189,6 +189,35 @@ def test_create_grpc_channel_wires_credentials_options_and_interceptors(monkeypa
     assert len(intercept_channel.call_args.args[1:]) == 2
 
 
+def test_http_grpc_channel_uses_plaintext_and_retains_call_policy(monkeypatch) -> None:
+    secure, intercept, credentials = _patch_channel(monkeypatch)
+    insecure = MagicMock(return_value="plaintext-channel")
+    monkeypatch.setattr(grpc, "insecure_channel", insecure)
+
+    assert (
+        create_grpc_channel(
+            api_base_url="http://127.0.0.1:20000/api",
+            service_config=_config(),
+            user_agent="test-agent",
+            auth_header="Bearer tok",
+            header_provider=None,
+        )
+        == "intercepted-channel"
+    )
+
+    secure.assert_not_called()
+    credentials.assert_not_called()
+    assert insecure.call_args.args == ("127.0.0.1:20000",)
+    assert insecure.call_args.kwargs["compression"] == grpc.Compression.Gzip
+    assert dict(insecure.call_args.kwargs["options"])["grpc.primary_user_agent"] == "test-agent"
+    assert intercept.call_args.args[0] == "plaintext-channel"
+    details = _details()
+    for interceptor in intercept.call_args.args[1:]:
+        details = interceptor._amend(details)
+    assert ("authorization", "Bearer tok") in details.metadata
+    assert details.timeout == _config().read_timeout
+
+
 @pytest.mark.parametrize(
     "code, expected",
     [

--- a/tests/core/test_workspace_grpc.py
+++ b/tests/core/test_workspace_grpc.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import grpc
+import pytest
+
+from nominal.core.client import NominalClient
+from nominal.core.exceptions import NominalNotFoundError
+from nominal.protos.workspaces.v1 import workspaces_pb2, workspaces_pb2_grpc
+
+WORKSPACE_RID = "ri.security.desktop.workspace.local"
+
+
+@pytest.fixture
+def grpc_runtime():
+    calls = []
+
+    class Workspaces(workspaces_pb2_grpc.WorkspaceServiceServicer):
+        def GetWorkspace(self, request, context):
+            calls.append(("get", dict(context.invocation_metadata())))
+            if request.workspace_rid != WORKSPACE_RID:
+                context.abort(grpc.StatusCode.NOT_FOUND, "missing workspace")
+            return workspaces_pb2.GetWorkspaceResponse(workspace=workspaces_pb2.Workspace(rid=WORKSPACE_RID))
+
+        def GetDefaultWorkspace(self, request, context):
+            calls.append(("default", dict(context.invocation_metadata())))
+            return workspaces_pb2.GetDefaultWorkspaceResponse(workspace=workspaces_pb2.Workspace(rid=WORKSPACE_RID))
+
+        def GetWorkspaces(self, request, context):
+            calls.append(("list", dict(context.invocation_metadata())))
+            return workspaces_pb2.GetWorkspacesResponse(workspaces=[workspaces_pb2.Workspace(rid=WORKSPACE_RID)])
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        server = grpc.server(executor)
+        workspaces_pb2_grpc.add_WorkspaceServiceServicer_to_server(Workspaces(), server)
+        port = server.add_insecure_port("127.0.0.1:0")
+        server.start()
+        try:
+            yield f"http://127.0.0.1:{port}/api", calls
+        finally:
+            server.stop(0).wait()
+
+
+@pytest.mark.parametrize("pinned", [False, True])
+def test_plaintext_workspace_resolution_listing_auth_and_cache(grpc_runtime, pinned):
+    base_url, calls = grpc_runtime
+    client = NominalClient.from_token(
+        "local-token",
+        base_url=base_url,
+        workspace_rid=WORKSPACE_RID if pinned else None,
+        extra_headers={"X-Test-Header": "present"},
+    )
+    assert client.get_workspace().rid == WORKSPACE_RID
+    assert client.get_workspace(WORKSPACE_RID).rid == WORKSPACE_RID
+    assert [workspace.rid for workspace in client.list_workspaces()] == [WORKSPACE_RID]
+    assert [method for method, _ in calls] == ["get" if pinned else "default", "list"]
+    for _, headers in calls:
+        assert headers["authorization"] == "Bearer local-token"
+        assert headers["x-test-header"] == "present"
+
+
+def test_plaintext_workspace_errors_use_existing_nominal_translation(grpc_runtime):
+    base_url, _ = grpc_runtime
+    client = NominalClient.from_token("local-token", base_url=base_url)
+    with pytest.raises(NominalNotFoundError, match="missing workspace") as exc:
+        client.get_workspace("ri.security.desktop.workspace.missing")
+    assert isinstance(exc.value.__cause__, grpc.RpcError)

--- a/tests/core/test_workspace_grpc.py
+++ b/tests/core/test_workspace_grpc.py
@@ -1,3 +1,5 @@
+"""Exercise workspace calls and error translation over a real plaintext gRPC channel."""
+
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
@@ -14,22 +16,15 @@ WORKSPACE_RID = "ri.security.desktop.workspace.local"
 
 @pytest.fixture
 def grpc_runtime():
-    calls = []
+    """Run a local plaintext workspace service and capture its received metadata."""
+    headers = {}
 
     class Workspaces(workspaces_pb2_grpc.WorkspaceServiceServicer):
         def GetWorkspace(self, request, context):
-            calls.append(("get", dict(context.invocation_metadata())))
+            headers.update(context.invocation_metadata())
             if request.workspace_rid != WORKSPACE_RID:
                 context.abort(grpc.StatusCode.NOT_FOUND, "missing workspace")
             return workspaces_pb2.GetWorkspaceResponse(workspace=workspaces_pb2.Workspace(rid=WORKSPACE_RID))
-
-        def GetDefaultWorkspace(self, request, context):
-            calls.append(("default", dict(context.invocation_metadata())))
-            return workspaces_pb2.GetDefaultWorkspaceResponse(workspace=workspaces_pb2.Workspace(rid=WORKSPACE_RID))
-
-        def GetWorkspaces(self, request, context):
-            calls.append(("list", dict(context.invocation_metadata())))
-            return workspaces_pb2.GetWorkspacesResponse(workspaces=[workspaces_pb2.Workspace(rid=WORKSPACE_RID)])
 
     with ThreadPoolExecutor(max_workers=1) as executor:
         server = grpc.server(executor)
@@ -37,30 +32,26 @@ def grpc_runtime():
         port = server.add_insecure_port("127.0.0.1:0")
         server.start()
         try:
-            yield f"http://127.0.0.1:{port}/api", calls
+            yield f"http://127.0.0.1:{port}/api", headers
         finally:
             server.stop(0).wait()
 
 
-@pytest.mark.parametrize("pinned", [False, True])
-def test_plaintext_workspace_resolution_listing_auth_and_cache(grpc_runtime, pinned):
-    base_url, calls = grpc_runtime
+def test_plaintext_workspace_resolution_preserves_metadata(grpc_runtime):
+    """Workspace calls reach the plaintext server with bearer auth and custom metadata intact."""
+    base_url, headers = grpc_runtime
     client = NominalClient.from_token(
         "local-token",
         base_url=base_url,
-        workspace_rid=WORKSPACE_RID if pinned else None,
         extra_headers={"X-Test-Header": "present"},
     )
-    assert client.get_workspace().rid == WORKSPACE_RID
     assert client.get_workspace(WORKSPACE_RID).rid == WORKSPACE_RID
-    assert [workspace.rid for workspace in client.list_workspaces()] == [WORKSPACE_RID]
-    assert [method for method, _ in calls] == ["get" if pinned else "default", "list"]
-    for _, headers in calls:
-        assert headers["authorization"] == "Bearer local-token"
-        assert headers["x-test-header"] == "present"
+    assert headers["authorization"] == "Bearer local-token"
+    assert headers["x-test-header"] == "present"
 
 
 def test_plaintext_workspace_errors_use_existing_nominal_translation(grpc_runtime):
+    """Plaintext gRPC failures retain the existing Nominal exception and underlying cause."""
     base_url, _ = grpc_runtime
     client = NominalClient.from_token("local-token", base_url=base_url)
     with pytest.raises(NominalNotFoundError, match="missing workspace") as exc:


### PR DESCRIPTION
HTTP API URLs now use plaintext gRPC on the same host and port; HTTPS continues to use TLS. This lets the Python SDK use Desktop Core's new HTTP/2 ingress while retaining the existing generated stubs, workspace caching, authentication, custom headers, retry/deadline policy, and Nominal error translation.

The change is limited to shared channel construction, networking documentation, and regression tests. Workspace calls use the same gRPC path as other services; no workspace-specific Twirp adapter is needed.

Requires the packaged-runtime gRPC ingress in nominal-io/scout#20452. Ship that runtime change first. HTTP-only ingresses without gRPC support are not supported by this change.

### Testing plan

- Static checks: mypy (161 source files), ruff check, ruff format --check, and git diff --check pass.
- 36 focused gRPC/client tests pass. A real plaintext gRPC server exercises workspace resolution, bearer/custom headers, and NominalNotFoundError translation. Existing unit tests cover pinned/default resolution and cache reuse. Channel construction tests retain TLS coverage and verify plaintext avoids loading TLS credentials.
- Four HTTPS workspace E2Es pass against staging. The separate staging pandas export-visibility failure remains under investigation in #953; this PR does not include or depend on those test changes.
- Scout's paired ingress test passes with the actual packaged nginx binary, verifying HTTP/1.1 and gRPC coexistence, workspace/units routing, credential forwarding, and ingress boundaries.
- Full installed Desktop Core dataset creation and point readback remain unverified.



