### PR TITLE
refactor: migrate RunService to gRPC

### DIFF
--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -43,6 +43,7 @@ from nominal.protos.comments.v1 import comments_pb2_grpc
 from nominal.protos.event.v2 import event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc, ingest_service_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2_grpc
+from nominal.protos.run.v1 import run_service_pb2_grpc
 from nominal.protos.sandbox.v1 import sandbox_workspace_pb2_grpc
 from nominal.protos.secrets.v1 import secrets_pb2_grpc
 from nominal.protos.units.v1 import units_pb2_grpc
@@ -161,7 +162,6 @@ class ClientsBunch:
     ingest: ingest_api.IngestService
     notebook: scout.NotebookService
     proto_write: ProtoWriteService
-    run: scout.RunService
     series_metadata: timeseries_metadata.SeriesMetadataService
     storage_writer: storage_writer_api.NominalChannelWriterService
     storage: storage_datasource_api.NominalDataSourceService
@@ -171,6 +171,7 @@ class ClientsBunch:
     video: scout_video.VideoService
 
     # GRPC services
+    run: run_service_pb2_grpc.RunServiceStub
     comments: comments_pb2_grpc.CommentsServiceStub
     containerized_extractor: containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub
     event: event_pb2_grpc.EventServiceStub
@@ -327,7 +328,6 @@ class ClientsBunch:
             ingest=client_factory(ingest_api.IngestService),
             notebook=client_factory(scout.NotebookService),
             proto_write=client_factory(ProtoWriteService),
-            run=client_factory(scout.RunService),
             series_metadata=client_factory(timeseries_metadata.SeriesMetadataService),
             storage_writer=client_factory(storage_writer_api.NominalChannelWriterService),
             storage=client_factory(storage_datasource_api.NominalDataSourceService),
@@ -336,6 +336,7 @@ class ClientsBunch:
             video_file=client_factory(scout_video.VideoFileService),
             video=client_factory(scout_video.VideoService),
             # GRPC Service Stubs
+            run=grpc_factory(run_service_pb2_grpc.RunServiceStub),
             comments=grpc_factory(comments_pb2_grpc.CommentsServiceStub),
             containerized_extractor=grpc_factory(containerized_extractor_pb2_grpc.ContainerizedExtractorServiceStub),
             event=grpc_factory(event_pb2_grpc.EventServiceStub),

--- a/nominal/core/_utils/api_tools.py
+++ b/nominal/core/_utils/api_tools.py
@@ -108,17 +108,22 @@ class LinkDict(TypedDict):
     title: NotRequired[str]
 
 
-def create_links(links: Sequence[str | Link | LinkDict]) -> list[scout_run_api.Link]:
-    links_conjure = []
+def normalize_links(links: Sequence[str | Link | LinkDict]) -> list[tuple[str, str | None]]:
+    """Reduce every accepted link spelling -- url, (url, title), or dict -- to (url, title) pairs."""
+    normalized: list[tuple[str, str | None]] = []
     for link in links:
         if isinstance(link, tuple):
             url, title = link
-            links_conjure.append(scout_run_api.Link(url=url, title=title))
+            normalized.append((url, title))
         elif isinstance(link, dict):
-            links_conjure.append(scout_run_api.Link(url=link["url"], title=link.get("title")))
+            normalized.append((link["url"], link.get("title")))
         else:
-            links_conjure.append(scout_run_api.Link(url=link))
-    return links_conjure
+            normalized.append((link, None))
+    return normalized
+
+
+def create_links(links: Sequence[str | Link | LinkDict]) -> list[scout_run_api.Link]:
+    return [scout_run_api.Link(url=url, title=title) for url, title in normalize_links(links)]
 
 
 def create_api_tags(tags: Mapping[str, str] | None = None) -> dict[str, scout_compute_api.StringConstant]:

