### PR TITLE
feat: add a nominal-extractors skill for containerized extractors

### DIFF
--- a/.agents/skills/nominal-extractors/SKILL.md
+++ b/.agents/skills/nominal-extractors/SKILL.md
@@ -15,45 +15,45 @@ tags:
 # Nominal Containerized Extractors
 
 A containerized extractor is a Docker image that Nominal runs server-side during ingest.
-The platform mounts the uploaded raw file(s) into the container, runs your code, and
-ingests whatever your code writes to the output directory into the target dataset. Once
-registered, anyone in the workspace can upload raw files in that format — from the SDK or
-the Nominal web app — without having the parsing code on their machine.
+The platform mounts the uploaded raw files into the container, runs your code, and ingests
+whatever your code writes to the output directory. Once registered, anyone in the workspace
+can upload files in that format, from the SDK or the web app, without the parsing code on
+their machine.
 
 ## Where extractors fit in Nominal's data model
 
-Nominal organizes time-series data into **datasets**. A dataset is built up from ingested
-**files**: each ingest parses a file's columns/records into **channels** (series), using
-timestamp metadata to place samples in time, with optional **tags** partitioning data
-within the dataset (e.g. per test-run or per vehicle).
+Nominal stores time-series data in **datasets**, built from ingested **files**. Each ingest
+parses a file's columns or records into **channels**, places samples in time using timestamp
+metadata, and optionally applies **tags** that partition the data within the dataset (per
+test-run, per vehicle).
 
-The SDK's `Dataset` class has native ingest methods for formats the platform parses
-itself: `add_tabular_data` (CSV/Parquet), `add_avro_stream`, `add_journal_json` (logs),
-`add_mcap`, `add_video`, `add_mcap_video`, `add_ardupilot_dataflash`.
+`Dataset` has native ingest methods for the formats the platform parses itself:
+`add_tabular_data` (CSV/Parquet), `add_avro_stream`, `add_journal_json` (logs), `add_mcap`,
+`add_video`, `add_mcap_video`, `add_ardupilot_dataflash`.
 
-A containerized extractor extends that same ingest pipeline with your code. Use one when:
+A containerized extractor runs your code in that same pipeline. Use one when:
 
-- the raw format is proprietary or unsupported (binary telemetry, packed structs, vendor
-  logger output, custom CSV dialects needing preprocessing);
-- the format recurs — many files, many uploaders — so parsing logic should live in one
-  versioned, centrally-run place rather than on each engineer's laptop;
-- non-developers (operators, technicians) upload files through the web app and the
-  conversion must happen automatically.
+- the format is proprietary or unsupported (binary telemetry, packed structs, vendor logger
+  output, CSV dialects needing preprocessing);
+- the format recurs, so the parsing logic should live in one versioned place instead of on
+  each engineer's laptop;
+- non-developers upload the files through the web app, so the conversion has to happen
+  without them running anything.
 
-For a one-off conversion where you already have a parsing script, skip the extractor:
-convert locally and call `dataset.add_tabular_data(...)` directly.
+For a one-off conversion with a script you already have, convert locally and call
+`dataset.add_tabular_data(...)` instead.
 
