### PR TITLE
chore: bump nominal API packages to 0.1437.0

### DIFF
--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -1571,6 +1571,7 @@ def _create_dataset(
     marking_rids: Sequence[str] | None = None,
 ) -> scout_catalog.EnrichedDataset:
     request = scout_catalog.CreateDataset(
+        channel_search_split_tag_keys=[],
         name=name,
         description=description,
         labels=list(labels),

--- a/nominal/experimental/compute_as_code/_derived_datasets.py
+++ b/nominal/experimental/compute_as_code/_derived_datasets.py
@@ -52,6 +52,7 @@ def create_derived_dataset(
         Reference to the created derived dataset in Nominal.
     """
     request = scout_catalog.CreateDataset(
+        channel_search_split_tag_keys=[],
         name=name,
         description=description,
         labels=list(labels),

--- a/nominal/experimental/dataset_utils/_dataset_utils.py
+++ b/nominal/experimental/dataset_utils/_dataset_utils.py
@@ -40,6 +40,7 @@ def create_dataset_with_uuid(
         Reference to the created dataset in Nominal.
     """
     create_dataset_request = scout_catalog.CreateDataset(
+        channel_search_split_tag_keys=[],
         name=name,
         description=description,
         labels=list(labels),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "conjure-python-client>=3.1.0,<4",
     "exceptiongroup>=1.3.0",
-    "nominal-api==0.1379.0",
-    "nominal-api-protos==0.1379.0",
+    "nominal-api==0.1437.0",
+    "nominal-api-protos==0.1437.0",
     "truststore>=0.10.4",
     "typing-extensions>=4,<5",
     "pandas>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -798,8 +798,8 @@ requires-dist = [
     { name = "conjure-python-client", specifier = ">=3.1.0,<4" },
     { name = "exceptiongroup", specifier = ">=1.3.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
-    { name = "nominal-api", specifier = "==0.1379.0" },
-    { name = "nominal-api-protos", specifier = "==0.1379.0" },
+    { name = "nominal-api", specifier = "==0.1437.0" },
+    { name = "nominal-api-protos", specifier = "==0.1437.0" },
     { name = "nominal-compute", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin' and extra == 'compute') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'compute') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'compute') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32' and extra == 'compute')", specifier = "==0.1315.0" },
     { name = "nominal-streaming", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')", specifier = "==0.9.6" },
     { name = "nominal-tdms", marker = "extra == 'tdms'", editable = "packages/nominal-tdms" },
@@ -841,19 +841,19 @@ dev = [
 
 [[package]]
 name = "nominal-api"
-version = "0.1379.0"
+version = "0.1437.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "conjure-python-client" },
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/56/d32189b617c03465d72ae91131233d30e177fee6cba84acf96d1cfd4bc4f/nominal_api-0.1379.0-py3-none-any.whl", hash = "sha256:bad6f3722201c2597054f54b355dfaf3d623ffedaae1b2fe0228d76e85d92877", size = 956356, upload-time = "2026-08-11T17:02:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/95/02/606712203c579115ec249fd06a0c914b9487ff9756892d1da06d5055de17/nominal_api-0.1437.0-py3-none-any.whl", hash = "sha256:128f5aa81b89a327189e6b98778ff37ca01ca2804078e674c6a11028d87658b5", size = 1011045, upload-time = "2026-09-09T20:32:16.862Z" },
 ]
 
 [[package]]
 name = "nominal-api-protos"
-version = "0.1379.0"
+version = "0.1437.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -861,7 +861,7 @@ dependencies = [
     { name = "protobuf" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/d8/64b92d5a3d9412d6720f6e20fc81ef44c713e7092cc48931988b9346bfb7/nominal_api_protos-0.1379.0-py3-none-any.whl", hash = "sha256:a130c438c3651cdf700b5e8ccb1c9b91c4979b765ddfe004a4f4e3497b442646", size = 675212, upload-time = "2026-08-11T17:02:50.606Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3a/eab1358c8ed12f05f7190851dc7414be721c8d04b78b9c9182c06f232c94/nominal_api_protos-0.1437.0-py3-none-any.whl", hash = "sha256:1972eca770b26623028b2b6aa28a5777b58a5273a448979b91718b2fae91a19d", size = 745562, upload-time = "2026-09-09T20:32:18.26Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bump `nominal-api` and `nominal-api-protos` from 0.1379.0 to 0.1437.0, making the newly released RunService gRPC API available to the next PR in this stack.

The new `CreateDataset` constructor requires `channel_search_split_tag_keys`. Pass an empty list in the standard, derived-dataset, and explicit-UUID creation paths to preserve existing behavior. Keep the lockfile update scoped to the two API packages.

Validation: 980 unit tests passed, 1 skipped (GStreamer unavailable); mypy passed for 163 source files; Ruff lint/format and `uv lock --check --offline` passed.

Stack: this PR → #962 (RunService gRPC port). Merge this PR first.
