### PR TITLE
fix: wait out both stages of an ingest job's files

### DIFF
--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -950,11 +950,11 @@ class Dataset(DataSource, RefreshableConjureMixin[scout_catalog.EnrichedDataset]
         the tracking `IngestionJob` immediately rather than a single file, and `job.cancel()` cancels it.
 
         Waiting takes two stages: the container finishes producing files, then those files finish
-        ingesting. For the first, poll `job.refresh()` then `job.status` until the job is terminal —
-        `status` is a snapshot, so refreshing is what advances it. Only then is the file list complete:
-        `job.dataset_files()` returns the files that exist when it is called, and `job.as_files_ingested()`
-        calls it once, so either one returns empty rather than waiting if the container has not produced
-        anything yet.
+        ingesting. `job.as_files_ingested()` covers both — it re-reads the file list while the job runs,
+        so it picks up outputs that do not exist yet at the time of the call. `job.dataset_files()`, by
+        contrast, returns only the files that exist when it is called, which is empty until a manifest
+        extractor's container has exited; and `job.status` is a snapshot, so polling it requires
+        `job.refresh()` to advance it.
 
         Args:
             extractor: ContainerizedExtractor instance (or rid of one) to use for extracting and ingesting data.

--- a/nominal/core/dataset_file.py
+++ b/nominal/core/dataset_file.py
@@ -438,7 +438,18 @@ def _poll_files_once(files: Sequence[DatasetFile]) -> tuple[list[DatasetFile], l
     return done, not_done, has_failed
 
 
-def _sleep_until_next_poll(poll_interval: datetime.timedelta, deadline: datetime.datetime | None) -> bool:
+def _deadline_from(timeout: datetime.timedelta | None) -> float | None:
+    """Turn a caller's timeout into a monotonic deadline, or None for an unbounded wait.
+
+    Monotonic rather than wall-clock: a wait bounded by `datetime.now()` stretches past the budget the
+    caller asked for when the system clock steps backwards, and expires early when it steps forwards.
+    Pair with `_sleep_until_next_poll`, which reads the same clock — a deadline from anywhere else is
+    not comparable to it.
+    """
+    return None if timeout is None else time.monotonic() + timeout.total_seconds()
+
+
+def _sleep_until_next_poll(poll_interval: datetime.timedelta, deadline: float | None) -> bool:
     """Sleep until the next poll is due, capped at `deadline`. Returns whether any budget remained.
 
     Never sleeps past the deadline: waiting out a whole poll interval near the end of a caller's budget
@@ -447,7 +458,7 @@ def _sleep_until_next_poll(poll_interval: datetime.timedelta, deadline: datetime
     """
     sleep_for = poll_interval.total_seconds()
     if deadline is not None:
-        remaining = (deadline - datetime.datetime.now()).total_seconds()
+        remaining = deadline - time.monotonic()
         if remaining <= 0:
             return False
         sleep_for = min(sleep_for, remaining)
@@ -482,12 +493,12 @@ def wait_for_files_to_ingest(
     Returns:
         Returns a tuple of (done, not done) dataset files.
     """
-    deadline = None if timeout is None else datetime.datetime.now() + timeout
+    deadline = _deadline_from(timeout)
     done: list[DatasetFile] = []
     not_done: list[DatasetFile] = [*files]
     has_failed = False
 
-    while not_done and (deadline is None or datetime.datetime.now() < deadline):
+    while not_done and (deadline is None or time.monotonic() < deadline):
         logger.info("Polling for ingestion completion for %d files (%d total)", len(not_done), len(files))
 
         newly_done, not_done, newly_failed = _poll_files_once(not_done)

--- a/nominal/core/dataset_file.py
+++ b/nominal/core/dataset_file.py
@@ -328,6 +328,8 @@ class IngestStatus(Enum):
     QUEUED = "QUEUED"
     PARSING = "PARSING"
     INGESTING = "INGESTING"
+    UNKNOWN = "UNKNOWN"
+    """Unknown or unrecognized status returned by a newer server."""
 
     @classmethod
     def _from_conjure(cls, status: api.IngestStatusV2) -> IngestStatus:
@@ -349,7 +351,10 @@ class IngestStatus(Enum):
             case "ingesting":
                 ingest_status = cls.INGESTING
             case _:
-                raise ValueError(f"Unknown ingest status: {status.type}")
+                # Mirrors IngestionJobStatus: a status a newer server adds must not break a wait that
+                # is only asking whether the file is still in flight.
+                logger.warning("Unrecognized ingest status %s; treating as UNKNOWN.", status.type)
+                ingest_status = cls.UNKNOWN
         return ingest_status
 
 

--- a/nominal/core/dataset_file.py
+++ b/nominal/core/dataset_file.py
@@ -364,7 +364,7 @@ class IngestWaitType(Enum):
     ALL_COMPLETED = "ALL_COMPLETED"
 
 
-def _batch_refresh_files(files: list[DatasetFile], *, batch_size: int = 100) -> set[str]:
+def _batch_refresh_files(files: Sequence[DatasetFile], *, batch_size: int = 100) -> set[str]:
     """Batch-fetches the latest API state for all files and refreshes them in-place.
 
     Returns the set of file IDs that were absent from the batch response (i.e. not found on the server).
@@ -399,7 +399,7 @@ def _poll_files_once(files: Sequence[DatasetFile]) -> tuple[list[DatasetFile], l
     not_done: list[DatasetFile] = []
     has_failed = False
 
-    absent_ids = _batch_refresh_files([*files])
+    absent_ids = _batch_refresh_files(files)
 
     for file in files:
         if file.id in absent_ids:

--- a/nominal/core/dataset_file.py
+++ b/nominal/core/dataset_file.py
@@ -438,6 +438,25 @@ def _poll_files_once(files: Sequence[DatasetFile]) -> tuple[list[DatasetFile], l
     return done, not_done, has_failed
 
 
+def _sleep_until_next_poll(poll_interval: datetime.timedelta, deadline: datetime.datetime | None) -> bool:
+    """Sleep until the next poll is due, capped at `deadline`. Returns whether any budget remained.
+
+    Never sleeps past the deadline: waiting out a whole poll interval near the end of a caller's budget
+    would overshoot the timeout they asked for. Callers own what an exhausted budget means — this only
+    reports it, since one waiter raises on it and another returns what it has.
+    """
+    sleep_for = poll_interval.total_seconds()
+    if deadline is not None:
+        remaining = (deadline - datetime.datetime.now()).total_seconds()
+        if remaining <= 0:
+            return False
+        sleep_for = min(sleep_for, remaining)
+
+    logger.info("Sleeping for %f seconds until the next poll...", sleep_for)
+    time.sleep(sleep_for)
+    return True
+
+
 def wait_for_files_to_ingest(
     files: Sequence[DatasetFile],
     *,
@@ -454,7 +473,7 @@ def wait_for_files_to_ingest(
     Args:
         files: Dataset files to monitor for ingestion completion.
         poll_interval: Interval to sleep between polling the remaining files under watch.
-        timeout: If given, the maximum time to wait before returning
+        timeout: If given, the maximum time to wait before returning. Never sleeps past the deadline.
         return_when: Condition for this function to exit. By default, this function will block until all files
             have completed their ingestion (successfully or unsuccessfully), but this can be changed to return
             upon the first completed or first failing ingest. This behavior mirrors that of
@@ -463,12 +482,12 @@ def wait_for_files_to_ingest(
     Returns:
         Returns a tuple of (done, not done) dataset files.
     """
-    start_time = datetime.datetime.now()
+    deadline = None if timeout is None else datetime.datetime.now() + timeout
     done: list[DatasetFile] = []
     not_done: list[DatasetFile] = [*files]
     has_failed = False
 
-    while not_done and (timeout is None or datetime.datetime.now() - start_time < timeout):
+    while not_done and (deadline is None or datetime.datetime.now() < deadline):
         logger.info("Polling for ingestion completion for %d files (%d total)", len(not_done), len(files))
 
         newly_done, not_done, newly_failed = _poll_files_once(not_done)
@@ -482,14 +501,8 @@ def wait_for_files_to_ingest(
         elif not not_done:
             break
 
-        if timeout is None or datetime.datetime.now() - start_time < timeout:
-            logger.info(
-                "Sleeping for %f seconds while awaiting ingestion for %d files (%d total)... ",
-                poll_interval.total_seconds(),
-                len(not_done),
-                len(files),
-            )
-            time.sleep(poll_interval.total_seconds())
+        if not _sleep_until_next_poll(poll_interval, deadline):
+            break
 
     return done, not_done
 

--- a/nominal/core/dataset_file.py
+++ b/nominal/core/dataset_file.py
@@ -384,6 +384,55 @@ def _batch_refresh_files(files: list[DatasetFile], *, batch_size: int = 100) -> 
     return absent_ids
 
 
+def _poll_files_once(files: Sequence[DatasetFile]) -> tuple[list[DatasetFile], list[DatasetFile], bool]:
+    """Refresh `files` from the server once and partition them into (done, not done, any failed).
+
+    A file that is absent from the batch response, has failed, or reports an unrecognized status is
+    treated as done, so an unknown status can never wedge a caller's polling loop.
+    """
+    done: list[DatasetFile] = []
+    not_done: list[DatasetFile] = []
+    has_failed = False
+
+    absent_ids = _batch_refresh_files([*files])
+
+    for file in files:
+        if file.id in absent_ids:
+            logger.warning(
+                "Dataset file %s from dataset %s was absent from the batch response "
+                "— it may have been deleted or never created successfully.",
+                file.id,
+                file.dataset_rid,
+            )
+            done.append(file)
+            has_failed = True
+            continue
+        match file.ingest_status:
+            case IngestStatus.SUCCESS | IngestStatus.DELETION_IN_PROGRESS | IngestStatus.DELETED:
+                done.append(file)
+            case IngestStatus.FAILED:
+                logger.warning(
+                    "Dataset file %s from dataset %s failed to ingest! Error: %s",
+                    file.id,
+                    file.dataset_rid,
+                    file._ingest_error_message,
+                )
+                done.append(file)
+                has_failed = True
+            case IngestStatus.IN_PROGRESS | IngestStatus.QUEUED | IngestStatus.PARSING | IngestStatus.INGESTING:
+                not_done.append(file)
+            case _:
+                logger.warning(
+                    "Dataset file %s from dataset %s had unknown ingest status %s; treating as done.",
+                    file.id,
+                    file.dataset_rid,
+                    file.ingest_status,
+                )
+                done.append(file)
+
+    return done, not_done, has_failed
+
+
 def wait_for_files_to_ingest(
     files: Sequence[DatasetFile],
     *,
@@ -417,44 +466,9 @@ def wait_for_files_to_ingest(
     while not_done and (timeout is None or datetime.datetime.now() - start_time < timeout):
         logger.info("Polling for ingestion completion for %d files (%d total)", len(not_done), len(files))
 
-        absent_ids = _batch_refresh_files(not_done)
-
-        next_not_done = []
-        for file in not_done:
-            if file.id in absent_ids:
-                logger.warning(
-                    "Dataset file %s from dataset %s was absent from the batch response "
-                    "— it may have been deleted or never created successfully.",
-                    file.id,
-                    file.dataset_rid,
-                )
-                done.append(file)
-                has_failed = True
-                continue
-            match file.ingest_status:
-                case IngestStatus.SUCCESS | IngestStatus.DELETION_IN_PROGRESS | IngestStatus.DELETED:
-                    done.append(file)
-                case IngestStatus.FAILED:
-                    logger.warning(
-                        "Dataset file %s from dataset %s failed to ingest! Error: %s",
-                        file.id,
-                        file.dataset_rid,
-                        file._ingest_error_message,
-                    )
-                    done.append(file)
-                    has_failed = True
-                case IngestStatus.IN_PROGRESS | IngestStatus.QUEUED | IngestStatus.PARSING | IngestStatus.INGESTING:
-                    next_not_done.append(file)
-                case _:
-                    logger.warning(
-                        "Dataset file %s from dataset %s had unknown ingest status %s; treating as done.",
-                        file.id,
-                        file.dataset_rid,
-                        file.ingest_status,
-                    )
-                    done.append(file)
-
-        not_done = next_not_done
+        newly_done, not_done, newly_failed = _poll_files_once(not_done)
+        done.extend(newly_done)
+        has_failed = has_failed or newly_failed
 
         if has_failed and return_when is IngestWaitType.FIRST_EXCEPTION:
             break

--- a/nominal/core/ingestion_job.py
+++ b/nominal/core/ingestion_job.py
@@ -308,11 +308,13 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
         deadline = _deadline_from(timeout)
         seen_file_ids: set[str] = set()
         pending: list[DatasetFile] = []
-        job_running = True
+        # Not `self.status in _RUNNING_JOB_STATUSES`: a job that is already terminal here still owes
+        # one listing pass, which is the whole file set for a job that finished before this was called.
+        may_produce_more = True
 
         while True:
-            if job_running:
-                job_running, new_files = self._poll_for_new_files(seen_file_ids)
+            if may_produce_more:
+                may_produce_more, new_files = self._poll_for_new_files(seen_file_ids)
                 seen_file_ids.update(file.id for file in new_files)
                 pending.extend(new_files)
 
@@ -320,7 +322,7 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
                 newly_done, pending, _ = _poll_files_once(pending)
                 yield from newly_done
 
-            if not job_running and not pending:
+            if not may_produce_more and not pending:
                 break
 
             logger.info(

--- a/nominal/core/ingestion_job.py
+++ b/nominal/core/ingestion_job.py
@@ -13,7 +13,7 @@ from typing_extensions import Self
 from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin
 from nominal.core._utils.frontend_urls import ingestion_job_url
 from nominal.core.dataset_file import DatasetFile, _dataset_file_from_conjure, _poll_files_once
-from nominal.core.exceptions import NominalIngestError
+from nominal.core.exceptions import NominalIngestFailed, NominalIngestTimeout
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
 
 logger = logging.getLogger(__name__)
@@ -77,9 +77,6 @@ _RUNNING_JOB_STATUSES = frozenset(
 Deliberately the running set rather than the terminal set: a status this client does not recognize
 stops a wait instead of looping forever on it.
 """
-
-_FAILED_JOB_STATUSES = frozenset({IngestionJobStatus.FAILED, IngestionJobStatus.CANCELLED})
-"""Terminal statuses meaning the job did not deliver what it was asked for."""
 
 
 class IngestType(Enum):
@@ -233,22 +230,31 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
         the job is terminal and every file it produced has finished ingesting.
 
         Yielded files may have failed: a job can complete with some of its files FAILED, so check
-        `ingest_status` on each yielded file if that matters. For timeout / return-when control over
-        a fixed set of files, use `nominal.core.wait_for_files_to_ingest(job.dataset_files(), ...)`.
+        `ingest_status` on each yielded file if that matters. A job that was cancelled yields whatever
+        did ingest and logs a warning, since a cancelled job is the caller getting what they asked for.
+
+        Unlike the free function `nominal.core.as_files_ingested`, which only ever reports per-file
+        status, this raises when the job itself fails — a failed job can have no files to report the
+        failure through. Iterating this rather than wrapping it in `list()` keeps the files yielded
+        before that point. For timeout / return-when control over a fixed set of files, use
+        `nominal.core.wait_for_files_to_ingest(job.dataset_files(), ...)`.
 
         Args:
             poll_interval: Interval to sleep between polls of this job and of its pending files.
-            timeout: If given, the maximum time to wait before raising `TimeoutError`.
+            timeout: Give up after this long and raise `NominalIngestTimeout`; None waits
+                indefinitely. Never sleeps past the deadline.
 
         Yields:
             Dataset files as they finish ingesting. Due to the polling mechanics, the files are not
             yielded in strictly sorted order based on their ingestion completion time.
 
         Raises:
-            NominalIngestError: The job itself finished FAILED or CANCELLED.
-            TimeoutError: `timeout` elapsed while the job or one of its files was still in progress.
+            NominalIngestFailed: The job itself finished FAILED. Files that did ingest are named in
+                the error, and were yielded before it was raised.
+            NominalIngestTimeout: `timeout` elapsed while the job or one of its files was still in
+                progress.
         """
-        start_time = datetime.datetime.now()
+        deadline = None if timeout is None else datetime.datetime.now() + timeout
         seen_file_ids: set[str] = set()
         pending: list[DatasetFile] = []
         job_running = True
@@ -266,28 +272,33 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
             if not job_running and not pending:
                 break
 
-            if timeout is not None and datetime.datetime.now() - start_time >= timeout:
-                raise TimeoutError(
-                    f"timed out after {timeout} waiting for ingest job {self.rid}: "
-                    f"job status {self.status.name}, {len(pending)} file(s) still ingesting"
-                )
+            # Sleeping the full interval near the deadline would overshoot the caller's timeout.
+            sleep_for = poll_interval.total_seconds()
+            if deadline is not None:
+                remaining = (deadline - datetime.datetime.now()).total_seconds()
+                if remaining <= 0:
+                    raise NominalIngestTimeout(
+                        f"ingest job {self.rid} was still {self.status.name.lower()} after {timeout}, "
+                        f"with {len(pending)} file(s) still ingesting"
+                    )
+                sleep_for = min(sleep_for, remaining)
 
             logger.info(
                 "Sleeping for %f seconds while awaiting ingest job %s (status %s, %d file(s) ingesting)...",
-                poll_interval.total_seconds(),
+                sleep_for,
                 self.rid,
                 self.status.name,
                 len(pending),
             )
-            time.sleep(poll_interval.total_seconds())
+            time.sleep(sleep_for)
 
-        if self.status in _FAILED_JOB_STATUSES:
-            raise NominalIngestError(
-                f"ingest job {self.rid} finished {self.status.name} after producing {len(seen_file_ids)} file(s)"
+        if self.status is IngestionJobStatus.FAILED:
+            raise NominalIngestFailed(
+                f"ingest job {self.rid} failed after producing {len(seen_file_ids)} file(s): {sorted(seen_file_ids)}"
             )
         elif self.status is not IngestionJobStatus.COMPLETED:
             logger.warning(
-                "Ingest job %s had unrecognized status %s; treating as terminal after %d file(s).",
+                "Ingest job %s finished %s rather than COMPLETED, after producing %d file(s).",
                 self.rid,
                 self.status.name,
                 len(seen_file_ids),

--- a/nominal/core/ingestion_job.py
+++ b/nominal/core/ingestion_job.py
@@ -220,6 +220,66 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
         new_files = {file.id: file for file in self._iter_dataset_files() if file.id not in seen_file_ids}
         return job_running, list(new_files.values())
 
+    def _wait_for_next_poll(
+        self,
+        poll_interval: datetime.timedelta,
+        deadline: datetime.datetime | None,
+        pending: Sequence[DatasetFile],
+    ) -> None:
+        """Sleep until the next poll is due, raising if `deadline` has already passed.
+
+        Never sleeps beyond the deadline: waiting out a whole poll interval near the end of the
+        caller's budget would overshoot the timeout they asked for.
+        """
+        sleep_for = poll_interval.total_seconds()
+        if deadline is not None:
+            remaining = (deadline - datetime.datetime.now()).total_seconds()
+            if remaining <= 0:
+                raise NominalIngestTimeout(
+                    f"ingest job {self.rid} was still {self.status.name.lower()} when its wait budget "
+                    f"expired, with {len(pending)} file(s) still ingesting"
+                )
+            sleep_for = min(sleep_for, remaining)
+
+        logger.info(
+            "Sleeping for %f seconds while awaiting ingest job %s (status %s, %d file(s) ingesting)...",
+            sleep_for,
+            self.rid,
+            self.status.name,
+            len(pending),
+        )
+        time.sleep(sleep_for)
+
+    def _report_terminal_state(self, seen_file_ids: Collection[str]) -> None:
+        """Raise or warn about how this job finished, once every file it produced has been waited out.
+
+        `produced_file_count` is the only cross-check available on whether the paged listing returned
+        everything: it counts the same rows the listing selects, before that listing drops unlanded
+        files and ones in datasets this caller cannot read. Those two make a shortfall legitimate for
+        some jobs, so it is reported rather than raised.
+        """
+        if self.produced_file_count is not None and len(seen_file_ids) < self.produced_file_count:
+            logger.warning(
+                "Ingest job %s reports %d produced file(s) but only %d could be listed. Unlanded files "
+                "and files in datasets you cannot read are counted but not listed; otherwise the paged "
+                "listing dropped rows.",
+                self.rid,
+                self.produced_file_count,
+                len(seen_file_ids),
+            )
+
+        if self.status is IngestionJobStatus.FAILED:
+            raise NominalIngestFailed(
+                f"ingest job {self.rid} failed after producing {len(seen_file_ids)} file(s): {sorted(seen_file_ids)}"
+            )
+        elif self.status is not IngestionJobStatus.COMPLETED:
+            logger.warning(
+                "Ingest job %s finished %s rather than COMPLETED, after producing %d file(s).",
+                self.rid,
+                self.status.name,
+                len(seen_file_ids),
+            )
+
     def as_files_ingested(
         self,
         *,
@@ -277,48 +337,6 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
             if not job_running and not pending:
                 break
 
-            # Sleeping the full interval near the deadline would overshoot the caller's timeout.
-            sleep_for = poll_interval.total_seconds()
-            if deadline is not None:
-                remaining = (deadline - datetime.datetime.now()).total_seconds()
-                if remaining <= 0:
-                    raise NominalIngestTimeout(
-                        f"ingest job {self.rid} was still {self.status.name.lower()} after {timeout}, "
-                        f"with {len(pending)} file(s) still ingesting"
-                    )
-                sleep_for = min(sleep_for, remaining)
+            self._wait_for_next_poll(poll_interval, deadline, pending)
 
-            logger.info(
-                "Sleeping for %f seconds while awaiting ingest job %s (status %s, %d file(s) ingesting)...",
-                sleep_for,
-                self.rid,
-                self.status.name,
-                len(pending),
-            )
-            time.sleep(sleep_for)
-
-        # The job's own count is the only cross-check available on whether the paged listing returned
-        # everything: it counts the same rows the listing selects, before that listing drops unlanded
-        # files and ones in datasets this caller cannot read. Those make a shortfall legitimate, so
-        # this reports rather than raises.
-        if self.produced_file_count is not None and len(seen_file_ids) < self.produced_file_count:
-            logger.warning(
-                "Ingest job %s reports %d produced file(s) but only %d could be listed. Unlanded files "
-                "and files in datasets you cannot read are counted but not listed; otherwise the paged "
-                "listing dropped rows.",
-                self.rid,
-                self.produced_file_count,
-                len(seen_file_ids),
-            )
-
-        if self.status is IngestionJobStatus.FAILED:
-            raise NominalIngestFailed(
-                f"ingest job {self.rid} failed after producing {len(seen_file_ids)} file(s): {sorted(seen_file_ids)}"
-            )
-        elif self.status is not IngestionJobStatus.COMPLETED:
-            logger.warning(
-                "Ingest job %s finished %s rather than COMPLETED, after producing %d file(s).",
-                self.rid,
-                self.status.name,
-                len(seen_file_ids),
-            )
+        self._report_terminal_state(seen_file_ids)

--- a/nominal/core/ingestion_job.py
+++ b/nominal/core/ingestion_job.py
@@ -206,6 +206,10 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
         many files to expect, but an unchanged one does mean a re-listing cannot turn up anything new,
         which is worth skipping for a job holding thousands of files. A job that has stopped running is
         always listed once more, so the final file set never depends on that count.
+
+        Keyed by file id rather than filtered into a list: the listing pages by offset over a column
+        that is not unique, so a row written while a pass is in flight shifts later pages and can serve
+        the same file twice within that one pass.
         """
         if self.status in _RUNNING_JOB_STATUSES:
             self.refresh()
@@ -213,7 +217,8 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
 
         if job_running and self.produced_file_count == len(seen_file_ids):
             return True, []
-        return job_running, [file for file in self._iter_dataset_files() if file.id not in seen_file_ids]
+        new_files = {file.id: file for file in self._iter_dataset_files() if file.id not in seen_file_ids}
+        return job_running, list(new_files.values())
 
     def as_files_ingested(
         self,

--- a/nominal/core/ingestion_job.py
+++ b/nominal/core/ingestion_job.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Collection, Iterable, Protocol, Sequence
+from typing import AbstractSet, Collection, Iterable, Protocol, Sequence
 
 from nominal_api import ingest_api
 from typing_extensions import Self
@@ -14,6 +14,7 @@ from nominal.core._utils.frontend_urls import ingestion_job_url
 from nominal.core.dataset_file import (
     DatasetFile,
     _dataset_file_from_conjure,
+    _deadline_from,
     _poll_files_once,
     _sleep_until_next_poll,
 )
@@ -203,7 +204,7 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
         """
         return list(self._iter_dataset_files())
 
-    def _poll_for_new_files(self, seen_file_ids: Collection[str]) -> tuple[bool, list[DatasetFile]]:
+    def _poll_for_new_files(self, seen_file_ids: AbstractSet[str]) -> tuple[bool, list[DatasetFile]]:
         """Refresh this job once, returning whether it can still produce files and any not yet seen.
 
         `produced_file_count` is a live count that arrives with the refresh. It says nothing about how
@@ -224,7 +225,7 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
         new_files = {file.id: file for file in self._iter_dataset_files() if file.id not in seen_file_ids}
         return job_running, list(new_files.values())
 
-    def _timed_out(self, pending: Sequence[DatasetFile]) -> NominalIngestTimeout:
+    def _timeout_error(self, pending: Sequence[DatasetFile]) -> NominalIngestTimeout:
         """Describe which of the two stages this wait was still blocked on when its budget expired."""
         blocked_on = (
             f"was still {self.status.name.lower()}"
@@ -304,7 +305,7 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
             NominalIngestTimeout: `timeout` elapsed while the job or one of its files was still in
                 progress.
         """
-        deadline = None if timeout is None else datetime.datetime.now() + timeout
+        deadline = _deadline_from(timeout)
         seen_file_ids: set[str] = set()
         pending: list[DatasetFile] = []
         job_running = True
@@ -329,6 +330,6 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
                 len(pending),
             )
             if not _sleep_until_next_poll(poll_interval, deadline):
-                raise self._timed_out(pending)
+                raise self._timeout_error(pending)
 
         self._report_terminal_state(seen_file_ids)

--- a/nominal/core/ingestion_job.py
+++ b/nominal/core/ingestion_job.py
@@ -238,8 +238,10 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
 
         `produced_file_count` is the only cross-check available on whether the paged listing returned
         everything: it counts the same rows the listing selects, before that listing drops unlanded
-        files and ones in datasets this caller cannot read. Those two make a shortfall legitimate for
-        some jobs, so it is reported rather than raised.
+        files and ones in datasets this caller cannot read. Neither is a race a longer wait would win.
+        A file is unlanded only while its row is still a reservation, and a reservation is non-terminal
+        work that holds the job itself off COMPLETED — so one still unlanded here is one that failed
+        before it landed. A shortfall is legitimate for some jobs, so it is reported rather than raised.
         """
         if self.produced_file_count is not None and len(seen_file_ids) < self.produced_file_count:
             logger.warning(

--- a/nominal/core/ingestion_job.py
+++ b/nominal/core/ingestion_job.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import datetime
+import logging
+import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Iterable, Protocol, Sequence
@@ -10,9 +12,11 @@ from typing_extensions import Self
 
 from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin
 from nominal.core._utils.frontend_urls import ingestion_job_url
-from nominal.core.dataset_file import DatasetFile, _dataset_file_from_conjure
-from nominal.core.dataset_file import as_files_ingested as _as_files_ingested
+from nominal.core.dataset_file import DatasetFile, _dataset_file_from_conjure, _poll_files_once
+from nominal.core.exceptions import NominalIngestError
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
+
+logger = logging.getLogger(__name__)
 
 
 class IngestionJobStatus(Enum):
@@ -63,6 +67,16 @@ class IngestionJobStatus(Enum):
             case _:
                 result = ingest_api.IngestJobStatus.UNKNOWN
         return result
+
+
+_RUNNING_JOB_STATUSES = frozenset(
+    {IngestionJobStatus.SUBMITTED, IngestionJobStatus.QUEUED, IngestionJobStatus.IN_PROGRESS}
+)
+"""Statuses from which a job can still produce more files.
+
+Deliberately the running set rather than the terminal set: a status this client does not recognize
+stops the wait instead of looping forever on it.
+"""
 
 
 class IngestType(Enum):
@@ -177,16 +191,96 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
             next_page_token = page.next_page
 
     def dataset_files(self) -> Sequence[DatasetFile]:
-        """Return the dataset files produced by this ingest job."""
+        """Return the dataset files this ingest job has produced so far.
+
+        This is a point-in-time snapshot: a job that is not yet terminal can still produce more files,
+        and one that produces its files in bulk has none to report until its work is done. To wait for
+        the complete set, use `as_files_ingested()`.
+        """
         return list(self._iter_dataset_files())
 
     def as_files_ingested(
-        self, *, poll_interval: datetime.timedelta = datetime.timedelta(seconds=1)
+        self,
+        *,
+        poll_interval: datetime.timedelta = datetime.timedelta(seconds=1),
+        timeout: datetime.timedelta | None = None,
     ) -> Iterable[DatasetFile]:
         """Yield this job's dataset files as each completes ingestion.
 
-        Polls the files produced by this job (as of the call) until each finishes ingesting, mirroring
-        `nominal.core.as_files_ingested`. `list(job.as_files_ingested())` blocks until all are ingested.
-        For timeout / return-when control, use `nominal.core.wait_for_files_to_ingest(job.dataset_files(), ...)`.
+        Waits out both stages of an ingest: the job producing its files, then those files finishing
+        ingestion. The file list is re-read on each poll for as long as the job is still running, so
+        files that do not exist yet when this is called are still picked up — a job that emits many
+        files registers none of them until its work is done, and a wait that read the list only once
+        would report success over zero files. `list(job.as_files_ingested())` therefore blocks until
+        the job is terminal and every file it produced has finished ingesting.
+
+        Yielded files may have failed: a job can complete with some of its files FAILED, so check
+        `ingest_status` on each yielded file if that matters. For timeout / return-when control over
+        a fixed set of files, use `nominal.core.wait_for_files_to_ingest(job.dataset_files(), ...)`.
+
+        Args:
+            poll_interval: Interval to sleep between polls of this job and of its pending files.
+            timeout: If given, the maximum time to wait before raising `TimeoutError`.
+
+        Yields:
+            Dataset files as they finish ingesting. Due to the polling mechanics, the files are not
+            yielded in strictly sorted order based on their ingestion completion time.
+
+        Raises:
+            NominalIngestError: The job itself finished FAILED or CANCELLED.
+            TimeoutError: `timeout` elapsed while the job or one of its files was still in progress.
         """
-        yield from _as_files_ingested(self.dataset_files(), poll_interval=poll_interval)
+        start_time = datetime.datetime.now()
+        seen_file_ids: set[str] = set()
+        pending: list[DatasetFile] = []
+        job_running = True
+
+        while True:
+            if job_running:
+                if self.status in _RUNNING_JOB_STATUSES:
+                    self.refresh()
+                # A terminal job's file list is complete, so read it once more and then stop looking.
+                job_running = self.status in _RUNNING_JOB_STATUSES
+                # produced_file_count is a live count that comes free with the refresh above. It says
+                # nothing about how many files to expect, but an unchanged one does mean a re-listing
+                # cannot turn up anything new — worth skipping for a job holding thousands of files.
+                # The pass that observes a terminal status always lists, whatever the count says.
+                if not job_running or self.produced_file_count != len(seen_file_ids):
+                    for file in self._iter_dataset_files():
+                        if file.id not in seen_file_ids:
+                            seen_file_ids.add(file.id)
+                            pending.append(file)
+
+            if pending:
+                newly_done, pending, _ = _poll_files_once(pending)
+                yield from newly_done
+
+            if not job_running and not pending:
+                break
+
+            if timeout is not None and datetime.datetime.now() - start_time >= timeout:
+                raise TimeoutError(
+                    f"timed out after {timeout} waiting for ingest job {self.rid}: "
+                    f"job status {self.status.name}, {len(pending)} file(s) still ingesting"
+                )
+
+            logger.info(
+                "Sleeping for %f seconds while awaiting ingest job %s (status %s, %d file(s) ingesting)...",
+                poll_interval.total_seconds(),
+                self.rid,
+                self.status.name,
+                len(pending),
+            )
+            time.sleep(poll_interval.total_seconds())
+
+        if self.status in (IngestionJobStatus.FAILED, IngestionJobStatus.CANCELLED):
+            raise NominalIngestError(
+                f"ingest job {self.rid} finished {self.status.name} after producing {len(seen_file_ids)} file(s)"
+            )
+        elif self.status is not IngestionJobStatus.COMPLETED:
+            logger.warning(
+                "Ingest job %s had unrecognized status %s; treating as terminal after %d file(s).",
+                self.rid,
+                self.status.name,
+                len(seen_file_ids),
+            )

--- a/nominal/core/ingestion_job.py
+++ b/nominal/core/ingestion_job.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import logging
-import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Collection, Iterable, Protocol, Sequence
@@ -12,7 +11,12 @@ from typing_extensions import Self
 
 from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin
 from nominal.core._utils.frontend_urls import ingestion_job_url
-from nominal.core.dataset_file import DatasetFile, _dataset_file_from_conjure, _poll_files_once
+from nominal.core.dataset_file import (
+    DatasetFile,
+    _dataset_file_from_conjure,
+    _poll_files_once,
+    _sleep_until_next_poll,
+)
 from nominal.core.exceptions import NominalIngestFailed, NominalIngestTimeout
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
 
@@ -220,35 +224,14 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
         new_files = {file.id: file for file in self._iter_dataset_files() if file.id not in seen_file_ids}
         return job_running, list(new_files.values())
 
-    def _wait_for_next_poll(
-        self,
-        poll_interval: datetime.timedelta,
-        deadline: datetime.datetime | None,
-        pending: Sequence[DatasetFile],
-    ) -> None:
-        """Sleep until the next poll is due, raising if `deadline` has already passed.
-
-        Never sleeps beyond the deadline: waiting out a whole poll interval near the end of the
-        caller's budget would overshoot the timeout they asked for.
-        """
-        sleep_for = poll_interval.total_seconds()
-        if deadline is not None:
-            remaining = (deadline - datetime.datetime.now()).total_seconds()
-            if remaining <= 0:
-                raise NominalIngestTimeout(
-                    f"ingest job {self.rid} was still {self.status.name.lower()} when its wait budget "
-                    f"expired, with {len(pending)} file(s) still ingesting"
-                )
-            sleep_for = min(sleep_for, remaining)
-
-        logger.info(
-            "Sleeping for %f seconds while awaiting ingest job %s (status %s, %d file(s) ingesting)...",
-            sleep_for,
-            self.rid,
-            self.status.name,
-            len(pending),
+    def _timed_out(self, pending: Sequence[DatasetFile]) -> NominalIngestTimeout:
+        """Describe which of the two stages this wait was still blocked on when its budget expired."""
+        blocked_on = (
+            f"was still {self.status.name.lower()}"
+            if self.status in _RUNNING_JOB_STATUSES
+            else f"{self.status.name.lower()}, but {len(pending)} of its file(s) were still ingesting"
         )
-        time.sleep(sleep_for)
+        return NominalIngestTimeout(f"ingest job {self.rid} {blocked_on} when its wait budget expired")
 
     def _report_terminal_state(self, seen_file_ids: Collection[str]) -> None:
         """Raise or warn about how this job finished, once every file it produced has been waited out.
@@ -337,6 +320,13 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
             if not job_running and not pending:
                 break
 
-            self._wait_for_next_poll(poll_interval, deadline, pending)
+            logger.info(
+                "Awaiting ingest job %s (status %s, %d file(s) ingesting)...",
+                self.rid,
+                self.status.name,
+                len(pending),
+            )
+            if not _sleep_until_next_poll(poll_interval, deadline):
+                raise self._timed_out(pending)
 
         self._report_terminal_state(seen_file_ids)

--- a/nominal/core/ingestion_job.py
+++ b/nominal/core/ingestion_job.py
@@ -5,7 +5,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Iterable, Protocol, Sequence
+from typing import Collection, Iterable, Protocol, Sequence
 
 from nominal_api import ingest_api
 from typing_extensions import Self
@@ -75,8 +75,11 @@ _RUNNING_JOB_STATUSES = frozenset(
 """Statuses from which a job can still produce more files.
 
 Deliberately the running set rather than the terminal set: a status this client does not recognize
-stops the wait instead of looping forever on it.
+stops a wait instead of looping forever on it.
 """
+
+_FAILED_JOB_STATUSES = frozenset({IngestionJobStatus.FAILED, IngestionJobStatus.CANCELLED})
+"""Terminal statuses meaning the job did not deliver what it was asked for."""
 
 
 class IngestType(Enum):
@@ -199,6 +202,22 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
         """
         return list(self._iter_dataset_files())
 
+    def _poll_for_new_files(self, seen_file_ids: Collection[str]) -> tuple[bool, list[DatasetFile]]:
+        """Refresh this job once, returning whether it can still produce files and any not yet seen.
+
+        `produced_file_count` is a live count that arrives with the refresh. It says nothing about how
+        many files to expect, but an unchanged one does mean a re-listing cannot turn up anything new,
+        which is worth skipping for a job holding thousands of files. A job that has stopped running is
+        always listed once more, so the final file set never depends on that count.
+        """
+        if self.status in _RUNNING_JOB_STATUSES:
+            self.refresh()
+        job_running = self.status in _RUNNING_JOB_STATUSES
+
+        if job_running and self.produced_file_count == len(seen_file_ids):
+            return True, []
+        return job_running, [file for file in self._iter_dataset_files() if file.id not in seen_file_ids]
+
     def as_files_ingested(
         self,
         *,
@@ -208,10 +227,9 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
         """Yield this job's dataset files as each completes ingestion.
 
         Waits out both stages of an ingest: the job producing its files, then those files finishing
-        ingestion. The file list is re-read on each poll for as long as the job is still running, so
-        files that do not exist yet when this is called are still picked up — a job that emits many
-        files registers none of them until its work is done, and a wait that read the list only once
-        would report success over zero files. `list(job.as_files_ingested())` therefore blocks until
+        ingestion. The file list is re-read on each poll while the job is still running, so files that
+        do not exist yet when this is called are still picked up — a containerized extractor registers
+        its outputs only once its container has exited. `list(job.as_files_ingested())` blocks until
         the job is terminal and every file it produced has finished ingesting.
 
         Yielded files may have failed: a job can complete with some of its files FAILED, so check
@@ -237,19 +255,9 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
 
         while True:
             if job_running:
-                if self.status in _RUNNING_JOB_STATUSES:
-                    self.refresh()
-                # A terminal job's file list is complete, so read it once more and then stop looking.
-                job_running = self.status in _RUNNING_JOB_STATUSES
-                # produced_file_count is a live count that comes free with the refresh above. It says
-                # nothing about how many files to expect, but an unchanged one does mean a re-listing
-                # cannot turn up anything new — worth skipping for a job holding thousands of files.
-                # The pass that observes a terminal status always lists, whatever the count says.
-                if not job_running or self.produced_file_count != len(seen_file_ids):
-                    for file in self._iter_dataset_files():
-                        if file.id not in seen_file_ids:
-                            seen_file_ids.add(file.id)
-                            pending.append(file)
+                job_running, new_files = self._poll_for_new_files(seen_file_ids)
+                seen_file_ids.update(file.id for file in new_files)
+                pending.extend(new_files)
 
             if pending:
                 newly_done, pending, _ = _poll_files_once(pending)
@@ -273,7 +281,7 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
             )
             time.sleep(poll_interval.total_seconds())
 
-        if self.status in (IngestionJobStatus.FAILED, IngestionJobStatus.CANCELLED):
+        if self.status in _FAILED_JOB_STATUSES:
             raise NominalIngestError(
                 f"ingest job {self.rid} finished {self.status.name} after producing {len(seen_file_ids)} file(s)"
             )

--- a/nominal/core/ingestion_job.py
+++ b/nominal/core/ingestion_job.py
@@ -292,6 +292,20 @@ class IngestionJob(HasRid, RefreshableConjureMixin[ingest_api.IngestJob]):
             )
             time.sleep(sleep_for)
 
+        # The job's own count is the only cross-check available on whether the paged listing returned
+        # everything: it counts the same rows the listing selects, before that listing drops unlanded
+        # files and ones in datasets this caller cannot read. Those make a shortfall legitimate, so
+        # this reports rather than raises.
+        if self.produced_file_count is not None and len(seen_file_ids) < self.produced_file_count:
+            logger.warning(
+                "Ingest job %s reports %d produced file(s) but only %d could be listed. Unlanded files "
+                "and files in datasets you cannot read are counted but not listed; otherwise the paged "
+                "listing dropped rows.",
+                self.rid,
+                self.produced_file_count,
+                len(seen_file_ids),
+            )
+
         if self.status is IngestionJobStatus.FAILED:
             raise NominalIngestFailed(
                 f"ingest job {self.rid} failed after producing {len(seen_file_ids)} file(s): {sorted(seen_file_ids)}"

--- a/nominal/experimental/extractor/README.md
+++ b/nominal/experimental/extractor/README.md
@@ -439,8 +439,12 @@ for file in job.as_files_ingested():             # blocks until each output fini
 ```
 
 A containerized extraction is asynchronous and may produce many files, so it returns an
-`IngestionJob` rather than a single file. Use `job.status` to poll, `job.dataset_files()` for what it
-produced, and `job.cancel()` to stop it.
+`IngestionJob` rather than a single file. `as_files_ingested()` waits out both stages — the container
+producing its outputs, then each output ingesting — and re-reads the job's file list as it goes, which
+matters for a manifest extractor: none of its outputs are registered until the container exits, so a
+list read at trigger time is empty. Use `job.refresh()` then `job.status` to poll the job itself
+(`status` is a snapshot; refreshing is what advances it), `job.dataset_files()` for a point-in-time
+list of what it has produced so far, and `job.cancel()` to stop it.
 
 The keys of `sources` are the input environment variables you registered, and they must match the
 active image's inputs exactly. `timestamp_column` / `timestamp_type` on this call override the image's

--- a/tests/core/test_dataset_file.py
+++ b/tests/core/test_dataset_file.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
+import time
 from datetime import timedelta
-from types import SimpleNamespace
 from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
-from nominal_api import api
 
 from nominal.core.dataset_file import (
     DatasetFile,
@@ -209,27 +208,18 @@ def test_wait_for_files_to_ingest_returns_after_absent_file_with_first_exception
     assert not_done == [pending]
 
 
-def test_from_conjure_unknown_ingest_status_falls_back_to_unknown():
-    """An unrecognized wire ingest status maps to UNKNOWN rather than raising, for forward-compatibility."""
-    future = SimpleNamespace(type="someFutureStatus")
-    assert IngestStatus._from_conjure(cast(api.IngestStatusV2, future)) is IngestStatus.UNKNOWN
+def test_wait_for_files_to_ingest_gives_up_on_the_timeout_not_a_full_poll_interval_later():
+    """A timeout shorter than the poll interval returns when the budget runs out, not an interval later."""
+    file = _make_file("file-1", [IngestStatus.IN_PROGRESS])
 
+    started = time.monotonic()
+    done, not_done = wait_for_files_to_ingest(
+        [file], poll_interval=timedelta(seconds=5), timeout=timedelta(seconds=0.05)
+    )
 
-def test_wait_for_files_to_ingest_does_not_sleep_past_the_timeout_deadline():
-    """A poll interval longer than the remaining budget is shortened to the budget, not slept in full."""
-    file = _make_file("file-1", [IngestStatus.IN_PROGRESS, IngestStatus.SUCCESS])
-
-    with (
-        patch("nominal.core.dataset_file.time.sleep") as mock_sleep,
-        patch("nominal.core.dataset_file.time.monotonic", return_value=100.0),
-    ):
-        done, not_done = wait_for_files_to_ingest(
-            [file], poll_interval=timedelta(minutes=5), timeout=timedelta(seconds=2)
-        )
-
-    assert done == [file]
-    assert not not_done
-    mock_sleep.assert_called_once_with(2.0)
+    assert time.monotonic() - started < 2
+    assert not done
+    assert not_done == [file]
 
 
 def test_wait_for_files_to_ingest_treats_unknown_status_as_done():

--- a/tests/core/test_dataset_file.py
+++ b/tests/core/test_dataset_file.py
@@ -207,6 +207,17 @@ def test_wait_for_files_to_ingest_returns_after_absent_file_with_first_exception
     assert not_done == [pending]
 
 
+def test_wait_for_files_to_ingest_treats_unknown_status_as_done():
+    """A file reporting a status this client does not recognize is treated as done, not polled forever."""
+    file = _make_file("future-1", [IngestStatus.UNKNOWN])
+
+    with patch("nominal.core.dataset_file._batch_refresh_files", return_value=set()):
+        done, not_done = wait_for_files_to_ingest([file])
+
+    assert done == [file]
+    assert not not_done
+
+
 def test_as_files_ingested_does_not_sleep_when_all_files_complete_in_first_poll():
     """Does not sleep when all files complete ingestion on the first poll."""
     first = _make_file("first-file", [IngestStatus.SUCCESS])

--- a/tests/core/test_dataset_file.py
+++ b/tests/core/test_dataset_file.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from types import SimpleNamespace
 from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
+from nominal_api import api
 
 from nominal.core.dataset_file import (
     DatasetFile,
@@ -205,6 +207,26 @@ def test_wait_for_files_to_ingest_returns_after_absent_file_with_first_exception
 
     assert done == [absent]
     assert not_done == [pending]
+
+
+def test_from_conjure_unknown_ingest_status_falls_back_to_unknown():
+    """An unrecognized wire ingest status maps to UNKNOWN rather than raising, for forward-compatibility."""
+    future = SimpleNamespace(type="someFutureStatus")
+    assert IngestStatus._from_conjure(cast(api.IngestStatusV2, future)) is IngestStatus.UNKNOWN
+
+
+def test_wait_for_files_to_ingest_does_not_sleep_past_the_timeout_deadline():
+    """A poll interval longer than the remaining budget is shortened to the budget, not slept in full."""
+    file = _make_file("file-1", [IngestStatus.IN_PROGRESS, IngestStatus.SUCCESS])
+
+    with patch("nominal.core.dataset_file.time.sleep") as mock_sleep:
+        done, not_done = wait_for_files_to_ingest(
+            [file], poll_interval=timedelta(minutes=5), timeout=timedelta(seconds=2)
+        )
+
+    assert done == [file]
+    assert not not_done
+    assert 0 < mock_sleep.call_args.args[0] <= 2
 
 
 def test_wait_for_files_to_ingest_treats_unknown_status_as_done():

--- a/tests/core/test_dataset_file.py
+++ b/tests/core/test_dataset_file.py
@@ -219,14 +219,17 @@ def test_wait_for_files_to_ingest_does_not_sleep_past_the_timeout_deadline():
     """A poll interval longer than the remaining budget is shortened to the budget, not slept in full."""
     file = _make_file("file-1", [IngestStatus.IN_PROGRESS, IngestStatus.SUCCESS])
 
-    with patch("nominal.core.dataset_file.time.sleep") as mock_sleep:
+    with (
+        patch("nominal.core.dataset_file.time.sleep") as mock_sleep,
+        patch("nominal.core.dataset_file.time.monotonic", return_value=100.0),
+    ):
         done, not_done = wait_for_files_to_ingest(
             [file], poll_interval=timedelta(minutes=5), timeout=timedelta(seconds=2)
         )
 
     assert done == [file]
     assert not not_done
-    assert 0 < mock_sleep.call_args.args[0] <= 2
+    mock_sleep.assert_called_once_with(2.0)
 
 
 def test_wait_for_files_to_ingest_treats_unknown_status_as_done():

--- a/tests/core/test_ingestion_job.py
+++ b/tests/core/test_ingestion_job.py
@@ -179,6 +179,22 @@ def test_as_files_ingested_does_not_poll_a_job_that_is_already_terminal(mock_cli
     mock_sleep.assert_not_called()
 
 
+def test_as_files_ingested_yields_each_file_once_when_a_page_repeats_it(mock_clients: MagicMock) -> None:
+    """A file served on two pages of one listing pass is yielded once, as offset paging can repeat rows."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.COMPLETED))
+    repeated = _make_file("repeated-file", [IngestStatus.SUCCESS])
+    other = _make_file("other-file", [IngestStatus.SUCCESS])
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(
+        SimpleNamespace(files=[repeated, other], next_page="t2"),
+        SimpleNamespace(files=[repeated], next_page=None),
+    )
+
+    with _polling():
+        yielded = list(job.as_files_ingested())
+
+    assert yielded == [repeated, other]
+
+
 def test_as_files_ingested_yields_each_file_once_when_the_list_grows(mock_clients: MagicMock) -> None:
     """A file seen on an earlier poll is not yielded again when it reappears in a later file listing."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))

--- a/tests/core/test_ingestion_job.py
+++ b/tests/core/test_ingestion_job.py
@@ -1,22 +1,27 @@
 from __future__ import annotations
 
 import logging
-from contextlib import contextmanager
+import time
 from datetime import timedelta
-from types import SimpleNamespace
-from typing import Callable, Iterator, Sequence
-from unittest.mock import MagicMock, patch
+from typing import Callable, Mapping, Sequence
+from unittest.mock import MagicMock
 
 import pytest
-from nominal_api import ingest_api
+from nominal_api import api, ingest_api, scout_catalog
 
-from nominal.core.dataset_file import IngestStatus
+from nominal.core.dataset_file import DatasetFile, IngestStatus
 from nominal.core.exceptions import NominalIngestFailed, NominalIngestTimeout
 from nominal.core.ingestion_job import IngestionJob, IngestionJobStatus
 
+DATASET_RID = "ri.catalog.test.dataset.def"
 
-class _StopPolling(Exception):
-    """Raised from a mocked sleep to end a wait loop that would otherwise never reach its deadline."""
+IN_PROGRESS = api.IngestStatusV2(in_progress=api.InProgressResult())
+SUCCESS = api.IngestStatusV2(success=api.SuccessResult())
+FAILED = api.IngestStatusV2(error=api.ErrorResult(error_type="INTERNAL", message="boom"))
+
+# These tests drive the job through the conjure clients and assert on what the caller receives, so the
+# poll interval only sets how fast the loop spins. Nothing here patches time or module internals.
+FAST = timedelta(0)
 
 
 def _job_bean(**overrides: object) -> ingest_api.IngestJob:
@@ -28,7 +33,7 @@ def _job_bean(**overrides: object) -> ingest_api.IngestJob:
         created_by="11111111-1111-1111-1111-111111111111",
         org_uuid="22222222-2222-2222-2222-222222222222",
         created_by_rid="ri.authn.test.user.abc",
-        dataset_rid="ri.catalog.test.dataset.def",
+        dataset_rid=DATASET_RID,
         origin_files=None,
         produced_file_count=None,
         created_at=None,
@@ -39,14 +44,61 @@ def _job_bean(**overrides: object) -> ingest_api.IngestJob:
     return ingest_api.IngestJob(**kwargs)
 
 
-def test_from_conjure_unknown_status_falls_back_to_unknown() -> None:
-    """An unrecognized wire status name maps to UNKNOWN for forward-compatibility."""
-    future = SimpleNamespace(name="SOME_FUTURE_STATUS")
-    assert IngestionJobStatus._from_conjure(future) is IngestionJobStatus.UNKNOWN
+def _file_bean(file_id: str, ingest_status: api.IngestStatusV2) -> scout_catalog.DatasetFile:
+    """Build a conjure DatasetFile bean as the catalog service would return it."""
+    return scout_catalog.DatasetFile(
+        dataset_rid=DATASET_RID,
+        handle=scout_catalog.Handle(s3=scout_catalog.S3Handle(bucket="test-bucket", key=file_id)),
+        id=file_id,
+        ingest_status=ingest_status,
+        name=f"{file_id}.csv",
+        uploaded_at="2026-01-01T00:00:00Z",
+    )
+
+
+def _page(*files: scout_catalog.DatasetFile, next_page: str | None = None) -> scout_catalog.DatasetFilesPage:
+    """Build one page of a get_dataset_files_for_job response."""
+    return scout_catalog.DatasetFilesPage(files=list(files), next_page=next_page)
+
+
+def _responses(*values: object) -> Callable[..., object]:
+    """Successive service responses, repeating the last one for any further calls."""
+    remaining = list(values)
+
+    def _next(*_args: object, **_kwargs: object) -> object:
+        return remaining.pop(0) if len(remaining) > 1 else remaining[0]
+
+    return _next
+
+
+def _serve_job(mock_clients: MagicMock, *statuses: ingest_api.IngestJobStatus) -> None:
+    """Serve the job status each successive refresh sees, repeating the last."""
+    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(*(_job_bean(status=s) for s in statuses))
+
+
+def _serve_listing(mock_clients: MagicMock, *pages: scout_catalog.DatasetFilesPage) -> None:
+    """Serve successive file listings for the job, repeating the last."""
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(*pages)
+
+
+def _serve_refreshes(mock_clients: MagicMock, *states: Mapping[str, api.IngestStatusV2]) -> None:
+    """Serve successive batch refreshes, each mapping a file id to the status it now reports.
+
+    A file left out of a state is absent from that batch response, which is how the service reports one
+    that has been deleted.
+    """
+    mock_clients.catalog.batch_get_dataset_files.side_effect = _responses(
+        *({file_id: _file_bean(file_id, status) for file_id, status in state.items()} for state in states)
+    )
+
+
+def _ids(files: Sequence[DatasetFile]) -> list[str]:
+    """The ids of the dataset files a wait produced, in order."""
+    return [file.id for file in files]
 
 
 def test_cancel_calls_service_and_refreshes(mock_clients: MagicMock) -> None:
-    """cancel() calls the cancel endpoint and refreshes the job in place from the response."""
+    """cancel() cancels the job server-side and leaves the local job reporting the new status."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
     mock_clients.ingest_jobs.cancel_ingest_job.return_value = _job_bean(status=ingest_api.IngestJobStatus.CANCELLED)
 
@@ -57,168 +109,81 @@ def test_cancel_calls_service_and_refreshes(mock_clients: MagicMock) -> None:
     assert job.status is IngestionJobStatus.CANCELLED
 
 
-def test_dataset_files_paginates_and_maps(mock_clients: MagicMock) -> None:
-    """dataset_files() pages through the per-job files endpoint, threading the page token."""
+def test_dataset_files_returns_every_page(mock_clients: MagicMock) -> None:
+    """dataset_files() returns the files from every page of the listing, not just the first."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean())
+    _serve_listing(
+        mock_clients,
+        _page(_file_bean("f1", SUCCESS), _file_bean("f2", SUCCESS), next_page="t2"),
+        _page(_file_bean("f3", SUCCESS)),
+    )
 
-    raw_file_1 = object()
-    raw_file_2 = object()
-    raw_file_3 = object()
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = [
-        SimpleNamespace(files=[raw_file_1, raw_file_2], next_page="t2"),
-        SimpleNamespace(files=[raw_file_3], next_page=None),
-    ]
-
-    sentinels = {raw_file_1: "f1", raw_file_2: "f2", raw_file_3: "f3"}
-    with patch(
-        "nominal.core.ingestion_job._dataset_file_from_conjure",
-        side_effect=lambda _clients, raw_file: sentinels[raw_file],
-    ):
-        result = job.dataset_files()
-
-    assert result == ["f1", "f2", "f3"]
-    assert mock_clients.catalog.get_dataset_files_for_job.call_count == 2
-    first_call = mock_clients.catalog.get_dataset_files_for_job.call_args_list[0]
-    assert first_call.args == (mock_clients.auth_header, job.rid, None)
-    second_call = mock_clients.catalog.get_dataset_files_for_job.call_args_list[1]
-    assert second_call.args[2] == "t2"
-
-
-def _page(*files: object) -> SimpleNamespace:
-    """Build a single-page get_dataset_files_for_job response."""
-    return SimpleNamespace(files=list(files), next_page=None)
-
-
-def _responses(*values: object) -> Callable[..., object]:
-    """Successive mock responses, repeating the last one for any further calls."""
-    remaining = list(values)
-
-    def _next(*_args: object, **_kwargs: object) -> object:
-        return remaining.pop(0) if len(remaining) > 1 else remaining[0]
-
-    return _next
-
-
-def _make_file(file_id: str, statuses: Sequence[IngestStatus]) -> MagicMock:
-    """Build a stand-in dataset file whose ingest_status advances one step per refresh."""
-    file = MagicMock()
-    file.id = file_id
-    file.dataset_rid = "ri.catalog.test.dataset.def"
-    file.ingest_status = statuses[0]
-    observed = iter(statuses)
-
-    def refresh(_: object) -> MagicMock:
-        file.ingest_status = next(observed, statuses[-1])
-        return file
-
-    file._refresh_from_api.side_effect = refresh
-    return file
-
-
-def _advance_polled_files(files: Sequence[MagicMock], **_kwargs: object) -> set[str]:
-    """Stand in for _batch_refresh_files: refresh every polled file, report none absent."""
-    for file in files:
-        file._refresh_from_api(None)
-    return set()
-
-
-@contextmanager
-def _polling() -> Iterator[MagicMock]:
-    """Patch out file refreshes, conjure file conversion, and sleeping; yield the sleep mock."""
-    with (
-        patch("nominal.core.dataset_file._batch_refresh_files", side_effect=_advance_polled_files),
-        patch("nominal.core.ingestion_job._dataset_file_from_conjure", side_effect=lambda _clients, file: file),
-        patch("nominal.core.dataset_file.time.sleep") as mock_sleep,
-    ):
-        yield mock_sleep
+    assert _ids(job.dataset_files()) == ["f1", "f2", "f3"]
 
 
 def test_as_files_ingested_waits_for_files_registered_after_the_call(mock_clients: MagicMock) -> None:
     """Files that do not exist yet when the wait starts are still yielded once the job registers them."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
-    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
-        _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS),
-        _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS),
-        _job_bean(status=ingest_api.IngestJobStatus.COMPLETED),
+    _serve_job(
+        mock_clients,
+        ingest_api.IngestJobStatus.IN_PROGRESS,
+        ingest_api.IngestJobStatus.IN_PROGRESS,
+        ingest_api.IngestJobStatus.COMPLETED,
     )
-    first = _make_file("first-file", [IngestStatus.SUCCESS])
-    second = _make_file("second-file", [IngestStatus.SUCCESS])
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(
-        _page(),
-        _page(),
-        _page(first, second),
-    )
+    _serve_listing(mock_clients, _page(), _page(), _page(_file_bean("first", SUCCESS), _file_bean("second", SUCCESS)))
+    _serve_refreshes(mock_clients, {"first": SUCCESS, "second": SUCCESS})
 
-    with _polling():
-        yielded = list(job.as_files_ingested())
-
-    assert yielded == [first, second]
+    assert _ids(list(job.as_files_ingested(poll_interval=FAST))) == ["first", "second"]
 
 
 def test_as_files_ingested_yields_completed_files_while_the_job_is_still_running(mock_clients: MagicMock) -> None:
     """A file that finishes ingesting is yielded without waiting for the job to reach a terminal status."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
-    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
-        _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS)
-    )
-    file = _make_file("only-file", [IngestStatus.SUCCESS])
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+    _serve_job(mock_clients, ingest_api.IngestJobStatus.IN_PROGRESS)
+    _serve_listing(mock_clients, _page(_file_bean("only", SUCCESS)))
+    _serve_refreshes(mock_clients, {"only": SUCCESS})
 
-    with _polling():
-        first_yielded = next(iter(job.as_files_ingested()))
+    first_yielded = next(iter(job.as_files_ingested(poll_interval=FAST)))
 
-    assert first_yielded is file
+    assert first_yielded.id == "only"
     assert job.status is IngestionJobStatus.IN_PROGRESS
 
 
-def test_as_files_ingested_does_not_poll_a_job_that_is_already_terminal(mock_clients: MagicMock) -> None:
-    """An already-completed job yields its files without re-fetching the job or sleeping."""
+def test_as_files_ingested_does_not_refetch_a_job_that_is_already_terminal(mock_clients: MagicMock) -> None:
+    """An already-completed job yields its files without asking the service for the job again."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.COMPLETED))
-    file = _make_file("only-file", [IngestStatus.SUCCESS])
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+    _serve_listing(mock_clients, _page(_file_bean("only", SUCCESS)))
+    _serve_refreshes(mock_clients, {"only": SUCCESS})
 
-    with _polling() as mock_sleep:
-        yielded = list(job.as_files_ingested())
-
-    assert yielded == [file]
+    assert _ids(list(job.as_files_ingested(poll_interval=FAST))) == ["only"]
     mock_clients.ingest_jobs.get_ingest_job.assert_not_called()
-    mock_sleep.assert_not_called()
 
 
 def test_as_files_ingested_yields_each_file_once_when_a_page_repeats_it(mock_clients: MagicMock) -> None:
     """A file served on two pages of one listing pass is yielded once, as offset paging can repeat rows."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.COMPLETED))
-    repeated = _make_file("repeated-file", [IngestStatus.SUCCESS])
-    other = _make_file("other-file", [IngestStatus.SUCCESS])
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(
-        SimpleNamespace(files=[repeated, other], next_page="t2"),
-        SimpleNamespace(files=[repeated], next_page=None),
+    _serve_listing(
+        mock_clients,
+        _page(_file_bean("repeated", SUCCESS), _file_bean("other", SUCCESS), next_page="t2"),
+        _page(_file_bean("repeated", SUCCESS)),
     )
+    _serve_refreshes(mock_clients, {"repeated": SUCCESS, "other": SUCCESS})
 
-    with _polling():
-        yielded = list(job.as_files_ingested())
-
-    assert yielded == [repeated, other]
+    assert _ids(list(job.as_files_ingested(poll_interval=FAST))) == ["repeated", "other"]
 
 
 def test_as_files_ingested_yields_each_file_once_when_the_list_grows(mock_clients: MagicMock) -> None:
     """A file seen on an earlier poll is not yielded again when it reappears in a later file listing."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
-    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
-        _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS),
-        _job_bean(status=ingest_api.IngestJobStatus.COMPLETED),
+    _serve_job(mock_clients, ingest_api.IngestJobStatus.IN_PROGRESS, ingest_api.IngestJobStatus.COMPLETED)
+    _serve_listing(
+        mock_clients,
+        _page(_file_bean("first", IN_PROGRESS)),
+        _page(_file_bean("first", SUCCESS), _file_bean("second", SUCCESS)),
     )
-    first = _make_file("first-file", [IngestStatus.IN_PROGRESS, IngestStatus.SUCCESS])
-    second = _make_file("second-file", [IngestStatus.SUCCESS])
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(
-        _page(first),
-        _page(first, second),
-    )
+    _serve_refreshes(mock_clients, {"first": IN_PROGRESS}, {"first": SUCCESS, "second": SUCCESS})
 
-    with _polling():
-        yielded = list(job.as_files_ingested())
-
-    assert yielded == [first, second]
+    assert _ids(list(job.as_files_ingested(poll_interval=FAST))) == ["first", "second"]
 
 
 def test_as_files_ingested_skips_relisting_files_while_the_produced_count_is_unchanged(
@@ -231,13 +196,10 @@ def test_as_files_ingested_skips_relisting_files_while_the_produced_count_is_unc
         _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS, produced_file_count=1),
         _job_bean(status=ingest_api.IngestJobStatus.COMPLETED, produced_file_count=1),
     )
-    file = _make_file("only-file", [IngestStatus.IN_PROGRESS, IngestStatus.SUCCESS])
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+    _serve_listing(mock_clients, _page(_file_bean("only", IN_PROGRESS)))
+    _serve_refreshes(mock_clients, {"only": IN_PROGRESS}, {"only": SUCCESS})
 
-    with _polling():
-        yielded = list(job.as_files_ingested())
-
-    assert yielded == [file]
+    assert _ids(list(job.as_files_ingested(poll_interval=FAST))) == ["only"]
     assert mock_clients.catalog.get_dataset_files_for_job.call_count == 2
 
 
@@ -248,131 +210,104 @@ def test_as_files_ingested_warns_when_fewer_files_listed_than_the_job_reports(
     job = IngestionJob._from_conjure(
         mock_clients, _job_bean(status=ingest_api.IngestJobStatus.COMPLETED, produced_file_count=3)
     )
-    file = _make_file("only-file", [IngestStatus.SUCCESS])
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+    _serve_listing(mock_clients, _page(_file_bean("only", SUCCESS)))
+    _serve_refreshes(mock_clients, {"only": SUCCESS})
 
-    with _polling(), caplog.at_level(logging.WARNING):
-        yielded = list(job.as_files_ingested())
+    with caplog.at_level(logging.WARNING):
+        yielded = list(job.as_files_ingested(poll_interval=FAST))
 
-    assert yielded == [file]
+    assert _ids(yielded) == ["only"]
     assert "reports 3 produced file(s) but only 1 could be listed" in caplog.text
 
 
 def test_as_files_ingested_yields_files_that_failed_to_ingest(mock_clients: MagicMock) -> None:
     """A completed job's failed file is yielded rather than dropped, so the caller can see its status."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.COMPLETED))
-    failed = _make_file("failed-file", [IngestStatus.FAILED])
-    succeeded = _make_file("good-file", [IngestStatus.SUCCESS])
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(failed, succeeded))
+    _serve_listing(mock_clients, _page(_file_bean("bad", IN_PROGRESS), _file_bean("good", IN_PROGRESS)))
+    _serve_refreshes(mock_clients, {"bad": FAILED, "good": SUCCESS})
 
-    with _polling():
-        yielded = list(job.as_files_ingested())
+    yielded = list(job.as_files_ingested(poll_interval=FAST))
 
-    assert yielded == [failed, succeeded]
-    assert failed.ingest_status is IngestStatus.FAILED
+    assert _ids(yielded) == ["bad", "good"]
+    assert yielded[0].ingest_status is IngestStatus.FAILED
 
 
 def test_as_files_ingested_yields_a_file_absent_from_the_batch_response(mock_clients: MagicMock) -> None:
     """A file that disappears mid-wait is treated as done rather than polled forever."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.COMPLETED))
-    file = _make_file("deleted-file", [IngestStatus.IN_PROGRESS])
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+    _serve_listing(mock_clients, _page(_file_bean("deleted", IN_PROGRESS)))
+    _serve_refreshes(mock_clients, {})
 
-    with (
-        patch("nominal.core.dataset_file._batch_refresh_files", return_value={"deleted-file"}),
-        patch("nominal.core.ingestion_job._dataset_file_from_conjure", side_effect=lambda _clients, f: f),
-        patch("nominal.core.dataset_file.time.sleep"),
-    ):
-        yielded = list(job.as_files_ingested())
-
-    assert yielded == [file]
+    assert _ids(list(job.as_files_ingested(poll_interval=FAST))) == ["deleted"]
 
 
 def test_as_files_ingested_raises_when_the_job_fails(mock_clients: MagicMock) -> None:
     """A job that ends FAILED raises rather than quietly yielding nothing."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
-    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
-        _job_bean(status=ingest_api.IngestJobStatus.FAILED)
-    )
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page())
+    _serve_job(mock_clients, ingest_api.IngestJobStatus.FAILED)
+    _serve_listing(mock_clients, _page())
 
-    with _polling(), pytest.raises(NominalIngestFailed, match="failed"):
-        list(job.as_files_ingested())
+    with pytest.raises(NominalIngestFailed, match="failed"):
+        list(job.as_files_ingested(poll_interval=FAST))
 
 
 def test_as_files_ingested_names_ingested_files_when_the_job_fails(mock_clients: MagicMock) -> None:
-    """A failing job's error names the files that did ingest, which the raise discards from list()."""
+    """The failure names the files that did ingest, so a partial result is still reconcilable."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
-    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
-        _job_bean(status=ingest_api.IngestJobStatus.FAILED)
-    )
-    file = _make_file("landed-file", [IngestStatus.SUCCESS])
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+    _serve_job(mock_clients, ingest_api.IngestJobStatus.FAILED)
+    _serve_listing(mock_clients, _page(_file_bean("landed", SUCCESS)))
+    _serve_refreshes(mock_clients, {"landed": SUCCESS})
 
-    with _polling(), pytest.raises(NominalIngestFailed, match="landed-file"):
-        list(job.as_files_ingested())
+    with pytest.raises(NominalIngestFailed, match="landed"):
+        list(job.as_files_ingested(poll_interval=FAST))
 
 
 def test_as_files_ingested_yields_without_raising_when_the_job_is_cancelled(mock_clients: MagicMock) -> None:
     """A cancelled job yields what did ingest instead of raising, since cancelling was the caller's ask."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
-    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
-        _job_bean(status=ingest_api.IngestJobStatus.CANCELLED)
-    )
-    file = _make_file("landed-file", [IngestStatus.SUCCESS])
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+    _serve_job(mock_clients, ingest_api.IngestJobStatus.CANCELLED)
+    _serve_listing(mock_clients, _page(_file_bean("landed", SUCCESS)))
+    _serve_refreshes(mock_clients, {"landed": SUCCESS})
 
-    with _polling():
-        yielded = list(job.as_files_ingested())
-
-    assert yielded == [file]
+    assert _ids(list(job.as_files_ingested(poll_interval=FAST))) == ["landed"]
 
 
 def test_as_files_ingested_stops_on_an_unrecognized_job_status(mock_clients: MagicMock) -> None:
-    """An unrecognized job status ends the wait instead of looping on it forever."""
+    """A job status this client does not recognize ends the wait instead of looping on it forever.
+
+    `IngestJobStatus.UNKNOWN` is what conjure decodes any status a newer server adds into, so this is
+    the forward-compatibility case exactly as it arrives.
+    """
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
-    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
-        _job_bean(status=ingest_api.IngestJobStatus.UNKNOWN)
-    )
-    file = _make_file("only-file", [IngestStatus.SUCCESS])
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+    _serve_job(mock_clients, ingest_api.IngestJobStatus.UNKNOWN)
+    _serve_listing(mock_clients, _page(_file_bean("only", SUCCESS)))
+    _serve_refreshes(mock_clients, {"only": SUCCESS})
 
-    with _polling():
-        yielded = list(job.as_files_ingested())
-
-    assert yielded == [file]
+    assert _ids(list(job.as_files_ingested(poll_interval=FAST))) == ["only"]
     assert job.status is IngestionJobStatus.UNKNOWN
 
 
 def test_as_files_ingested_raises_timeout_while_the_job_is_still_running(mock_clients: MagicMock) -> None:
     """An exhausted wait budget raises rather than blocking on a job that is still running."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
-    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
-        _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS)
-    )
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page())
+    _serve_job(mock_clients, ingest_api.IngestJobStatus.IN_PROGRESS)
+    _serve_listing(mock_clients, _page())
 
-    with _polling() as mock_sleep, pytest.raises(NominalIngestTimeout, match="in_progress"):
+    with pytest.raises(NominalIngestTimeout, match="in_progress"):
         list(job.as_files_ingested(timeout=timedelta(0)))
 
-    mock_sleep.assert_not_called()
 
-
-def test_as_files_ingested_does_not_sleep_past_the_timeout_deadline(mock_clients: MagicMock) -> None:
-    """A poll interval longer than the remaining budget is shortened to the budget, not slept in full."""
+def test_as_files_ingested_gives_up_on_the_timeout_not_a_full_poll_interval_later(mock_clients: MagicMock) -> None:
+    """A timeout shorter than the poll interval ends the wait when the budget runs out, not an interval later."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
-    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
-        _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS)
-    )
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page())
+    _serve_job(mock_clients, ingest_api.IngestJobStatus.IN_PROGRESS)
+    _serve_listing(mock_clients, _page())
 
-    with _polling() as mock_sleep, patch("nominal.core.dataset_file.time.monotonic", return_value=100.0):
-        # The frozen clock never reaches the deadline, so stop at the first sleep to inspect its length.
-        mock_sleep.side_effect = _StopPolling
-        with pytest.raises(_StopPolling):
-            list(job.as_files_ingested(poll_interval=timedelta(minutes=5), timeout=timedelta(seconds=2)))
+    started = time.monotonic()
+    with pytest.raises(NominalIngestTimeout):
+        list(job.as_files_ingested(poll_interval=timedelta(seconds=5), timeout=timedelta(seconds=0.05)))
 
-    mock_sleep.assert_called_once_with(2.0)
+    assert time.monotonic() - started < 2
 
 
 def test_as_files_ingested_timeout_names_the_pending_files_when_the_job_is_terminal(
@@ -380,11 +315,9 @@ def test_as_files_ingested_timeout_names_the_pending_files_when_the_job_is_termi
 ) -> None:
     """A timeout on a job that finished blames its still-ingesting files, not the job's own status."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
-    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
-        _job_bean(status=ingest_api.IngestJobStatus.COMPLETED)
-    )
-    file = _make_file("slow-file", [IngestStatus.IN_PROGRESS])
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+    _serve_job(mock_clients, ingest_api.IngestJobStatus.COMPLETED)
+    _serve_listing(mock_clients, _page(_file_bean("slow", IN_PROGRESS)))
+    _serve_refreshes(mock_clients, {"slow": IN_PROGRESS})
 
-    with _polling(), pytest.raises(NominalIngestTimeout, match="completed, but 1 of its file"):
+    with pytest.raises(NominalIngestTimeout, match="completed, but 1 of its file"):
         list(job.as_files_ingested(timeout=timedelta(0)))

--- a/tests/core/test_ingestion_job.py
+++ b/tests/core/test_ingestion_job.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from contextlib import contextmanager
 from datetime import timedelta
 from types import SimpleNamespace
@@ -216,6 +217,23 @@ def test_as_files_ingested_skips_relisting_files_while_the_produced_count_is_unc
 
     assert yielded == [file]
     assert mock_clients.catalog.get_dataset_files_for_job.call_count == 2
+
+
+def test_as_files_ingested_warns_when_fewer_files_listed_than_the_job_reports(
+    mock_clients: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Listing fewer files than the job's produced count is reported rather than passing silently."""
+    job = IngestionJob._from_conjure(
+        mock_clients, _job_bean(status=ingest_api.IngestJobStatus.COMPLETED, produced_file_count=3)
+    )
+    file = _make_file("only-file", [IngestStatus.SUCCESS])
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+
+    with _polling(), caplog.at_level(logging.WARNING):
+        yielded = list(job.as_files_ingested())
+
+    assert yielded == [file]
+    assert "reports 3 produced file(s) but only 1 could be listed" in caplog.text
 
 
 def test_as_files_ingested_yields_files_that_failed_to_ingest(mock_clients: MagicMock) -> None:

--- a/tests/core/test_ingestion_job.py
+++ b/tests/core/test_ingestion_job.py
@@ -366,13 +366,13 @@ def test_as_files_ingested_does_not_sleep_past_the_timeout_deadline(mock_clients
     )
     mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page())
 
-    with _polling() as mock_sleep:
-        # Sleep is mocked, so no wall-clock time passes; stop at the first sleep to inspect its length.
+    with _polling() as mock_sleep, patch("nominal.core.dataset_file.time.monotonic", return_value=100.0):
+        # The frozen clock never reaches the deadline, so stop at the first sleep to inspect its length.
         mock_sleep.side_effect = _StopPolling
         with pytest.raises(_StopPolling):
             list(job.as_files_ingested(poll_interval=timedelta(minutes=5), timeout=timedelta(seconds=2)))
 
-    assert 0 < mock_sleep.call_args.args[0] <= 2
+    mock_sleep.assert_called_once_with(2.0)
 
 
 def test_as_files_ingested_timeout_names_the_pending_files_when_the_job_is_terminal(

--- a/tests/core/test_ingestion_job.py
+++ b/tests/core/test_ingestion_job.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
+from datetime import timedelta
 from types import SimpleNamespace
+from typing import Callable, Iterator, Sequence
 from unittest.mock import MagicMock, patch
 
+import pytest
 from nominal_api import ingest_api
 
+from nominal.core.dataset_file import IngestStatus
+from nominal.core.exceptions import NominalIngestError
 from nominal.core.ingestion_job import IngestionJob, IngestionJobStatus
 
 
@@ -71,3 +77,223 @@ def test_dataset_files_paginates_and_maps(mock_clients: MagicMock) -> None:
     assert first_call.args == (mock_clients.auth_header, job.rid, None)
     second_call = mock_clients.catalog.get_dataset_files_for_job.call_args_list[1]
     assert second_call.args[2] == "t2"
+
+
+def _page(*files: object) -> SimpleNamespace:
+    """Build a single-page get_dataset_files_for_job response."""
+    return SimpleNamespace(files=list(files), next_page=None)
+
+
+def _responses(*values: object) -> Callable[..., object]:
+    """Successive mock responses, repeating the last one for any further calls."""
+    remaining = list(values)
+
+    def _next(*_args: object, **_kwargs: object) -> object:
+        return remaining.pop(0) if len(remaining) > 1 else remaining[0]
+
+    return _next
+
+
+def _make_file(file_id: str, statuses: Sequence[IngestStatus]) -> MagicMock:
+    """Build a stand-in dataset file whose ingest_status advances one step per batch refresh."""
+    file = MagicMock()
+    file.id = file_id
+    file.dataset_rid = "ri.catalog.test.dataset.def"
+    file.ingest_status = statuses[0]
+    observed = iter(statuses)
+    file._advance_status = lambda: setattr(file, "ingest_status", next(observed, statuses[-1]))
+    return file
+
+
+def _advance_polled_files(files: Sequence[MagicMock], **_kwargs: object) -> set[str]:
+    """Stand in for _batch_refresh_files: advance every polled file, report none absent."""
+    for file in files:
+        file._advance_status()
+    return set()
+
+
+@contextmanager
+def _polling() -> Iterator[MagicMock]:
+    """Patch out file refreshes, conjure file conversion, and sleeping; yield the sleep mock."""
+    with (
+        patch("nominal.core.dataset_file._batch_refresh_files", side_effect=_advance_polled_files),
+        patch("nominal.core.ingestion_job._dataset_file_from_conjure", side_effect=lambda _clients, file: file),
+        patch("nominal.core.ingestion_job.time.sleep") as mock_sleep,
+    ):
+        yield mock_sleep
+
+
+def test_as_files_ingested_waits_for_files_registered_after_the_call(mock_clients: MagicMock) -> None:
+    """Files that do not exist yet when the wait starts are still yielded once the job registers them."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
+    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
+        _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS),
+        _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS),
+        _job_bean(status=ingest_api.IngestJobStatus.COMPLETED),
+    )
+    first = _make_file("first-file", [IngestStatus.SUCCESS])
+    second = _make_file("second-file", [IngestStatus.SUCCESS])
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(
+        _page(),
+        _page(),
+        _page(first, second),
+    )
+
+    with _polling():
+        yielded = list(job.as_files_ingested())
+
+    assert yielded == [first, second]
+
+
+def test_as_files_ingested_yields_completed_files_while_the_job_is_still_running(mock_clients: MagicMock) -> None:
+    """A file that finishes ingesting is yielded without waiting for the job to reach a terminal status."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
+    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
+        _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS)
+    )
+    file = _make_file("only-file", [IngestStatus.SUCCESS])
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+
+    with _polling():
+        first_yielded = next(iter(job.as_files_ingested()))
+
+    assert first_yielded is file
+    assert job.status is IngestionJobStatus.IN_PROGRESS
+
+
+def test_as_files_ingested_does_not_poll_a_job_that_is_already_terminal(mock_clients: MagicMock) -> None:
+    """An already-completed job yields its files without re-fetching the job or sleeping."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.COMPLETED))
+    file = _make_file("only-file", [IngestStatus.SUCCESS])
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+
+    with _polling() as mock_sleep:
+        yielded = list(job.as_files_ingested())
+
+    assert yielded == [file]
+    mock_clients.ingest_jobs.get_ingest_job.assert_not_called()
+    mock_sleep.assert_not_called()
+
+
+def test_as_files_ingested_yields_each_file_once_when_the_list_grows(mock_clients: MagicMock) -> None:
+    """A file seen on an earlier poll is not yielded again when it reappears in a later file listing."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
+    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
+        _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS),
+        _job_bean(status=ingest_api.IngestJobStatus.COMPLETED),
+    )
+    first = _make_file("first-file", [IngestStatus.IN_PROGRESS, IngestStatus.SUCCESS])
+    second = _make_file("second-file", [IngestStatus.SUCCESS])
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(
+        _page(first),
+        _page(first, second),
+    )
+
+    with _polling():
+        yielded = list(job.as_files_ingested())
+
+    assert yielded == [first, second]
+
+
+def test_as_files_ingested_skips_relisting_files_while_the_produced_count_is_unchanged(
+    mock_clients: MagicMock,
+) -> None:
+    """The file list is not re-read on a poll where the job's produced file count has not moved."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
+    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
+        _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS, produced_file_count=1),
+        _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS, produced_file_count=1),
+        _job_bean(status=ingest_api.IngestJobStatus.COMPLETED, produced_file_count=1),
+    )
+    file = _make_file("only-file", [IngestStatus.IN_PROGRESS, IngestStatus.SUCCESS])
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+
+    with _polling():
+        yielded = list(job.as_files_ingested())
+
+    assert yielded == [file]
+    assert mock_clients.catalog.get_dataset_files_for_job.call_count == 2
+
+
+def test_as_files_ingested_yields_files_that_failed_to_ingest(mock_clients: MagicMock) -> None:
+    """A completed job's failed file is yielded rather than dropped, so the caller can see its status."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.COMPLETED))
+    failed = _make_file("failed-file", [IngestStatus.FAILED])
+    succeeded = _make_file("good-file", [IngestStatus.SUCCESS])
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(failed, succeeded))
+
+    with _polling():
+        yielded = list(job.as_files_ingested())
+
+    assert yielded == [failed, succeeded]
+    assert failed.ingest_status is IngestStatus.FAILED
+
+
+def test_as_files_ingested_yields_a_file_absent_from_the_batch_response(mock_clients: MagicMock) -> None:
+    """A file that disappears mid-wait is treated as done rather than polled forever."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.COMPLETED))
+    file = _make_file("deleted-file", [IngestStatus.IN_PROGRESS])
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+
+    with (
+        patch("nominal.core.dataset_file._batch_refresh_files", return_value={"deleted-file"}),
+        patch("nominal.core.ingestion_job._dataset_file_from_conjure", side_effect=lambda _clients, f: f),
+        patch("nominal.core.ingestion_job.time.sleep"),
+    ):
+        yielded = list(job.as_files_ingested())
+
+    assert yielded == [file]
+
+
+def test_as_files_ingested_raises_when_the_job_fails(mock_clients: MagicMock) -> None:
+    """A job that ends FAILED raises rather than quietly yielding nothing."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
+    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
+        _job_bean(status=ingest_api.IngestJobStatus.FAILED)
+    )
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page())
+
+    with _polling(), pytest.raises(NominalIngestError, match="FAILED"):
+        list(job.as_files_ingested())
+
+
+def test_as_files_ingested_raises_when_the_job_is_cancelled(mock_clients: MagicMock) -> None:
+    """A job that ends CANCELLED raises rather than quietly yielding nothing."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
+    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
+        _job_bean(status=ingest_api.IngestJobStatus.CANCELLED)
+    )
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page())
+
+    with _polling(), pytest.raises(NominalIngestError, match="CANCELLED"):
+        list(job.as_files_ingested())
+
+
+def test_as_files_ingested_stops_on_an_unrecognized_job_status(mock_clients: MagicMock) -> None:
+    """An unrecognized job status ends the wait instead of looping on it forever."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
+    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
+        _job_bean(status=ingest_api.IngestJobStatus.UNKNOWN)
+    )
+    file = _make_file("only-file", [IngestStatus.SUCCESS])
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+
+    with _polling():
+        yielded = list(job.as_files_ingested())
+
+    assert yielded == [file]
+    assert job.status is IngestionJobStatus.UNKNOWN
+
+
+def test_as_files_ingested_raises_timeout_while_the_job_is_still_running(mock_clients: MagicMock) -> None:
+    """An exhausted wait budget raises TimeoutError instead of blocking on a job that is still running."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
+    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
+        _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS)
+    )
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page())
+
+    with _polling() as mock_sleep, pytest.raises(TimeoutError, match="IN_PROGRESS"):
+        list(job.as_files_ingested(timeout=timedelta(0)))
+
+    mock_sleep.assert_not_called()

--- a/tests/core/test_ingestion_job.py
+++ b/tests/core/test_ingestion_job.py
@@ -39,6 +39,12 @@ def _job_bean(**overrides: object) -> ingest_api.IngestJob:
     return ingest_api.IngestJob(**kwargs)
 
 
+def test_from_conjure_unknown_status_falls_back_to_unknown() -> None:
+    """An unrecognized wire status name maps to UNKNOWN for forward-compatibility."""
+    future = SimpleNamespace(name="SOME_FUTURE_STATUS")
+    assert IngestionJobStatus._from_conjure(future) is IngestionJobStatus.UNKNOWN
+
+
 def test_cancel_calls_service_and_refreshes(mock_clients: MagicMock) -> None:
     """cancel() calls the cancel endpoint and refreshes the job in place from the response."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
