### PR TITLE
fix(e2e): wait for pandas exports to become readable

### DIFF
--- a/tests/e2e/_export.py
+++ b/tests/e2e/_export.py
@@ -1,0 +1,35 @@
+"""Readiness polling for exports of freshly ingested E2E datasets."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Sized, TypeVar
+
+from conjure_python_client import ConjureHTTPError
+
+_Export = TypeVar("_Export", bound=Sized)
+
+
+def _wait_for_export(export: Callable[[], _Export], expected_rows: int, *, timeout_seconds: float = 120) -> _Export:
+    # Ingestion completion can precede Iceberg table creation and data visibility.
+    # Missing tables currently produce Default:InvalidArgument; subsequent reads
+    # can be empty or partial until the commit becomes visible.
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        try:
+            result = export()
+        except ConjureHTTPError as exc:
+            if (
+                exc.response.status_code != 400
+                or getattr(exc, "error_name", None) != "Default:InvalidArgument"
+                or time.monotonic() >= deadline
+            ):
+                raise
+        else:
+            if len(result) == expected_rows:
+                return result
+            if time.monotonic() >= deadline:
+                raise AssertionError(
+                    f"Export did not become readable: expected {expected_rows} rows, got {len(result)}"
+                )
+        time.sleep(2)

--- a/tests/e2e/_export.py
+++ b/tests/e2e/_export.py
@@ -9,12 +9,43 @@ from conjure_python_client import ConjureHTTPError
 
 _Export = TypeVar("_Export", bound=Sized)
 
+# Avoid hammering the export endpoint while its ingestion commit becomes visible.
+EXPORT_POLL_INTERVAL_SECONDS = 2
+DEFAULT_EXPORT_TIMEOUT_SECONDS = 120
 
-def _wait_for_export(export: Callable[[], _Export], expected_rows: int, *, timeout_seconds: float = 120) -> _Export:
+
+def wait_for_export(
+    export: Callable[[], _Export],
+    expected_rows: int,
+    *,
+    is_ready: Callable[[_Export], bool] | None = None,
+    timeout_seconds: float = DEFAULT_EXPORT_TIMEOUT_SECONDS,
+    now: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> _Export:
+    """Poll a fixed dataset's export until its rows and optional readiness check match.
+
+    Args:
+        export: Read-only export operation that is safe to retry.
+        expected_rows: Exact row count of the fixed input dataset.
+        is_ready: Additional readiness check, such as matching DataFrame column names.
+        timeout_seconds: Remaining polling budget; zero still allows one immediate read.
+        now: Monotonic clock used to measure the polling budget.
+        sleep: Wait function used between attempts.
+
+    Returns:
+        The first export matching both readiness checks.
+
+    Raises:
+        AssertionError: The export has excess rows or exhausts its readiness budget.
+        ConjureHTTPError: An unrelated HTTP error, or the last missing-table error at timeout.
+
+    The budget bounds retries; an individual export retains its own request timeout.
+    """
     # Ingestion completion can precede Iceberg table creation and data visibility.
     # Missing tables currently produce Default:InvalidArgument; subsequent reads
     # can be empty or partial until the commit becomes visible.
-    deadline = time.monotonic() + timeout_seconds
+    deadline = now() + timeout_seconds
     while True:
         try:
             result = export()
@@ -22,14 +53,18 @@ def _wait_for_export(export: Callable[[], _Export], expected_rows: int, *, timeo
             if (
                 exc.response.status_code != 400
                 or getattr(exc, "error_name", None) != "Default:InvalidArgument"
-                or time.monotonic() >= deadline
+                or now() >= deadline
             ):
                 raise
         else:
-            if len(result) == expected_rows:
+            rows = len(result)
+            if rows > expected_rows:
+                raise AssertionError(f"Export has excess rows: expected {expected_rows} rows, got {rows}")
+            if rows == expected_rows and (is_ready is None or is_ready(result)):
                 return result
-            if time.monotonic() >= deadline:
+            if now() >= deadline:
                 raise AssertionError(
-                    f"Export did not become readable: expected {expected_rows} rows, got {len(result)}"
+                    f"Export readiness budget exhausted: expected {expected_rows} rows, got {rows}"
+                    + ("; additional readiness check failed" if rows == expected_rows else "")
                 )
-        time.sleep(2)
+        sleep(min(EXPORT_POLL_INTERVAL_SECONDS, max(0, deadline - now())))

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -16,6 +16,8 @@ Shared resource fixtures
 ------------------------
 ``ingested_dataset`` — a single session-scoped dataset ingested from csv_data; shared
                        by all read-only channel/pandas tests to avoid redundant ingest calls.
+``wait_for_export`` — polls each pandas export's rows and optional readiness predicate,
+                      sharing a 600-second budget starting after ingestion completes.
 
 Teardown helpers
 ----------------
@@ -38,7 +40,11 @@ import pytest
 from nominal.core import NominalClient
 from nominal.core.dataset import Dataset
 from tests.e2e import POLL_INTERVAL
-from tests.e2e._export import _wait_for_export
+from tests.e2e._export import wait_for_export as poll_export
+
+# CI has observed visibility lag beyond four minutes after ingestion completes.
+# Share one budget so the 15-minute job retains time for the other tests.
+EXPORT_READINESS_BUDGET_SECONDS = 600
 
 
 def pytest_addoption(parser):
@@ -100,12 +106,12 @@ def ingested_dataset(client: NominalClient, csv_data: bytes) -> Iterator[Dataset
 def wait_for_export(ingested_dataset: Dataset, csv_data: bytes):
     """Poll each export path within one shared deadline, starting after ingestion."""
     expected_rows = len(list(csv.DictReader(csv_data.decode().splitlines())))
-    # CI has observed visibility lag beyond four minutes after ingestion completes.
-    # Share one deadline so the 15-minute job retains time for the other tests.
-    deadline = time.monotonic() + 600
+    deadline = time.monotonic() + EXPORT_READINESS_BUDGET_SECONDS
 
-    def wait(export):
-        return _wait_for_export(export, expected_rows, timeout_seconds=max(0, deadline - time.monotonic()))
+    def wait(export, *, is_ready=None):
+        return poll_export(
+            export, expected_rows, is_ready=is_ready, timeout_seconds=max(0, deadline - time.monotonic())
+        )
 
     return wait
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -25,7 +25,9 @@ Teardown helpers
 
 from __future__ import annotations
 
+import csv
 import gzip
+import time
 from io import BytesIO
 from pathlib import Path
 from typing import Iterator
@@ -36,6 +38,7 @@ import pytest
 from nominal.core import NominalClient
 from nominal.core.dataset import Dataset
 from tests.e2e import POLL_INTERVAL
+from tests.e2e._export import _wait_for_export
 
 
 def pytest_addoption(parser):
@@ -91,6 +94,20 @@ def ingested_dataset(client: NominalClient, csv_data: bytes) -> Iterator[Dataset
     ds.add_from_io(BytesIO(csv_data), "timestamp", "iso_8601").poll_until_ingestion_completed(interval=POLL_INTERVAL)
     yield ds
     ds.archive()
+
+
+@pytest.fixture(scope="session")
+def wait_for_export(ingested_dataset: Dataset, csv_data: bytes):
+    """Poll each export path within one shared deadline, starting after ingestion."""
+    expected_rows = len(list(csv.DictReader(csv_data.decode().splitlines())))
+    # CI has observed visibility lag beyond four minutes after ingestion completes.
+    # Share one deadline so the 15-minute job retains time for the other tests.
+    deadline = time.monotonic() + 600
+
+    def wait(export):
+        return _wait_for_export(export, expected_rows, timeout_seconds=max(0, deadline - time.monotonic()))
+
+    return wait
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/test_core.py
+++ b/tests/e2e/test_core.py
@@ -296,14 +296,18 @@ def test_get_dataset_pandas(ingested_dataset: Dataset, csv_data, wait_for_export
     for col in expected_data.columns:
         expected_data[col] = expected_data[col].astype(float)
 
-    df = wait_for_export(lambda: datasource_to_dataframe(ingested_dataset))
+    df = wait_for_export(
+        lambda: datasource_to_dataframe(ingested_dataset),
+        is_ready=lambda frame: sorted(frame.columns) == sorted(expected_data.columns),
+    )
     df_sorted = df.reindex(expected_data.columns, axis=1)
     pd.testing.assert_frame_equal(df_sorted, expected_data)
 
     # channel_exact_match filters to channels whose names contain ALL listed substrings;
     # "relative" AND "minutes" matches only "relative_minutes"
     df2 = wait_for_export(
-        lambda: datasource_to_dataframe(ingested_dataset, channel_exact_match=["relative", "minutes"])
+        lambda: datasource_to_dataframe(ingested_dataset, channel_exact_match=["relative", "minutes"]),
+        is_ready=lambda frame: list(frame.columns) == ["relative_minutes"],
     )
     pd.testing.assert_frame_equal(df2, expected_data[["relative_minutes"]])
 

--- a/tests/e2e/test_core.py
+++ b/tests/e2e/test_core.py
@@ -276,34 +276,35 @@ def test_get_channel(ingested_dataset: Dataset):
     assert c.description is None
 
 
-def test_get_channel_pandas(ingested_dataset: Dataset, csv_data):
+def test_get_channel_pandas(ingested_dataset: Dataset, csv_data, wait_for_export):
     """Converting a channel to a pandas Series produces values identical to the original CSV."""
     c = ingested_dataset.get_channel("temperature")
-    s = channel_to_series(c)
-    assert s.name == c.name == "temperature"
-    assert s.index.name == "timestamp"
-    assert s.dtype == "float64"
-
     # Parse the reference CSV with matching dtype and index for a direct comparison
     df = pd.read_csv(
         BytesIO(csv_data), parse_dates=["timestamp"], index_col="timestamp", dtype={"temperature": "float64"}
     )
+    s = wait_for_export(lambda: channel_to_series(c))
+    assert s.name == c.name == "temperature"
+    assert s.index.name == "timestamp"
+    assert s.dtype == "float64"
     assert s.equals(df["temperature"])
 
 
-def test_get_dataset_pandas(ingested_dataset: Dataset, csv_data):
+def test_get_dataset_pandas(ingested_dataset: Dataset, csv_data, wait_for_export):
     """Converting a full dataset to a DataFrame matches the original CSV; channel_exact_match filters columns."""
     expected_data = pd.read_csv(BytesIO(csv_data), index_col="timestamp", parse_dates=["timestamp"])
     for col in expected_data.columns:
         expected_data[col] = expected_data[col].astype(float)
 
-    df = datasource_to_dataframe(ingested_dataset)
+    df = wait_for_export(lambda: datasource_to_dataframe(ingested_dataset))
     df_sorted = df.reindex(expected_data.columns, axis=1)
     pd.testing.assert_frame_equal(df_sorted, expected_data)
 
     # channel_exact_match filters to channels whose names contain ALL listed substrings;
     # "relative" AND "minutes" matches only "relative_minutes"
-    df2 = datasource_to_dataframe(ingested_dataset, channel_exact_match=["relative", "minutes"])
+    df2 = wait_for_export(
+        lambda: datasource_to_dataframe(ingested_dataset, channel_exact_match=["relative", "minutes"])
+    )
     pd.testing.assert_frame_equal(df2, expected_data[["relative_minutes"]])
 
 

--- a/tests/test_e2e_export.py
+++ b/tests/test_e2e_export.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock
+
+import pytest
+import requests
+from conjure_python_client import ConjureHTTPError
+
+from tests.e2e._export import _wait_for_export
+
+
+def _export_error(status: int = 400, name: str = "Default:InvalidArgument") -> ConjureHTTPError:
+    response = requests.Response()
+    response.status_code = status
+    response._content = json.dumps({"errorName": name}).encode()
+    return ConjureHTTPError(requests.HTTPError(response=response))
+
+
+def test_export_waits_for_missing_table_then_empty_and_partial_data(monkeypatch):
+    monkeypatch.setattr("tests.e2e._export.time.monotonic", lambda: 0)
+    sleep = Mock()
+    monkeypatch.setattr("tests.e2e._export.time.sleep", sleep)
+    expected = [20.0, 21.0]
+    export = Mock(side_effect=[_export_error(), [], [20.0], expected])
+
+    assert _wait_for_export(export, expected_rows=2) is expected
+    assert sleep.call_count == 3
+
+
+@pytest.mark.parametrize(
+    ("status", "name"),
+    [
+        (401, "Authorization:Unauthorized"),
+        (403, "Authorization:Forbidden"),
+        (400, "Compute:InvalidRange"),
+        (500, "Default:Internal"),
+    ],
+)
+def test_export_does_not_retry_unrelated_http_errors(monkeypatch, status, name):
+    sleep = Mock()
+    monkeypatch.setattr("tests.e2e._export.time.sleep", sleep)
+    error = _export_error(status, name)
+
+    with pytest.raises(ConjureHTTPError) as exc:
+        _wait_for_export(Mock(side_effect=error), expected_rows=2)
+
+    assert exc.value is error
+    sleep.assert_not_called()
+
+
+def test_export_preserves_html_bad_request(monkeypatch):
+    sleep = Mock()
+    monkeypatch.setattr("tests.e2e._export.time.sleep", sleep)
+    response = requests.Response()
+    response.status_code = 400
+    response._content = b"<html>Bad Request</html>"
+    error = ConjureHTTPError(requests.HTTPError(response=response))
+
+    with pytest.raises(ConjureHTTPError) as exc:
+        _wait_for_export(Mock(side_effect=error), expected_rows=2)
+
+    assert exc.value is error
+    assert "Bad Request" in str(exc.value)
+    sleep.assert_not_called()
+
+
+@pytest.mark.parametrize("rows", [[], [20.0], [20.0, 21.0, 22.0]])
+def test_export_fails_if_row_count_never_matches(monkeypatch, rows):
+    monkeypatch.setattr("tests.e2e._export.time.monotonic", Mock(side_effect=[0, 120]))
+
+    with pytest.raises(AssertionError, match=f"expected 2 rows, got {len(rows)}"):
+        _wait_for_export(lambda: rows, expected_rows=2)
+
+
+def test_export_preserves_http_error_at_deadline(monkeypatch):
+    monkeypatch.setattr("tests.e2e._export.time.monotonic", Mock(side_effect=[0, 120]))
+    error = _export_error()
+
+    with pytest.raises(ConjureHTTPError) as exc:
+        _wait_for_export(Mock(side_effect=error), expected_rows=2)
+
+    assert exc.value is error
+
+
+def test_export_uses_configured_readiness_deadline(monkeypatch):
+    monkeypatch.setattr("tests.e2e._export.time.monotonic", Mock(side_effect=[0, 120, 600]))
+    sleep = Mock()
+    monkeypatch.setattr("tests.e2e._export.time.sleep", sleep)
+    export = Mock(return_value=[])
+
+    with pytest.raises(AssertionError, match="expected 2 rows, got 0"):
+        _wait_for_export(export, expected_rows=2, timeout_seconds=600)
+
+    assert export.call_count == 2
+    sleep.assert_called_once()

--- a/tests/test_e2e_export.py
+++ b/tests/test_e2e_export.py
@@ -1,13 +1,35 @@
+"""Export readiness contracts, exercised without network requests or real sleeps."""
+
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from unittest.mock import Mock
 
+import pandas as pd
 import pytest
 import requests
 from conjure_python_client import ConjureHTTPError
 
-from tests.e2e._export import _wait_for_export
+from tests.e2e._export import wait_for_export
+
+
+@dataclass
+class FakeClock:
+    """Advance elapsed time only when the polling helper sleeps."""
+
+    elapsed: float = 0
+
+    def now(self) -> float:
+        return self.elapsed
+
+    def sleep(self, seconds: float) -> None:
+        self.elapsed += seconds
+
+
+@pytest.fixture
+def clock() -> FakeClock:
+    return FakeClock()
 
 
 def _export_error(status: int = 400, name: str = "Default:InvalidArgument") -> ConjureHTTPError:
@@ -17,15 +39,62 @@ def _export_error(status: int = 400, name: str = "Default:InvalidArgument") -> C
     return ConjureHTTPError(requests.HTTPError(response=response))
 
 
-def test_export_waits_for_missing_table_then_empty_and_partial_data(monkeypatch):
-    monkeypatch.setattr("tests.e2e._export.time.monotonic", lambda: 0)
-    sleep = Mock()
-    monkeypatch.setattr("tests.e2e._export.time.sleep", sleep)
+def test_export_ready_on_first_read(clock):
+    """A complete export returns immediately without consuming the polling budget."""
+    expected = [20.0, 21.0]
+    export = Mock(return_value=expected)
+
+    assert wait_for_export(export, 2, now=clock.now, sleep=clock.sleep) is expected
+    export.assert_called_once()
+    assert clock.elapsed == 0
+
+
+def test_export_waits_for_missing_table_then_empty_and_partial_data(clock):
+    """Missing tables and incomplete exports are retried until all rows are visible."""
     expected = [20.0, 21.0]
     export = Mock(side_effect=[_export_error(), [], [20.0], expected])
 
-    assert _wait_for_export(export, expected_rows=2) is expected
-    assert sleep.call_count == 3
+    assert wait_for_export(export, 2, now=clock.now, sleep=clock.sleep) is expected
+    assert clock.elapsed > 0
+
+
+@pytest.mark.parametrize("columns", [["temperature"], ["relative_minutes", "temperature", "humidity"]])
+def test_dataframe_waits_for_expected_column_names(clock, columns):
+    """Correct row counts cannot hide missing or incorrectly named columns."""
+    expected = pd.DataFrame({name: range(10) for name in columns})
+    export = Mock(
+        side_effect=[
+            expected.iloc[:, :-1],
+            expected.rename(columns={columns[0]: "wrong_channel"}),
+            expected.iloc[:, ::-1],
+        ]
+    )
+
+    result = wait_for_export(
+        export,
+        10,
+        is_ready=lambda frame: sorted(frame.columns) == sorted(columns),
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+
+    pd.testing.assert_frame_equal(result, expected.iloc[:, ::-1])
+    assert export.call_count == 3
+
+
+def test_dataframe_fails_when_columns_never_become_ready(clock):
+    """A full row count with a missing column exhausts the readiness budget."""
+    with pytest.raises(AssertionError, match="budget exhausted.*additional readiness check failed"):
+        wait_for_export(
+            lambda: pd.DataFrame({"temperature": range(10)}),
+            10,
+            is_ready=lambda frame: list(frame.columns) == ["temperature", "humidity"],
+            timeout_seconds=5,
+            now=clock.now,
+            sleep=clock.sleep,
+        )
+
+    assert clock.elapsed == 5
 
 
 @pytest.mark.parametrize(
@@ -37,60 +106,83 @@ def test_export_waits_for_missing_table_then_empty_and_partial_data(monkeypatch)
         (500, "Default:Internal"),
     ],
 )
-def test_export_does_not_retry_unrelated_http_errors(monkeypatch, status, name):
-    sleep = Mock()
-    monkeypatch.setattr("tests.e2e._export.time.sleep", sleep)
+def test_export_does_not_retry_unrelated_http_errors(clock, status, name):
+    """Only the known missing-table HTTP error is eligible for retry."""
     error = _export_error(status, name)
+    export = Mock(side_effect=error)
 
     with pytest.raises(ConjureHTTPError) as exc:
-        _wait_for_export(Mock(side_effect=error), expected_rows=2)
+        wait_for_export(export, 2, now=clock.now, sleep=clock.sleep)
 
     assert exc.value is error
-    sleep.assert_not_called()
+    export.assert_called_once()
+    assert clock.elapsed == 0
 
 
-def test_export_preserves_html_bad_request(monkeypatch):
-    sleep = Mock()
-    monkeypatch.setattr("tests.e2e._export.time.sleep", sleep)
+def test_export_preserves_html_bad_request(clock):
+    """An ingress HTML error is preserved even without a Conjure error_name attribute."""
     response = requests.Response()
     response.status_code = 400
     response._content = b"<html>Bad Request</html>"
     error = ConjureHTTPError(requests.HTTPError(response=response))
 
     with pytest.raises(ConjureHTTPError) as exc:
-        _wait_for_export(Mock(side_effect=error), expected_rows=2)
+        wait_for_export(Mock(side_effect=error), 2, now=clock.now, sleep=clock.sleep)
 
     assert exc.value is error
     assert "Bad Request" in str(exc.value)
-    sleep.assert_not_called()
+    assert clock.elapsed == 0
 
 
-@pytest.mark.parametrize("rows", [[], [20.0], [20.0, 21.0, 22.0]])
-def test_export_fails_if_row_count_never_matches(monkeypatch, rows):
-    monkeypatch.setattr("tests.e2e._export.time.monotonic", Mock(side_effect=[0, 120]))
+@pytest.mark.parametrize("rows", [[], [20.0]])
+def test_export_fails_if_row_count_never_matches(clock, rows):
+    """Incomplete data reports its last row count when the budget expires."""
+    with pytest.raises(AssertionError, match=f"budget exhausted: expected 2 rows, got {len(rows)}"):
+        wait_for_export(lambda: rows, 2, timeout_seconds=5, now=clock.now, sleep=clock.sleep)
 
-    with pytest.raises(AssertionError, match=f"expected 2 rows, got {len(rows)}"):
-        _wait_for_export(lambda: rows, expected_rows=2)
+    assert clock.elapsed == 5
 
 
-def test_export_preserves_http_error_at_deadline(monkeypatch):
-    monkeypatch.setattr("tests.e2e._export.time.monotonic", Mock(side_effect=[0, 120]))
+def test_export_fails_immediately_on_excess_rows(clock):
+    """Excess rows in the fixed dataset fail without consuming siblings' shared budget."""
+    export = Mock(return_value=[20.0, 21.0, 22.0])
+
+    with pytest.raises(AssertionError, match="excess rows: expected 2 rows, got 3"):
+        wait_for_export(export, 2, now=clock.now, sleep=clock.sleep)
+
+    export.assert_called_once()
+    assert clock.elapsed == 0
+
+
+def test_export_preserves_http_error_at_deadline(clock):
+    """Retry exhaustion re-raises the original server error for diagnosis."""
     error = _export_error()
 
     with pytest.raises(ConjureHTTPError) as exc:
-        _wait_for_export(Mock(side_effect=error), expected_rows=2)
+        wait_for_export(Mock(side_effect=error), 2, timeout_seconds=5, now=clock.now, sleep=clock.sleep)
 
     assert exc.value is error
+    assert clock.elapsed == 5
 
 
-def test_export_uses_configured_readiness_deadline(monkeypatch):
-    monkeypatch.setattr("tests.e2e._export.time.monotonic", Mock(side_effect=[0, 120, 600]))
-    sleep = Mock()
-    monkeypatch.setattr("tests.e2e._export.time.sleep", sleep)
-    export = Mock(return_value=[])
-
+def test_export_uses_configured_readiness_deadline(clock):
+    """A caller's larger budget replaces the default timeout."""
     with pytest.raises(AssertionError, match="expected 2 rows, got 0"):
-        _wait_for_export(export, expected_rows=2, timeout_seconds=600)
+        wait_for_export(lambda: [], 2, timeout_seconds=600, now=clock.now, sleep=clock.sleep)
 
-    assert export.call_count == 2
-    sleep.assert_called_once()
+    assert clock.elapsed == 600
+
+
+@pytest.mark.parametrize("rows", [[], [20.0, 21.0]])
+def test_export_with_exhausted_shared_budget_reads_once(clock, rows):
+    """Later callers can still read ready data, but cannot start another retry budget."""
+    export = Mock(return_value=rows)
+
+    if rows:
+        assert wait_for_export(export, 2, timeout_seconds=0, now=clock.now, sleep=clock.sleep) is rows
+    else:
+        with pytest.raises(AssertionError, match="budget exhausted"):
+            wait_for_export(export, 2, timeout_seconds=0, now=clock.now, sleep=clock.sleep)
+
+    export.assert_called_once()
+    assert clock.elapsed == 0