-Two SDK surfaces are involved, and it's important not to mix them up:
+Two SDK surfaces are involved. Do not mix them up:
 
 | Surface | Runs where | Import |
 |---|---|---|
 | Authoring runtime (the extractor's own code) | Inside the container, during ingest | `nominal.experimental.extractor` |
 | Management & triggering (create/register/activate/run) | On your machine | `nominal.core` via `NominalClient` |
 
-One more distinction: a **ContainerizedExtractor** carries identity (name, description);
-the **ContainerImage**s registered against it carry the execution contract (inputs,
-parameters, output format, default timestamp metadata). Exactly one image is active at a
-time, so you can register a new image version and switch over atomically.
+A **ContainerizedExtractor** carries identity (name, description). The **ContainerImage**s
+registered against it carry the execution contract (inputs, parameters, output format,
+default timestamp metadata). Exactly one image is active at a time, so you can register a
+new version and switch over atomically.
 
 ## Lifecycle
 
@@ -68,28 +68,26 @@ time, so you can register a new image version and switch over atomically.
 6. **Trigger ingests** with `Dataset.add_containerized` and track the `IngestionJob` —
    `references/running.md`
 
-Read the reference file for whichever stage you're working on before writing code — each
-stage has contract details (exact env variables, timestamp resolution rules, format
-restrictions) that are easy to get subtly wrong from memory.
+Read the reference file for the stage you're working on before writing code. Each stage has
+contract details — exact env variables, timestamp resolution rules, format restrictions —
+that are easy to get subtly wrong from memory.
 
-Step 1 is the one people skip, and it's the one that's expensive to undo: inputs and
-parameters are fixed at registration, and timestamp and tag choices shape every query
-written against the data afterward. If the extractor's shape isn't already settled, read
-`modeling.md` before writing code.
+Step 1 is the one people skip and the one that is expensive to undo: inputs and parameters
+are fixed at registration, and the timestamp and tag choices shape every query written
+against the data afterward. If the shape isn't settled, read `modeling.md` first.
 
 ## The output contract: write manifest extractors
 
-**New extractors use `@manifest_extractor`, registered with `output_format=MANIFEST`.**
-That is the current contract and a strict superset of the alternative: it describes every
-output file individually, so one image can emit several files, mix telemetry with logs and
-video, and give each file its own timestamps, tag columns, and channel prefix.
+**New extractors use `@manifest_extractor`, registered with `output_format=MANIFEST`.** It
+is the current contract and a strict superset of the alternative: it describes each output
+file individually, so one image can emit several files, mix telemetry with logs and video,
+and set per-file timestamps, tag columns, and channel prefixes.
 
-`@single_file_extractor` is the original contract, still supported for images already
-registered with `PARQUET`, `CSV`, or `AVRO_STREAM`. You need it when maintaining one of
-those; don't reach for it for new work, even when the extractor happens to produce a single
-table today. It costs nothing to declare one file through the manifest contract, and the
-choice is not cheap to reverse — the output format is fixed at registration, so changing it
-later means registering and activating a new image.
+`@single_file_extractor` is the original contract, still supported for images registered
+with `PARQUET`, `CSV`, or `AVRO_STREAM`. Use it to maintain one of those, not for new work —
+not even when the extractor produces a single table today. Declaring one file through the
+manifest contract costs nothing, and the choice is expensive to reverse: the output format
+is fixed at registration, so changing it later requires registering a new image.
 
 | | `@manifest_extractor` (use this) | `@single_file_extractor` (existing images) |
 |---|---|---|
@@ -99,8 +97,8 @@ later means registering and activating a new image.
 | Per-output tag columns, channel prefixes, timestamps | Yes | No |
 | Video outputs | Yes (recent platform versions) | No |
 
-Whichever you use, the decorator and the registered format must agree — `Extractor.run`
-fails at startup if they disagree, rather than emitting output the pipeline rejects.
+Whichever you use, the decorator and the registered format must agree. `Extractor.run` fails
+at startup if they disagree, rather than emitting output the pipeline rejects.
 
 ## Minimal end-to-end example
 
@@ -192,56 +190,55 @@ if job.status is not IngestionJobStatus.COMPLETED:
 files, _ = wait_for_files_to_ingest(job.dataset_files())
 ```
 
-The two-stage wait is not optional: `job.dataset_files()` returns only the files that exist
-at the moment of the call, and `job.as_files_ingested()` calls it once — so either one, run
-before the container has produced anything, returns empty instead of waiting. Details and the
-failure modes are in `references/running.md`.
+The two-stage wait is not optional. `job.dataset_files()` returns only the files that exist
+when it is called, and `job.as_files_ingested()` calls it once, so either one returns empty
+instead of waiting if the container has not produced anything yet. See
+`references/running.md` for the failure modes.
 
 ## Rules that trip people up
 
-- **Outputs must be written under `ctx.output_dir` and declared.** The pipeline ingests
-  only declared files; undeclared files earn a warning and are silently dropped.
-- **`manifest.json` belongs to the runtime.** Never write it yourself — declare outputs
-  through the `add_*` methods and the runtime writes it when your function returns.
-- **Parameters arrive as strings.** Coerce them yourself (`int(ctx.param("PARTS"))`).
+- **Outputs must be written under `ctx.output_dir` and declared.** The pipeline ingests only
+  declared files. An undeclared file earns a warning and is dropped.
+- **`manifest.json` belongs to the runtime.** Declare outputs through the `add_*` methods;
+  the runtime writes the manifest when your function returns.
+- **Parameters arrive as strings.** Coerce them yourself: `int(ctx.param("PARTS"))`.
 - **The decorator must match the registered output format.** A mismatch fails at container
-  startup with a clear error (better than emitting output the pipeline rejects).
-- **Build for `linux/amd64`.** Nominal runs images on amd64; on Apple Silicon always pass
-  `--platform linux/amd64` to `docker build`. Nothing validates this — an arm64 image
-  registers and activates, then fails at ingest with an exec format error — so verify before
-  registering with `scripts/check_image_arch.py <tarball>` (or `docker inspect`), and put it
-  in CI.
+  startup, which beats emitting output the pipeline rejects.
+- **Build for `linux/amd64`.** Nominal runs images on amd64, so on Apple Silicon always pass
+  `--platform linux/amd64` to `docker build`. Nothing checks this: an arm64 image registers
+  and activates, then fails at ingest with an exec format error. Verify before registering
+  with `scripts/check_image_arch.py <tarball>` (or `docker inspect`), and run it in CI.
 - **Image tags are immutable.** Re-registering an existing tag raises
-  `NominalAlreadyExistsError` — bump the tag instead.
+  `NominalAlreadyExistsError`. Bump the tag instead.
 - **Registration does not activate.** A new image runs only after
   `extractor.set_active_image(image)`.
 - **Timestamp metadata resolves in order:** per-output manifest metadata → the ingest
   request's `timestamp_column`/`timestamp_type` override → the image's registered default.
-  Registration requires a default; per-output metadata supports only numeric types
-  (epoch/relative, seconds→nanoseconds) — richer formats (ISO 8601, custom) must come from
+  Registration requires a default. Per-output metadata takes numeric types only
+  (epoch/relative, seconds through nanoseconds); ISO 8601 and custom formats must come from
   the job-level metadata.
 - **Failures should fail loudly.** Any exception escaping your function exits non-zero and
-  fails the ingest job — that's the designed behavior. Don't swallow errors into empty
+  fails the ingest job. That is the designed behavior — do not swallow errors into empty
   outputs.
-- **`required=True` means far less on a parameter than on an input.** A missing required
-  input raises in `add_containerized` before anything uploads; a missing required parameter
-  is only warned about at container start, then fails mid-run when `ctx.param()` reads it.
-- **Never register `Relative` as the image's default timestamp type.** The `start` would be
-  baked in once and applied to every future ingest. Register an absolute default and
-  declare `Relative` per output in the manifest.
+- **`required=True` means much less on a parameter than on an input.** A missing required
+  input raises in `add_containerized` before anything uploads. A missing required parameter
+  only warns at container start, then fails mid-run when `ctx.param()` reads it.
+- **Never register `Relative` as the image's default timestamp type.** The `start` is set
+  once and applied to every future ingest. Register an absolute default and declare
+  `Relative` per output in the manifest.
 
 ## Reference files
 
 - `references/modeling.md` — the decisions that outlive the code: inputs vs parameters,
-  absolute vs relative time, and what to tag (plus tagging pitfalls). Read before writing
-  code for a new extractor, or when reviewing one whose shape isn't settled.
-- `references/authoring.md` — the full in-container runtime: context API, per-format
-  declaration methods, system metadata, error semantics, and local testing patterns.
-  Read before writing or reviewing extractor code.
-- `references/registration.md` — Dockerfile conventions, building/saving the image,
-  verifying its architecture, `register_image` arguments, image lifecycle (statuses,
-  activation, deletion, search). Read before registering or upgrading an image.
-- `scripts/check_image_arch.py` — exits non-zero if a `docker save` tarball isn't amd64.
-  Run it before registering and in CI; nothing in the SDK or the platform checks this.
-- `references/running.md` — triggering ingests with `add_containerized`, tracking
-  `IngestionJob`s, and debugging failed jobs. Read when running or troubleshooting.
+  absolute vs relative time, what to tag, and the tagging pitfalls. Read before writing code
+  for a new extractor, or when reviewing one whose shape isn't settled.
+- `references/authoring.md` — the in-container runtime: context API, per-format declaration
+  methods, system metadata, error semantics, local testing. Read before writing or reviewing
+  extractor code.
+- `references/registration.md` — Dockerfile conventions, building and saving the image,
+  verifying its architecture, `register_image` arguments, image lifecycle. Read before
+  registering or upgrading an image.
+- `references/running.md` — triggering ingests with `add_containerized`, tracking an
+  `IngestionJob`, debugging failed jobs. Read when running or troubleshooting.
+- `scripts/check_image_arch.py` — exits non-zero if a `docker save` tarball isn't amd64. Run
+  it before registering and in CI; nothing in the SDK or the platform checks this.

--- a/.agents/skills/nominal-extractors/SKILL.md
+++ b/.agents/skills/nominal-extractors/SKILL.md
@@ -48,35 +48,50 @@ time, so you can register a new image version and switch over atomically.
 
 ## Lifecycle
 
-1. **Author** the extractor function — `references/authoring.md`
-2. **Test locally** with `my_extractor.run(env={...}, exit=False)` — no Docker or platform
+1. **Decide the shape** — which values are inputs vs parameters, how timestamps are
+   encoded, what the tags are — `references/modeling.md`
+2. **Author** the extractor function — `references/authoring.md`
+3. **Test locally** with `my_extractor.run(env={...}, exit=False)` — no Docker or platform
    access needed — `references/authoring.md` (Local testing section)
-3. **Build** the image for `linux/amd64` and `docker save` it to a tarball —
+4. **Build** the image for `linux/amd64` and `docker save` it to a tarball —
    `references/registration.md`
-4. **Register and activate** the image against an extractor — `references/registration.md`
-5. **Trigger ingests** with `Dataset.add_containerized` and track the `IngestionJob` —
+5. **Register and activate** the image against an extractor — `references/registration.md`
+6. **Trigger ingests** with `Dataset.add_containerized` and track the `IngestionJob` —
    `references/running.md`
 
 Read the reference file for whichever stage you're working on before writing code — each
 stage has contract details (exact env variables, timestamp resolution rules, format
 restrictions) that are easy to get subtly wrong from memory.
 
-## Choosing the output contract
+Step 1 is the one people skip, and it's the one that's expensive to undo: inputs and
+parameters are fixed at registration, and timestamp and tag choices shape every query
+written against the data afterward. If the extractor's shape isn't already settled, read
+`modeling.md` before writing code.
 
-The image's registered output format fixes which of two contracts the ingest pipeline
-applies, and the decorator you use must agree with it:
+## The output contract: write manifest extractors
 
-| | `@single_file_extractor` | `@manifest_extractor` |
+**New extractors use `@manifest_extractor`, registered with `output_format=MANIFEST`.**
+That is the current contract and a strict superset of the alternative: it describes every
+output file individually, so one image can emit several files, mix telemetry with logs and
+video, and give each file its own timestamps, tag columns, and channel prefix.
+
+`@single_file_extractor` is the original contract, still supported for images already
+registered with `PARQUET`, `CSV`, or `AVRO_STREAM`. You need it when maintaining one of
+those; don't reach for it for new work, even when the extractor happens to produce a single
+table today. It costs nothing to declare one file through the manifest contract, and the
+choice is not cheap to reverse — the output format is fixed at registration, so changing it
+later means registering and activating a new image.
+
+| | `@manifest_extractor` (use this) | `@single_file_extractor` (existing images) |
 |---|---|---|
-| Registered `output_format` | `PARQUET`, `CSV`, or `AVRO_STREAM` | `MANIFEST` |
-| Outputs | Exactly one file | Any number, mixed formats |
-| Declare with | `ctx.set_output(path)` | `ctx.add_tabular` / `add_avro_stream` / `add_journal_json` / `add_video` |
-| Per-output tag columns, channel prefixes, timestamps | No | Yes |
-| Video outputs | No | Yes (recent platform versions) |
+| Registered `output_format` | `MANIFEST` | `PARQUET`, `CSV`, or `AVRO_STREAM` |
+| Outputs | Any number, mixed formats | Exactly one file |
+| Declare with | `ctx.add_tabular` / `add_avro_stream` / `add_journal_json` / `add_video` | `ctx.set_output(path)` |
+| Per-output tag columns, channel prefixes, timestamps | Yes | No |
+| Video outputs | Yes (recent platform versions) | No |
 
-Default to `@manifest_extractor` unless the extractor genuinely produces one file and
-nothing else will ever be needed — the manifest contract is a superset, and re-registering
-an image under a different output format is a new registration.
+Whichever you use, the decorator and the registered format must agree — `Extractor.run`
+fails at startup if they disagree, rather than emitting output the pipeline rejects.
 
 ## Minimal end-to-end example
 
@@ -173,9 +188,18 @@ files = list(job.as_files_ingested())          # blocks until ingested
 - **Failures should fail loudly.** Any exception escaping your function exits non-zero and
   fails the ingest job — that's the designed behavior. Don't swallow errors into empty
   outputs.
+- **`required=True` means far less on a parameter than on an input.** A missing required
+  input raises in `add_containerized` before anything uploads; a missing required parameter
+  is only warned about at container start, then fails mid-run when `ctx.param()` reads it.
+- **Never register `Relative` as the image's default timestamp type.** The `start` would be
+  baked in once and applied to every future ingest. Register an absolute default and
+  declare `Relative` per output in the manifest.
 
 ## Reference files
 
+- `references/modeling.md` — the decisions that outlive the code: inputs vs parameters,
+  absolute vs relative time, and what to tag (plus tagging pitfalls). Read before writing
+  code for a new extractor, or when reviewing one whose shape isn't settled.
 - `references/authoring.md` — the full in-container runtime: context API, per-format
   declaration methods, system metadata, error semantics, and local testing patterns.
   Read before writing or reviewing extractor code.

--- a/.agents/skills/nominal-extractors/SKILL.md
+++ b/.agents/skills/nominal-extractors/SKILL.md
@@ -207,7 +207,10 @@ failure modes are in `references/running.md`.
 - **The decorator must match the registered output format.** A mismatch fails at container
   startup with a clear error (better than emitting output the pipeline rejects).
 - **Build for `linux/amd64`.** Nominal runs images on amd64; on Apple Silicon always pass
-  `--platform linux/amd64` to `docker build`.
+  `--platform linux/amd64` to `docker build`. Nothing validates this — an arm64 image
+  registers and activates, then fails at ingest with an exec format error — so verify before
+  registering with `scripts/check_image_arch.py <tarball>` (or `docker inspect`), and put it
+  in CI.
 - **Image tags are immutable.** Re-registering an existing tag raises
   `NominalAlreadyExistsError` — bump the tag instead.
 - **Registration does not activate.** A new image runs only after
@@ -236,7 +239,9 @@ failure modes are in `references/running.md`.
   declaration methods, system metadata, error semantics, and local testing patterns.
   Read before writing or reviewing extractor code.
 - `references/registration.md` — Dockerfile conventions, building/saving the image,
-  `register_image` arguments, image lifecycle (statuses, activation, deletion, search).
-  Read before registering or upgrading an image.
+  verifying its architecture, `register_image` arguments, image lifecycle (statuses,
+  activation, deletion, search). Read before registering or upgrading an image.
+- `scripts/check_image_arch.py` — exits non-zero if a `docker save` tarball isn't amd64.
+  Run it before registering and in CI; nothing in the SDK or the platform checks this.
 - `references/running.md` — triggering ingests with `add_containerized`, tracking
   `IngestionJob`s, and debugging failed jobs. Read when running or troubleshooting.

--- a/.agents/skills/nominal-extractors/SKILL.md
+++ b/.agents/skills/nominal-extractors/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: nominal-extractors
 description: Build, test, register, and run Nominal containerized extractors — custom Docker images the Nominal platform runs during ingest to parse proprietary or unsupported file formats into datasets. Use this whenever the user mentions containerized extractors, custom extractors, nominal.experimental.extractor, @single_file_extractor / @manifest_extractor, register_image, add_containerized, extractor manifests, or asks how to ingest a file format Nominal doesn't natively support (binary telemetry, vendor logger output, packed/proprietary formats), how to convert files server-side during ingest, or how to debug a containerized ingest job.
+visibility: public
+category: data-ingest
+tags:
+  - containerized-extractors
+  - ingest
+  - docker
+  - data-modeling
+  - experimental
+  - nominal-sdk
 ---
 
 # Nominal Containerized Extractors
@@ -129,8 +138,16 @@ ENTRYPOINT ["python", "/app/extract.py"]
 Build, save, register, activate, run (on your machine):
 
 ```python
-from nominal.core import NominalClient
-from nominal.core.container_image import FileExtractionInput, FileExtractionParameter, FileOutputFormat
+import time
+
+from nominal.core import (
+    FileExtractionInput,
+    FileExtractionParameter,
+    FileOutputFormat,
+    IngestionJobStatus,
+    NominalClient,
+    wait_for_files_to_ingest,
+)
 
 client = NominalClient.from_profile("default")
 
@@ -162,8 +179,20 @@ job = dataset.add_containerized(
     sources={"RAW_FILE": "flight_042.bin"},   # keyed by environment variable
     arguments={"THRESHOLD": "0.8"},           # values are strings
 )
-files = list(job.as_files_ingested())          # blocks until ingested
+
+# Waiting takes two stages: the container run, then the files it produced.
+TERMINAL = (IngestionJobStatus.COMPLETED, IngestionJobStatus.FAILED, IngestionJobStatus.CANCELLED)
+while job.refresh().status not in TERMINAL:
+    time.sleep(2)
+if job.status is not IngestionJobStatus.COMPLETED:
+    raise RuntimeError(f"extraction {job.status.name} — see {job.nominal_url}")
+files, _ = wait_for_files_to_ingest(job.dataset_files())
 ```
+
+The two-stage wait is not optional: `job.dataset_files()` returns only the files that exist
+at the moment of the call, and `job.as_files_ingested()` calls it once — so either one, run
+before the container has produced anything, returns empty instead of waiting. Details and the
+failure modes are in `references/running.md`.
 
 ## Rules that trip people up
 

--- a/.agents/skills/nominal-extractors/SKILL.md
+++ b/.agents/skills/nominal-extractors/SKILL.md
@@ -181,8 +181,11 @@ job = dataset.add_containerized(
 )
 
 # Waiting takes two stages: the container run, then the files it produced.
-TERMINAL = (IngestionJobStatus.COMPLETED, IngestionJobStatus.FAILED, IngestionJobStatus.CANCELLED)
-while job.refresh().status not in TERMINAL:
+RUNNING = (IngestionJobStatus.SUBMITTED, IngestionJobStatus.QUEUED, IngestionJobStatus.IN_PROGRESS)
+deadline = time.monotonic() + 3600
+while job.refresh().status in RUNNING:
+    if time.monotonic() > deadline:
+        raise TimeoutError(f"extraction still {job.status.name} — see {job.nominal_url}")
     time.sleep(2)
 if job.status is not IngestionJobStatus.COMPLETED:
     raise RuntimeError(f"extraction {job.status.name} — see {job.nominal_url}")

--- a/.agents/skills/nominal-extractors/SKILL.md
+++ b/.agents/skills/nominal-extractors/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: nominal-extractors
+description: Build, test, register, and run Nominal containerized extractors — custom Docker images the Nominal platform runs during ingest to parse proprietary or unsupported file formats into datasets. Use this whenever the user mentions containerized extractors, custom extractors, nominal.experimental.extractor, @single_file_extractor / @manifest_extractor, register_image, add_containerized, extractor manifests, or asks how to ingest a file format Nominal doesn't natively support (binary telemetry, vendor logger output, packed/proprietary formats), how to convert files server-side during ingest, or how to debug a containerized ingest job.
+---
+
+# Nominal Containerized Extractors
+
+A containerized extractor is a Docker image that Nominal runs server-side during ingest.
+The platform mounts the uploaded raw file(s) into the container, runs your code, and
+ingests whatever your code writes to the output directory into the target dataset. Once
+registered, anyone in the workspace can upload raw files in that format — from the SDK or
+the Nominal web app — without having the parsing code on their machine.
+
+## Where extractors fit in Nominal's data model
+
+Nominal organizes time-series data into **datasets**. A dataset is built up from ingested
+**files**: each ingest parses a file's columns/records into **channels** (series), using
+timestamp metadata to place samples in time, with optional **tags** partitioning data
+within the dataset (e.g. per test-run or per vehicle).
+
+The SDK's `Dataset` class has native ingest methods for formats the platform parses
+itself: `add_tabular_data` (CSV/Parquet), `add_avro_stream`, `add_journal_json` (logs),
+`add_mcap`, `add_video`, `add_mcap_video`, `add_ardupilot_dataflash`.
+
+A containerized extractor extends that same ingest pipeline with your code. Use one when:
+
+- the raw format is proprietary or unsupported (binary telemetry, packed structs, vendor
+  logger output, custom CSV dialects needing preprocessing);
+- the format recurs — many files, many uploaders — so parsing logic should live in one
+  versioned, centrally-run place rather than on each engineer's laptop;
+- non-developers (operators, technicians) upload files through the web app and the
+  conversion must happen automatically.
+
+For a one-off conversion where you already have a parsing script, skip the extractor:
+convert locally and call `dataset.add_tabular_data(...)` directly.
+
+Two SDK surfaces are involved, and it's important not to mix them up:
+
+| Surface | Runs where | Import |
+|---|---|---|
+| Authoring runtime (the extractor's own code) | Inside the container, during ingest | `nominal.experimental.extractor` |
+| Management & triggering (create/register/activate/run) | On your machine | `nominal.core` via `NominalClient` |
+
+One more distinction: a **ContainerizedExtractor** carries identity (name, description);
+the **ContainerImage**s registered against it carry the execution contract (inputs,
+parameters, output format, default timestamp metadata). Exactly one image is active at a
+time, so you can register a new image version and switch over atomically.
+
+## Lifecycle
+
+1. **Author** the extractor function — `references/authoring.md`
+2. **Test locally** with `my_extractor.run(env={...}, exit=False)` — no Docker or platform
+   access needed — `references/authoring.md` (Local testing section)
+3. **Build** the image for `linux/amd64` and `docker save` it to a tarball —
+   `references/registration.md`
+4. **Register and activate** the image against an extractor — `references/registration.md`
+5. **Trigger ingests** with `Dataset.add_containerized` and track the `IngestionJob` —
+   `references/running.md`
+
+Read the reference file for whichever stage you're working on before writing code — each
+stage has contract details (exact env variables, timestamp resolution rules, format
+restrictions) that are easy to get subtly wrong from memory.
+
+## Choosing the output contract
+
+The image's registered output format fixes which of two contracts the ingest pipeline
+applies, and the decorator you use must agree with it:
+
+| | `@single_file_extractor` | `@manifest_extractor` |
+|---|---|---|
+| Registered `output_format` | `PARQUET`, `CSV`, or `AVRO_STREAM` | `MANIFEST` |
+| Outputs | Exactly one file | Any number, mixed formats |
+| Declare with | `ctx.set_output(path)` | `ctx.add_tabular` / `add_avro_stream` / `add_journal_json` / `add_video` |
+| Per-output tag columns, channel prefixes, timestamps | No | Yes |
+| Video outputs | No | Yes (recent platform versions) |
+
+Default to `@manifest_extractor` unless the extractor genuinely produces one file and
+nothing else will ever be needed — the manifest contract is a superset, and re-registering
+an image under a different output format is a new registration.
+
+## Minimal end-to-end example
+
+Extractor code (`extract.py`, runs inside the container):
+
+```python
+import pandas as pd
+
+from nominal.experimental.extractor import ManifestExtractorContext, manifest_extractor
+
+
+@manifest_extractor
+def convert(ctx: ManifestExtractorContext) -> None:
+    df = parse_proprietary(ctx.input("RAW_FILE"))       # your parsing logic
+    threshold = float(ctx.get_param("THRESHOLD", "0.5"))  # params are always strings
+
+    out = ctx.output_dir / "telemetry.parquet"
+    df[df.quality > threshold].to_parquet(out)
+    ctx.add_tabular(out, timestamp_column="time_s", timestamp_type="epoch_seconds")
+
+
+if __name__ == "__main__":
+    convert.run()
+```
+
+Dockerfile:
+
+```dockerfile
+FROM python:3.12-slim
+RUN pip install --no-cache-dir nominal pandas pyarrow
+COPY extract.py /app/extract.py
+ENTRYPOINT ["python", "/app/extract.py"]
+```
+
+Build, save, register, activate, run (on your machine):
+
+```python
+from nominal.core import NominalClient
+from nominal.core.container_image import FileExtractionInput, FileExtractionParameter, FileOutputFormat
+
+client = NominalClient.from_profile("default")
+
+# docker build --platform linux/amd64 -t my-extractor:0.1.0 .
+# docker save my-extractor:0.1.0 -o my-extractor-0.1.0.tar
+
+extractor = client.create_containerized_extractor("My Format Converter")
+image = extractor.register_image(
+    "my-extractor-0.1.0.tar",
+    tag="0.1.0",
+    inputs=[
+        FileExtractionInput(
+            name="Raw file", environment_variable="RAW_FILE",
+            file_suffixes=["bin"], required=True,
+        )
+    ],
+    parameters=[
+        FileExtractionParameter(name="Quality threshold", environment_variable="THRESHOLD"),
+    ],
+    output_format=FileOutputFormat.MANIFEST,
+    default_timestamp_column="time_s",
+    default_timestamp_type="epoch_seconds",
+)
+extractor.set_active_image(image)
+
+dataset = client.get_dataset("ri.catalog....")
+job = dataset.add_containerized(
+    extractor,
+    sources={"RAW_FILE": "flight_042.bin"},   # keyed by environment variable
+    arguments={"THRESHOLD": "0.8"},           # values are strings
+)
+files = list(job.as_files_ingested())          # blocks until ingested
+```
+
+## Rules that trip people up
+
+- **Outputs must be written under `ctx.output_dir` and declared.** The pipeline ingests
+  only declared files; undeclared files earn a warning and are silently dropped.
+- **`manifest.json` belongs to the runtime.** Never write it yourself — declare outputs
+  through the `add_*` methods and the runtime writes it when your function returns.
+- **Parameters arrive as strings.** Coerce them yourself (`int(ctx.param("PARTS"))`).
+- **The decorator must match the registered output format.** A mismatch fails at container
+  startup with a clear error (better than emitting output the pipeline rejects).
+- **Build for `linux/amd64`.** Nominal runs images on amd64; on Apple Silicon always pass
+  `--platform linux/amd64` to `docker build`.
+- **Image tags are immutable.** Re-registering an existing tag raises
+  `NominalAlreadyExistsError` — bump the tag instead.
+- **Registration does not activate.** A new image runs only after
+  `extractor.set_active_image(image)`.
+- **Timestamp metadata resolves in order:** per-output manifest metadata → the ingest
+  request's `timestamp_column`/`timestamp_type` override → the image's registered default.
+  Registration requires a default; per-output metadata supports only numeric types
+  (epoch/relative, seconds→nanoseconds) — richer formats (ISO 8601, custom) must come from
+  the job-level metadata.
+- **Failures should fail loudly.** Any exception escaping your function exits non-zero and
+  fails the ingest job — that's the designed behavior. Don't swallow errors into empty
+  outputs.
+
+## Reference files
+
+- `references/authoring.md` — the full in-container runtime: context API, per-format
+  declaration methods, system metadata, error semantics, and local testing patterns.
+  Read before writing or reviewing extractor code.
+- `references/registration.md` — Dockerfile conventions, building/saving the image,
+  `register_image` arguments, image lifecycle (statuses, activation, deletion, search).
+  Read before registering or upgrading an image.
+- `references/running.md` — triggering ingests with `add_containerized`, tracking
+  `IngestionJob`s, and debugging failed jobs. Read when running or troubleshooting.

--- a/.agents/skills/nominal-extractors/references/authoring.md
+++ b/.agents/skills/nominal-extractors/references/authoring.md
@@ -179,8 +179,12 @@ is the main reason not to start here.
 
 - `ExtractorError` (from `nominal.experimental.extractor`) — violations of the extractor
   contract: missing required parameter, unknown input name, output outside `output_dir`,
-  reserved `manifest.json` name, wrong file extension for a declaration method.
-- `ValueError` and friends — malformed arguments, same as the rest of the SDK.
+  reserved `manifest.json` name, a timestamp unit the manifest can't express.
+- `ValueError` and friends — malformed arguments, *and a file extension the declaration
+  method can't read*, same as the rest of the SDK. Note that `ExtractorError` subclasses
+  `NominalError`, not `ValueError`, so the two are disjoint: `except ExtractorError` around a
+  declaration will not catch the extension mismatch. Catch both, or neither, and let `run()`
+  fail the job.
 - Any exception escaping your function (or the runtime) prints a traceback and exits
   non-zero, failing the ingest job. That is the correct way to fail: don't catch broad
   exceptions to "keep going" — an empty dataset with a green job status is much worse

--- a/.agents/skills/nominal-extractors/references/authoring.md
+++ b/.agents/skills/nominal-extractors/references/authoring.md
@@ -1,0 +1,242 @@
+# Authoring extractor code
+
+Everything here runs *inside* the container, using `nominal.experimental.extractor`.
+The container needs `nominal` installed plus whatever format libraries your code uses
+(`pyarrow`, `pandas`, ...) — format I/O is your own dependency, the runtime only manages
+the contract with the ingest pipeline.
+
+## The environment contract
+
+Nominal drives the container entirely through the environment:
+
+- Each input file is mounted under `/input`, and its path is also exposed in the
+  environment variable declared for that input at registration time.
+- Output goes to the directory named by `$OUTPUT_DIR`.
+- Declared parameters arrive as environment variables; values are always strings.
+- Nominal also injects `_NOMINAL_*` metadata describing the registered contract (output
+  format, inputs, parameters) and, on newer platforms, system metadata (job/dataset RIDs,
+  resolved timestamp metadata, tags). All optional — absent on local runs.
+
+You never read these variables directly: the context object (`ctx`) resolves all of it.
+
+## Entrypoint shape
+
+```python
+from nominal.experimental.extractor import ManifestExtractorContext, manifest_extractor
+
+@manifest_extractor
+def my_extractor(ctx: ManifestExtractorContext) -> None:
+    ...
+
+if __name__ == "__main__":
+    my_extractor.run()
+```
+
+`run()` builds the context from the environment, validates the registered contract,
+calls your function, finalizes outputs (writes `manifest.json` in manifest mode), and
+turns any failure — including `SystemExit` from user code — into a non-zero exit so the
+ingest job fails cleanly. It also calls `logging.basicConfig(level=logging.INFO)` when
+running as a real entrypoint, so `logging` output lands in the job's captured logs;
+prefer `logging` over `print` for anything you'll want when debugging a failed job.
+
+Exports from `nominal.experimental.extractor`:
+`single_file_extractor`, `manifest_extractor`, `Extractor`, `ExtractorContext`,
+`SingleFileExtractorContext`, `ManifestExtractorContext`, `ExtractorError`,
+`TimestampMetadata`.
+
+## Reading inputs
+
+```python
+ctx.inputs                # list[Path]: every mounted input file
+ctx.input()               # Path: the sole input (raises unless exactly one)
+ctx.input("RAW_FILE")     # Path: by env variable, or registered display name
+```
+
+With registered contract metadata present (a real run), `ctx.input(name)` accepts the
+input's registered display name or its environment variable; an unknown name raises
+`ExtractorError` listing the valid ones. An optional input the ingest request didn't
+provide is *not* among the run's inputs — probe `ctx.inputs` or catch `ExtractorError`
+if an input may legitimately be absent.
+
+On local runs (no injected metadata), `ctx.input("NAME")` reads the environment variable
+`NAME` directly, and `ctx.inputs` lists the input directory (default `/input`, overridable
+via `NOMINAL_EXTRACTOR_INPUT_DIR`).
+
+## Reading parameters
+
+```python
+ctx.param("THRESHOLD")           # str: raises ExtractorError if unset
+ctx.get_param("PARTS", "2")      # str: default when unset
+ctx.get_param("MAYBE")           # str | None
+```
+
+Values are always strings — coerce yourself: `int(ctx.get_param("PARTS", "2"))`. Names
+resolve like inputs do (registered display name or env variable; env variable directly on
+local runs). With contract metadata present, an unregistered name raises `ExtractorError`
+— it's an authoring bug, not a missing value.
+
+## System metadata (all optional; None/empty on local runs)
+
+```python
+ctx.ingest_job_rid          # str | None
+ctx.dataset_rid             # str | None
+ctx.additional_tags         # dict[str, str]: tags the ingest request applies to all data
+ctx.job_timestamp_metadata  # TimestampMetadata | None: the job-level default your outputs inherit
+```
+
+## Declaring outputs — single-file mode
+
+For images registered with output format `PARQUET`, `CSV`, or `AVRO_STREAM`. The pipeline
+ingests exactly one output file, parsed per the registered format.
+
+```python
+@single_file_extractor
+def convert(ctx: SingleFileExtractorContext) -> None:
+    out = ctx.output_dir / "converted.parquet"
+    write_parquet(read_input(ctx.input()), out)
+    ctx.set_output(out)
+```
+
+`set_output` records a file you already wrote under `ctx.output_dir`; a second call
+raises. Producing no output fails the run.
+
+## Declaring outputs — manifest mode
+
+For images registered with output format `MANIFEST`. Declare each file with the method
+for its format; the runtime writes `manifest.json` from the declarations when your
+function returns. At least one declaration is required.
+
+```python
+ctx.add_tabular(
+    path,                          # .csv or .parquet under ctx.output_dir
+    tag_columns={"vehicle": "vehicle_id"},   # tag name -> column carrying its values
+    channel_prefix="engine",       # prepended to every channel from this file
+    timestamp_column="time_ns",    # with timestamp_type, overrides job-level metadata
+    timestamp_type="epoch_nanoseconds",
+)
+
+ctx.add_avro_stream(
+    path,                          # .avro or .avro.gz
+    channel_prefix="bus",
+    timestamp_type="epoch_nanoseconds",  # how to read the schema's timestamps field
+)
+
+ctx.add_journal_json(
+    path,                          # .jsonl or .jsonl.gz, ingested as logs
+    timestamp_column="ts",         # top-level JSON field holding each line's timestamp
+    timestamp_type="epoch_seconds",
+)
+
+ctx.add_video(
+    path,                          # a supported video container (e.g. .mp4) under ctx.output_dir
+    channel="camera/front",
+    start=recording_started_at,    # OR frame_timestamps=[...] (exactly one of the two)
+)
+```
+
+Format-specific rules:
+
+- **`add_tabular`**: columns become channels. `timestamp_column`/`timestamp_type` must be
+  passed together or not at all (the overloads make a half-pair a type error).
+- **`add_avro_stream`**: avro records carry their own channel, values, and tags, so there
+  are no tag columns and no timestamp column — the schema fixes which field holds
+  timestamps (`timestamps`); `timestamp_type` only says how to read the numbers in it.
+  Omitting it inherits the job-level metadata, which is only correct when that metadata is
+  numeric (avro timestamps are integers; a string format can't read them).
+- **`add_journal_json`**: each line needs a `MESSAGE` field and a timestamp field; lines
+  missing either are skipped. Other top-level fields become log args (stringified). Log
+  outputs take neither tag columns nor a channel prefix.
+- **`add_video`**: exactly one of `start` (absolute start; frame times come from the
+  video's encoded presentation timestamps) or `frame_timestamps` (one absolute nanosecond
+  timestamp per frame — the runtime writes and declares the sidecar file for you). With
+  `start`, at most one of `ending_timestamp`, `true_frame_rate`, `scale_factor` corrects
+  playback-rate mismatch. Requires a recent platform version: an older ingest pipeline
+  ignores video outputs and rejects a manifest whose only outputs are videos.
+- Declaring the same file more than once is allowed and each declaration becomes its own
+  manifest entry (e.g. one table ingested under two timestamp columns).
+
+## Timestamp metadata in outputs
+
+Per-output timestamp metadata supports **numeric types only**: string literals
+`"epoch_seconds"`, `"epoch_milliseconds"`, `"epoch_microseconds"`, `"epoch_nanoseconds"`,
+or the typed forms `ts.Epoch(unit=...)` / `ts.Relative(unit=..., start=...)`, with units
+seconds through nanoseconds. Outputs needing ISO 8601 or custom formats must omit the
+per-output pair and rely on the job-level metadata (the ingest request override or the
+image's registered default), which supports the full range.
+
+Resolution order per output file: per-output manifest metadata → ingest request override
+→ image default. The override-or-default portion is resolved *before* the container runs
+and ingestion fails if both are absent — so registration always requires a default.
+
+## Error semantics
+
+- `ExtractorError` (from `nominal.experimental.extractor`) — violations of the extractor
+  contract: missing required parameter, unknown input name, output outside `output_dir`,
+  reserved `manifest.json` name, wrong file extension for a declaration method.
+- `ValueError` and friends — malformed arguments, same as the rest of the SDK.
+- Any exception escaping your function (or the runtime) prints a traceback and exits
+  non-zero, failing the ingest job. That is the correct way to fail: don't catch broad
+  exceptions to "keep going" — an empty dataset with a green job status is much worse
+  than a red job.
+
+Decide deliberately what a degenerate input means. An empty or truncated source file can
+either raise or produce a valid zero-row output, and the runtime accepts both — a declared
+zero-row table is a legitimate output, so the job succeeds and the dataset simply gains
+nothing. Raising is usually the better default precisely because of that: a green job that
+ingested nothing is the hardest failure for the uploader to notice, while a red job names
+itself. Reserve the zero-row path for cases where "this capture is legitimately empty" is a
+real, expected state rather than a symptom.
+
+The runtime also logs advisory warnings at startup (registered-required parameter unset,
+registered input missing from the mount) and at finalize (undeclared files left in the
+output directory). Watch for these in job logs — they usually point at the bug.
+
+## Local testing
+
+`Extractor.run` takes an explicit environment, so extractors are testable without Docker
+or platform access:
+
+```python
+def test_convert(tmp_path):
+    raw = tmp_path / "raw.bin"
+    raw.write_bytes(make_test_frames())
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    ctx = convert.run(
+        env={
+            "OUTPUT_DIR": str(out_dir),
+            "RAW_FILE": str(raw),        # local runs read input env vars directly
+            "THRESHOLD": "0.9",
+        },
+        exit=False,                       # re-raise failures instead of sys.exit(1)
+    )
+
+    table = pq.read_table(out_dir / "telemetry.parquet")
+    assert table.num_rows > 0
+```
+
+Notes:
+
+- **`env` replaces the environment, it does not merge into it.** The mapping you pass is the
+  entire environment the run sees, so it must carry `OUTPUT_DIR`, every input, and every
+  parameter the code reads — nothing is inherited from the ambient process. Omitting
+  `OUTPUT_DIR` raises `ExtractorError` rather than falling back to a real value, which is
+  the single most common way a local test fails before it tests anything.
+- `run(..., exit=False)` returns the context on success and re-raises on failure —
+  assert on the exception in failure tests.
+- In manifest mode, `ctx.build_manifest()` returns the manifest document exactly as
+  written — assert on declared entries rather than re-parsing `manifest.json`.
+- To exercise the *registered-contract* code paths (display-name resolution, unknown-name
+  errors), inject the metadata Nominal would:
+  `_NOMINAL_INPUTS='[{"name": "Raw file", "environmentVariable": "RAW_FILE", "path": "/tmp/raw.bin"}]'`,
+  `_NOMINAL_PARAMETERS='[{"name": "Quality threshold", "environmentVariable": "THRESHOLD", "required": false}]'`,
+  `_NOMINAL_OUTPUT_FORMAT="MANIFEST"`.
+- After building the image, a full dress rehearsal under Docker:
+
+  ```sh
+  docker run --rm \
+    -v "$PWD/testdata:/input:ro" -v "$PWD/out:/output" \
+    -e OUTPUT_DIR=/output -e RAW_FILE=/input/raw.bin -e THRESHOLD=0.9 \
+    my-extractor:0.1.0
+  ```

--- a/.agents/skills/nominal-extractors/references/authoring.md
+++ b/.agents/skills/nominal-extractors/references/authoring.md
@@ -1,9 +1,9 @@
 # Authoring extractor code
 
-Everything here runs *inside* the container, using `nominal.experimental.extractor`.
-The container needs `nominal` installed plus whatever format libraries your code uses
-(`pyarrow`, `pandas`, ...) — format I/O is your own dependency, the runtime only manages
-the contract with the ingest pipeline.
+Everything here runs *inside* the container, using `nominal.experimental.extractor`. The
+container needs `nominal` installed plus whatever format libraries your code uses (`pyarrow`,
+`pandas`, ...). Format I/O is your own dependency; the runtime only manages the contract with
+the ingest pipeline.
 
 ## The environment contract
 
@@ -14,10 +14,10 @@ Nominal drives the container entirely through the environment:
 - Output goes to the directory named by `$OUTPUT_DIR`.
 - Declared parameters arrive as environment variables; values are always strings.
 - Nominal also injects `_NOMINAL_*` metadata describing the registered contract (output
-  format, inputs, parameters) and, on newer platforms, system metadata (job/dataset RIDs,
-  resolved timestamp metadata, tags). All optional — absent on local runs.
+  format, inputs, parameters) and, on newer platforms, system metadata (job and dataset RIDs,
+  resolved timestamp metadata, tags). All optional, and absent on local runs.
 
-You never read these variables directly: the context object (`ctx`) resolves all of it.
+Never read these variables directly. The context object (`ctx`) resolves all of it.
 
 ## Entrypoint shape
 
@@ -32,12 +32,12 @@ if __name__ == "__main__":
     my_extractor.run()
 ```
 
-`run()` builds the context from the environment, validates the registered contract,
-calls your function, finalizes outputs (writes `manifest.json` in manifest mode), and
-turns any failure — including `SystemExit` from user code — into a non-zero exit so the
-ingest job fails cleanly. It also calls `logging.basicConfig(level=logging.INFO)` when
-running as a real entrypoint, so `logging` output lands in the job's captured logs;
-prefer `logging` over `print` for anything you'll want when debugging a failed job.
+`run()` builds the context from the environment, validates the registered contract, calls
+your function, finalizes outputs (writing `manifest.json` in manifest mode), and turns any
+failure — including a `SystemExit` from your code — into a non-zero exit so the ingest job
+fails cleanly. As a real entrypoint it also calls `logging.basicConfig(level=logging.INFO)`,
+so `logging` output lands in the job's captured logs. Prefer `logging` over `print` for
+anything you will want when debugging a failed job.
 
 Exports from `nominal.experimental.extractor`:
 `single_file_extractor`, `manifest_extractor`, `Extractor`, `ExtractorContext`,
@@ -181,26 +181,23 @@ is the main reason not to start here.
   contract: missing required parameter, unknown input name, output outside `output_dir`,
   reserved `manifest.json` name, a timestamp unit the manifest can't express.
 - `ValueError` and friends — malformed arguments, *and a file extension the declaration
-  method can't read*, same as the rest of the SDK. Note that `ExtractorError` subclasses
-  `NominalError`, not `ValueError`, so the two are disjoint: `except ExtractorError` around a
-  declaration will not catch the extension mismatch. Catch both, or neither, and let `run()`
-  fail the job.
-- Any exception escaping your function (or the runtime) prints a traceback and exits
-  non-zero, failing the ingest job. That is the correct way to fail: don't catch broad
-  exceptions to "keep going" — an empty dataset with a green job status is much worse
-  than a red job.
+  method can't read*, same as the rest of the SDK. `ExtractorError` subclasses `NominalError`,
+  not `ValueError`, so the two are disjoint: `except ExtractorError` around a declaration will
+  not catch the extension mismatch. Catch both, or neither and let `run()` fail the job.
+- Any exception escaping your function or the runtime prints a traceback and exits non-zero,
+  failing the ingest job. That is the correct way to fail. Do not catch broad exceptions to
+  keep going: an empty dataset under a green job status is much worse than a red job.
 
 Decide deliberately what a degenerate input means. An empty or truncated source file can
 either raise or produce a valid zero-row output, and the runtime accepts both — a declared
-zero-row table is a legitimate output, so the job succeeds and the dataset simply gains
-nothing. Raising is usually the better default precisely because of that: a green job that
-ingested nothing is the hardest failure for the uploader to notice, while a red job names
-itself. Reserve the zero-row path for cases where "this capture is legitimately empty" is a
-real, expected state rather than a symptom.
+zero-row table is a legitimate output, so the job succeeds and the dataset gains nothing.
+Raising is usually the better default for that reason: a green job that ingested nothing is
+the hardest failure for an uploader to notice, while a red job names itself. Use the zero-row
+path only where "this capture is legitimately empty" is an expected state, not a symptom.
 
-The runtime also logs advisory warnings at startup (registered-required parameter unset,
-registered input missing from the mount) and at finalize (undeclared files left in the
-output directory). Watch for these in job logs — they usually point at the bug.
+The runtime also logs advisory warnings at startup (a registered-required parameter unset, a
+registered input missing from the mount) and at finalize (undeclared files left in the output
+directory). Watch for these in job logs; they usually point straight at the bug.
 
 ## Local testing
 
@@ -231,13 +228,13 @@ Notes:
 
 - **`env` replaces the environment, it does not merge into it.** The mapping you pass is the
   entire environment the run sees, so it must carry `OUTPUT_DIR`, every input, and every
-  parameter the code reads — nothing is inherited from the ambient process. Omitting
-  `OUTPUT_DIR` raises `ExtractorError` rather than falling back to a real value, which is
-  the single most common way a local test fails before it tests anything.
-- `run(..., exit=False)` returns the context on success and re-raises on failure —
-  assert on the exception in failure tests.
-- In manifest mode, `ctx.build_manifest()` returns the manifest document exactly as
-  written — assert on declared entries rather than re-parsing `manifest.json`.
+  parameter the code reads. Nothing is inherited from the ambient process. Omitting
+  `OUTPUT_DIR` raises `ExtractorError` instead of falling back to a real value — the most
+  common way a local test fails before it tests anything.
+- `run(..., exit=False)` returns the context on success and re-raises on failure. Assert on
+  the exception in failure tests.
+- In manifest mode, `ctx.build_manifest()` returns the manifest document exactly as written.
+  Assert on that rather than re-parsing `manifest.json`.
 - To exercise the *registered-contract* code paths (display-name resolution, unknown-name
   errors), inject the metadata Nominal would:
   `_NOMINAL_INPUTS='[{"name": "Raw file", "environmentVariable": "RAW_FILE", "path": "/tmp/raw.bin"}]'`,

--- a/.agents/skills/nominal-extractors/references/authoring.md
+++ b/.agents/skills/nominal-extractors/references/authoring.md
@@ -84,27 +84,11 @@ ctx.additional_tags         # dict[str, str]: tags the ingest request applies to
 ctx.job_timestamp_metadata  # TimestampMetadata | None: the job-level default your outputs inherit
 ```
 
-## Declaring outputs — single-file mode
-
-For images registered with output format `PARQUET`, `CSV`, or `AVRO_STREAM`. The pipeline
-ingests exactly one output file, parsed per the registered format.
-
-```python
-@single_file_extractor
-def convert(ctx: SingleFileExtractorContext) -> None:
-    out = ctx.output_dir / "converted.parquet"
-    write_parquet(read_input(ctx.input()), out)
-    ctx.set_output(out)
-```
-
-`set_output` records a file you already wrote under `ctx.output_dir`; a second call
-raises. Producing no output fails the run.
-
 ## Declaring outputs — manifest mode
 
-For images registered with output format `MANIFEST`. Declare each file with the method
-for its format; the runtime writes `manifest.json` from the declarations when your
-function returns. At least one declaration is required.
+The contract new extractors use, for images registered with output format `MANIFEST`.
+Declare each file with the method for its format; the runtime writes `manifest.json` from
+the declarations when your function returns. At least one declaration is required.
 
 ```python
 ctx.add_tabular(
@@ -167,6 +151,29 @@ image's registered default), which supports the full range.
 Resolution order per output file: per-output manifest metadata → ingest request override
 → image default. The override-or-default portion is resolved *before* the container runs
 and ingestion fails if both are absent — so registration always requires a default.
+
+See `modeling.md` for choosing between absolute and relative time, which is the decision
+this machinery exists to serve.
+
+## Declaring outputs — single-file mode
+
+The original contract, for images registered with output format `PARQUET`, `CSV`, or
+`AVRO_STREAM`: the pipeline ingests exactly one output file, parsed per the registered
+format. You need this when maintaining an image already registered that way; write new
+extractors as manifest extractors instead.
+
+```python
+@single_file_extractor
+def convert(ctx: SingleFileExtractorContext) -> None:
+    out = ctx.output_dir / "converted.parquet"
+    write_parquet(read_input(ctx.input()), out)
+    ctx.set_output(out)
+```
+
+`set_output` records a file you already wrote under `ctx.output_dir`; a second call
+raises. Producing no output fails the run. There is no per-output timestamp, tag-column, or
+channel-prefix control in this mode — everything comes from the job-level metadata, which
+is the main reason not to start here.
 
 ## Error semantics
 

--- a/.agents/skills/nominal-extractors/references/modeling.md
+++ b/.agents/skills/nominal-extractors/references/modeling.md
@@ -1,54 +1,55 @@
 # Modeling decisions
 
-The mechanics of writing an extractor are in `authoring.md`; this file covers the choices
-that decide whether the resulting data is pleasant or painful to work with. These are the
-decisions that are cheap now and expensive later: inputs and parameters are fixed at
-registration, and timestamps and tags shape how every downstream query has to be written.
+The mechanics of writing an extractor are in `authoring.md`. This file covers the choices
+that decide whether the resulting data is pleasant or painful to work with. They are cheap
+now and expensive later: inputs and parameters are fixed at registration, and timestamps and
+tags shape how every downstream query has to be written.
 
 ## Inputs vs parameters
 
-Both arrive through the environment, and the distinction is about *kind*, not size:
+Both arrive through the environment. The distinction is *kind*, not size:
 
-- **Input** — a file the extractor reads. Nominal mounts it and puts its path in the
-  declared environment variable. The ingest request supplies it as
-  `sources={"ENV_VAR": path}`.
-- **Parameter** — a scalar that tunes behavior, delivered as an environment-variable
-  string. The ingest request supplies it as `arguments={"ENV_VAR": "value"}`.
+- **Input** — a file the extractor reads. Nominal mounts it and puts its path in the declared
+  environment variable. The ingest request supplies it as `sources={"ENV_VAR": path}`.
+- **Parameter** — a scalar that tunes behavior, delivered as an environment-variable string.
+  The ingest request supplies it as `arguments={"ENV_VAR": "value"}`.
 
-Decide with two questions. *Is it content, or is it a knob?* A calibration table, a channel
-map, a vendor schema sidecar — content, so make it an input even though it feels like
-configuration. A sample-rate divisor, a mode flag, a quality threshold — a knob, so make it
-a parameter. *Does it vary per ingest?* If it never varies, it belongs in the image itself,
-baked into the code or a `COPY`'d file, not in either mechanism — every parameter you
-register is a field somebody has to understand and fill in.
+Decide with two questions.
 
-Two properties push structured configuration toward inputs specifically:
+*Is it content, or a knob?* A calibration table, a channel map, a vendor schema sidecar is
+content: make it an input, even though it feels like configuration. A sample-rate divisor, a
+mode flag, a quality threshold is a knob: make it a parameter.
 
-- Parameter values are strings with no schema. Anything with structure — a mapping, a list,
-  a nested document — has to be encoded and parsed by hand, and a malformed value fails
-  inside your parsing code with whatever message you happen to write.
-- Inputs carry declared suffixes (`file_suffixes=["json"]`) saying what the input accepts —
-  which is what `search_containerized_extractors(file_extension=...)` matches on, so they
-  decide which extractors a given file is offered for — and, more importantly, a real
-  client-side required check. The suffixes are descriptive, not enforced locally: passing a
-  `.txt` to an input registered `["json"]` still uploads.
+*Does it vary per ingest?* If it never varies, put it in the image — in the code or a
+`COPY`'d file — rather than either mechanism. Every registered parameter is a field somebody
+has to understand and fill in.
+
+Two things push structured configuration toward inputs:
+
+- Parameter values are strings with no schema. A mapping, a list, or a nested document has to
+  be encoded and parsed by hand, and a malformed value fails inside your parsing code with
+  whatever message you wrote.
+- Inputs declare accepted suffixes (`file_suffixes=["json"]`), which is what
+  `search_containerized_extractors(file_extension=...)` matches on, so they determine which
+  extractors a given file is offered for. Inputs also get a real client-side required check.
+  The suffixes are descriptive, not enforced locally: a `.txt` sent to an input registered
+  `["json"]` still uploads.
 
 **`required=True` is much stronger on an input than on a parameter.** A missing required
 input raises in `add_containerized` before anything uploads. A missing required parameter is
-not checked client-side at all: the runtime logs a warning at container start, and the run
-then fails at whatever moment `ctx.param()` reads it — after the upload, after the container
-spun up, in the middle of the job. So for a parameter the code cannot proceed without,
-either read it early (fail fast, at the top of the function) or give it a real default with
-`ctx.get_param(name, default)` and skip the required flag.
+not checked client-side: the runtime warns at container start, and the run fails whenever
+`ctx.param()` reads it — after the upload, after the container started, mid-job. So for a
+parameter the code cannot run without, either read it at the top of the function or give it a
+default with `ctx.get_param(name, default)` and drop the required flag.
 
-Name the environment variables like the contract they are. The `name` field is what a person
-sees in the app; the `environment_variable` is what the code reads, and changing it later is
-a new registration plus an update to every caller's `sources`/`arguments`.
+Name the environment variables carefully. `name` is what a person sees in the app;
+`environment_variable` is what the code reads. Changing it later means a new registration
+plus an update to every caller's `sources` or `arguments`.
 
 ## Absolute vs relative time
 
-Nominal places every sample on an absolute timeline, so the question is only how your
-output encodes the position:
+Nominal places every sample on an absolute timeline. The only question is how your output
+encodes the position:
 
 | Type | Encodes | Use when |
 |---|---|---|
@@ -57,78 +58,73 @@ output encodes the position:
 | `ts.Iso8601` | absolute timestamp strings | the source carries formatted timestamps you don't want to parse |
 | `ts.Custom(format=...)` | absolute strings in a `DateTimeFormatter` pattern | the same, in a non-ISO layout |
 
-**Prefer absolute.** If the source has absolute time anywhere — per record, or a header
-start plus per-record offsets you can add — convert once inside the extractor and emit
-`Epoch`. Absolute output is self-describing: it survives re-registration, it doesn't depend
-on metadata staying correctly paired with the file, and it can't be silently wrong.
+**Prefer absolute.** If the source has absolute time anywhere, per record or as a header
+start plus offsets you can add, convert it in the extractor and emit `Epoch`. Absolute
+output is self-describing: it survives re-registration, does not depend on metadata staying
+paired with the file, and cannot be silently wrong.
 
-Reach for `Relative` when the logger genuinely only knows elapsed time. Then t0 has to come
-from somewhere, and where it comes from is the real design decision: a header inside the
-file (best — the file stays self-contained), the filename, a registered parameter, or
-`ctx.additional_tags`. Prefer reading it from the file, because a t0 passed in as a
-parameter is a value someone has to get right on every single upload.
+Use `Relative` when the logger knows nothing but elapsed time. Then t0 has to come from
+somewhere, and that choice matters: a header inside the file, the filename, a registered
+parameter, or `ctx.additional_tags`. Prefer the file, which keeps it self-contained. A t0
+passed as a parameter is a value someone has to get right on every upload.
 
-**Do not register `Relative` as an image's `default_timestamp_type`.** A default is baked in
-once and applies to every future ingest, so a fixed `start` would assign the same t0 to
-every file the extractor ever processes — correct for the first one and wrong for all the
-rest. Register an absolute default, and declare `Relative` per output in the manifest, where
-each file carries its own start. This is one of the concrete reasons manifest extractors are
-the right default: single-file mode has nowhere to put per-file timestamp metadata.
+**Do not register `Relative` as an image's `default_timestamp_type`.** A default is set once
+and applies to every future ingest, so a fixed `start` would give every file the same t0 —
+right for the first, wrong for the rest. Register an absolute default and declare `Relative`
+per output in the manifest, where each file carries its own start. This is one concrete
+reason to prefer manifest extractors: single-file mode has nowhere to put per-file timestamp
+metadata.
 
-On units: pick the one the data actually has, not a rounder one. Declaring
-`epoch_milliseconds` for microsecond data doesn't just lose precision, it misplaces every
-sample by a factor of a thousand. Per-output metadata in a manifest accepts only numeric
-types (seconds through nanoseconds) — an output needing ISO 8601 or a custom format must
-omit the per-output pair and inherit the job-level metadata.
+Use the unit the data actually has, not a rounder one. Declaring `epoch_milliseconds` for
+microsecond data does not just lose precision, it misplaces every sample by a factor of 1000.
+Per-output metadata accepts numeric types only, seconds through nanoseconds; an output needing
+ISO 8601 or a custom format must omit the per-output pair and inherit the job-level metadata.
 
 ## Tags
 
-Tags are the dimensions that separate otherwise-identical channels. A channel is identified
-by its name, so two test stands both producing `chamber_pressure` collide into one series
-unless something distinguishes them — and that something is a tag. Get this wrong and the
-data isn't lost, it's blended, which is harder to notice and harder to undo than a failed
-ingest.
+Tags separate otherwise-identical channels. A channel is identified by its name, so two test
+stands both producing `chamber_pressure` collide into one series unless a tag distinguishes
+them. Get this wrong and the data is not lost, it is blended — harder to notice and harder to
+undo than a failed ingest.
 
-Three places tags can come from, in increasing order of specificity:
+Tags come from three places, in increasing order of specificity:
 
 1. **The ingest request** — `dataset.add_containerized(..., tags={"vehicle": "n1234"})`.
-   Applied uniformly to everything the run produces, and visible in-container as
-   `ctx.additional_tags`. This is the right home for facts about *this upload* that the file
-   itself doesn't know: which vehicle, which campaign, which operator.
+   Applied to everything the run produces, and readable in-container as
+   `ctx.additional_tags`. Use it for facts about *this upload* that the file does not know:
+   which vehicle, which campaign, which operator.
 2. **A tag column** — `ctx.add_tabular(path, tag_columns={"motor": "motor_id"})`. Reads the
-   value per row from a column, so one file can carry data from several sources. Use this
-   when the distinguishing fact varies *within* the file.
-3. **Avro records**, which carry their own tags inline. This is why `add_avro_stream` takes
-   no tag columns — there would be nothing to map.
+   value per row, so one file can carry data from several sources. Use it when the
+   distinguishing fact varies *within* the file.
+3. **Avro records**, which carry tags inline. Hence no tag columns on `add_avro_stream`:
+   there would be nothing to map.
 
-Log outputs (`add_journal_json`) and videos (`add_video`) take neither: log samples carry no
+Log outputs (`add_journal_json`) and videos (`add_video`) take neither. Log samples carry no
 tags and land on a single channel, and a video is identified by its `channel`.
 
 **A tag column is consumed, not ingested.** Naming a column in `tag_columns` applies its
-values as tags to that file's rows; the column does not also become a channel. So each
-column is either a measurement you can plot or a dimension you can filter by, never both —
-and if you need the same value in both roles, write it to the output twice under two names.
-That makes tagging an authoring-time decision, not a registration-time one: you are
-choosing, per column, which of the two things it becomes.
+values as tags to that file's rows; the column does not also become a channel. Each column is
+either a measurement you can plot or a dimension you can filter by, never both. Write it out
+twice, under two names, if you need both. So tagging is an authoring-time decision: per
+column, you choose which of the two it becomes.
 
-What makes a good tag is a fact that *identifies a source*, stays stable for the life of the
-data, and has few distinct values: vehicle, stand, motor serial, run identifier, sensor
-location. What makes a bad tag is a measurement (that's a channel), a timestamp or anything
-derived from one (that's the timeline), a value that changes constantly (it fragments the
-series into noise), or free text that varies by upload — the same concept spelled `Stand A`,
-`stand-a`, and `standA` produces three unrelated series that nobody can join.
+A good tag *identifies a source*, stays stable for the life of the data, and has few distinct
+values: vehicle, stand, motor serial, run identifier, sensor location. A bad tag is a
+measurement (that is a channel), a timestamp or anything derived from one (that is the
+timeline), a value that changes constantly (it fragments the series into noise), or free text
+that varies by upload — `Stand A`, `stand-a`, and `standA` become three unrelated series.
 
-Two things worth settling before the first real ingest:
+Two things to settle before the first real ingest:
 
 - **Fix a vocabulary and enforce it in the extractor.** Tag keys and values are strings
-  chosen by whoever wrote the caller, and nothing normalizes them for you. If the extractor
-  is the one deciding tag values, normalize there — lowercase, canonical separators,
-  validated against a known set — rather than trusting each uploader.
-- **Decide tag-versus-channel-prefix deliberately.** `channel_prefix` renames channels
-  (`engine/chamber_pressure`); a tag leaves the name alone and adds a dimension. Prefixes
-  are convenient when two outputs would otherwise collide by name and you want them visibly
-  distinct; tags are better when you want to compare the same measurement across sources,
-  because a tag can be filtered and grouped while a prefix has to be matched by string.
+  chosen by whoever wrote the caller, and nothing normalizes them. If the extractor sets tag
+  values, normalize there — lowercase, canonical separators, validated against a known set —
+  rather than trusting each uploader.
+- **Choose between a tag and a channel prefix deliberately.** `channel_prefix` renames
+  channels (`engine/chamber_pressure`); a tag leaves the name alone and adds a dimension. A
+  prefix suits two outputs that would collide by name and should look distinct. A tag suits
+  comparing the same measurement across sources, since a tag can be filtered and grouped
+  while a prefix has to be matched as a string.
 
 Both are painful to change once there is data: tag values are baked into every series
 already ingested, so a renamed key or a re-spelled value doesn't migrate — it forks.

--- a/.agents/skills/nominal-extractors/references/modeling.md
+++ b/.agents/skills/nominal-extractors/references/modeling.md
@@ -1,0 +1,127 @@
+# Modeling decisions
+
+The mechanics of writing an extractor are in `authoring.md`; this file covers the choices
+that decide whether the resulting data is pleasant or painful to work with. These are the
+decisions that are cheap now and expensive later: inputs and parameters are fixed at
+registration, and timestamps and tags shape how every downstream query has to be written.
+
+## Inputs vs parameters
+
+Both arrive through the environment, and the distinction is about *kind*, not size:
+
+- **Input** — a file the extractor reads. Nominal mounts it and puts its path in the
+  declared environment variable. The ingest request supplies it as
+  `sources={"ENV_VAR": path}`.
+- **Parameter** — a scalar that tunes behavior, delivered as an environment-variable
+  string. The ingest request supplies it as `arguments={"ENV_VAR": "value"}`.
+
+Decide with two questions. *Is it content, or is it a knob?* A calibration table, a channel
+map, a vendor schema sidecar — content, so make it an input even though it feels like
+configuration. A sample-rate divisor, a mode flag, a quality threshold — a knob, so make it
+a parameter. *Does it vary per ingest?* If it never varies, it belongs in the image itself,
+baked into the code or a `COPY`'d file, not in either mechanism — every parameter you
+register is a field somebody has to understand and fill in.
+
+Two properties push structured configuration toward inputs specifically:
+
+- Parameter values are strings with no schema. Anything with structure — a mapping, a list,
+  a nested document — has to be encoded and parsed by hand, and a malformed value fails
+  inside your parsing code with whatever message you happen to write.
+- Inputs get suffix validation (`file_suffixes=["json"]`) and, more importantly, a real
+  client-side required check.
+
+**`required=True` is much stronger on an input than on a parameter.** A missing required
+input raises in `add_containerized` before anything uploads. A missing required parameter is
+not checked client-side at all: the runtime logs a warning at container start, and the run
+then fails at whatever moment `ctx.param()` reads it — after the upload, after the container
+spun up, in the middle of the job. So for a parameter the code cannot proceed without,
+either read it early (fail fast, at the top of the function) or give it a real default with
+`ctx.get_param(name, default)` and skip the required flag.
+
+Name the environment variables like the contract they are. The `name` field is what a person
+sees in the app; the `environment_variable` is what the code reads, and changing it later is
+a new registration plus an update to every caller's `sources`/`arguments`.
+
+## Absolute vs relative time
+
+Nominal places every sample on an absolute timeline, so the question is only how your
+output encodes the position:
+
+| Type | Encodes | Use when |
+|---|---|---|
+| `ts.Epoch(unit=...)` / `"epoch_nanoseconds"` etc. | numeric offset from the Unix epoch | the source records absolute time — the default choice |
+| `ts.Relative(unit=..., start=...)` | numeric offset from an absolute `start` | the source records only elapsed time, and you can establish t0 |
+| `ts.Iso8601` | absolute timestamp strings | the source carries formatted timestamps you don't want to parse |
+| `ts.Custom(format=...)` | absolute strings in a `DateTimeFormatter` pattern | the same, in a non-ISO layout |
+
+**Prefer absolute.** If the source has absolute time anywhere — per record, or a header
+start plus per-record offsets you can add — convert once inside the extractor and emit
+`Epoch`. Absolute output is self-describing: it survives re-registration, it doesn't depend
+on metadata staying correctly paired with the file, and it can't be silently wrong.
+
+Reach for `Relative` when the logger genuinely only knows elapsed time. Then t0 has to come
+from somewhere, and where it comes from is the real design decision: a header inside the
+file (best — the file stays self-contained), the filename, a registered parameter, or
+`ctx.additional_tags`. Prefer reading it from the file, because a t0 passed in as a
+parameter is a value someone has to get right on every single upload.
+
+**Do not register `Relative` as an image's `default_timestamp_type`.** A default is baked in
+once and applies to every future ingest, so a fixed `start` would assign the same t0 to
+every file the extractor ever processes — correct for the first one and wrong for all the
+rest. Register an absolute default, and declare `Relative` per output in the manifest, where
+each file carries its own start. This is one of the concrete reasons manifest extractors are
+the right default: single-file mode has nowhere to put per-file timestamp metadata.
+
+On units: pick the one the data actually has, not a rounder one. Declaring
+`epoch_milliseconds` for microsecond data doesn't just lose precision, it misplaces every
+sample by a factor of a thousand. Per-output metadata in a manifest accepts only numeric
+types (seconds through nanoseconds) — an output needing ISO 8601 or a custom format must
+omit the per-output pair and inherit the job-level metadata.
+
+## Tags
+
+Tags are the dimensions that separate otherwise-identical channels. A channel is identified
+by its name, so two test stands both producing `chamber_pressure` collide into one series
+unless something distinguishes them — and that something is a tag. Get this wrong and the
+data isn't lost, it's blended, which is harder to notice and harder to undo than a failed
+ingest.
+
+Three places tags can come from, in increasing order of specificity:
+
+1. **The ingest request** — `dataset.add_containerized(..., tags={"vehicle": "n1234"})`.
+   Applied uniformly to everything the run produces, and visible in-container as
+   `ctx.additional_tags`. This is the right home for facts about *this upload* that the file
+   itself doesn't know: which vehicle, which campaign, which operator.
+2. **A tag column** — `ctx.add_tabular(path, tag_columns={"motor": "motor_id"})`. Reads the
+   value per row from a column, so one file can carry data from several sources. Use this
+   when the distinguishing fact varies *within* the file.
+3. **Avro records**, which carry their own tags inline. This is why `add_avro_stream` takes
+   no tag columns — there would be nothing to map.
+
+Log outputs (`add_journal_json`) and videos (`add_video`) take neither: log samples carry no
+tags and land on a single channel, and a video is identified by its `channel`.
+
+What makes a good tag is a fact that *identifies a source*, stays stable for the life of the
+data, and has few distinct values: vehicle, stand, motor serial, run identifier, sensor
+location. What makes a bad tag is a measurement (that's a channel), a timestamp or anything
+derived from one (that's the timeline), a value that changes constantly (it fragments the
+series into noise), or free text that varies by upload — the same concept spelled `Stand A`,
+`stand-a`, and `standA` produces three unrelated series that nobody can join.
+
+Two things worth settling before the first real ingest, because both are painful to change
+once there's data:
+
+- **Fix a vocabulary and enforce it in the extractor.** Tag keys and values are strings
+  chosen by whoever wrote the caller, and nothing normalizes them for you. If the extractor
+  is the one deciding tag values, normalize there — lowercase, canonical separators,
+  validated against a known set — rather than trusting each uploader.
+- **Decide tag-versus-channel-prefix deliberately.** `channel_prefix` renames channels
+  (`engine/chamber_pressure`); a tag leaves the name alone and adds a dimension. Prefixes
+  are convenient when two outputs would otherwise collide by name and you want them visibly
+  distinct; tags are better when you want to compare the same measurement across sources,
+  because a tag can be filtered and grouped while a prefix has to be matched by string.
+
+If you're unsure whether a column named in `tag_columns` also remains available as a
+channel, confirm it on a throwaway dataset before committing to the layout — it's a
+one-ingest experiment, and the answer determines whether you drop the column from the
+output or leave it in.

--- a/.agents/skills/nominal-extractors/references/modeling.md
+++ b/.agents/skills/nominal-extractors/references/modeling.md
@@ -27,8 +27,11 @@ Two properties push structured configuration toward inputs specifically:
 - Parameter values are strings with no schema. Anything with structure — a mapping, a list,
   a nested document — has to be encoded and parsed by hand, and a malformed value fails
   inside your parsing code with whatever message you happen to write.
-- Inputs get suffix validation (`file_suffixes=["json"]`) and, more importantly, a real
-  client-side required check.
+- Inputs carry declared suffixes (`file_suffixes=["json"]`) saying what the input accepts —
+  which is what `search_containerized_extractors(file_extension=...)` matches on, so they
+  decide which extractors a given file is offered for — and, more importantly, a real
+  client-side required check. The suffixes are descriptive, not enforced locally: passing a
+  `.txt` to an input registered `["json"]` still uploads.
 
 **`required=True` is much stronger on an input than on a parameter.** A missing required
 input raises in `add_containerized` before anything uploads. A missing required parameter is

--- a/.agents/skills/nominal-extractors/references/modeling.md
+++ b/.agents/skills/nominal-extractors/references/modeling.md
@@ -101,6 +101,13 @@ Three places tags can come from, in increasing order of specificity:
 Log outputs (`add_journal_json`) and videos (`add_video`) take neither: log samples carry no
 tags and land on a single channel, and a video is identified by its `channel`.
 
+**A tag column is consumed, not ingested.** Naming a column in `tag_columns` applies its
+values as tags to that file's rows; the column does not also become a channel. So each
+column is either a measurement you can plot or a dimension you can filter by, never both —
+and if you need the same value in both roles, write it to the output twice under two names.
+That makes tagging an authoring-time decision, not a registration-time one: you are
+choosing, per column, which of the two things it becomes.
+
 What makes a good tag is a fact that *identifies a source*, stays stable for the life of the
 data, and has few distinct values: vehicle, stand, motor serial, run identifier, sensor
 location. What makes a bad tag is a measurement (that's a channel), a timestamp or anything
@@ -108,8 +115,7 @@ derived from one (that's the timeline), a value that changes constantly (it frag
 series into noise), or free text that varies by upload — the same concept spelled `Stand A`,
 `stand-a`, and `standA` produces three unrelated series that nobody can join.
 
-Two things worth settling before the first real ingest, because both are painful to change
-once there's data:
+Two things worth settling before the first real ingest:
 
 - **Fix a vocabulary and enforce it in the extractor.** Tag keys and values are strings
   chosen by whoever wrote the caller, and nothing normalizes them for you. If the extractor
@@ -121,7 +127,5 @@ once there's data:
   distinct; tags are better when you want to compare the same measurement across sources,
   because a tag can be filtered and grouped while a prefix has to be matched by string.
 
-If you're unsure whether a column named in `tag_columns` also remains available as a
-channel, confirm it on a throwaway dataset before committing to the layout — it's a
-one-ingest experiment, and the answer determines whether you drop the column from the
-output or leave it in.
+Both are painful to change once there is data: tag values are baked into every series
+already ingested, so a renamed key or a re-spelled value doesn't migrate — it forks.

--- a/.agents/skills/nominal-extractors/references/registration.md
+++ b/.agents/skills/nominal-extractors/references/registration.md
@@ -36,10 +36,10 @@ docker push and no external registry involved; Nominal hosts the image in its ow
 ### Verify the architecture before registering
 
 Registration does not check it. An arm64 image registers, activates, and reports READY, then
-fails at ingest with an exec format error — so the mistake surfaces in a job log long after
-the upload, and looks like a broken extractor rather than a wrong build flag. Confirm it
-before you register, and put the check in CI so a forgotten `--platform` can't reach the
-platform at all:
+fails at ingest with an exec format error, so the mistake surfaces in a job log long after
+the upload and looks like a broken extractor rather than a wrong build flag. Confirm it
+before registering, and run the check in CI so a forgotten `--platform` never reaches the
+platform:
 
 ```sh
 # with the image still in the local daemon
@@ -49,14 +49,14 @@ docker inspect my-extractor:0.1.0 --format '{{.Architecture}}'   # want: amd64
 python scripts/check_image_arch.py my-extractor-0.1.0.tar
 ```
 
-`scripts/check_image_arch.py` reads the architecture out of the tarball — handling both
-layouts `docker save` produces, the OCI layout (`index.json` + `blobs/`) and the legacy one
-(`manifest.json` plus a config per image) — and exits non-zero when it isn't amd64, so it
-drops straight into a pipeline before the registration step. It exits 2 when it can't parse
-the tarball, which means *check by hand*, not *proceed*.
+`scripts/check_image_arch.py` reads the architecture out of the tarball and exits non-zero
+when it isn't amd64, so it drops into a pipeline before the registration step. It handles
+both layouts `docker save` produces: the OCI layout (`index.json` + `blobs/`) and the legacy
+one (`manifest.json` plus a config per image). It exits 2 when it cannot parse the tarball,
+which means *check by hand*, not *proceed*.
 
-This check belongs in your build, not in the SDK: `register_image` deliberately does not
-inspect the tarball today, so nothing server-side will catch this for you.
+Keep this check in your build, not in the SDK. `register_image` does not inspect the tarball
+today, so nothing server-side catches it for you.
 
 ## Create the extractor (once)
 
@@ -171,10 +171,10 @@ ingests started after this run the new image.
 
 ## Contract-change checklist
 
-When a new image version changes the *contract* — not just the code — remember both sides:
+When a new image version changes the *contract*, not just the code, update both sides:
 
-- New/renamed input or parameter env vars: update ingest callers' `sources`/`arguments`.
-- Output format change (single-file ↔ manifest): change the decorator too; the runtime
-  fails at startup if they disagree.
-- Timestamp column/type change in outputs: update the registered default (it's per-image,
-  so the new registration carries the new default) and any per-output metadata in code.
+- New or renamed input/parameter env vars: update every caller's `sources` and `arguments`.
+- Output format change (single-file ↔ manifest): change the decorator too. The runtime fails
+  at startup if they disagree.
+- Timestamp column or type change: update the registered default, which is per-image so the
+  new registration carries it, plus any per-output metadata in the code.

--- a/.agents/skills/nominal-extractors/references/registration.md
+++ b/.agents/skills/nominal-extractors/references/registration.md
@@ -53,7 +53,7 @@ underneath it. Retrieve later with `client.get_containerized_extractor(rid)` or
 ## Register an image against it
 
 ```python
-from nominal.core.container_image import (
+from nominal.core import (
     FileExtractionInput,
     FileExtractionParameter,
     FileOutputFormat,

--- a/.agents/skills/nominal-extractors/references/registration.md
+++ b/.agents/skills/nominal-extractors/references/registration.md
@@ -33,6 +33,31 @@ docker save my-extractor:0.1.0 -o my-extractor-0.1.0.tar
 `register_image` uploads the `docker save` tarball — not a registry reference. There is no
 docker push and no external registry involved; Nominal hosts the image in its own registry.
 
+### Verify the architecture before registering
+
+Registration does not check it. An arm64 image registers, activates, and reports READY, then
+fails at ingest with an exec format error — so the mistake surfaces in a job log long after
+the upload, and looks like a broken extractor rather than a wrong build flag. Confirm it
+before you register, and put the check in CI so a forgotten `--platform` can't reach the
+platform at all:
+
+```sh
+# with the image still in the local daemon
+docker inspect my-extractor:0.1.0 --format '{{.Architecture}}'   # want: amd64
+
+# or from the tarball alone, e.g. in CI where the artifact is all you have
+python scripts/check_image_arch.py my-extractor-0.1.0.tar
+```
+
+`scripts/check_image_arch.py` reads the architecture out of the tarball — handling both
+layouts `docker save` produces, the OCI layout (`index.json` + `blobs/`) and the legacy one
+(`manifest.json` plus a config per image) — and exits non-zero when it isn't amd64, so it
+drops straight into a pipeline before the registration step. It exits 2 when it can't parse
+the tarball, which means *check by hand*, not *proceed*.
+
+This check belongs in your build, not in the SDK: `register_image` deliberately does not
+inspect the tarball today, so nothing server-side will catch this for you.
+
 ## Create the extractor (once)
 
 ```python

--- a/.agents/skills/nominal-extractors/references/registration.md
+++ b/.agents/skills/nominal-extractors/references/registration.md
@@ -101,6 +101,9 @@ Argument notes:
   which values belong here rather than in `inputs` or in the image itself.
 - **`output_format`** — must match the decorator in the code (`MANIFEST` ↔
   `@manifest_extractor`; `PARQUET`/`CSV`/`AVRO_STREAM` ↔ `@single_file_extractor`).
+  **It defaults to `PARQUET`, so a manifest extractor has to pass it explicitly** — follow the
+  manifest-first guidance and omit the argument and you register the single-file contract, after
+  which every run fails at container startup on the mismatch described below.
   Only those four register: the backend can't currently ingest the other proto formats,
   so `register_image` rejects them up-front (`REGISTERABLE_OUTPUT_FORMATS`).
 - **`default_timestamp_column` / `default_timestamp_type`** — required. This is the

--- a/.agents/skills/nominal-extractors/references/registration.md
+++ b/.agents/skills/nominal-extractors/references/registration.md
@@ -1,0 +1,148 @@
+# Building and registering extractor images
+
+Everything here runs on your machine, against the platform, via `NominalClient`.
+
+## Dockerfile conventions
+
+The image is an ordinary Docker image whose entrypoint runs your extractor script:
+
+```dockerfile
+FROM python:3.12-slim
+RUN pip install --no-cache-dir nominal pandas pyarrow
+COPY extract.py /app/extract.py
+ENTRYPOINT ["python", "/app/extract.py"]
+```
+
+- Install `nominal` (the runtime) plus your format libraries. Pin versions for
+  reproducible rebuilds.
+- No CMD arguments, no shell wrapper needed — all configuration arrives through the
+  environment.
+- Keep the image lean (slim base, `--no-cache-dir`): the whole image is uploaded as a
+  tarball on every registration.
+
+## Build and save — linux/amd64 is required
+
+Nominal runs extractor images on amd64. On Apple Silicon (or any non-amd64 host) an image
+built without `--platform` will fail at runtime on the platform, so always build:
+
+```sh
+docker build --platform linux/amd64 -t my-extractor:0.1.0 .
+docker save my-extractor:0.1.0 -o my-extractor-0.1.0.tar
+```
+
+`register_image` uploads the `docker save` tarball — not a registry reference. There is no
+docker push and no external registry involved; Nominal hosts the image in its own registry.
+
+## Create the extractor (once)
+
+```python
+from nominal.core import NominalClient
+
+client = NominalClient.from_profile("default")
+extractor = client.create_containerized_extractor(
+    "My Format Converter",
+    description="Parses ACME vX binary telemetry into channels",
+)
+print(extractor.rid)   # save this; it's the stable handle
+```
+
+The extractor is the stable identity users select when ingesting; images come and go
+underneath it. Retrieve later with `client.get_containerized_extractor(rid)` or
+`client.search_containerized_extractors()`.
+
+## Register an image against it
+
+```python
+from nominal.core.container_image import (
+    FileExtractionInput,
+    FileExtractionParameter,
+    FileOutputFormat,
+)
+
+image = extractor.register_image(
+    "my-extractor-0.1.0.tar",
+    tag="0.1.0",
+    inputs=[
+        FileExtractionInput(
+            name="Raw file",                    # display name shown to uploaders
+            environment_variable="RAW_FILE",    # how your code reads it
+            description="ACME logger .bin capture",
+            file_suffixes=["bin"],              # accepted suffixes; empty = any file
+            required=True,
+        ),
+    ],
+    parameters=[
+        FileExtractionParameter(
+            name="Quality threshold",
+            environment_variable="THRESHOLD",
+            description="Drop samples with quality below this value (0-1)",
+            required=False,
+        ),
+    ],
+    output_format=FileOutputFormat.MANIFEST,
+    default_timestamp_column="time_s",
+    default_timestamp_type="epoch_seconds",
+)
+```
+
+Argument notes:
+
+- **`tag`** — immutable. Registering an already-used tag raises
+  `NominalAlreadyExistsError`; version your tags (`0.1.0`, `0.2.0`, ...) and register a
+  new one for every code change.
+- **`inputs`** — one `FileExtractionInput` per file the container consumes. The
+  `environment_variable` is the contract key everywhere: it's how the extractor code reads
+  the file (`ctx.input("RAW_FILE")`) and how ingest requests supply it
+  (`sources={"RAW_FILE": path}`). `required=True` makes ingest requests fail fast when the
+  input is missing; an optional input simply isn't among the run's inputs when omitted.
+- **`parameters`** — scalar knobs, delivered as environment-variable strings. Same
+  name/env-var duality as inputs.
+- **`output_format`** — must match the decorator in the code (`MANIFEST` ↔
+  `@manifest_extractor`; `PARQUET`/`CSV`/`AVRO_STREAM` ↔ `@single_file_extractor`).
+  Only those four register: the backend can't currently ingest the other proto formats,
+  so `register_image` rejects them up-front (`REGISTERABLE_OUTPUT_FORMATS`).
+- **`default_timestamp_column` / `default_timestamp_type`** — required. This is the
+  image's `default_timestamp_metadata`: the fallback timestamp encoding for outputs that
+  don't carry their own, and the last stop in the resolution order (per-output manifest
+  metadata → ingest request override → this default). Accepts the full range of types:
+  string literals (`"epoch_seconds"`, `"iso_8601"`, ...) or typed forms (`ts.Epoch`,
+  `ts.Iso8601`, `ts.Custom(format=...)`, `ts.Relative`).
+
+## Activate the image
+
+Registration attaches the image to the extractor but does not change what runs:
+
+```python
+extractor = extractor.set_active_image(image)
+```
+
+`set_active_image` polls the image to `READY` before activating (pass
+`poll_until_ready=False` to raise immediately if it isn't). This is the atomic switch —
+ingests started after this run the new image.
+
+## Image lifecycle
+
+- **Statuses**: `PENDING` (processing) → `READY` or `FAILED`. Current backends return
+  images `READY` from `register_image` directly; `image.poll_until_ready()` covers
+  asynchronous backends.
+- **Upgrade flow**: build new tarball → `register_image(tag="0.2.0", ...)` →
+  `set_active_image`. The old image stays registered; roll back by re-activating it.
+- **Inspect**: `extractor.search_container_images(tag=..., status=...)` lists images
+  registered against this extractor; `client.get_container_image(rid)` fetches one.
+  `extractor.active_image` is the currently-active one (or None — ingests fail until one
+  is activated).
+- **Delete**: `image.delete()` — fails server-side while an extractor references it as
+  active.
+- **Extractor updates**: `extractor.update(name=..., description=...)`;
+  `extractor.archive()` hides it from search and rejects new ingests;
+  `extractor.unarchive()` reverses that.
+
+## Contract-change checklist
+
+When a new image version changes the *contract* — not just the code — remember both sides:
+
+- New/renamed input or parameter env vars: update ingest callers' `sources`/`arguments`.
+- Output format change (single-file ↔ manifest): change the decorator too; the runtime
+  fails at startup if they disagree.
+- Timestamp column/type change in outputs: update the registered default (it's per-image,
+  so the new registration carries the new default) and any per-output metadata in code.

--- a/.agents/skills/nominal-extractors/references/registration.md
+++ b/.agents/skills/nominal-extractors/references/registration.md
@@ -96,7 +96,9 @@ Argument notes:
   (`sources={"RAW_FILE": path}`). `required=True` makes ingest requests fail fast when the
   input is missing; an optional input simply isn't among the run's inputs when omitted.
 - **`parameters`** — scalar knobs, delivered as environment-variable strings. Same
-  name/env-var duality as inputs.
+  name/env-var duality as inputs, but a weaker `required`: unlike a required input, a
+  missing required parameter is not checked before the ingest starts. See `modeling.md` for
+  which values belong here rather than in `inputs` or in the image itself.
 - **`output_format`** — must match the decorator in the code (`MANIFEST` ↔
   `@manifest_extractor`; `PARQUET`/`CSV`/`AVRO_STREAM` ↔ `@single_file_extractor`).
   Only those four register: the backend can't currently ingest the other proto formats,
@@ -106,7 +108,9 @@ Argument notes:
   don't carry their own, and the last stop in the resolution order (per-output manifest
   metadata → ingest request override → this default). Accepts the full range of types:
   string literals (`"epoch_seconds"`, `"iso_8601"`, ...) or typed forms (`ts.Epoch`,
-  `ts.Iso8601`, `ts.Custom(format=...)`, `ts.Relative`).
+  `ts.Iso8601`, `ts.Custom(format=...)`, `ts.Relative`). `ts.Relative` is accepted here but
+  is almost always wrong as a *default* — its `start` would apply to every future ingest;
+  see `modeling.md`.
 
 ## Activate the image
 

--- a/.agents/skills/nominal-extractors/references/running.md
+++ b/.agents/skills/nominal-extractors/references/running.md
@@ -40,10 +40,13 @@ import time
 
 from nominal.core import IngestionJobStatus, wait_for_files_to_ingest
 
-TERMINAL = (IngestionJobStatus.COMPLETED, IngestionJobStatus.FAILED, IngestionJobStatus.CANCELLED)
+RUNNING = (IngestionJobStatus.SUBMITTED, IngestionJobStatus.QUEUED, IngestionJobStatus.IN_PROGRESS)
 
 # 1. the container run
-while job.refresh().status not in TERMINAL:
+deadline = time.monotonic() + 3600
+while job.refresh().status in RUNNING:
+    if time.monotonic() > deadline:
+        raise TimeoutError(f"extraction still {job.status.name} — see {job.nominal_url}")
     time.sleep(2)
 if job.status is not IngestionJobStatus.COMPLETED:
     raise RuntimeError(f"extraction {job.status.name} — see {job.nominal_url}")
@@ -58,6 +61,15 @@ after `add_containerized`, before the container has produced anything, and it se
 list — so `list(job.as_files_ingested())` returns `[]` immediately, having waited for
 nothing. It looks like a successful wait over zero outputs. Once the job is `COMPLETED` the
 file list is complete, and `as_files_ingested()` is then a fine substitute for stage 2.
+
+Why the loop tests the *running* set rather than a terminal set: `IngestionJobStatus` has a
+seventh member, `UNKNOWN`, which this client maps any status a newer server introduces into.
+Waiting *while* the status is known-running exits on anything unrecognized, and the
+`COMPLETED` check then turns it into a loud failure. Waiting *until* the status is one of a
+hard-coded terminal set does the opposite — an unrecognized status is never terminal, so a
+client one release behind its server spins forever, which is the same class of bug as the
+snapshot above. The deadline covers the remaining case, a server that adds a non-terminal
+status; pick a bound that suits your extractor's real runtime.
 
 The rest of the handle:
 

--- a/.agents/skills/nominal-extractors/references/running.md
+++ b/.agents/skills/nominal-extractors/references/running.md
@@ -13,27 +13,27 @@ job = dataset.add_containerized(
 )
 ```
 
-- **`sources`** — maps each input's *environment variable* (as registered on the active
-  image) to a local file path. The SDK uploads each file, then triggers the ingest. Keys
-  must match the active image's registered inputs; missing a `required` input raises
-  before anything is uploaded. The extractor must have an active image.
-- **`arguments`** — parameter values, keyed by the parameter's environment variable.
-  Values are strings (that's how they arrive in the container).
-- **`tags`** — applied to all data ingested from this run; also exposed to the container
-  as `ctx.additional_tags`. Use tags to partition recurring uploads within one dataset
-  (per run, per vehicle) instead of creating a dataset per file.
+- **`sources`** — maps each input's *environment variable*, as registered on the active
+  image, to a local file path. The SDK uploads each file, then triggers the ingest. Keys must
+  match the active image's registered inputs, and a missing `required` input raises before
+  anything uploads. The extractor must have an active image.
+- **`arguments`** — parameter values, keyed by the parameter's environment variable. Values
+  are strings, which is how they arrive in the container.
+- **`tags`** — applied to all data from this run, and exposed to the container as
+  `ctx.additional_tags`. Use tags to partition recurring uploads within one dataset (per run,
+  per vehicle) instead of creating a dataset per file.
 - **`timestamp_column=` / `timestamp_type=`** (together) — override the image's default
-  timestamp metadata for this ingest, applied uniformly to all output files. Per-output
-  metadata declared in a manifest still wins over this override.
+  timestamp metadata for this ingest, applied to all output files. Per-output metadata
+  declared in a manifest still wins over this override.
 
 Containerized ingest is asynchronous and can emit many files, so the call returns an
 `IngestionJob` immediately.
 
 ## Tracking the job
 
-Waiting for a containerized ingest has **two stages**, and conflating them is the most
-common mistake here. First the container has to finish producing files; only then do those
-files exist to be waited on, and they ingest asynchronously in turn.
+Waiting has **two stages**, and conflating them is the most common mistake here. The
+container has to finish producing files; only then do those files exist to be waited on, and
+they ingest asynchronously in turn.
 
 ```python
 import time
@@ -55,21 +55,21 @@ if job.status is not IngestionJobStatus.COMPLETED:
 done, still_ingesting = wait_for_files_to_ingest(job.dataset_files())  # timeout=, return_when= available
 ```
 
-Why stage 1 can't be skipped: `job.dataset_files()` returns the files that exist *at the
-moment of the call*, and `job.as_files_ingested()` calls it exactly once. Run either right
-after `add_containerized`, before the container has produced anything, and it sees an empty
-list — so `list(job.as_files_ingested())` returns `[]` immediately, having waited for
-nothing. It looks like a successful wait over zero outputs. Once the job is `COMPLETED` the
-file list is complete, and `as_files_ingested()` is then a fine substitute for stage 2.
+**Why stage 1 can't be skipped.** `job.dataset_files()` returns the files that exist *when it
+is called*, and `job.as_files_ingested()` calls it exactly once. Run either right after
+`add_containerized` and it sees an empty list, so `list(job.as_files_ingested())` returns
+`[]` immediately, having waited for nothing. It looks like a successful wait over zero
+outputs. Once the job is `COMPLETED` the file list is complete, and `as_files_ingested()`
+works fine for stage 2.
 
-Why the loop tests the *running* set rather than a terminal set: `IngestionJobStatus` has a
-seventh member, `UNKNOWN`, which this client maps any status a newer server introduces into.
+**Why the loop tests the running set, not a terminal set.** `IngestionJobStatus` has a
+seventh member, `UNKNOWN`, which this client maps any status a newer server adds into.
 Waiting *while* the status is known-running exits on anything unrecognized, and the
-`COMPLETED` check then turns it into a loud failure. Waiting *until* the status is one of a
-hard-coded terminal set does the opposite — an unrecognized status is never terminal, so a
-client one release behind its server spins forever, which is the same class of bug as the
-snapshot above. The deadline covers the remaining case, a server that adds a non-terminal
-status; pick a bound that suits your extractor's real runtime.
+`COMPLETED` check turns that into a loud failure. Waiting *until* the status is one of a
+fixed terminal set does the opposite: an unrecognized status is never terminal, so a client a
+release behind its server spins forever — the same class of bug as the snapshot above. The
+deadline covers the remaining case, a server that adds a non-terminal status. Pick a bound
+that suits your extractor's real runtime.
 
 The rest of the handle:
 
@@ -98,31 +98,32 @@ Work from the outside in:
    - "output directory contains file(s) not passed to ..." (at the end) — the code wrote
      files it never declared; they were not ingested.
 3. **Common failure signatures**:
-   - `@manifest_extractor disagrees with the image's registered output format ...` — the
-     code and the registration disagree; re-register or switch decorators.
-   - `exec format error` / container exits instantly with no Python traceback — the image
-     was built for the wrong architecture; rebuild with `--platform linux/amd64`.
-   - `ModuleNotFoundError` — a dependency missing from the image; it must be installed in
-     the Dockerfile, not assumed from your dev machine.
-   - Job `COMPLETED` but no data visible — reason about it from what `COMPLETED` actually
-     proves: the container exited 0, which means the runtime finalized *at least one*
-     declared output. A run that declared nothing at all cannot land here, because
-     `_finalize` raises and the job shows `FAILED`. So the live possibilities are: the code
-     declared some file but not the one carrying the data (the stray-file warning names it);
-     the declared file is genuinely empty because a parse failure was swallowed by a broad
-     `except`; the timestamp column or unit is wrong, so the data landed at a time nobody is
-     looking at; tags or a channel prefix are filtering it out of view; or the file is still
-     ingesting — job status and each file's own `ingest_status` are separate, so check
-     `job.dataset_files()` before concluding data is missing. If the entrypoint is
-     hand-rolled rather than using this runtime, none of the declaration guarantees hold and
-     that is the first thing to check.
+   - `@manifest_extractor disagrees with the image's registered output format ...` — the code
+     and the registration disagree. Re-register or switch decorators.
+   - `exec format error`, or the container exits instantly with no Python traceback — wrong
+     architecture. Rebuild with `--platform linux/amd64`.
+   - `ModuleNotFoundError` — a dependency is missing from the image. Install it in the
+     Dockerfile; nothing carries over from your dev machine.
    - Ingestion fails before the container ran, complaining about timestamp metadata — the
-     image was registered without a default (older registration path) and the request
+     image was registered without a default (an older registration path) and the request
      supplied no override.
-4. **Reproduce locally** — the same code path runs with
+4. **Job `COMPLETED` but no data visible.** Start from what `COMPLETED` proves: the container
+   exited 0, so the runtime finalized *at least one* declared output. A run that declared
+   nothing cannot land here — `_finalize` raises and the job shows `FAILED`. That leaves:
+   - the code declared some file, but not the one carrying the data. The stray-file warning
+     names it;
+   - the declared file is empty because a broad `except` swallowed a parse failure;
+   - the timestamp column or unit is wrong, so the data landed at a time nobody is looking at;
+   - tags or a channel prefix are filtering it out of view;
+   - the file is still ingesting. Job status and each file's `ingest_status` are separate, so
+     check `job.dataset_files()` before concluding the data is missing.
+
+   If the entrypoint is hand-rolled rather than using this runtime, none of the declaration
+   guarantees hold. Check that first.
+5. **Reproduce locally.** The same code path runs under
    `my_extractor.run(env={...}, exit=False)` (see `authoring.md`, Local testing), or under
-   Docker with the input mounted. Local reproduction is almost always faster than
-   iterating through platform ingests.
+   Docker with the input mounted. This is almost always faster than iterating through
+   platform ingests.
 
 ## Fitting into recurring workflows
 
@@ -130,13 +131,12 @@ Once the extractor is registered, ingest triggering is the only per-file step. T
 patterns:
 
 - **Scripted batch**: loop `add_containerized` over every file and collect the jobs *before*
-  waiting on any of them — they run server-side and in parallel, so waiting inside the loop
-  serializes work that didn't need to be. Then apply the two-stage wait per job: poll each to
-  a terminal status, then `wait_for_files_to_ingest` over the files they produced. Waiting on
-  a batch is where skipping stage 1 hurts most, since an empty snapshot per job makes the
-  whole batch look instantly finished.
-- **Operator self-serve**: users upload raw files through the Nominal web app and pick the
-  extractor; no SDK involved. This is the main reason to prefer an extractor over local
-  conversion.
+  waiting on any of them. They run server-side and in parallel, so waiting inside the loop
+  serializes work that need not be. Then apply the two-stage wait per job: poll each to a
+  terminal status, then `wait_for_files_to_ingest` over the files it produced. A batch is
+  where skipping stage 1 hurts most, since an empty snapshot per job makes the whole batch
+  look instantly finished.
+- **Operator self-serve**: users upload raw files through the web app and pick the extractor,
+  with no SDK involved. This is the main reason to prefer an extractor over local conversion.
 - **Version upgrades**: register the new image tag and `set_active_image` — in-flight jobs
   finish on the image they started with; new ingests use the new image.

--- a/.agents/skills/nominal-extractors/references/running.md
+++ b/.agents/skills/nominal-extractors/references/running.md
@@ -1,0 +1,103 @@
+# Running extractors and debugging ingest jobs
+
+## Triggering an ingest
+
+```python
+dataset = client.get_dataset("ri.catalog.gov-staging.dataset.abc123")
+
+job = dataset.add_containerized(
+    extractor,                                # ContainerizedExtractor or its rid
+    sources={"RAW_FILE": "captures/flight_042.bin"},
+    arguments={"THRESHOLD": "0.8"},
+    tags={"vehicle": "N042", "campaign": "sept-flight-test"},
+)
+```
+
+- **`sources`** — maps each input's *environment variable* (as registered on the active
+  image) to a local file path. The SDK uploads each file, then triggers the ingest. Keys
+  must match the active image's registered inputs; missing a `required` input raises
+  before anything is uploaded. The extractor must have an active image.
+- **`arguments`** — parameter values, keyed by the parameter's environment variable.
+  Values are strings (that's how they arrive in the container).
+- **`tags`** — applied to all data ingested from this run; also exposed to the container
+  as `ctx.additional_tags`. Use tags to partition recurring uploads within one dataset
+  (per run, per vehicle) instead of creating a dataset per file.
+- **`timestamp_column=` / `timestamp_type=`** (together) — override the image's default
+  timestamp metadata for this ingest, applied uniformly to all output files. Per-output
+  metadata declared in a manifest still wins over this override.
+
+Containerized ingest is asynchronous and can emit many files, so the call returns an
+`IngestionJob` immediately.
+
+## Tracking the job
+
+```python
+# Block until every produced file finishes ingesting:
+files = list(job.as_files_ingested())
+
+# Or poll manually:
+job.refresh()
+job.status          # SUBMITTED → QUEUED → IN_PROGRESS → COMPLETED | FAILED | CANCELLED
+job.dataset_files() # the DatasetFiles produced so far
+job.cancel()
+job.nominal_url     # link to the job's page in the Nominal app
+```
+
+For timeout control over the blocking wait, use
+`nominal.core.wait_for_files_to_ingest(job.dataset_files(), ...)`.
+
+## Debugging a failed job
+
+Work from the outside in:
+
+1. **Open `job.nominal_url`** — the job page in the Nominal app shows status, produced
+   files, and the container's captured stdout/stderr. The extractor runtime logs its
+   startup line (mode, function name, input count), contract warnings, and the final
+   traceback there.
+2. **Read the runtime's advisory warnings** near the top of the log:
+   - "required parameter ... has no value set" — the ingest request omitted an argument
+     the image registered as required.
+   - "input ... is not present at ..." — a registered input wasn't mounted (usually an
+     optional input the request didn't supply).
+   - "output directory contains file(s) not passed to ..." (at the end) — the code wrote
+     files it never declared; they were not ingested.
+3. **Common failure signatures**:
+   - `@manifest_extractor disagrees with the image's registered output format ...` — the
+     code and the registration disagree; re-register or switch decorators.
+   - `exec format error` / container exits instantly with no Python traceback — the image
+     was built for the wrong architecture; rebuild with `--platform linux/amd64`.
+   - `ModuleNotFoundError` — a dependency missing from the image; it must be installed in
+     the Dockerfile, not assumed from your dev machine.
+   - Job `COMPLETED` but no data visible — reason about it from what `COMPLETED` actually
+     proves: the container exited 0, which means the runtime finalized *at least one*
+     declared output. A run that declared nothing at all cannot land here, because
+     `_finalize` raises and the job shows `FAILED`. So the live possibilities are: the code
+     declared some file but not the one carrying the data (the stray-file warning names it);
+     the declared file is genuinely empty because a parse failure was swallowed by a broad
+     `except`; the timestamp column or unit is wrong, so the data landed at a time nobody is
+     looking at; tags or a channel prefix are filtering it out of view; or the file is still
+     ingesting — job status and each file's own `ingest_status` are separate, so check
+     `job.dataset_files()` before concluding data is missing. If the entrypoint is
+     hand-rolled rather than using this runtime, none of the declaration guarantees hold and
+     that is the first thing to check.
+   - Ingestion fails before the container ran, complaining about timestamp metadata — the
+     image was registered without a default (older registration path) and the request
+     supplied no override.
+4. **Reproduce locally** — the same code path runs with
+   `my_extractor.run(env={...}, exit=False)` (see `authoring.md`, Local testing), or under
+   Docker with the input mounted. Local reproduction is almost always faster than
+   iterating through platform ingests.
+
+## Fitting into recurring workflows
+
+Once the extractor is registered, ingest triggering is the only per-file step. Typical
+patterns:
+
+- **Scripted batch**: loop `add_containerized` over files, collect jobs, then wait on all
+  (`[list(j.as_files_ingested()) for j in jobs]`) — jobs run server-side, so trigger them
+  all before waiting.
+- **Operator self-serve**: users upload raw files through the Nominal web app and pick the
+  extractor; no SDK involved. This is the main reason to prefer an extractor over local
+  conversion.
+- **Version upgrades**: register the new image tag and `set_active_image` — in-flight jobs
+  finish on the image they started with; new ingests use the new image.

--- a/.agents/skills/nominal-extractors/references/running.md
+++ b/.agents/skills/nominal-extractors/references/running.md
@@ -31,20 +31,44 @@ Containerized ingest is asynchronous and can emit many files, so the call return
 
 ## Tracking the job
 
-```python
-# Block until every produced file finishes ingesting:
-files = list(job.as_files_ingested())
+Waiting for a containerized ingest has **two stages**, and conflating them is the most
+common mistake here. First the container has to finish producing files; only then do those
+files exist to be waited on, and they ingest asynchronously in turn.
 
-# Or poll manually:
-job.refresh()
-job.status          # SUBMITTED → QUEUED → IN_PROGRESS → COMPLETED | FAILED | CANCELLED
-job.dataset_files() # the DatasetFiles produced so far
-job.cancel()
-job.nominal_url     # link to the job's page in the Nominal app
+```python
+import time
+
+from nominal.core import IngestionJobStatus, wait_for_files_to_ingest
+
+TERMINAL = (IngestionJobStatus.COMPLETED, IngestionJobStatus.FAILED, IngestionJobStatus.CANCELLED)
+
+# 1. the container run
+while job.refresh().status not in TERMINAL:
+    time.sleep(2)
+if job.status is not IngestionJobStatus.COMPLETED:
+    raise RuntimeError(f"extraction {job.status.name} — see {job.nominal_url}")
+
+# 2. the files it produced
+done, still_ingesting = wait_for_files_to_ingest(job.dataset_files())  # timeout=, return_when= available
 ```
 
-For timeout control over the blocking wait, use
-`nominal.core.wait_for_files_to_ingest(job.dataset_files(), ...)`.
+Why stage 1 can't be skipped: `job.dataset_files()` returns the files that exist *at the
+moment of the call*, and `job.as_files_ingested()` calls it exactly once. Run either right
+after `add_containerized`, before the container has produced anything, and it sees an empty
+list — so `list(job.as_files_ingested())` returns `[]` immediately, having waited for
+nothing. It looks like a successful wait over zero outputs. Once the job is `COMPLETED` the
+file list is complete, and `as_files_ingested()` is then a fine substitute for stage 2.
+
+The rest of the handle:
+
+```python
+job.refresh()       # re-reads from the server; status is a snapshot without it
+job.status          # SUBMITTED → QUEUED → IN_PROGRESS → COMPLETED | FAILED | CANCELLED
+job.dataset_files() # the DatasetFiles produced as of this call
+job.produced_file_count
+job.cancel()        # stop a job that is still running
+job.nominal_url     # link to the job's page in the Nominal app
+```
 
 ## Debugging a failed job
 
@@ -93,9 +117,12 @@ Work from the outside in:
 Once the extractor is registered, ingest triggering is the only per-file step. Typical
 patterns:
 
-- **Scripted batch**: loop `add_containerized` over files, collect jobs, then wait on all
-  (`[list(j.as_files_ingested()) for j in jobs]`) — jobs run server-side, so trigger them
-  all before waiting.
+- **Scripted batch**: loop `add_containerized` over every file and collect the jobs *before*
+  waiting on any of them — they run server-side and in parallel, so waiting inside the loop
+  serializes work that didn't need to be. Then apply the two-stage wait per job: poll each to
+  a terminal status, then `wait_for_files_to_ingest` over the files they produced. Waiting on
+  a batch is where skipping stage 1 hurts most, since an empty snapshot per job makes the
+  whole batch look instantly finished.
 - **Operator self-serve**: users upload raw files through the Nominal web app and pick the
   extractor; no SDK involved. This is the main reason to prefer an extractor over local
   conversion.

--- a/.agents/skills/nominal-extractors/scripts/check_image_arch.py
+++ b/.agents/skills/nominal-extractors/scripts/check_image_arch.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Check that a `docker save` tarball is built for the architecture Nominal runs.
+
+Nominal runs extractor images on amd64, and `register_image` does not inspect the tarball's
+architecture: an arm64 image (the default on Apple Silicon) registers and activates
+successfully, then fails at ingest with an exec format error. That failure surfaces long
+after the mistake, in a job log, so it is worth catching before the upload.
+
+Usage:
+    python check_image_arch.py image.tar
+    python check_image_arch.py image.tar --expect arm64   # if you know what you're doing
+
+Exits 0 when every image in the tarball matches, 1 when any doesn't, 2 when the tarball
+can't be understood (treat that as "check it by hand", not as a pass).
+
+`docker inspect <tag> --format '{{.Architecture}}'` is simpler when the image is still in
+the local daemon. This script exists for the case the daemon isn't there — CI that only has
+the artifact, or a tarball someone handed you.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tarfile
+from typing import Any
+
+
+class TarballError(Exception):
+    """The tarball isn't a layout this script understands."""
+
+
+def _read_json(tar: tarfile.TarFile, name: str) -> Any:
+    try:
+        member = tar.extractfile(name)
+    except KeyError as ex:
+        raise TarballError(f"{name} is not in the tarball") from ex
+    if member is None:
+        raise TarballError(f"{name} is not a regular file")
+    try:
+        return json.load(member)
+    except json.JSONDecodeError as ex:
+        raise TarballError(f"{name} is not valid JSON: {ex}") from ex
+
+
+def _blob_path(digest: str) -> str:
+    """Map an OCI descriptor digest ("sha256:abc...") to its path inside the tarball."""
+    algorithm, _, hex_digest = digest.partition(":")
+    if not algorithm or not hex_digest:
+        raise TarballError(f"malformed digest {digest!r}")
+    return f"blobs/{algorithm}/{hex_digest}"
+
+
+def _architectures_from_oci(tar: tarfile.TarFile) -> list[str]:
+    """Read architectures from an OCI layout (`index.json` + `blobs/`).
+
+    An index entry usually carries a `platform`, but a single-image save may omit it, so fall
+    back to following the manifest to its config blob, which always has `architecture`.
+    """
+    index = _read_json(tar, "index.json")
+    manifests = index.get("manifests") or []
+    if not manifests:
+        raise TarballError("index.json lists no manifests")
+
+    architectures = []
+    for descriptor in manifests:
+        platform = descriptor.get("platform") or {}
+        if platform.get("architecture"):
+            architectures.append(platform["architecture"])
+            continue
+        digest = descriptor.get("digest")
+        if not digest:
+            raise TarballError("a manifest descriptor has neither platform nor digest")
+        manifest = _read_json(tar, _blob_path(digest))
+        # A nested index (a manifest list saved as one entry) needs the same treatment; one
+        # level is enough for anything `docker save` produces.
+        if nested := manifest.get("manifests"):
+            for entry in nested:
+                nested_platform = entry.get("platform") or {}
+                if nested_platform.get("architecture"):
+                    architectures.append(nested_platform["architecture"])
+            continue
+        config_digest = (manifest.get("config") or {}).get("digest")
+        if not config_digest:
+            raise TarballError(f"manifest {digest} has no config descriptor")
+        config = _read_json(tar, _blob_path(config_digest))
+        if not config.get("architecture"):
+            raise TarballError(f"config {config_digest} declares no architecture")
+        architectures.append(config["architecture"])
+    return architectures
+
+
+def _architectures_from_legacy(tar: tarfile.TarFile) -> list[str]:
+    """Read architectures from the legacy layout (`manifest.json` + per-image config JSON)."""
+    entries = _read_json(tar, "manifest.json")
+    if not isinstance(entries, list) or not entries:
+        raise TarballError("manifest.json is not a non-empty list")
+
+    architectures = []
+    for entry in entries:
+        config_name = entry.get("Config")
+        if not config_name:
+            raise TarballError("a manifest.json entry has no Config")
+        config = _read_json(tar, config_name)
+        if not config.get("architecture"):
+            raise TarballError(f"{config_name} declares no architecture")
+        architectures.append(config["architecture"])
+    return architectures
+
+
+def architectures(tarball: str) -> list[str]:
+    """Return every image architecture in a `docker save` tarball.
+
+    Handles both layouts `docker save` produces: the OCI layout (`index.json` + `blobs/`,
+    written by newer Docker with the containerd image store) and the legacy layout
+    (`manifest.json` plus a config JSON per image).
+    """
+    try:
+        tar = tarfile.open(tarball)
+    except (OSError, tarfile.TarError) as ex:
+        raise TarballError(f"cannot open {tarball}: {ex}") from ex
+    with tar:
+        names = set(tar.getnames())
+        if "index.json" in names:
+            return _architectures_from_oci(tar)
+        if "manifest.json" in names:
+            return _architectures_from_legacy(tar)
+        raise TarballError("no index.json or manifest.json — is this a `docker save` tarball?")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("tarball", help="path to the `docker save` tarball")
+    parser.add_argument(
+        "--expect",
+        default="amd64",
+        help="architecture the image must be built for (default: amd64, which is what Nominal runs)",
+    )
+    args = parser.parse_args()
+
+    try:
+        found = architectures(args.tarball)
+    except TarballError as ex:
+        print(f"could not determine the architecture: {ex}", file=sys.stderr)
+        print("check it by hand before registering; do not assume it is correct", file=sys.stderr)
+        return 2
+
+    distinct = sorted(set(found))
+    if args.expect not in distinct:
+        print(f"{args.tarball} contains {', '.join(distinct)}, not {args.expect}", file=sys.stderr)
+        print(f"rebuild with: docker build --platform linux/{args.expect} -t <tag> .", file=sys.stderr)
+        return 1
+
+    if len(distinct) > 1:
+        # The expected architecture is in there, so a registry that selects by platform would
+        # run the right image -- but whether Nominal's does is not something this script can
+        # know, and a single-architecture tarball removes the question.
+        others = ", ".join(arch for arch in distinct if arch != args.expect)
+        print(
+            f"{args.tarball}: multi-architecture ({', '.join(distinct)}). {args.expect} is present, "
+            f"but this relies on the registry selecting it over {others}; prefer saving a single "
+            f"{args.expect} image.",
+            file=sys.stderr,
+        )
+        return 0
+
+    print(f"{args.tarball}: {distinct[0]} — ok to register")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/nominal-extractors
+++ b/.claude/skills/nominal-extractors
@@ -1,0 +1,1 @@
+../../.agents/skills/nominal-extractors

--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,7 @@ uv.toml
 .claude/skills/*
 !.claude/skills/thermo-nuclear-code-quality-review
 !.claude/skills/reviewing-nominal-api-bumps
+!.claude/skills/nominal-extractors
 
 # Agent-neutral skills home (Codex, Cursor, etc. read here; .claude/skills symlinks into it).
 .agents/*
@@ -195,3 +196,4 @@ uv.toml
 .agents/skills/*
 !.agents/skills/thermo-nuclear-code-quality-review
 !.agents/skills/reviewing-nominal-api-bumps
+!.agents/skills/nominal-extractors


### PR DESCRIPTION
A skill covering the full containerized-extractor lifecycle, for coworkers and customers building against `nominal.experimental.extractor`.

```
.agents/skills/nominal-extractors/
├── SKILL.md                      # data-model framing, lifecycle, contract choice, gotchas
└── references/
    ├── modeling.md               # inputs vs parameters, absolute vs relative time, tagging
    ├── authoring.md              # in-container runtime, per-format declarations, local testing
    ├── registration.md           # Dockerfile, build/save, register_image, image lifecycle
    └── running.md                # add_containerized, IngestionJob, debugging playbook
```

Layout follows the two existing repo skills: content in `.agents/skills/` so non-Claude agents read it too, a `.claude/skills/` symlink, matching `.gitignore` allowlist entries, and the same `visibility`/`category`/`tags` frontmatter. (`x-atlas-id` is left out — it looks registry-assigned and shouldn't be invented — as is `departments`, which only one sibling sets.)

## Why

Extractors are the hardest thing in the SDK to pick up cold. Authoring code runs inside a container against an environment-driven contract; registration is a separate gRPC surface with its own vocabulary; the two must agree or the run fails at startup. The docstrings and package README each cover a slice, but nothing walked the whole path, and nothing covered where an extractor sits in the dataset/channel/tag model or which modeling decisions are expensive to reverse.

## How it was validated

Built with `skill-creator`: two iterations, three test cases (author an extractor for a packed binary format; produce the Dockerfile + registration + ingest scripts; answer a data-model-fit and a debugging question), each run three ways — with the skill, with only the package README, and with nothing.

Iteration 2 ran in an isolated scratch directory with only the pip-installed `nominal` package, no repo checkout, so the baselines had to recover the contract from `site-packages` the way a customer would.

| Route | Assertions passed | Total time | Total tokens |
|---|---|---|---|
| Skill | 20/20 | 432s | 154k |
| Package README only | 19/20 | 639s | 190k |
| Nothing (SDK source only) | 20/20 | 687s | 213k |

**Correctness is not the differentiator, and this PR doesn't claim it is.** A determined agent reconstructs the contract from the docstrings, which are good. What it can't do is reconstruct it cheaply: the skill was ~37% faster and ~28% cheaper than the unaided baseline. For a surface customers hit repeatedly, that plus consistent framing is the value.

The README-only route failed its one assertion by faithfully copying a broken example from the package README (`file.rid`, which doesn't exist). That and several other doc defects the evals surfaced are fixed in #957.

## Defects the evals and review found in the skill itself

All fixed here:

- **The wait didn't wait.** `job.dataset_files()` returns only the files that exist at the moment of the call and `job.as_files_ingested()` calls it once, so `list(...)` right after `add_containerized` returns `[]` immediately — a wait over zero outputs that reads as a completed ingest. `SKILL.md` and `running.md` now do the two-stage wait (refresh-poll to terminal status, handle `FAILED`/`CANCELLED`, then `wait_for_files_to_ingest` over the produced files). The batch pattern is corrected the same way, where an empty snapshot per job made a whole batch look instantly finished.
- **`COMPLETED` with an undeclared output.** `running.md` originally implied that combination was general. It isn't — a run declaring nothing hits `_finalize`, raises, and shows `FAILED`. The debugging section now reasons from what `COMPLETED` actually proves.
- **`run(env=...)` replaces the environment.** The local-test pattern was shown without saying so; an agent adapting it dropped `OUTPUT_DIR` and produced a snippet that raises.
- **A wrong file extension raises `ValueError`, not `ExtractorError`**, and the two are disjoint (`ExtractorError` subclasses `NominalError`), so `except ExtractorError` around a declaration misses it. It was filed under the wrong bullet.
- **Import path.** Examples now import `FileExtractionInput`/`FileExtractionParameter`/`FileOutputFormat` from `nominal.core`, which re-exports all three, rather than the internal `nominal.core.container_image` path — this skill is what customers copy.
- **Empty-input behavior was unspecified** (one eval arm emitted a zero-row parquet, two raised). The skill now says to decide deliberately and why raising is usually better: a green job that ingested nothing is the hardest failure to notice.

## Review changes since first push

- **Manifest first.** The skill presented the two output contracts as co-equal with single-file documented first. Manifest is the current contract and a strict superset, so it now leads in `SKILL.md` and `authoring.md`, and single-file is framed as the original contract kept for already-registered images. No deprecation claimed — both decorators shipped together and neither is marked deprecated in code.
- **New `references/modeling.md`** for the decisions that outlive the code: inputs vs parameters vs baking a constant into the image (including that `required=True` is far weaker on a parameter — no client-side check — than on an input, which raises before upload); absolute vs relative time, where a relative t0 should come from, and why `ts.Relative` must not be an image's registered default; and what tags are for, what makes a bad tag, that a tag column is consumed rather than ingested, and settling vocabulary and tag-vs-channel-prefix before the first real ingest.

## Verification

Every API reference across all five files was resolved against the current source — `Dataset.add_*`, `NominalClient`, `ContainerizedExtractor`, `ContainerImage`, `IngestionJob`, `DatasetFile` fields, both context classes and their per-format keyword availability, `FileExtraction*` fields, `REGISTERABLE_OUTPUT_FORMATS`, the timestamp literals — and every example's import line was executed. Frontmatter parses as YAML with the same key set as the sibling skill.

Docs-only; no library code touched. Independent of #957 — merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