@@ -122,7 +128,7 @@ def _polling() -> Iterator[MagicMock]:
     with (
         patch("nominal.core.dataset_file._batch_refresh_files", side_effect=_advance_polled_files),
         patch("nominal.core.ingestion_job._dataset_file_from_conjure", side_effect=lambda _clients, file: file),
-        patch("nominal.core.ingestion_job.time.sleep") as mock_sleep,
+        patch("nominal.core.dataset_file.time.sleep") as mock_sleep,
     ):
         yield mock_sleep
 
@@ -275,7 +281,7 @@ def test_as_files_ingested_yields_a_file_absent_from_the_batch_response(mock_cli
     with (
         patch("nominal.core.dataset_file._batch_refresh_files", return_value={"deleted-file"}),
         patch("nominal.core.ingestion_job._dataset_file_from_conjure", side_effect=lambda _clients, f: f),
-        patch("nominal.core.ingestion_job.time.sleep"),
+        patch("nominal.core.dataset_file.time.sleep"),
     ):
         yielded = list(job.as_files_ingested())
 
@@ -367,3 +373,18 @@ def test_as_files_ingested_does_not_sleep_past_the_timeout_deadline(mock_clients
             list(job.as_files_ingested(poll_interval=timedelta(minutes=5), timeout=timedelta(seconds=2)))
 
     assert 0 < mock_sleep.call_args.args[0] <= 2
+
+
+def test_as_files_ingested_timeout_names_the_pending_files_when_the_job_is_terminal(
+    mock_clients: MagicMock,
+) -> None:
+    """A timeout on a job that finished blames its still-ingesting files, not the job's own status."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
+    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
+        _job_bean(status=ingest_api.IngestJobStatus.COMPLETED)
+    )
+    file = _make_file("slow-file", [IngestStatus.IN_PROGRESS])
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+
+    with _polling(), pytest.raises(NominalIngestTimeout, match="completed, but 1 of its file"):
+        list(job.as_files_ingested(timeout=timedelta(0)))

--- a/tests/core/test_ingestion_job.py
+++ b/tests/core/test_ingestion_job.py
@@ -95,20 +95,25 @@ def _responses(*values: object) -> Callable[..., object]:
 
 
 def _make_file(file_id: str, statuses: Sequence[IngestStatus]) -> MagicMock:
-    """Build a stand-in dataset file whose ingest_status advances one step per batch refresh."""
+    """Build a stand-in dataset file whose ingest_status advances one step per refresh."""
     file = MagicMock()
     file.id = file_id
     file.dataset_rid = "ri.catalog.test.dataset.def"
     file.ingest_status = statuses[0]
     observed = iter(statuses)
-    file._advance_status = lambda: setattr(file, "ingest_status", next(observed, statuses[-1]))
+
+    def refresh(_: object) -> MagicMock:
+        file.ingest_status = next(observed, statuses[-1])
+        return file
+
+    file._refresh_from_api.side_effect = refresh
     return file
 
 
 def _advance_polled_files(files: Sequence[MagicMock], **_kwargs: object) -> set[str]:
-    """Stand in for _batch_refresh_files: advance every polled file, report none absent."""
+    """Stand in for _batch_refresh_files: refresh every polled file, report none absent."""
     for file in files:
-        file._advance_status()
+        file._refresh_from_api(None)
     return set()
 
 

--- a/tests/core/test_ingestion_job.py
+++ b/tests/core/test_ingestion_job.py
@@ -10,8 +10,12 @@ import pytest
 from nominal_api import ingest_api
 
 from nominal.core.dataset_file import IngestStatus
-from nominal.core.exceptions import NominalIngestError
+from nominal.core.exceptions import NominalIngestFailed, NominalIngestTimeout
 from nominal.core.ingestion_job import IngestionJob, IngestionJobStatus
+
+
+class _StopPolling(Exception):
+    """Raised from a mocked sleep to end a wait loop that would otherwise never reach its deadline."""
 
 
 def _job_bean(**overrides: object) -> ingest_api.IngestJob:
@@ -32,12 +36,6 @@ def _job_bean(**overrides: object) -> ingest_api.IngestJob:
     )
     kwargs.update(overrides)
     return ingest_api.IngestJob(**kwargs)
-
-
-def test_from_conjure_unknown_status_falls_back_to_unknown() -> None:
-    """An unrecognized wire status name maps to UNKNOWN for forward-compatibility."""
-    future = SimpleNamespace(name="SOME_FUTURE_STATUS")
-    assert IngestionJobStatus._from_conjure(future) is IngestionJobStatus.UNKNOWN
 
 
 def test_cancel_calls_service_and_refreshes(mock_clients: MagicMock) -> None:
@@ -258,20 +256,36 @@ def test_as_files_ingested_raises_when_the_job_fails(mock_clients: MagicMock) ->
     )
     mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page())
 
-    with _polling(), pytest.raises(NominalIngestError, match="FAILED"):
+    with _polling(), pytest.raises(NominalIngestFailed, match="failed"):
         list(job.as_files_ingested())
 
 
-def test_as_files_ingested_raises_when_the_job_is_cancelled(mock_clients: MagicMock) -> None:
-    """A job that ends CANCELLED raises rather than quietly yielding nothing."""
+def test_as_files_ingested_names_ingested_files_when_the_job_fails(mock_clients: MagicMock) -> None:
+    """A failing job's error names the files that did ingest, which the raise discards from list()."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
+    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
+        _job_bean(status=ingest_api.IngestJobStatus.FAILED)
+    )
+    file = _make_file("landed-file", [IngestStatus.SUCCESS])
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
+
+    with _polling(), pytest.raises(NominalIngestFailed, match="landed-file"):
+        list(job.as_files_ingested())
+
+
+def test_as_files_ingested_yields_without_raising_when_the_job_is_cancelled(mock_clients: MagicMock) -> None:
+    """A cancelled job yields what did ingest instead of raising, since cancelling was the caller's ask."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
     mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
         _job_bean(status=ingest_api.IngestJobStatus.CANCELLED)
     )
-    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page())
+    file = _make_file("landed-file", [IngestStatus.SUCCESS])
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page(file))
 
-    with _polling(), pytest.raises(NominalIngestError, match="CANCELLED"):
-        list(job.as_files_ingested())
+    with _polling():
+        yielded = list(job.as_files_ingested())
+
+    assert yielded == [file]
 
 
 def test_as_files_ingested_stops_on_an_unrecognized_job_status(mock_clients: MagicMock) -> None:
@@ -291,14 +305,31 @@ def test_as_files_ingested_stops_on_an_unrecognized_job_status(mock_clients: Mag
 
 
 def test_as_files_ingested_raises_timeout_while_the_job_is_still_running(mock_clients: MagicMock) -> None:
-    """An exhausted wait budget raises TimeoutError instead of blocking on a job that is still running."""
+    """An exhausted wait budget raises rather than blocking on a job that is still running."""
     job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
     mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
         _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS)
     )
     mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page())
 
-    with _polling() as mock_sleep, pytest.raises(TimeoutError, match="IN_PROGRESS"):
+    with _polling() as mock_sleep, pytest.raises(NominalIngestTimeout, match="in_progress"):
         list(job.as_files_ingested(timeout=timedelta(0)))
 
     mock_sleep.assert_not_called()
+
+
+def test_as_files_ingested_does_not_sleep_past_the_timeout_deadline(mock_clients: MagicMock) -> None:
+    """A poll interval longer than the remaining budget is shortened to the budget, not slept in full."""
+    job = IngestionJob._from_conjure(mock_clients, _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS))
+    mock_clients.ingest_jobs.get_ingest_job.side_effect = _responses(
+        _job_bean(status=ingest_api.IngestJobStatus.IN_PROGRESS)
+    )
+    mock_clients.catalog.get_dataset_files_for_job.side_effect = _responses(_page())
+
+    with _polling() as mock_sleep:
+        # Sleep is mocked, so no wall-clock time passes; stop at the first sleep to inspect its length.
+        mock_sleep.side_effect = _StopPolling
+        with pytest.raises(_StopPolling):
+            list(job.as_files_ingested(poll_interval=timedelta(minutes=5), timeout=timedelta(seconds=2)))
+
+    assert 0 < mock_sleep.call_args.args[0] <= 2


### PR DESCRIPTION
<!-- This is a public repo: reminder to abide by the Nominal Public Repo Handbook. -->

`IngestionJob.as_files_ingested()` now waits out both stages of an ingest — the job producing its files, then those files ingesting — rather than only waiting on the files that already existed when it was called.

This mainly matters for containerized extractors. A manifest extractor registers all of its outputs at once, when its container exits, so a wait started right after triggering the ingest found an empty file list and returned straight away. The file list is now re-read on each poll for as long as the job is running, so those outputs are picked up as the job registers them.

## User-facing changes

- `list(job.as_files_ingested())` blocks until the job is terminal and every file it produced has finished ingesting. For a containerized ingest it previously returned immediately, often with nothing.
- A job that ends `FAILED` raises `NominalIngestFailed`, naming the files that did ingest. A job that ends `CANCELLED` yields whatever ingested and logs a warning — cancelling is the caller's own request, via this class's `cancel()`.
- New optional `timeout` argument, raising `NominalIngestTimeout`. The error names whichever stage the wait was blocked on: the job's status while it is still running, otherwise how many of its files were still ingesting.
- Files still yield as they finish, so single-output ingests behave as they did before.
- `Dataset.add_containerized` and the extractor README no longer describe the two-stage manual wait, which is now unnecessary.

## Fixes to the existing file waiter

The job waiter needed a poll that respects a deadline, and `wait_for_files_to_ingest` already had a weaker version of one. Rather than write a second, both now share it — which fixes two things for callers of the existing function:

- `wait_for_files_to_ingest` no longer sleeps a full `poll_interval` past its own `timeout`. Previously a 1s timeout with a 60s poll interval could block for 60s.
- Both waiters bound their timeout on a monotonic clock rather than the wall clock, so an NTP step mid-wait no longer stretches the budget or expires it early.

## Forward compatibility

An unrecognized file ingest status maps to `IngestStatus.UNKNOWN` instead of raising `ValueError`, mirroring `IngestionJobStatus` and `IngestType`. A wait treats an unrecognized status as done rather than crashing or looping on it.

To be precise about what this does and does not cover: it handles a `nominal-api` bump that adds an `IngestStatusV2` variant this client has not mapped yet. It does not make the client tolerant of a *server* ahead of its pinned `nominal-api` — conjure raises on an unknown union variant while decoding the response, before any of this client's code runs. The job-status axis does not have that limitation, since conjure decodes an unrecognized enum value to `IngestJobStatus.UNKNOWN`.

## Tests

Adds tests for the job-level waiter, which previously had none. They drive the wait through the conjure clients — scripting the two endpoints it calls and asserting on the files a caller is yielded — rather than patching module internals or the clock, so the conjure conversion, the batch refresh, and the poll loop all run for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