### PR DESCRIPTION
Freshly ingested staging datasets can report ingestion complete before Iceberg exports are readable. The pandas E2Es then receive a missing-table error or incomplete data.

Poll each channel, dataset, and filtered dataset export until its expected row count is visible. DataFrame reads also require the exact expected column names, so partial channel registration cannot pass readiness just by returning all ten rows. Keep the existing value, dtype, and index assertions.

All three reads share a ten-minute polling budget after ingestion. Retry the known missing-table error and incomplete results; fail immediately on excess rows in this fixed dataset and preserve unrelated HTTP errors, including HTML 400 responses. The helper uses injectable clock and sleep functions for deterministic tests and reports when its readiness budget is exhausted. Individual requests retain their own timeouts.

Split from #952 so local-runtime transport support stays focused. #952 is stacked on this PR, which should merge first.

### Testing plan

- Unit suite: 921 passed, 1 skipped, including 17 export-readiness regressions covering missing/wrong columns, excess rows, immediate readiness, shared-budget exhaustion, and HTTP errors.
- Both pandas E2Es passed against staging with a fresh dataset in 3 minutes 45 seconds; the fixture archived it afterward.
- mypy passes for all 161 SDK source files and the modified helper/test module; ruff check, ruff format --check, and git diff --check pass.
