### PR TITLE
chore: bump nominal-api and nominal-api-protos to 0.1441.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "conjure-python-client>=3.1.0,<4",
     "exceptiongroup>=1.3.0",
-    "nominal-api==0.1437.0",
-    "nominal-api-protos==0.1437.0",
+    "nominal-api==0.1441.0",
+    "nominal-api-protos==0.1441.0",
     "truststore>=0.10.4",
     "typing-extensions>=4,<5",
     "pandas>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -798,8 +798,8 @@ requires-dist = [
     { name = "conjure-python-client", specifier = ">=3.1.0,<4" },
     { name = "exceptiongroup", specifier = ">=1.3.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
-    { name = "nominal-api", specifier = "==0.1437.0" },
-    { name = "nominal-api-protos", specifier = "==0.1437.0" },
+    { name = "nominal-api", specifier = "==0.1441.0" },
+    { name = "nominal-api-protos", specifier = "==0.1441.0" },
     { name = "nominal-compute", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin' and extra == 'compute') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'compute') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'compute') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32' and extra == 'compute')", specifier = "==0.1315.0" },
     { name = "nominal-streaming", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')", specifier = "==0.9.6" },
     { name = "nominal-tdms", marker = "extra == 'tdms'", editable = "packages/nominal-tdms" },
@@ -841,19 +841,19 @@ dev = [
 
 [[package]]
 name = "nominal-api"
-version = "0.1437.0"
+version = "0.1441.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "conjure-python-client" },
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/02/606712203c579115ec249fd06a0c914b9487ff9756892d1da06d5055de17/nominal_api-0.1437.0-py3-none-any.whl", hash = "sha256:128f5aa81b89a327189e6b98778ff37ca01ca2804078e674c6a11028d87658b5", size = 1011045, upload-time = "2026-09-09T20:32:16.862Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d2/dd9fcf65bf55310d534cc476de2118c48575b1c95dfd40cd03d81a699d14/nominal_api-0.1441.0-py3-none-any.whl", hash = "sha256:8f971a17a5bc133bc0f9c514ed9fe77597ac7a7bcd50c5d0425a18f6e2f38109", size = 1011116, upload-time = "2026-09-11T17:34:35.551Z" },
 ]
 
 [[package]]
 name = "nominal-api-protos"
-version = "0.1437.0"
+version = "0.1441.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -861,7 +861,7 @@ dependencies = [
     { name = "protobuf" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/3a/eab1358c8ed12f05f7190851dc7414be721c8d04b78b9c9182c06f232c94/nominal_api_protos-0.1437.0-py3-none-any.whl", hash = "sha256:1972eca770b26623028b2b6aa28a5777b58a5273a448979b91718b2fae91a19d", size = 745562, upload-time = "2026-09-09T20:32:18.26Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ae/23be3bba076f244d4665a4350b5d6707c3cb34cefacd410543b47b5c2929/nominal_api_protos-0.1441.0-py3-none-any.whl", hash = "sha256:f7c9558e30fcadea89fa6c79fbee1176deac4f8d4b66d36d7f6fd3994d6dc8d5", size = 748011, upload-time = "2026-09-11T17:34:37.394Z" },
 ]
 
 [[package]]
@@ -871,10 +871,8 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/32/ee82060c2e7adcc47d625175fd024c97ff6e1d6de8498ec5b9171bacfcdf/nominal_compute-0.1315.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a7da7b1c63cd72335a1377a36096bde474b4e5d4b2e8f035a35c0cf35632cbb3", size = 852919, upload-time = "2026-07-07T20:12:55.363Z" },
     { url = "https://files.pythonhosted.org/packages/53/06/6d3b3415f14a6959b9cbae59ccff96b74f3219397d5005330fbe9d14c2da/nominal_compute-0.1315.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f090aa05c4b7de14b5f3523cb9462a0380f66a6f58e4f5bd29782722b419235", size = 917946, upload-time = "2026-07-07T20:12:56.95Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/2e/5824bff948d644dfee1ba1df01bdef3d657f1195fa0faaca57a32925b665/nominal_compute-0.1315.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c9e48782321cd14539df20c8c0bd32088e14dc67a17f77f0ff7475dc87885cc", size = 900901, upload-time = "2026-07-07T20:12:58.126Z" },
     { url = "https://files.pythonhosted.org/packages/40/33/ee35625d1c4ce9c0c02216de52ad148c27cdeeb37693fef103cbcbc39371/nominal_compute-0.1315.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8b5baa605c9dc0a0d713fee76f02588d62253836dbe7a8a64ce798b87cb0819", size = 968040, upload-time = "2026-07-07T20:12:59.551Z" },
     { url = "https://files.pythonhosted.org/packages/f3/ce/26313ac059fa177dea96d550c810fa766d12c1db9057369f93670fdf897e/nominal_compute-0.1315.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d890feb1f23d40b30f831e33b78f531d55c5daad048376329e1ec57f2397da9d", size = 1092611, upload-time = "2026-07-07T20:13:00.579Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/f6/38587188d9e0b9b02c7aad498ef4aa9ed6b045730032fc2f2c7014d42e4e/nominal_compute-0.1315.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:792fc61e03a4fc89454095c5b76951d5a707415d996876bb25a1195150afc66a", size = 1166712, upload-time = "2026-07-07T20:13:01.83Z" },
     { url = "https://files.pythonhosted.org/packages/34/02/0701f5d542e40b029c9a62f274eeca69a3e02e2090a259c13ced9334819f/nominal_compute-0.1315.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a857373f2a82bbba98ead32d00f51f55ffb12e60cac6c739ceb22446e3039e1d", size = 1146554, upload-time = "2026-07-07T20:13:02.97Z" },
     { url = "https://files.pythonhosted.org/packages/95/27/498924cf2d5a1fe775b7f60d10f67258d1356783310b3e620977bfb48f69/nominal_compute-0.1315.0-cp310-abi3-win_amd64.whl", hash = "sha256:2ef5c68f4901e6bd10ebec53a990e0f2c9eb9a47ec29fdb87935521ca3cb7a8a", size = 722052, upload-time = "2026-07-07T20:13:04.012Z" },
 ]


### PR DESCRIPTION
Bumps both generated-binding pins from 0.1437.0 to 0.1441.0. Picks up `SqlCatalogColumn.data_type` (scout#20883), which #948 uses to type catalog columns. No client code changes were needed.

Bindings diff (`reviewing-nominal-api-bumps`, 0.1437.0 → 0.1441.0): no breaking change on either transport references client code. Proto additions are the AI agent conversation RPCs, a `file_ingest` CSV option, and the SQL catalog data types; conjure additions are chart-definition viz actions. The two dropped `armv7l` wheels in `uv.lock` are an unreachable-platform prune from the local uv version, not a dependency change.

### Testing plan

- `just verify` green (825 passed)
- `just check-types-all` green (3.10 through 3.14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)