--- a/nominal/core/_utils/pagination_tools.py
+++ b/nominal/core/_utils/pagination_tools.py
@@ -13,7 +13,6 @@ from nominal_api import (
     scout_checks_api,
     scout_datareview_api,
     scout_notebook_api,
-    scout_run_api,
     scout_template_api,
     scout_video,
     scout_video_api,
@@ -25,6 +24,7 @@ from nominal.protos.authorization.markings.v1 import markings_pb2, markings_pb2_
 from nominal.protos.event.v2 import event_pb2, event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2, containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2, registry_pb2_grpc
+from nominal.protos.run.v1 import run_service_pb2, run_service_pb2_grpc
 from nominal.protos.secrets.v1 import secrets_pb2, secrets_pb2_grpc
 
 DEFAULT_PAGE_SIZE = 100
@@ -211,36 +211,36 @@ def search_checklists_paginated(
 
 
 def search_runs_paginated(
-    run: scout.RunService,
-    auth_header: str,
-    query: scout_run_api.SearchQuery,
+    run: run_service_pb2_grpc.RunServiceStub,
+    query: run_service_pb2.SearchQuery,
     archive_status: ArchiveStatusFilter = ArchiveStatusFilter.NOT_ARCHIVED,
-) -> Iterable[scout_run_api.Run]:
-    def factory(page_token: str | None) -> scout_run_api.SearchRunsRequest:
-        return scout_run_api.SearchRunsRequest(
+) -> Iterable[run_service_pb2.Run]:
+    def factory(page_token: str | None) -> run_service_pb2.SearchRunsRequest:
+        return run_service_pb2.SearchRunsRequest(
             page_size=DEFAULT_PAGE_SIZE,
             query=query,
-            sort=scout_run_api.SortOptions(
-                field=scout_run_api.SortField.START_TIME,
+            sort=run_service_pb2.SortOptions(
+                field=run_service_pb2.START_TIME,
                 is_descending=True,
             ),
-            archived_statuses=archive_status.to_api_archived_statuses(),
+            archived_statuses=run_service_pb2.ArchivedStatusSet(
+                archived_statuses=archive_status.to_proto_archived_statuses()
+            ),
             next_page_token=page_token,
         )
 
-    for response in paginate_rpc(run.search_runs, auth_header, request_factory=factory):
+    for response in paginate_grpc(run.SearchRuns, request_factory=factory):
         yield from response.results
 
 
 def search_runs_by_asset_paginated(
-    run: scout.RunService,
-    auth_header: str,
+    run: run_service_pb2_grpc.RunServiceStub,
     asset_rid: str,
-) -> Iterable[scout_run_api.Run]:
-    def factory(page_token: str | None) -> scout_run_api.GetRunsByAssetRequest:
-        return scout_run_api.GetRunsByAssetRequest(asset=asset_rid, next_page_token=page_token)
+) -> Iterable[run_service_pb2.Run]:
+    def factory(page_token: str | None) -> run_service_pb2.GetRunsByAssetRequest:
+        return run_service_pb2.GetRunsByAssetRequest(asset=asset_rid, next_page_token=page_token)
 
-    for response in paginate_rpc(run.get_runs_by_asset, auth_header, request_factory=factory):
+    for response in paginate_grpc(run.GetRunsByAsset, request_factory=factory):
         yield from response.results
 
 

--- a/nominal/core/_utils/query_tools.py
+++ b/nominal/core/_utils/query_tools.py
@@ -12,8 +12,6 @@ from nominal_api import (
     scout_catalog,
     scout_checks_api,
     scout_notebook_api,
-    scout_rids_api,
-    scout_run_api,
     scout_template_api,
     scout_video_api,
 )
@@ -23,6 +21,7 @@ from nominal.core._utils.api_tools import rid_from_instance_or_string
 from nominal.protos.authorization.markings.v1 import markings_pb2
 from nominal.protos.event.v2 import event_pb2
 from nominal.protos.registry.v2 import registry_pb2
+from nominal.protos.run.v1 import run_service_pb2
 from nominal.protos.secrets.v1 import secrets_pb2
 from nominal.protos.types import types_pb2
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
@@ -414,63 +413,63 @@ def create_search_runs_query(
     created_after: str | datetime | IntegralNanosecondsUTC | None = None,
     created_before: str | datetime | IntegralNanosecondsUTC | None = None,
     workspace_rid: str | None = None,
-) -> scout_run_api.SearchQuery:
+) -> run_service_pb2.SearchQuery:
     queries = []
     if start is not None:
-        start_time = _SecondsNanos.from_flexible(start).to_scout_run_api()
+        start_time = _SecondsNanos.from_flexible(start).to_run_proto()
         queries.append(
-            scout_run_api.SearchQuery(
-                start_time=scout_run_api.TimeframeFilter(
-                    custom=scout_run_api.CustomTimeframeFilter(start_time=start_time, end_time=None)
+            run_service_pb2.SearchQuery(
+                start_time=run_service_pb2.TimeframeFilter(
+                    custom=run_service_pb2.CustomTimeframeFilter(start_time=start_time, end_time=None)
                 )
             )
         )
     if end is not None:
-        end_time = _SecondsNanos.from_flexible(end).to_scout_run_api()
+        end_time = _SecondsNanos.from_flexible(end).to_run_proto()
         queries.append(
-            scout_run_api.SearchQuery(
-                end_time=scout_run_api.TimeframeFilter(
-                    custom=scout_run_api.CustomTimeframeFilter(start_time=None, end_time=end_time)
+            run_service_pb2.SearchQuery(
+                end_time=run_service_pb2.TimeframeFilter(
+                    custom=run_service_pb2.CustomTimeframeFilter(start_time=None, end_time=end_time)
                 )
             )
         )
     if created_after is not None or created_before is not None:
         created_after_time = (
-            _SecondsNanos.from_flexible(created_after).to_scout_run_api() if created_after is not None else None
+            _SecondsNanos.from_flexible(created_after).to_run_proto() if created_after is not None else None
         )
         created_before_time = (
-            _SecondsNanos.from_flexible(created_before).to_scout_run_api() if created_before is not None else None
+            _SecondsNanos.from_flexible(created_before).to_run_proto() if created_before is not None else None
         )
         queries.append(
-            scout_run_api.SearchQuery(
-                created_at=scout_run_api.TimeframeFilter(
-                    custom=scout_run_api.CustomTimeframeFilter(
+            run_service_pb2.SearchQuery(
+                created_at=run_service_pb2.TimeframeFilter(
+                    custom=run_service_pb2.CustomTimeframeFilter(
                         start_time=created_after_time, end_time=created_before_time
                     )
                 )
             )
         )
     if name_substring is not None:
-        queries.append(scout_run_api.SearchQuery(exact_match=name_substring))
+        queries.append(run_service_pb2.SearchQuery(exact_match=name_substring))
     if labels:
         queries.append(
-            scout_run_api.SearchQuery(
-                labels=scout_rids_api.LabelsFilter(labels=list(labels), operator=api.SetOperator.AND)
+            run_service_pb2.SearchQuery(
+                labels=run_service_pb2.LabelsFilter(labels=list(labels), operator=run_service_pb2.AND)
             )
         )
     if properties:
         for name, value in properties.items():
             # original properties is a 1:1 map, so we will never have multiple values for the same name
             queries.append(
-                scout_run_api.SearchQuery(properties=scout_rids_api.PropertiesFilter(name=name, values=[value]))
+                run_service_pb2.SearchQuery(properties=run_service_pb2.PropertiesFilter(name=name, values=[value]))
             )
     if exact_match is not None:
-        queries.append(scout_run_api.SearchQuery(exact_match=exact_match))
+        queries.append(run_service_pb2.SearchQuery(exact_match=exact_match))
     if search_text is not None:
-        queries.append(scout_run_api.SearchQuery(search_text=search_text))
+        queries.append(run_service_pb2.SearchQuery(search_text=search_text))
     if workspace_rid is not None:
-        queries.append(scout_run_api.SearchQuery(workspace=workspace_rid))
-    return scout_run_api.SearchQuery(and_=queries)
+        queries.append(run_service_pb2.SearchQuery(workspace=workspace_rid))
+    return run_service_pb2.SearchQuery(all_of=run_service_pb2.SearchQueryList(queries=queries))
 
 
 def create_search_workbooks_query(

--- a/nominal/core/asset.py
+++ b/nominal/core/asset.py
@@ -7,7 +7,6 @@ from types import MappingProxyType
 from typing import Iterable, Mapping, Protocol, Sequence, TypeAlias
 
 from nominal_api import (
-    scout,
     scout_asset_api,
     scout_assets,
     scout_run_api,
@@ -40,6 +39,7 @@ from nominal.core.exceptions import LegacyVideoDeprecationWarning
 from nominal.core.video import Video, _create_video, _get_video
 from nominal.core.workbook import Workbook, _search_workbooks
 from nominal.protos.comments.v1 import comments_pb2_grpc
+from nominal.protos.run.v1 import run_service_pb2_grpc
 from nominal.ts import IntegralNanosecondsDuration, IntegralNanosecondsUTC, _SecondsNanos
 
 ScopeType: TypeAlias = Connection | Dataset | Video
@@ -75,7 +75,7 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
         @property
         def comments(self) -> comments_pb2_grpc.CommentsServiceStub: ...
         @property
-        def run(self) -> scout.RunService: ...
+        def run(self) -> run_service_pb2_grpc.RunServiceStub: ...
 
     @property
     def nominal_url(self) -> str:
@@ -89,6 +89,12 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
         if len(response) > 1:
             raise ValueError(f"multiple assets found with RID {self.rid!r}: {response!r}")
         return response[self.rid]
+
+    def _lookup_dataset_scope(self, data_scope_name: str) -> tuple[str, Mapping[str, str]] | None:
+        for scope in self._list_dataset_scopes():
+            if scope.data_scope_name == data_scope_name and scope.data_source.dataset is not None:
+                return scope.data_source.dataset, scope.series_tags
+        return None
 
     def _list_dataset_scopes(self) -> Sequence[scout_asset_api.DataScope]:
         return filter_scopes(self._get_latest_api().data_scopes, "dataset")
@@ -588,10 +594,9 @@ class Asset(_DatasetWrapper, HasRid, RefreshableConjureMixin[scout_asset_api.Ass
     def list_runs(self) -> Sequence[Run]:
         """List all runs associated with this Asset."""
         return [
-            Run._from_conjure(self._clients, run)
+            Run._from_proto(self._clients, run)
             for run in search_runs_by_asset_paginated(
                 self._clients.run,
-                self._clients.auth_header,
                 self.rid,
             )
         ]

--- a/nominal/core/client.py
+++ b/nominal/core/client.py
@@ -112,7 +112,7 @@ from nominal.core.marking import (
     _marking_rids,
     _search_markings,
 )
-from nominal.core.run import Run, _create_run
+from nominal.core.run import Run, _create_run, _get_run
 from nominal.core.secret import Secret
 from nominal.core.streaming_checklist import _iter_list_streaming_checklists
 from nominal.core.unit import Unit, _available_units
@@ -740,8 +740,7 @@ class NominalClient:
             Reference to the created run object
 
         Raises:
-            ValueError: both `asset` and `assets` provided
-            ConjureHTTPError: error making request
+            NominalError: If the run service request fails.
 
         """
         if assets is None:
@@ -762,8 +761,7 @@ class NominalClient:
 
     def get_run(self, rid: str) -> Run:
         """Retrieve a run by its RID."""
-        response = self._clients.run.get_run(self._clients.auth_header, rid)
-        return Run._from_conjure(self._clients, response)
+        return _get_run(self._clients, rid)
 
     def _iter_search_runs(
         self,
@@ -791,8 +789,8 @@ class NominalClient:
             created_before=created_before,
             workspace_rid=workspace_rid,
         )
-        for run in search_runs_paginated(self._clients.run, self._clients.auth_header, query, archive_status):
-            yield Run._from_conjure(self._clients, run)
+        for run in search_runs_paginated(self._clients.run, query, archive_status):
+            yield Run._from_proto(self._clients, run)
 
     def search_runs(
         self,

--- a/nominal/core/data_review.py
+++ b/nominal/core/data_review.py
@@ -6,7 +6,6 @@ from time import sleep
 from typing import TYPE_CHECKING, Iterable, Protocol, Sequence
 
 from nominal_api import (
-    scout,
     scout_api,
     scout_checklistexecution_api,
     scout_checks_api,
@@ -23,6 +22,7 @@ from nominal.core._utils.pagination_tools import search_data_reviews_paginated
 from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.core.event import Event, _get_events
 from nominal.protos.event.v2 import event_pb2_grpc
+from nominal.protos.run.v1 import run_service_pb2_grpc
 from nominal.ts import IntegralNanosecondsUTC, _SecondsNanos
 
 if TYPE_CHECKING:
@@ -53,7 +53,7 @@ class DataReview(HasRid):
         @property
         def event(self) -> event_pb2_grpc.EventServiceStub: ...
         @property
-        def run(self) -> scout.RunService: ...
+        def run(self) -> run_service_pb2_grpc.RunServiceStub: ...
 
     @classmethod
     def _from_conjure(cls, clients: _Clients, data_review: scout_datareview_api.DataReview) -> Self:
@@ -189,7 +189,9 @@ class DataReviewBuilder:
         run_rid = rid_from_instance_or_string(run)
         asset_rid = None if asset is None else rid_from_instance_or_string(asset)
 
-        raw_run = self._clients.run.get_run(self._clients.auth_header, run_rid)
+        from nominal.core.run import _get_run_proto
+
+        raw_run = _get_run_proto(self._clients.run, run_rid)
         if len(raw_run.assets) > 1 and asset is None:
             raise ValueError(
                 f"Cannot run data review on checklist {checklist_rid} and {run_rid} without specifying `asset_rid`: "

--- a/nominal/core/dataset.py
+++ b/nominal/core/dataset.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import BinaryIO, Iterable, Mapping, Sequence, TypeAlias, overload
 
-from nominal_api import api, ingest_api, scout_asset_api, scout_catalog, scout_video_api
+from nominal_api import api, ingest_api, scout_catalog, scout_video_api
 from typing_extensions import Self
 
 from nominal.core._stream.batch_processor import process_log_batch
@@ -1232,18 +1232,18 @@ class _DatasetWrapper(abc.ABC):
     - Some formats cannot be safely tagged with scope tags; those wrapper methods raise `RuntimeError` when the selected
       scope requires tags.
 
-    Subclasses must implement `_list_dataset_scopes`, which is used to resolve scopes.
+    Subclasses must implement `_lookup_dataset_scope`, which is used to resolve scopes.
     """
 
     # static typing for required field
     _clients: Dataset._Clients
 
     @abc.abstractmethod
-    def _list_dataset_scopes(self) -> Sequence[scout_asset_api.DataScope]:
-        """Return the data scopes available to this wrapper.
+    def _lookup_dataset_scope(self, data_scope_name: str) -> tuple[str, Mapping[str, str]] | None:
+        """The backing dataset rid and required series tags of the named scope, or None if there is none.
 
-        Subclasses provide the authoritative list of `scout_asset_api.DataScope` objects used to
-        resolve `data_scope_name` in wrapper methods.
+        Each subclass resolves the name against the data scopes its own transport returns, so this wrapper
+        never sees a wire type.
         """
 
     def _get_dataset_scope(self, data_scope_name: str) -> tuple[Dataset, Mapping[str, str]]:
@@ -1253,20 +1253,18 @@ class _DatasetWrapper(abc.ABC):
             A tuple of the resolved `Dataset` and the scope's required `series_tags`.
 
         Raises:
-            ValueError: If no scope exists with the given `data_scope_name`, or if the scope is not backed by a dataset.
+            ValueError: If no dataset-backed scope exists with the given `data_scope_name`.
         """
-        dataset_scopes = {scope.data_scope_name: scope for scope in self._list_dataset_scopes()}
-        data_scope = dataset_scopes.get(data_scope_name)
+        data_scope = self._lookup_dataset_scope(data_scope_name)
         if data_scope is None:
             raise ValueError(f"No such data scope found with data_scope_name {data_scope_name}")
-        elif data_scope.data_source.dataset is None:
-            raise ValueError(f"Datascope {data_scope_name} is not a dataset!")
 
+        dataset_rid, series_tags = data_scope
         dataset = Dataset._from_conjure(
             self._clients,
-            _get_dataset(self._clients.auth_header, self._clients.catalog, data_scope.data_source.dataset),
+            _get_dataset(self._clients.auth_header, self._clients.catalog, dataset_rid),
         )
-        return dataset, data_scope.series_tags
+        return dataset, series_tags
 
     ################
     # Add Data API #

--- a/nominal/core/run.py
+++ b/nominal/core/run.py
@@ -5,12 +5,7 @@ from datetime import datetime, timedelta
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Iterable, Mapping, Protocol, Sequence, cast
 
-from nominal_api import (
-    scout,
-    scout_asset_api,
-    scout_assets,
-    scout_run_api,
-)
+from nominal_api import scout_assets
 from typing_extensions import Self, deprecated
 
 from nominal.core._event_types import EventType, SearchEventOriginType
@@ -18,9 +13,8 @@ from nominal.core._utils.api_tools import (
     HasRid,
     Link,
     LinkDict,
-    RefreshableConjureMixin,
-    create_links,
-    filter_scopes,
+    RefreshableGrpcMixin,
+    normalize_links,
     rid_from_instance_or_string,
 )
 from nominal.core._utils.frontend_urls import run_url
@@ -36,14 +30,15 @@ from nominal.core.exceptions import LegacyVideoDeprecationWarning
 from nominal.core.video import Video, _get_video
 from nominal.core.workbook import Workbook, _search_workbooks
 from nominal.protos.comments.v1 import comments_pb2, comments_pb2_grpc
-from nominal.ts import IntegralNanosecondsDuration, IntegralNanosecondsUTC, _SecondsNanos, _to_api_duration
+from nominal.protos.run.v1 import run_service_pb2, run_service_pb2_grpc
+from nominal.ts import IntegralNanosecondsDuration, IntegralNanosecondsUTC, _SecondsNanos, _to_run_duration
 
 if TYPE_CHECKING:
     from nominal.core.asset import Asset
 
 
 @dataclass(frozen=True)
-class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
+class Run(HasRid, RefreshableGrpcMixin[run_service_pb2.Run], _DatasetWrapper):
     rid: str
     name: str
     description: str
@@ -73,15 +68,15 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
         @property
         def comments(self) -> comments_pb2_grpc.CommentsServiceStub: ...
         @property
-        def run(self) -> scout.RunService: ...
+        def run(self) -> run_service_pb2_grpc.RunServiceStub: ...
 
     @property
     def nominal_url(self) -> str:
         """Returns a link to the page for this Run in the Nominal app"""
         return run_url(self._clients, self.rid)
 
-    def _get_latest_api(self) -> scout_run_api.Run:
-        return self._clients.run.get_run(self._clients.auth_header, self.rid)
+    def _get_latest_api(self) -> run_service_pb2.Run:
+        return _get_run_proto(self._clients.run, self.rid)
 
     def update(
         self,
@@ -114,18 +109,23 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
 
             run = run.update(assets=[*run.assets, new_asset])
         """
-        request = scout_run_api.UpdateRunRequest(
+        request = run_service_pb2.UpdateRunRequest(
+            rid=self.rid,
             description=description,
-            labels=None if labels is None else list(labels),
-            properties=None if properties is None else dict(properties),
-            start_time=None if start is None else _SecondsNanos.from_flexible(start).to_scout_run_api(),
-            end_time=None if end is None else _SecondsNanos.from_flexible(end).to_scout_run_api(),
+            labels=None if labels is None else run_service_pb2.LabelSet(labels=labels),
+            properties=None if properties is None else run_service_pb2.PropertyMap(properties=properties),
+            start_time=None if start is None else _SecondsNanos.from_flexible(start).to_run_proto(),
+            end_time=None if end is None else _SecondsNanos.from_flexible(end).to_run_proto(),
             title=name,
             assets=[] if assets is None else [rid_from_instance_or_string(a) for a in assets],
-            links=None if links is None else create_links(links),
+            links=None if links is None else run_service_pb2.LinkList(links=_create_run_links(links)),
         )
-        updated_run = self._clients.run.update_run(self._clients.auth_header, request, self.rid)
-        return self._refresh_from_api(updated_run)
+        return self._apply_update(request)
+
+    def _apply_update(self, request: run_service_pb2.UpdateRunRequest) -> Self:
+        with translate_grpc_errors():
+            response = self._clients.run.UpdateRun(request)
+        return self._refresh_from_api(response.run)
 
     def add_comment(self, content: str) -> Comment:
         """Post a markdown comment to this run's discussion.
@@ -153,27 +153,22 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
             response = self._clients.comments.CreateComment(request)
         return Comment._from_proto(response.comment)
 
-    def _list_dataset_scopes(self) -> Sequence[scout_asset_api.DataScope]:
+    def _lookup_dataset_scope(self, data_scope_name: str) -> tuple[str, Mapping[str, str]] | None:
         api_run = self._get_latest_api()
         if len(api_run.assets) > 1:
             raise RuntimeError("Can't retrieve dataset scopes on multi-asset runs")
+        for scope in api_run.asset_data_scopes:
+            if scope.data_scope_name == data_scope_name and scope.data_source.WhichOneof("data_source") == "dataset":
+                return scope.data_source.dataset, dict(scope.series_tags)
+        return None
 
-        return filter_scopes(api_run.asset_data_scopes, "dataset")
-
-    def _list_datasource_rids(
-        self, datasource_type: str | None = None, property_name: str | None = None
-    ) -> Mapping[str, str]:
+    def _list_datasource_rids(self, datasource_type: str | None = None) -> Mapping[str, str]:
         enriched_run = self._get_latest_api()
         datasource_rids_by_ref_name = {}
         for ref_name, source in enriched_run.data_sources.items():
-            if datasource_type is not None and source.data_source.type != datasource_type:
-                continue
-
-            rid = cast(
-                str, getattr(source.data_source, source.data_source.type if property_name is None else property_name)
-            )
-            datasource_rids_by_ref_name[ref_name] = rid
-
+            kind = source.data_source.WhichOneof("data_source")
+            if kind is not None and (datasource_type is None or kind == datasource_type):
+                datasource_rids_by_ref_name[ref_name] = getattr(source.data_source, kind)
         return datasource_rids_by_ref_name
 
     def remove_data_sources(
@@ -189,28 +184,25 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
         ref_names = ref_names or []
         data_source_rids = {rid_from_instance_or_string(ds) for ds in data_sources or []}
 
-        conjure_run = self._get_latest_api()
-
-        data_sources_to_keep = {
-            ref_name: scout_run_api.CreateRunDataSource(
-                data_source=rds.data_source,
-                series_tags=rds.series_tags,
-                offset=rds.offset,
+        if "" in data_source_rids:
+            raise ValueError("Data source RIDs must not be empty")
+        api_run = self._get_latest_api()
+        data_sources_to_keep = {}
+        for ref_name, source in api_run.data_sources.items():
+            kind = source.data_source.WhichOneof("data_source")
+            if ref_name in ref_names or (kind is not None and getattr(source.data_source, kind) in data_source_rids):
+                continue
+            data_sources_to_keep[ref_name] = run_service_pb2.CreateRunDataSource(
+                data_source=source.data_source if source.HasField("data_source") else None,
+                series_tags=source.series_tags,
+                offset=source.offset if source.HasField("offset") else None,
             )
-            for ref_name, rds in conjure_run.data_sources.items()
-            if ref_name not in ref_names
-            and (rds.data_source.dataset or rds.data_source.connection or rds.data_source.video) not in data_source_rids
-        }
-
-        updated_run = self._clients.run.update_run(
-            self._clients.auth_header,
-            scout_run_api.UpdateRunRequest(
-                assets=[],
-                data_sources=data_sources_to_keep,
-            ),
-            self.rid,
+        self._apply_update(
+            run_service_pb2.UpdateRunRequest(
+                rid=self.rid,
+                data_sources=run_service_pb2.CreateRunDataSourceMap(data_sources=data_sources_to_keep),
+            )
         )
-        self._refresh_from_api(updated_run)
 
     def create_event(
         self,
@@ -348,14 +340,14 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
             offset: Add the datasets to the run with a pre-baked offset
         """
         data_sources = {
-            ref_name: scout_run_api.CreateRunDataSource(
-                data_source=scout_run_api.DataSource(dataset=rid_from_instance_or_string(dataset)),
+            ref_name: run_service_pb2.CreateRunDataSource(
+                data_source=run_service_pb2.DataSource(dataset=rid_from_instance_or_string(dataset)),
                 series_tags={**series_tags} if series_tags else {},
-                offset=None if offset is None else _to_api_duration(offset),
+                offset=None if offset is None else _to_run_duration(offset),
             )
             for ref_name, dataset in datasets.items()
         }
-        self._clients.run.add_data_sources_to_run(self._clients.auth_header, data_sources, self.rid)
+        self._add_data_sources(data_sources)
 
     def add_connection(
         self,
@@ -378,13 +370,13 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
             offset: Add the connection to the run with a pre-baked offset
         """
         data_sources = {
-            ref_name: scout_run_api.CreateRunDataSource(
-                data_source=scout_run_api.DataSource(connection=rid_from_instance_or_string(connection)),
+            ref_name: run_service_pb2.CreateRunDataSource(
+                data_source=run_service_pb2.DataSource(connection=rid_from_instance_or_string(connection)),
                 series_tags={**series_tags} if series_tags else {},
-                offset=None if offset is None else _to_api_duration(offset),
+                offset=None if offset is None else _to_run_duration(offset),
             )
         }
-        self._clients.run.add_data_sources_to_run(self._clients.auth_header, data_sources, self.rid)
+        self._add_data_sources(data_sources)
 
     @deprecated(
         "Attaching a standalone `Video` to a run is deprecated in favor of video channels on a dataset. Attach the "
@@ -393,12 +385,18 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
     )
     def add_video(self, ref_name: str, video: Video | str) -> None:
         """Add a video to a run via video object or RID."""
-        request = scout_run_api.CreateRunDataSource(
-            data_source=scout_run_api.DataSource(video=rid_from_instance_or_string(video)),
+        request = run_service_pb2.CreateRunDataSource(
+            data_source=run_service_pb2.DataSource(video=rid_from_instance_or_string(video)),
             series_tags={},
             offset=None,
         )
-        self._clients.run.add_data_sources_to_run(self._clients.auth_header, {ref_name: request}, self.rid)
+        self._add_data_sources({ref_name: request})
+
+    def _add_data_sources(self, data_sources: Mapping[str, run_service_pb2.CreateRunDataSource]) -> None:
+        with translate_grpc_errors():
+            self._clients.run.AddDataSourcesToRun(
+                run_service_pb2.AddDataSourcesToRunRequest(run_rid=self.rid, data_sources=data_sources)
+            )
 
     def add_attachments(self, attachments: Iterable[Attachment] | Iterable[str]) -> None:
         """Add attachments that have already been uploaded to this run.
@@ -406,8 +404,11 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
         `attachments` can be `Attachment` instances, or attachment RIDs.
         """
         rids = [rid_from_instance_or_string(a) for a in attachments]
-        request = scout_run_api.UpdateAttachmentsRequest(attachments_to_add=rids, attachments_to_remove=[])
-        self._clients.run.update_run_attachment(self._clients.auth_header, request, self.rid)
+        request = run_service_pb2.UpdateRunAttachmentRequest(
+            rid=self.rid, attachments_to_add=rids, attachments_to_remove=[]
+        )
+        with translate_grpc_errors():
+            self._clients.run.UpdateRunAttachment(request)
 
     def _iter_list_datasets(self) -> Iterable[tuple[str, Dataset]]:
         dataset_rids_by_ref_name = self._list_datasource_rids("dataset")
@@ -538,7 +539,7 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
 
         clients = cast(Asset._Clients, self._clients)
         run = self._get_latest_api()
-        assets = self._clients.assets.get_assets(self._clients.auth_header, run.assets)
+        assets = self._clients.assets.get_assets(self._clients.auth_header, list(run.assets))
         for a in assets.values():
             yield Asset._from_conjure(clients, a)
 
@@ -553,8 +554,11 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
         `attachments` can be `Attachment` instances, or attachment RIDs.
         """
         rids = [rid_from_instance_or_string(a) for a in attachments]
-        request = scout_run_api.UpdateAttachmentsRequest(attachments_to_add=[], attachments_to_remove=rids)
-        self._clients.run.update_run_attachment(self._clients.auth_header, request, self.rid)
+        request = run_service_pb2.UpdateRunAttachmentRequest(
+            rid=self.rid, attachments_to_add=[], attachments_to_remove=rids
+        )
+        with translate_grpc_errors():
+            self._clients.run.UpdateRunAttachment(request)
 
     def search_workbooks(
         self,
@@ -588,35 +592,37 @@ class Run(HasRid, RefreshableConjureMixin[scout_run_api.Run], _DatasetWrapper):
 
         Note: this does not update the instance in place; call `refresh()` to see the change reflected.
         """
-        self._clients.run.archive_run(self._clients.auth_header, self.rid)
+        with translate_grpc_errors():
+            self._clients.run.ArchiveRun(run_service_pb2.ArchiveRunRequest(rid=self.rid))
 
     def unarchive(self) -> None:
         """Unarchive this run, allowing it to appear on the UI.
 
         Note: this does not update the instance in place; call `refresh()` to see the change reflected.
         """
-        self._clients.run.unarchive_run(self._clients.auth_header, self.rid)
+        with translate_grpc_errors():
+            self._clients.run.UnarchiveRun(run_service_pb2.UnarchiveRunRequest(rid=self.rid))
 
     @classmethod
-    def _from_conjure(cls, clients: _Clients, run: scout_run_api.Run) -> Self:
+    def _from_proto(cls, clients: _Clients, run: run_service_pb2.Run) -> Self:
         return cls(
             rid=run.rid,
             name=run.title,
             description=run.description,
-            properties=MappingProxyType(run.properties),
+            properties=MappingProxyType(dict(run.properties)),
             labels=tuple(run.labels),
             links=tuple(
-                (dict(url=link.url, title=link.title) if link.title is not None else dict(url=link.url))
+                (dict(url=link.url, title=link.title) if link.HasField("title") else dict(url=link.url))
                 for link in run.links
             ),
-            start=_SecondsNanos.from_scout_run_api(run.start_time).to_nanoseconds(),
-            end=(_SecondsNanos.from_scout_run_api(run.end_time).to_nanoseconds() if run.end_time else None),
+            start=_SecondsNanos.from_run_proto(run.start_time).to_nanoseconds(),
+            end=(_SecondsNanos.from_run_proto(run.end_time).to_nanoseconds() if run.HasField("end_time") else None),
             run_number=run.run_number,
             assets=tuple(run.assets),
-            created_at=_SecondsNanos.from_flexible(run.created_at).to_nanoseconds(),
+            created_at=run.created_at.ToNanoseconds(),
             is_archived=run.is_archived,
             _clients=clients,
-            author_rid=run.author_rid,
+            author_rid=run.author_rid if run.HasField("author_rid") else None,
         )
 
 
@@ -634,19 +640,32 @@ def _create_run(
     asset_rids: Sequence[str] | None,
 ) -> Run:
     """Create a run."""
-    request = scout_run_api.CreateRunRequest(
+    request = run_service_pb2.CreateRunRequest(
         attachments=[rid_from_instance_or_string(a) for a in attachments or ()],
         data_sources={},
         description=description or "",
         labels=[] if labels is None else list(labels),
-        links=[] if links is None else create_links(links),
+        links=[] if links is None else _create_run_links(links),
         properties={} if properties is None else dict(properties),
-        typed_properties={},
-        start_time=_SecondsNanos.from_flexible(start).to_scout_run_api(),
+        start_time=_SecondsNanos.from_flexible(start).to_run_proto(),
         title=name,
-        end_time=None if end is None else _SecondsNanos.from_flexible(end).to_scout_run_api(),
+        end_time=None if end is None else _SecondsNanos.from_flexible(end).to_run_proto(),
         assets=[] if asset_rids is None else list(asset_rids),
         workspace=clients.resolve_default_workspace_rid(),
     )
-    response = clients.run.create_run(clients.auth_header, request)
-    return Run._from_conjure(clients, response)
+    with translate_grpc_errors():
+        response = clients.run.CreateRun(request)
+    return Run._from_proto(clients, response.run)
+
+
+def _get_run_proto(service: run_service_pb2_grpc.RunServiceStub, rid: str) -> run_service_pb2.Run:
+    with translate_grpc_errors():
+        return service.GetRun(run_service_pb2.GetRunRequest(rid=rid)).run
+
+
+def _get_run(clients: Run._Clients, rid: str) -> Run:
+    return Run._from_proto(clients, _get_run_proto(clients.run, rid))
+
+
+def _create_run_links(links: Sequence[str | Link | LinkDict]) -> list[run_service_pb2.Link]:
+    return [run_service_pb2.Link(url=url, title=title) for url, title in normalize_links(links)]

--- a/nominal/core/workbook.py
+++ b/nominal/core/workbook.py
@@ -13,6 +13,7 @@ from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin
 from nominal.core._utils.frontend_urls import workbook_url
 from nominal.core._utils.pagination_tools import search_workbooks_paginated
 from nominal.core._utils.query_tools import ArchiveStatusFilter, create_search_workbooks_query
+from nominal.protos.run.v1 import run_service_pb2_grpc
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +110,7 @@ class Workbook(HasRid, RefreshableConjureMixin[scout_notebook_api.Notebook]):
         @property
         def notebook(self) -> scout.NotebookService: ...
         @property
-        def run(self) -> scout.RunService: ...
+        def run(self) -> run_service_pb2_grpc.RunServiceStub: ...
         @property
         def template(self) -> scout.TemplateService: ...
 

--- a/nominal/core/workbook_template.py
+++ b/nominal/core/workbook_template.py
@@ -17,8 +17,9 @@ from nominal.core._clientsbunch import HasScoutParams
 from nominal.core._utils.api_tools import HasRid, RefreshableConjureMixin, rid_from_instance_or_string
 from nominal.core._utils.frontend_urls import workbook_template_url
 from nominal.core.asset import Asset
-from nominal.core.run import Run
+from nominal.core.run import Run, _get_run_proto
 from nominal.core.workbook import Workbook, WorkbookType
+from nominal.protos.run.v1 import run_service_pb2_grpc
 
 
 def _rebind_video_datasources(
@@ -79,7 +80,7 @@ class WorkbookTemplate(HasRid, RefreshableConjureMixin[scout_template_api.Templa
         @property
         def notebook(self) -> scout.NotebookService: ...
         @property
-        def run(self) -> scout.RunService: ...
+        def run(self) -> run_service_pb2_grpc.RunServiceStub: ...
         @property
         def template(self) -> scout.TemplateService: ...
 
@@ -202,7 +203,7 @@ class WorkbookTemplate(HasRid, RefreshableConjureMixin[scout_template_api.Templa
             elif isinstance(run, Run) and run.assets:
                 video_asset_rid = run.assets[0]
             elif run_rid is not None:
-                raw_run = self._clients.run.get_run(self._clients.auth_header, run_rid)
+                raw_run = _get_run_proto(self._clients.run, run_rid)
                 video_asset_rid = raw_run.assets[0] if raw_run.assets else None
             else:
                 raise ValueError(

--- a/nominal/ts/__init__.py
+++ b/nominal/ts/__init__.py
@@ -208,6 +208,7 @@ from google.protobuf import timestamp_pb2
 from nominal_api import api, ingest_api, scout_catalog, scout_dataexport_api, scout_run_api
 from typing_extensions import Self, assert_never
 
+from nominal.protos.run.v1 import run_pb2, run_service_pb2
 from nominal.protos.types import common_pb2
 from nominal.protos.types.time import time_pb2, timestamp_parsers_pb2
 
@@ -613,6 +614,9 @@ class _SecondsNanos(NamedTuple):
                 self.nanos,
             )
 
+    def to_run_proto(self) -> run_pb2.UtcTimestamp:
+        return run_pb2.UtcTimestamp(seconds_since_epoch=self.seconds, offset_nanoseconds=self.nanos)
+
     def to_scout_run_api(self) -> scout_run_api.UtcTimestamp:
         return scout_run_api.UtcTimestamp(seconds_since_epoch=self.seconds, offset_nanoseconds=self.nanos)
 
@@ -654,6 +658,10 @@ class _SecondsNanos(NamedTuple):
 
     def to_datetime(self) -> datetime:
         return datetime.fromtimestamp(self.seconds + self.nanos * 1e-9, timezone.utc)
+
+    @classmethod
+    def from_run_proto(cls, ts: run_pb2.UtcTimestamp) -> Self:
+        return cls(seconds=ts.seconds_since_epoch, nanos=ts.offset_nanoseconds)
 
     @classmethod
     def from_scout_run_api(cls, ts: scout_run_api.UtcTimestamp) -> Self:
@@ -717,6 +725,11 @@ def _to_seconds_nanos_duration(duration: timedelta | IntegralNanosecondsDuration
     """
     total_nanos = duration // _ONE_MICROSECOND * 1_000 if isinstance(duration, timedelta) else duration
     return divmod(total_nanos, 1_000_000_000)
+
+
+def _to_run_duration(duration: timedelta | IntegralNanosecondsDuration) -> run_service_pb2.Duration:
+    seconds, nanos = _to_seconds_nanos_duration(duration)
+    return run_service_pb2.Duration(seconds=seconds, nanos=nanos)
 
 
 def _to_api_duration(duration: timedelta | IntegralNanosecondsDuration) -> scout_run_api.Duration:

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -20,6 +20,7 @@ from nominal.protos.comments.v1 import comments_pb2_grpc
 from nominal.protos.event.v2 import event_pb2_grpc
 from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2_grpc
+from nominal.protos.run.v1 import run_service_pb2_grpc
 from nominal.protos.sandbox.v1 import sandbox_workspace_pb2_grpc
 from nominal.protos.secrets.v1 import secrets_pb2_grpc
 from nominal.protos.units.v1 import units_pb2_grpc
@@ -273,6 +274,7 @@ def test_from_config_wires_grpc_services_through_one_shared_channel(monkeypatch)
         None,
     )
 
+    assert isinstance(clients.run, run_service_pb2_grpc.RunServiceStub)
     assert isinstance(clients.units, units_pb2_grpc.UnitsServiceStub)
     assert isinstance(clients.comments, comments_pb2_grpc.CommentsServiceStub)
     assert isinstance(clients.workspace, workspaces_pb2_grpc.WorkspaceServiceStub)

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -360,8 +360,8 @@ def test_add_journal_json_rejects_non_epoch_timestamps_before_uploading(
 class _StubWrapper(_DatasetWrapper):
     """The wrapper with scope resolution stubbed: what is under test is the delegation, not lookup."""
 
-    def _list_dataset_scopes(self):
-        return []
+    def _lookup_dataset_scope(self, data_scope_name):
+        return None
 
 
 def test_data_scope_avro_stream_merges_scope_tags() -> None:

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -4,13 +4,16 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from nominal.core._utils.query_tools import ArchiveStatusFilter
 from nominal.core.run import Run
 from nominal.protos.event.v2 import event_pb2
 
 
 @pytest.fixture
 def mock_clients():
-    return MagicMock()
+    clients = MagicMock()
+    clients.resolve_default_workspace_rid.return_value = "workspace"
+    return clients
 
 
 @pytest.fixture
@@ -78,3 +81,304 @@ def test_nominal_url_identifies_the_run_by_rid(mock_run, mock_clients):
     mock_clients.resolve_default_workspace_rid.return_value = "ri.workspace.test"
 
     assert mock_run.nominal_url == "https://app.nominal.test/w/ri.workspace.test/runs/run-rid-1"
+
+
+def test_proto_hydration_preserves_presence_and_nanoseconds(mock_clients):
+    from nominal.protos.run.v1 import run_pb2
+    from nominal.protos.run.v1 import run_service_pb2 as pb
+
+    raw = pb.Run(
+        rid="run",
+        start_time=run_pb2.UtcTimestamp(seconds_since_epoch=1, offset_nanoseconds=23),
+        end_time=run_pb2.UtcTimestamp(),
+        links=[pb.Link(url="a"), pb.Link(url="b", title="")],
+        properties={"k": "v"},
+    )
+    raw.created_at.FromNanoseconds(123)
+    run = Run._from_proto(mock_clients, raw)
+    assert (run.start, run.end, run.created_at, run.author_rid) == (1_000_000_023, 0, 123, None)
+    assert run.links == ({"url": "a"}, {"url": "b", "title": ""})
+    raw.properties["k"] = "changed"
+    assert run.properties == {"k": "v"}
+    raw.ClearField("end_time")
+    assert Run._from_proto(mock_clients, raw).end is None
+
+
+def test_update_distinguishes_omission_from_empty_values(mock_run, mock_clients):
+    from nominal.protos.run.v1 import run_service_pb2 as pb
+
+    mock_clients.run.UpdateRun.return_value = pb.UpdateRunResponse(run=pb.Run(rid=mock_run.rid, title="new"))
+    assert mock_run.update(name="new") is mock_run
+    assert mock_run.name == "new"
+    request = mock_clients.run.UpdateRun.call_args.args[0]
+    assert request.rid == mock_run.rid
+    for field in ("labels", "properties", "links", "end_time", "description"):
+        assert not request.HasField(field)
+    mock_run.update(labels=[], properties={}, links=[], description="", end=0)
+    request = mock_clients.run.UpdateRun.call_args.args[0]
+    for field in ("labels", "properties", "links", "end_time", "description"):
+        assert request.HasField(field)
+    assert not request.labels.labels
+    assert not request.properties.properties
+    assert not request.links.links
+
+
+def test_add_dataset_preserves_exact_negative_offset(mock_run, mock_clients):
+    from nominal.protos.run.v1 import run_service_pb2 as pb
+
+    mock_run.add_dataset("telemetry", "dataset-rid", series_tags={"mode": "test"}, offset=-1)
+    request = mock_clients.run.AddDataSourcesToRun.call_args.args[0]
+    assert request == pb.AddDataSourcesToRunRequest(
+        run_rid=mock_run.rid,
+        data_sources={
+            "telemetry": pb.CreateRunDataSource(
+                data_source=pb.DataSource(dataset="dataset-rid"),
+                series_tags={"mode": "test"},
+                offset=pb.Duration(seconds=-1, nanos=999_999_999),
+            )
+        },
+    )
+    mock_run.add_connection("live", "connection-rid")
+    request = mock_clients.run.AddDataSourcesToRun.call_args.args[0]
+    assert not request.data_sources["live"].HasField("offset")
+
+
+def test_remove_sources_preserves_other_oneof_variants_and_absent_offset(mock_run, mock_clients):
+    from nominal.protos.run.v1 import run_service_pb2 as pb
+
+    raw = pb.Run(
+        rid=mock_run.rid,
+        data_sources={
+            "telemetry": pb.RunDataSource(data_source=pb.DataSource(dataset="dataset")),
+            "logs": pb.RunDataSource(data_source=pb.DataSource(log_set="logs"), series_tags={"k": "v"}),
+        },
+    )
+    mock_clients.run.GetRun.return_value = pb.GetRunResponse(run=raw)
+    mock_clients.run.UpdateRun.return_value = pb.UpdateRunResponse(run=raw)
+    mock_run.remove_data_sources(data_sources=["dataset"])
+    request = mock_clients.run.UpdateRun.call_args.args[0]
+    assert set(request.data_sources.data_sources) == {"logs"}
+    remaining = request.data_sources.data_sources["logs"]
+    assert remaining.data_source.WhichOneof("data_source") == "log_set"
+    assert remaining.series_tags == {"k": "v"}
+    assert not remaining.HasField("offset")
+    mock_run.remove_data_sources(ref_names=["telemetry", "logs"])
+    request = mock_clients.run.UpdateRun.call_args.args[0]
+    assert request.HasField("data_sources")
+    assert not request.data_sources.data_sources
+
+
+def test_remove_sources_rejects_empty_rid_before_rpc(mock_run, mock_clients):
+    with pytest.raises(ValueError, match="empty"):
+        mock_run.remove_data_sources(data_sources=[""])
+    mock_clients.run.GetRun.assert_not_called()
+    mock_clients.run.UpdateRun.assert_not_called()
+
+
+def test_create_run_resolves_workspace_and_hydrates_result(mock_clients):
+    from nominal.core.client import NominalClient
+    from nominal.protos.run.v1 import run_service_pb2 as pb
+
+    mock_clients.resolve_default_workspace_rid.return_value = "workspace"
+    mock_clients.run.CreateRun.return_value = pb.CreateRunResponse(run=pb.Run(rid="created", title="result"))
+    client = NominalClient(_clients=mock_clients)
+    created = client.create_run(
+        "name",
+        1_000_000_007,
+        0,
+        assets=["asset"],
+        links=["url", ("named", "title"), {"url": "empty", "title": ""}],
+        attachments=iter(["attachment"]),
+        properties={"key": "value"},
+        labels=["label"],
+    )
+    assert isinstance(created, Run)
+    assert created.rid == "created"
+    request = mock_clients.run.CreateRun.call_args.args[0]
+    assert request.workspace == "workspace"
+    assert request.start_time.seconds_since_epoch == 1
+    assert request.start_time.offset_nanoseconds == 7
+    assert request.HasField("end_time")
+    assert list(request.assets) == ["asset"]
+    assert list(request.attachments) == ["attachment"]
+    assert request.properties == {"key": "value"}
+    assert list(request.labels) == ["label"]
+    assert not request.links[0].HasField("title")
+    assert request.links[1].title == "title"
+    assert request.links[2].HasField("title")
+    client.create_run("open", 0, None)
+    assert not mock_clients.run.CreateRun.call_args.args[0].HasField("end_time")
+
+
+def test_get_and_refresh_return_sdk_runs(mock_clients):
+    from nominal.core.client import NominalClient
+    from nominal.protos.run.v1 import run_service_pb2 as pb
+
+    mock_clients.run.GetRun.return_value = pb.GetRunResponse(run=pb.Run(rid="run", title="initial"))
+    run = NominalClient(_clients=mock_clients).get_run("run")
+    mock_clients.run.GetRun.assert_called_once_with(pb.GetRunRequest(rid="run"))
+    mock_clients.run.GetRun.return_value = pb.GetRunResponse(run=pb.Run(rid="run", title="updated"))
+    assert run.name == "initial"
+    assert run.refresh() is run
+    assert run.name == "updated"
+
+
+@pytest.mark.parametrize("archived", [False, True])
+def test_archive_and_unarchive_leave_local_state_until_refresh(mock_run, mock_clients, archived):
+    from nominal.protos.run.v1 import run_service_pb2 as pb
+
+    if archived:
+        mock_run.archive()
+        mock_clients.run.ArchiveRun.assert_called_once_with(pb.ArchiveRunRequest(rid=mock_run.rid))
+    else:
+        mock_run.unarchive()
+        mock_clients.run.UnarchiveRun.assert_called_once_with(pb.UnarchiveRunRequest(rid=mock_run.rid))
+    mock_clients.run.GetRun.assert_not_called()
+    assert not mock_run.is_archived
+
+
+def test_attachment_updates_accept_generators(mock_run, mock_clients):
+    from nominal.protos.run.v1 import run_service_pb2 as pb
+
+    mock_run.add_attachments(iter(["first", "second"]))
+    mock_clients.run.UpdateRunAttachment.assert_called_with(
+        pb.UpdateRunAttachmentRequest(rid=mock_run.rid, attachments_to_add=["first", "second"])
+    )
+    mock_run.remove_attachments(iter(["first"]))
+    mock_clients.run.UpdateRunAttachment.assert_called_with(
+        pb.UpdateRunAttachmentRequest(rid=mock_run.rid, attachments_to_remove=["first"])
+    )
+
+
+def test_dataset_scope_lookup_filters_oneof_and_rejects_multi_asset_runs(mock_run, mock_clients):
+    from nominal.protos.run.v1 import run_service_pb2 as pb
+
+    raw = pb.Run(
+        assets=["asset"],
+        asset_data_scopes=[
+            pb.DataScope(data_scope_name="same", data_source=pb.DataSource(connection="connection")),
+            pb.DataScope(data_scope_name="same", data_source=pb.DataSource(dataset="dataset"), series_tags={"k": "v"}),
+        ],
+    )
+    mock_clients.run.GetRun.return_value = pb.GetRunResponse(run=raw)
+    assert mock_run._lookup_dataset_scope("same") == ("dataset", {"k": "v"})
+    assert mock_run._lookup_dataset_scope("missing") is None
+    mock_clients.run.GetRun.return_value.run.assets.append("second")
+    with pytest.raises(RuntimeError, match="multi-asset"):
+        mock_run._lookup_dataset_scope("same")
+
+
+def test_list_sources_uses_active_oneof(mock_run, mock_clients):
+    from nominal.protos.run.v1 import run_service_pb2 as pb
+
+    mock_clients.run.GetRun.return_value = pb.GetRunResponse(
+        run=pb.Run(
+            data_sources={
+                "dataset": pb.RunDataSource(data_source=pb.DataSource(dataset="dataset")),
+                "spatial": pb.RunDataSource(data_source=pb.DataSource(spatial="spatial")),
+                "unset": pb.RunDataSource(),
+            }
+        )
+    )
+    assert mock_run._list_datasource_rids("dataset") == {"dataset": "dataset"}
+    assert mock_run._list_datasource_rids() == {"dataset": "dataset", "spatial": "spatial"}
+
+
+@pytest.mark.parametrize("archive_status", list(ArchiveStatusFilter))
+def test_search_runs_paginates_and_preserves_query(mock_clients, archive_status):
+    from nominal.core.client import NominalClient
+    from nominal.protos.run.v1 import run_service_pb2 as pb
+
+    mock_clients.run.SearchRuns.side_effect = [
+        pb.SearchRunsResponse(results=[pb.Run(rid="first")], next_page_token="next"),
+        pb.SearchRunsResponse(results=[pb.Run(rid="second")]),
+    ]
+    result = NominalClient(_clients=mock_clients).search_runs(search_text="test", archive_status=archive_status)
+    assert [run.rid for run in result] == ["first", "second"]
+    assert all(isinstance(run, Run) for run in result)
+    first, second = [call.args[0] for call in mock_clients.run.SearchRuns.call_args_list]
+    assert not first.HasField("next_page_token")
+    assert second.next_page_token == "next"
+    assert first.query == second.query
+    assert first.query.all_of.queries[0].search_text == "test"
+    assert first.sort.field == pb.START_TIME and first.sort.is_descending
+    assert first.page_size == 100
+    assert list(first.archived_statuses.archived_statuses) == archive_status.to_proto_archived_statuses()
+
+
+def test_asset_run_pagination(mock_clients):
+    from nominal.core._utils.pagination_tools import search_runs_by_asset_paginated
+    from nominal.protos.run.v1 import run_service_pb2 as pb
+
+    mock_clients.run.GetRunsByAsset.side_effect = [
+        pb.GetRunsByAssetResponse(results=[pb.Run(rid="first")], next_page_token="next"),
+        pb.GetRunsByAssetResponse(results=[pb.Run(rid="second")]),
+    ]
+    assert [run.rid for run in search_runs_by_asset_paginated(mock_clients.run, "asset")] == ["first", "second"]
+    first, second = [call.args[0] for call in mock_clients.run.GetRunsByAsset.call_args_list]
+    assert first == pb.GetRunsByAssetRequest(asset="asset")
+    assert second == pb.GetRunsByAssetRequest(asset="asset", next_page_token="next")
+
+
+@pytest.mark.parametrize(
+    "assets, selected, error",
+    [
+        (["one"], None, None),
+        (["one"], "different", "different asset"),
+        (["one", "two"], None, "without specifying"),
+        (["one", "two"], "two", None),
+    ],
+)
+def test_data_review_builder_resolves_run_assets_over_grpc(mock_clients, assets, selected, error):
+    from nominal.core.data_review import DataReviewBuilder
+    from nominal.protos.run.v1 import run_service_pb2 as pb
+
+    mock_clients.run.GetRun.return_value = pb.GetRunResponse(run=pb.Run(assets=assets))
+    builder = DataReviewBuilder(_integration_rids=[], _requests=[], _tags=[], _clients=mock_clients)
+    if error:
+        with pytest.raises(ValueError, match=error):
+            builder.execute_checklist("run", "checklist", asset=selected)
+        assert not builder._requests
+    else:
+        assert builder.execute_checklist("run", "checklist", asset=selected) is builder
+        assert builder._requests[0].run_rid == "run"
+        assert builder._requests[0].asset_rid == selected
+    mock_clients.run.GetRun.assert_called_once_with(pb.GetRunRequest(rid="run"))
+
+
+def test_workbook_template_resolves_video_asset_from_grpc_run(mock_clients):
+    from unittest.mock import patch
+
+    from nominal_api import scout_chartdefinition_api as charts
+    from nominal_api import scout_workbookcommon_api as common
+
+    from nominal.core.workbook import Workbook, WorkbookType
+    from nominal.core.workbook_template import WorkbookTemplate
+    from nominal.protos.run.v1 import run_service_pb2 as pb
+
+    mock_clients.template.get.return_value.content = common.WorkbookContent(
+        channel_variables={},
+        charts={
+            "video": charts.VizDefinition(
+                video=charts.VideoVizDefinition(
+                    v1=charts.VideoVizDefinitionV1(comparison_run_groups=[], ref_name="camera")
+                )
+            )
+        },
+    )
+    mock_clients.run.GetRun.return_value = pb.GetRunResponse(run=pb.Run(assets=["asset"]))
+    template = WorkbookTemplate(
+        rid="template",
+        title="template",
+        description="",
+        labels=[],
+        properties={},
+        workbook_type=WorkbookType.WORKBOOK,
+        _clients=mock_clients,
+    )
+    with patch.object(Workbook, "_from_conjure"):
+        template.create_workbook(run="run")
+    mock_clients.run.GetRun.assert_called_once_with(pb.GetRunRequest(rid="run"))
+    request = mock_clients.notebook.create.call_args.args[1]
+    source = request.content_v2.workbook.charts["video"].video.v1.datasource
+    assert (source.asset_rid, source.run_rid, source.ref_name) == ("asset", "run", "camera")

--- a/tests/core/test_run_grpc.py
+++ b/tests/core/test_run_grpc.py
@@ -1,0 +1,111 @@
+"""Exercise run transport, metadata, and error translation over a local gRPC channel."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import grpc
+import pytest
+
+from nominal.core.client import NominalClient
+from nominal.core.exceptions import NominalNotFoundError
+from nominal.core.run import Run
+from nominal.protos.run.v1 import run_service_pb2 as pb
+from nominal.protos.run.v1 import run_service_pb2_grpc
+from nominal.protos.workspaces.v1 import workspaces_pb2, workspaces_pb2_grpc
+
+
+@pytest.fixture
+def grpc_runtime():
+    headers = {}
+
+    class Runs(run_service_pb2_grpc.RunServiceServicer):
+        def GetRun(self, request, context):
+            headers.update(context.invocation_metadata())
+            if request.rid == "missing":
+                context.abort(grpc.StatusCode.NOT_FOUND, "missing run")
+            return pb.GetRunResponse(run=pb.Run(rid=request.rid, title="from server"))
+
+        def CreateRun(self, request, context):
+            headers.update(context.invocation_metadata())
+            return pb.CreateRunResponse(run=pb.Run(rid="created", title=request.title, start_time=request.start_time))
+
+        def UpdateRun(self, request, context):
+            context.abort(grpc.StatusCode.NOT_FOUND, "missing run")
+
+        def AddDataSourcesToRun(self, request, context):
+            context.abort(grpc.StatusCode.NOT_FOUND, "missing run")
+
+        def UpdateRunAttachment(self, request, context):
+            context.abort(grpc.StatusCode.NOT_FOUND, "missing run")
+
+        def ArchiveRun(self, request, context):
+            context.abort(grpc.StatusCode.NOT_FOUND, "missing run")
+
+        def UnarchiveRun(self, request, context):
+            context.abort(grpc.StatusCode.NOT_FOUND, "missing run")
+
+        def SearchRuns(self, request, context):
+            if request.next_page_token:
+                context.abort(grpc.StatusCode.NOT_FOUND, "missing run")
+            return pb.SearchRunsResponse(results=[pb.Run(rid="first")], next_page_token="next")
+
+        def GetRunsByAsset(self, request, context):
+            context.abort(grpc.StatusCode.NOT_FOUND, "missing run")
+
+    class Workspaces(workspaces_pb2_grpc.WorkspaceServiceServicer):
+        def GetWorkspace(self, request, context):
+            return workspaces_pb2.GetWorkspaceResponse(workspace=workspaces_pb2.Workspace(rid=request.workspace_rid))
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        server = grpc.server(executor)
+        workspaces_pb2_grpc.add_WorkspaceServiceServicer_to_server(Workspaces(), server)
+        run_service_pb2_grpc.add_RunServiceServicer_to_server(Runs(), server)
+        port = server.add_insecure_port("127.0.0.1:0")
+        server.start()
+        try:
+            yield (
+                NominalClient.from_token(
+                    "local-token",
+                    base_url=f"http://127.0.0.1:{port}/api",
+                    workspace_rid="workspace",
+                    extra_headers={"X-Test-Header": "present"},
+                ),
+                headers,
+            )
+        finally:
+            server.stop(0).wait()
+
+
+def test_run_calls_preserve_metadata_and_serialize_nanoseconds(grpc_runtime):
+    client, headers = grpc_runtime
+    run = client.get_run("run")
+    assert isinstance(run, Run)
+    assert (run.rid, run.name) == ("run", "from server")
+    assert headers["authorization"] == "Bearer local-token"
+    assert headers["x-test-header"] == "present"
+    headers.clear()
+    created = client.create_run("name", 1_000_000_007, None)
+    assert (created.rid, created.start) == ("created", 1_000_000_007)
+    assert headers["authorization"] == "Bearer local-token"
+    assert headers["x-test-header"] == "present"
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        lambda client, run: client.get_run("missing"),
+        lambda client, run: run.update(name="new"),
+        lambda client, run: run.add_dataset("ref", "dataset"),
+        lambda client, run: run.add_attachments(["attachment"]),
+        lambda client, run: run.archive(),
+        lambda client, run: run.unarchive(),
+        lambda client, run: client.search_runs(),
+    ],
+)
+def test_run_failures_use_nominal_errors(grpc_runtime, operation):
+    client, _ = grpc_runtime
+    run = client.get_run("run")
+    with pytest.raises(NominalNotFoundError, match="missing run") as exc:
+        operation(client, run)
+    assert isinstance(exc.value.__cause__, grpc.RpcError)

--- a/tests/core/test_run_query_tools.py
+++ b/tests/core/test_run_query_tools.py
@@ -4,26 +4,25 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from nominal_api import api, scout_run_api
-
 from nominal.core._utils.query_tools import create_search_runs_query
+from nominal.protos.run.v1 import run_service_pb2
 from nominal.ts import _SecondsNanos
 
 
-def _and_queries(query: scout_run_api.SearchQuery) -> list[scout_run_api.SearchQuery]:
-    assert query.and_ is not None
-    return query.and_
+def _and_queries(query: run_service_pb2.SearchQuery) -> list[run_service_pb2.SearchQuery]:
+    assert query.WhichOneof("query") == "all_of"
+    return list(query.all_of.queries)
 
 
-def _only_sub_query(query: scout_run_api.SearchQuery) -> scout_run_api.SearchQuery:
+def _only_sub_query(query: run_service_pb2.SearchQuery) -> run_service_pb2.SearchQuery:
     sub_queries = _and_queries(query)
     assert len(sub_queries) == 1
     return sub_queries[0]
 
 
-def _custom_timeframe(filter_value: scout_run_api.TimeframeFilter | None) -> scout_run_api.CustomTimeframeFilter:
+def _custom_timeframe(filter_value: run_service_pb2.TimeframeFilter | None) -> run_service_pb2.CustomTimeframeFilter:
     assert filter_value is not None
-    assert filter_value.custom is not None
+    assert filter_value.HasField("custom")
     return filter_value.custom
 
 
@@ -44,8 +43,8 @@ def test_create_search_runs_query_with_start_time():
 
     # Should use startTime with CustomTimeframeFilter(start_time=...)
     start_time_filter = _custom_timeframe(sub_query.start_time)
-    assert start_time_filter.start_time == _SecondsNanos.from_datetime(start_time).to_scout_run_api()
-    assert start_time_filter.end_time is None
+    assert start_time_filter.start_time == _SecondsNanos.from_datetime(start_time).to_run_proto()
+    assert not start_time_filter.HasField("end_time")
 
 
 def test_create_search_runs_query_with_end_time():
@@ -57,8 +56,8 @@ def test_create_search_runs_query_with_end_time():
 
     # Should use endTime with CustomTimeframeFilter(end_time=...)
     end_time_filter = _custom_timeframe(sub_query.end_time)
-    assert end_time_filter.start_time is None
-    assert end_time_filter.end_time == _SecondsNanos.from_datetime(end_time).to_scout_run_api()
+    assert not end_time_filter.HasField("start_time")
+    assert end_time_filter.end_time == _SecondsNanos.from_datetime(end_time).to_run_proto()
 
 
 def test_create_search_runs_query_with_created_after():
@@ -70,8 +69,8 @@ def test_create_search_runs_query_with_created_after():
 
     # Should use createdAt with CustomTimeframeFilter(start_time=...)
     created_at_filter = _custom_timeframe(sub_query.created_at)
-    assert created_at_filter.start_time == _SecondsNanos.from_datetime(created_after).to_scout_run_api()
-    assert created_at_filter.end_time is None
+    assert created_at_filter.start_time == _SecondsNanos.from_datetime(created_after).to_run_proto()
+    assert not created_at_filter.HasField("end_time")
 
 
 def test_create_search_runs_query_with_created_before():
@@ -83,8 +82,8 @@ def test_create_search_runs_query_with_created_before():
 
     # Should use createdAt with CustomTimeframeFilter(end_time=...)
     created_at_filter = _custom_timeframe(sub_query.created_at)
-    assert created_at_filter.start_time is None
-    assert created_at_filter.end_time == _SecondsNanos.from_datetime(created_before).to_scout_run_api()
+    assert not created_at_filter.HasField("start_time")
+    assert created_at_filter.end_time == _SecondsNanos.from_datetime(created_before).to_run_proto()
 
 
 def test_create_search_runs_query_with_both_created_filters():
@@ -98,8 +97,8 @@ def test_create_search_runs_query_with_both_created_filters():
 
     # Should have one createdAt filter with both after and before
     created_at_filter = _custom_timeframe(sub_query.created_at)
-    assert created_at_filter.start_time == _SecondsNanos.from_datetime(created_after).to_scout_run_api()
-    assert created_at_filter.end_time == _SecondsNanos.from_datetime(created_before).to_scout_run_api()
+    assert created_at_filter.start_time == _SecondsNanos.from_datetime(created_after).to_run_proto()
+    assert created_at_filter.end_time == _SecondsNanos.from_datetime(created_before).to_run_proto()
 
 
 def test_create_search_runs_query_with_string_timestamps():
@@ -140,7 +139,7 @@ def test_create_search_runs_query_with_labels():
     # Should use LabelsFilter with labels wrapped in a list
     assert sub_query.labels is not None
     assert sub_query.labels.labels == labels  # labels is wrapped in a list
-    assert sub_query.labels.operator == api.SetOperator.AND
+    assert sub_query.labels.operator == run_service_pb2.AND
 
 
 def test_create_search_runs_query_with_properties():
@@ -280,8 +279,8 @@ def test_create_search_runs_query_created_at_only_after():
 
     sub_query = _only_sub_query(query)
     created_at_filter = _custom_timeframe(sub_query.created_at)
-    assert created_at_filter.start_time == _SecondsNanos.from_datetime(created_after).to_scout_run_api()
-    assert created_at_filter.end_time is None
+    assert created_at_filter.start_time == _SecondsNanos.from_datetime(created_after).to_run_proto()
+    assert not created_at_filter.HasField("end_time")
 
 
 def test_create_search_runs_query_created_at_only_before():
@@ -291,5 +290,5 @@ def test_create_search_runs_query_created_at_only_before():
 
     sub_query = _only_sub_query(query)
     created_at_filter = _custom_timeframe(sub_query.created_at)
-    assert created_at_filter.end_time == _SecondsNanos.from_datetime(created_before).to_scout_run_api()
-    assert created_at_filter.start_time is None
+    assert created_at_filter.end_time == _SecondsNanos.from_datetime(created_before).to_run_proto()
+    assert not created_at_filter.HasField("start_time")


### PR DESCRIPTION
Port the existing Run SDK operations from Conjure to the generated RunService gRPC stub: create/get/update/refresh, search, asset run listing, data sources, attachments, and archive/unarchive. Data-review asset validation and workbook video rebinding also fetch runs through gRPC.

Preserve the public SDK surface and request semantics, including optional versus explicitly empty updates, nanosecond timestamps, exact negative offsets, active data-source variants, and paginated archive filters. Route calls through the shared authenticated channel and existing Nominal error translation. Resolve dataset scopes through a transport-neutral RID/tag boundary, matching the asset port's approach.

Validation: 1,009 unit tests passed, 1 skipped (GStreamer unavailable); mypy passed for 163 source files; Ruff lint/format passed. Tests include a local gRPC server for request serialization, authentication metadata, and error translation. No live-platform validation was run.
