### PR TITLE
fix: restrict plaintext grpc to literal loopback addresses

### DIFF
--- a/docs/src/networking-tls.md
+++ b/docs/src/networking-tls.md
@@ -3,10 +3,16 @@
 The Nominal client talks to the platform over two transports: HTTP (conjure services) and gRPC
 (e.g. the Role Service). HTTPS URLs verify the server's TLS certificate on both transports.
 
-## Plaintext HTTP deployments
+## Local plaintext HTTP deployments
 
-An `http://` URL selects plaintext for both HTTP and gRPC on any host, including remote hosts.
-Credentials and custom headers are sent without TLS encryption. Use `https://` when TLS is required.
+An `http://` URL is accepted for gRPC only when its host is a literal loopback IP address:
+IPv4 `127.0.0.0/8` (normally `127.0.0.1`) or IPv6 `::1`. Use `https://` for remote deployments.
+Other HTTP hosts raise `NominalConfigError` during client construction, before a gRPC channel is created.
+There is no remote-plaintext override or automatic fallback from TLS to plaintext.
+
+Use `127.0.0.1` or `[::1]` rather than `localhost` or another hostname; the check does not trust DNS
+resolution. Loopback HTTP still sends credentials and custom headers without TLS encryption.
+This restriction applies to gRPC channel construction; it does not add TLS to the Conjure HTTP transport.
 
 For example, connect to a local runtime using its HTTP ingress URL, including `/api`:
 

--- a/docs/src/networking-tls.md
+++ b/docs/src/networking-tls.md
@@ -5,14 +5,16 @@ The Nominal client talks to the platform over two transports: HTTP (conjure serv
 
 ## Local plaintext HTTP deployments
 
-An `http://` URL is accepted for gRPC only when its host is a literal loopback IP address:
+An `http://` API base URL is accepted only when its host is a literal loopback IP address:
 IPv4 `127.0.0.0/8` (normally `127.0.0.1`) or IPv6 `::1`. Use `https://` for remote deployments.
-Other HTTP hosts raise `NominalConfigError` during client construction, before a gRPC channel is created.
+Other HTTP hosts raise `NominalConfigError` during client construction, even if you only intend to use
+Conjure HTTP APIs. URLs with embedded user information are rejected for both HTTP and HTTPS; supply
+your API token separately.
 There is no remote-plaintext override or automatic fallback from TLS to plaintext.
 
 Use `127.0.0.1` or `[::1]` rather than `localhost` or another hostname; the check does not trust DNS
 resolution. Loopback HTTP still sends credentials and custom headers without TLS encryption.
-This restriction applies to gRPC channel construction; it does not add TLS to the Conjure HTTP transport.
+This client-wide restriction does not add TLS to the Conjure HTTP transport.
 
 For example, connect to a local runtime using its HTTP ingress URL, including `/api`:
 

--- a/nominal/cli/util/verify_connection.py
+++ b/nominal/cli/util/verify_connection.py
@@ -12,7 +12,10 @@ def validate_token_url(token: str, base_url: str, workspace_rid: str | None) -> 
     docs_link = "https://docs.nominal.io/core/sdk/python-client/authentication"
     status_code = 200
     err_msg = ""
-    client = NominalClient.create(base_url, token)
+    try:
+        client = NominalClient.create(base_url, token)
+    except NominalConfigError as err:
+        raise click.ClickException(f"Invalid client configuration: {err}") from err
 
     # first, validate that the api key is correct for the tenant / org by fetching the
     # current user using the api key

--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -34,6 +34,7 @@ from nominal.core._utils.grpc_tools import GRPCStub, create_grpc_channel, transl
 from nominal.core._utils.networking import (
     HeaderProvider,
     create_conjure_client_factory,
+    validate_api_base_url,
 )
 from nominal.core.exceptions import NominalConfigError
 from nominal.protos.authorization.roles.v1 import roles_pb2_grpc
@@ -277,6 +278,7 @@ class ClientsBunch:
         *,
         header_provider: HeaderProvider | None = None,
     ) -> Self:
+        validate_api_base_url(base_url)
         app_base_url = api_base_url_to_app_base_url(base_url)
 
         def client_factory(service_class: type[TService]) -> TService:

--- a/nominal/core/_utils/grpc_tools.py
+++ b/nominal/core/_utils/grpc_tools.py
@@ -6,7 +6,7 @@ generated stub to, so every stub shares that one channel.
 
 The channel is configured to track the conjure HTTP transport as closely as gRPC allows:
 
-- HTTP URLs select plaintext gRPC on any host; HTTPS URLs select TLS.
+- HTTP URLs allow plaintext gRPC only for literal loopback IP addresses; HTTPS URLs select TLS.
 - For TLS, roots combine the configured trust store and the OS trust store (`_grpc_root_certificates`).
 - Retry mirrors conjure's `RetryWithJitter` (`_service_config_json`).
 - Per-call auth metadata and a default deadline are injected by client interceptors, so call sites never
@@ -15,6 +15,7 @@ The channel is configured to track the conjure HTTP transport as closely as gRPC
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import ssl
 import sys
@@ -33,6 +34,7 @@ from nominal.core._utils.networking import HeaderProvider, raise_header_conflict
 from nominal.core.exceptions import (
     NominalAlreadyExistsError,
     NominalAuthenticationError,
+    NominalConfigError,
     NominalError,
     NominalInvalidArgumentError,
     NominalNotFoundError,
@@ -68,6 +70,19 @@ def api_base_url_to_grpc_target(api_base_url: str) -> str:
     if not parsed.netloc:
         raise ValueError(f"Could not derive gRPC target from API base URL: {api_base_url}")
     return parsed.netloc
+
+
+def _is_loopback_address(host: str | None) -> bool:
+    """Accept literal loopback IPs without trusting DNS resolution or scoped IPv6 addresses."""
+    if host is None or "%" in host:
+        return False
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    if isinstance(address, ipaddress.IPv4Address):
+        return address.is_loopback
+    return address == ipaddress.IPv6Address("::1")
 
 
 @lru_cache(maxsize=None)
@@ -254,7 +269,7 @@ def create_grpc_channel(
     auth_header: str,
     header_provider: HeaderProvider | None,
 ) -> grpc.Channel:
-    """Build the shared gRPC channel, using plaintext for HTTP URLs and TLS otherwise.
+    """Build the shared gRPC channel, allowing plaintext only for loopback HTTP URLs.
 
     Configures gzip compression, native retry, lifted message-size limits, the SDK user-agent, and the
     auth-metadata + default-deadline interceptors. TLS channels use the union trust bundle; plaintext
@@ -268,7 +283,13 @@ def create_grpc_channel(
         ("grpc.max_receive_message_length", _MAX_MESSAGE_LENGTH),
     ]
     target = api_base_url_to_grpc_target(api_base_url)
-    if urlparse(api_base_url).scheme == "http":
+    parsed = urlparse(api_base_url)
+    if parsed.scheme == "http":
+        if parsed.username is not None or parsed.password is not None or not _is_loopback_address(parsed.hostname):
+            raise NominalConfigError(
+                "Plaintext gRPC requires a literal loopback IP address (127.0.0.1 or [::1]). "
+                "Use an https:// API URL for remote deployments."
+            )
         channel = grpc.insecure_channel(target, options=options, compression=grpc.Compression.Gzip)
     else:
         credentials = grpc.ssl_channel_credentials(

--- a/nominal/core/_utils/grpc_tools.py
+++ b/nominal/core/_utils/grpc_tools.py
@@ -15,7 +15,6 @@ The channel is configured to track the conjure HTTP transport as closely as gRPC
 
 from __future__ import annotations
 
-import ipaddress
 import json
 import ssl
 import sys
@@ -30,11 +29,10 @@ from urllib.parse import urlparse
 import grpc
 from conjure_python_client import ServiceConfiguration
 
-from nominal.core._utils.networking import HeaderProvider, raise_header_conflict
+from nominal.core._utils.networking import HeaderProvider, raise_header_conflict, validate_api_base_url
 from nominal.core.exceptions import (
     NominalAlreadyExistsError,
     NominalAuthenticationError,
-    NominalConfigError,
     NominalError,
     NominalInvalidArgumentError,
     NominalNotFoundError,
@@ -70,19 +68,6 @@ def api_base_url_to_grpc_target(api_base_url: str) -> str:
     if not parsed.netloc:
         raise ValueError(f"Could not derive gRPC target from API base URL: {api_base_url}")
     return parsed.netloc
-
-
-def _is_loopback_address(host: str | None) -> bool:
-    """Accept literal loopback IPs without trusting DNS resolution or scoped IPv6 addresses."""
-    if host is None or "%" in host:
-        return False
-    try:
-        address = ipaddress.ip_address(host)
-    except ValueError:
-        return False
-    if isinstance(address, ipaddress.IPv4Address):
-        return address.is_loopback
-    return address == ipaddress.IPv6Address("::1")
 
 
 @lru_cache(maxsize=None)
@@ -274,7 +259,22 @@ def create_grpc_channel(
     Configures gzip compression, native retry, lifted message-size limits, the SDK user-agent, and the
     auth-metadata + default-deadline interceptors. TLS channels use the union trust bundle; plaintext
     channels do not load TLS credentials. All of a client's gRPC stubs share this one channel.
+
+    Raises:
+        NominalConfigError: If the API URL is malformed, contains user information, or uses HTTP
+            without a literal loopback address.
     """
+    channel = _build_grpc_channel(api_base_url, service_config, user_agent)
+    # The two interceptors are order-independent: one rewrites metadata, the other the deadline.
+    return grpc.intercept_channel(
+        channel,
+        _AuthMetadataInterceptor(auth_header, header_provider),
+        _DefaultDeadlineInterceptor(service_config.read_timeout),
+    )
+
+
+def _build_grpc_channel(api_base_url: str, service_config: ServiceConfiguration, user_agent: str) -> grpc.Channel:
+    parsed = validate_api_base_url(api_base_url)
     options = [
         ("grpc.primary_user_agent", user_agent),
         ("grpc.enable_retries", 1),
@@ -282,28 +282,15 @@ def create_grpc_channel(
         ("grpc.max_send_message_length", _MAX_MESSAGE_LENGTH),
         ("grpc.max_receive_message_length", _MAX_MESSAGE_LENGTH),
     ]
-    target = api_base_url_to_grpc_target(api_base_url)
-    parsed = urlparse(api_base_url)
+    target = parsed.netloc
     if parsed.scheme == "http":
-        if parsed.username is not None or parsed.password is not None or not _is_loopback_address(parsed.hostname):
-            raise NominalConfigError(
-                "Plaintext gRPC requires a literal loopback IP address (127.0.0.1 or [::1]). "
-                "Use an https:// API URL for remote deployments."
-            )
-        channel = grpc.insecure_channel(target, options=options, compression=grpc.Compression.Gzip)
-    else:
-        credentials = grpc.ssl_channel_credentials(
-            root_certificates=_grpc_root_certificates(
-                None if service_config.security is None else service_config.security.trust_store_path
-            )
+        return grpc.insecure_channel(target, options=options, compression=grpc.Compression.Gzip)
+    credentials = grpc.ssl_channel_credentials(
+        root_certificates=_grpc_root_certificates(
+            None if service_config.security is None else service_config.security.trust_store_path
         )
-        channel = grpc.secure_channel(target, credentials, options=options, compression=grpc.Compression.Gzip)
-    # The two interceptors are order-independent: one rewrites metadata, the other the deadline.
-    return grpc.intercept_channel(
-        channel,
-        _AuthMetadataInterceptor(auth_header, header_provider),
-        _DefaultDeadlineInterceptor(service_config.read_timeout),
     )
+    return grpc.secure_channel(target, credentials, options=options, compression=grpc.Compression.Gzip)
 
 
 _GRPC_STATUS_TO_EXCEPTION: dict[grpc.StatusCode, type[NominalError]] = {

--- a/nominal/core/_utils/networking.py
+++ b/nominal/core/_utils/networking.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import gzip
+import ipaddress
 import logging
 import ssl
 import threading
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, Mapping, Type, TypeVar
+from urllib.parse import ParseResult, urlparse
 
 import requests
 import truststore
@@ -17,13 +19,55 @@ from requests.adapters import DEFAULT_POOLSIZE, CaseInsensitiveDict, HTTPAdapter
 from urllib3.connection import HTTPConnection
 from urllib3.util.retry import Retry
 
-from nominal.core.exceptions import HeaderConflictError
+from nominal.core.exceptions import HeaderConflictError, NominalConfigError
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
 GZIP_COMPRESSION_LEVEL = 1
+
+_LOOPBACK_NETWORKS = (ipaddress.ip_network("127.0.0.0/8"), ipaddress.ip_network("::1/128"))
+
+
+def _is_loopback_address(host: str | None) -> bool:
+    if host is None or "%" in host:
+        # Network membership alone does not exclude IPv6 scope identifiers.
+        return False
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    # Explicit networks keep IPv4-mapped IPv6 excluded regardless of Python's is_loopback semantics.
+    return any(address in network for network in _LOOPBACK_NETWORKS)
+
+
+def validate_api_base_url(api_base_url: str) -> ParseResult:
+    """Validate the client-wide URL policy without resolving hostnames.
+
+    Raises:
+        NominalConfigError: If the URL is malformed, contains user information, or uses HTTP
+            without a literal loopback address.
+    """
+    try:
+        parsed = urlparse(api_base_url)
+        host = parsed.hostname
+        parsed.port  # Validate the port without including untrusted URL contents in errors.
+    except ValueError:
+        raise NominalConfigError("Invalid API base URL: check its hostname and port.") from None
+    if not parsed.netloc or host is None:
+        raise NominalConfigError("Invalid API base URL: a hostname is required.")
+    if parsed.username is not None or parsed.password is not None:
+        raise NominalConfigError(
+            f"API base URL for host {host!r} must not contain user information; pass the token separately."
+        )
+    if parsed.scheme == "http" and not _is_loopback_address(host):
+        raise NominalConfigError(
+            f"HTTP API base URL for host {host!r} requires a literal loopback IP address "
+            "(127.0.0.0/8 or [::1]). Hostnames are not resolved; use 127.0.0.1 instead of localhost. "
+            "Use an https:// API URL for remote deployments."
+        )
+    return parsed
 
 
 class HeaderProvider(ABC):

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -159,6 +159,10 @@ class NominalClient:
                 your corporate CA PEM if you are behind a TLS-inspecting proxy.
             connect_timeout: Request connection timeout.
             extra_headers: Extra request headers, either as a mapping or HeaderProvider.
+
+        Raises:
+            NominalConfigError: If the base URL is malformed, contains user information, or uses HTTP
+                without a literal loopback IP. This prevents client construction even for HTTP-only usage.
         """
         config = NominalConfig.from_yaml()
         prof = config.get_profile(profile)
@@ -199,6 +203,10 @@ class NominalClient:
                 your corporate CA PEM if you are behind a TLS-inspecting proxy.
             connect_timeout: Request connection timeout.
             extra_headers: Extra request headers, either as a mapping or HeaderProvider.
+
+        Raises:
+            NominalConfigError: If the base URL is malformed, contains user information, or uses HTTP
+                without a literal loopback IP. This prevents client construction even for HTTP-only usage.
         """
         trust_store_path = certifi.where() if trust_store_path is None else trust_store_path
         timeout_seconds = connect_timeout.total_seconds() if isinstance(connect_timeout, timedelta) else connect_timeout
@@ -244,6 +252,10 @@ class NominalClient:
         workspace_rid: Optional workspace RID to pin the client to for operations that require a single
             workspace. If not provided, those operations resolve a default workspace client-side when needed.
         extra_headers: Extra request headers, either as a mapping or HeaderProvider.
+
+        Raises:
+            NominalConfigError: If the base URL is malformed, contains user information, or uses HTTP
+                without a literal loopback IP. This prevents client construction even for HTTP-only usage.
         """
         if token is None:
             token = _config.get_token(base_url)

--- a/tests/cli/test_verify_connection.py
+++ b/tests/cli/test_verify_connection.py
@@ -17,6 +17,20 @@ def _conjure_error(status_code: int) -> ConjureHTTPError:
     return ConjureHTTPError(HTTPError(response=response))
 
 
+def test_validate_token_url_reports_invalid_base_url() -> None:
+    with pytest.raises(click.ClickException, match="Invalid client configuration.*localhost") as exc:
+        validate_token_url("token", "http://localhost:20000/api", None)
+    assert isinstance(exc.value.__cause__, NominalConfigError)
+
+
+@pytest.mark.parametrize("scheme", ["http", "https"])
+def test_validate_token_url_does_not_expose_url_credentials(scheme: str) -> None:
+    with pytest.raises(click.ClickException, match="must not contain user information") as exc:
+        validate_token_url("token", f"{scheme}://secret-user:secret-password@127.0.0.1:20000/api", None)
+    assert "secret-user" not in str(exc.value)
+    assert "secret-password" not in str(exc.value)
+
+
 def test_validate_token_url_accepts_valid_credentials() -> None:
     """Successful auth and workspace resolution should not emit user-facing errors."""
     client = MagicMock()

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import fields
 from typing import cast
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from conjure_python_client import ServiceConfiguration
@@ -24,6 +24,26 @@ from nominal.protos.sandbox.v1 import sandbox_workspace_pb2_grpc
 from nominal.protos.secrets.v1 import secrets_pb2_grpc
 from nominal.protos.units.v1 import units_pb2_grpc
 from nominal.protos.workspaces.v1 import workspaces_pb2, workspaces_pb2_grpc
+
+
+@pytest.mark.parametrize(
+    ("base_url", "message"),
+    [
+        ("http://localhost:20000/api", "Hostnames are not resolved"),
+        ("http://10.0.0.1/api", "https://"),
+        ("https://user:password@api.example.com/api", "must not contain user information"),
+        ("https://api.example.com:invalid/api", "hostname and port"),
+    ],
+)
+def test_client_rejects_invalid_url_before_building_transports(base_url: str, message: str) -> None:
+    with (
+        patch("nominal.core._clientsbunch.create_grpc_channel") as grpc_channel,
+        patch("nominal.core._clientsbunch.create_conjure_client_factory") as conjure_factory,
+        pytest.raises(NominalConfigError, match=message),
+    ):
+        NominalClient.from_token("token", base_url=base_url)
+    grpc_channel.assert_not_called()
+    conjure_factory.assert_not_called()
 
 
 def _make_clients_bunch(*, workspace_rid: str | None) -> ClientsBunch:

--- a/tests/core/test_grpc.py
+++ b/tests/core/test_grpc.py
@@ -247,7 +247,7 @@ def test_http_grpc_channel_rejects_nonliteral_or_remote_hosts_before_channel_cre
     insecure = MagicMock()
     monkeypatch.setattr(grpc, "insecure_channel", insecure)
 
-    with pytest.raises(NominalConfigError, match="Use an https:// API URL"):
+    with pytest.raises(NominalConfigError, match="API base URL"):
         create_grpc_channel(
             api_base_url=f"http://{host}:20000/api",
             service_config=_config(),

--- a/tests/core/test_grpc.py
+++ b/tests/core/test_grpc.py
@@ -23,6 +23,7 @@ from nominal.core.exceptions import (
     HeaderConflictError,
     NominalAlreadyExistsError,
     NominalAuthenticationError,
+    NominalConfigError,
     NominalError,
     NominalInvalidArgumentError,
     NominalNotFoundError,
@@ -189,15 +190,16 @@ def test_create_grpc_channel_wires_credentials_options_and_interceptors(monkeypa
     assert len(intercept_channel.call_args.args[1:]) == 2
 
 
-def test_http_grpc_channel_uses_plaintext_and_retains_call_policy(monkeypatch) -> None:
-    """HTTP URLs use plaintext while retaining channel options, authentication, and deadlines."""
+@pytest.mark.parametrize("host", ["127.0.0.1", "127.12.34.56", "[::1]"])
+def test_http_grpc_channel_uses_plaintext_and_retains_call_policy(monkeypatch, host) -> None:
+    """Literal loopback HTTP URLs retain channel options, authentication, and deadlines."""
     secure, intercept, credentials = _patch_channel(monkeypatch)
     insecure = MagicMock(return_value="plaintext-channel")
     monkeypatch.setattr(grpc, "insecure_channel", insecure)
 
     assert (
         create_grpc_channel(
-            api_base_url="http://127.0.0.1:20000/api",
+            api_base_url=f"http://{host}:20000/api",
             service_config=_config(),
             user_agent="test-agent",
             auth_header="Bearer tok",
@@ -208,7 +210,7 @@ def test_http_grpc_channel_uses_plaintext_and_retains_call_policy(monkeypatch) -
 
     secure.assert_not_called()
     credentials.assert_not_called()
-    assert insecure.call_args.args == ("127.0.0.1:20000",)
+    assert insecure.call_args.args == (f"{host}:20000",)
     assert insecure.call_args.kwargs["compression"] == grpc.Compression.Gzip
     assert dict(insecure.call_args.kwargs["options"])["grpc.primary_user_agent"] == "test-agent"
     assert intercept.call_args.args[0] == "plaintext-channel"
@@ -217,6 +219,47 @@ def test_http_grpc_channel_uses_plaintext_and_retains_call_policy(monkeypatch) -
         details = interceptor._amend(details)
     assert ("authorization", "Bearer tok") in details.metadata
     assert details.timeout == _config().read_timeout
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "api.gov.nominal.io",
+        "10.0.0.1",
+        "192.168.1.2",
+        "8.8.8.8",
+        "0.0.0.0",
+        "[::]",
+        "[2001:db8::1]",
+        "localhost",
+        "127.0.0.1.example.com",
+        "127.1",
+        "2130706433",
+        "[::ffff:127.0.0.1]",
+        "[::1%25eth0]",
+        "user@127.0.0.1",
+        "127.0.0.1@api.gov.nominal.io",
+    ],
+)
+def test_http_grpc_channel_rejects_nonliteral_or_remote_hosts_before_channel_creation(monkeypatch, host):
+    """Remote addresses and ambiguous host forms cannot create a channel or attach credentials."""
+    secure, intercept, credentials = _patch_channel(monkeypatch)
+    insecure = MagicMock()
+    monkeypatch.setattr(grpc, "insecure_channel", insecure)
+
+    with pytest.raises(NominalConfigError, match="Use an https:// API URL"):
+        create_grpc_channel(
+            api_base_url=f"http://{host}:20000/api",
+            service_config=_config(),
+            user_agent="test-agent",
+            auth_header="Bearer tok",
+            header_provider=None,
+        )
+
+    insecure.assert_not_called()
+    secure.assert_not_called()
+    credentials.assert_not_called()
+    intercept.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
An accidental `http://` production API URL must not enable unencrypted calls. Reject HTTP base URLs unless their host is a literal IPv4 loopback address (127.0.0.0/8) or IPv6 ::1. This is a client-wide construction requirement, including for callers that only intend to use Conjure HTTP APIs. HTTPS retains the existing TLS and certificate-verification path.

Desktop Core remains supported with `http://127.0.0.1:<port>/api`. Hostnames, including localhost, are rejected without DNS resolution; scoped and IPv4-mapped IPv6 forms and 0.0.0.0 remain excluded. No remote-plaintext override is introduced. This restriction does not add TLS to the Conjure transport.

Centralize URL validation before transport construction, use explicit loopback networks and a gRPC builder with direct returns, and document construction-time errors. Reject embedded user information for both HTTP and HTTPS. Diagnostics identify the host without exposing URL credentials, and CLI profile verification translates configuration failures into friendly Click errors.

### Testing plan

- Full SDK unit suite: 931 passed, 1 skipped, including real plaintext workspace server tests.
- Existing channel tests retain coverage of accepted loopback and rejected remote/ambiguous addresses. New regressions cover rejection before either transport is built, malformed ports, friendly CLI errors, and HTTP/HTTPS URL credential redaction.
- `mypy -p nominal` passes (159 source files); Ruff check, Ruff format check, and git diff check pass.
- Staging E2Es were not rerun locally for these changes. The two previously observed pandas failures also reproduced on main: https://github.com/nominal-io/nominal-client/actions/runs/34169279850.
