### PR TITLE
feat: add the SqlService gRPC stub to the client bunch

### DIFF
--- a/nominal/core/_clientsbunch.py
+++ b/nominal/core/_clientsbunch.py
@@ -46,6 +46,7 @@ from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc, ingest_se
 from nominal.protos.registry.v2 import registry_pb2_grpc
 from nominal.protos.sandbox.v1 import sandbox_workspace_pb2_grpc
 from nominal.protos.secrets.v1 import secrets_pb2_grpc
+from nominal.protos.sql.v1 import sql_pb2_grpc
 from nominal.protos.units.v1 import units_pb2_grpc
 from nominal.protos.workspaces.v1 import workspaces_pb2, workspaces_pb2_grpc
 from nominal.ts import IntegralNanosecondsUTC
@@ -182,6 +183,7 @@ class ClientsBunch:
     roles: roles_pb2_grpc.RoleServiceStub
     sandbox_workspace: sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub
     secrets: secrets_pb2_grpc.SecretServiceStub
+    sql: sql_pb2_grpc.SqlServiceStub
     units: units_pb2_grpc.UnitsServiceStub
     workspace: workspaces_pb2_grpc.WorkspaceServiceStub
 
@@ -348,6 +350,7 @@ class ClientsBunch:
             roles=grpc_factory(roles_pb2_grpc.RoleServiceStub),
             sandbox_workspace=grpc_factory(sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub),
             secrets=grpc_factory(secrets_pb2_grpc.SecretServiceStub),
+            sql=grpc_factory(sql_pb2_grpc.SqlServiceStub),
             units=grpc_factory(units_pb2_grpc.UnitsServiceStub),
             workspace=grpc_factory(workspaces_pb2_grpc.WorkspaceServiceStub),
         )

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -258,9 +258,7 @@ def test_resolve_workspace_reuses_the_cached_configured_default_workspace_object
 
 
 def test_from_config_wires_grpc_services_through_one_shared_channel(monkeypatch):
-    """from_config builds `units`, `comments`, `workspace`, and `roles` as generated gRPC stubs, each bound
-    to a single shared channel.
-    """
+    """from_config builds every gRPC service as a generated stub bound to a single shared channel."""
     monkeypatch.setattr("nominal.core._clientsbunch.create_conjure_client_factory", _fake_create_conjure_client_factory)
     channel = MagicMock(name="grpc-channel")
     create_grpc_channel = MagicMock(return_value=channel)

--- a/tests/core/test_clientsbunch.py
+++ b/tests/core/test_clientsbunch.py
@@ -22,6 +22,7 @@ from nominal.protos.ingest.v2 import containerized_extractor_pb2_grpc
 from nominal.protos.registry.v2 import registry_pb2_grpc
 from nominal.protos.sandbox.v1 import sandbox_workspace_pb2_grpc
 from nominal.protos.secrets.v1 import secrets_pb2_grpc
+from nominal.protos.sql.v1 import sql_pb2_grpc
 from nominal.protos.units.v1 import units_pb2_grpc
 from nominal.protos.workspaces.v1 import workspaces_pb2, workspaces_pb2_grpc
 
@@ -284,6 +285,7 @@ def test_from_config_wires_grpc_services_through_one_shared_channel(monkeypatch)
     assert isinstance(clients.registry, registry_pb2_grpc.RegistryServiceStub)
     assert isinstance(clients.sandbox_workspace, sandbox_workspace_pb2_grpc.SandboxWorkspaceServiceStub)
     assert isinstance(clients.secrets, secrets_pb2_grpc.SecretServiceStub)
+    assert isinstance(clients.sql, sql_pb2_grpc.SqlServiceStub)
     # Exactly one channel, built from the right transport params and shared by every gRPC stub.
     create_grpc_channel.assert_called_once()
     assert create_grpc_channel.call_args.kwargs["auth_header"] == "Bearer token"


### PR DESCRIPTION
Wires `SqlServiceStub` (published in `nominal-api-protos` 0.1437.0 via scout#20687, pulled in by #961) into `_ClientsBunch` on the shared gRPC channel, alongside the other service stubs. No behavior change on its own; #948 builds the Ibis backend on top of it instead of raw HTTP.

### Testing plan

- `test_clientsbunch` asserts the stub is constructed like the others
- `just verify` green (755 passed); mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)